### PR TITLE
fix: support markdown code templates and logout auto-login loop

### DIFF
--- a/frontend/src/components/CreateNoteMenu.tsx
+++ b/frontend/src/components/CreateNoteMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { FileText, FileCode, FileType2, Calendar } from "lucide-react";
+import { setNextMarkdownNoteTemplate, type MarkdownNoteTemplate } from "@/lib/newNoteDefaults";
 
 export type NoteType = "normal" | "markdown" | "word" | "journal";
 
@@ -17,6 +18,8 @@ export interface CreateNoteMenuProps {
  * 菜单项：
  *   - 新建笔记（富文本编辑器）
  *   - 新建 Markdown 笔记（原生 Markdown 编辑器）
+ *   - 新建代码块笔记（Markdown + ```text``` 模板）
+ *   - 新建 SQL 笔记（Markdown + ```sql``` 模板）
  *   - 今日日记（自动创建或打开今日日记）
  *   - 导入 Word 文档（.docx 转可编辑笔记）
  */
@@ -49,27 +52,54 @@ export default function CreateNoteMenu({ onPick, onClose, anchorRef }: CreateNot
 
   if (!pos) return null;
 
-  const items = [
+  const items: Array<{
+    id: string;
+    noteType: NoteType;
+    label: string;
+    desc: string;
+    icon: React.ReactNode;
+    markdownTemplate?: MarkdownNoteTemplate;
+  }> = [
     {
-      id: "normal" as NoteType,
+      id: "normal",
+      noteType: "normal",
       label: "新建笔记",
       desc: "富文本编辑器",
       icon: <FileText size={14} />,
     },
     {
-      id: "markdown" as NoteType,
+      id: "markdown",
+      noteType: "markdown",
       label: "新建 Markdown 笔记",
       desc: "原生 Markdown 编辑器",
       icon: <FileCode size={14} />,
     },
     {
-      id: "journal" as NoteType,
+      id: "markdown-code",
+      noteType: "markdown",
+      label: "新建代码块笔记",
+      desc: "Markdown · ```text``` 模板",
+      icon: <FileCode size={14} />,
+      markdownTemplate: "code",
+    },
+    {
+      id: "markdown-sql",
+      noteType: "markdown",
+      label: "新建 SQL 笔记",
+      desc: "Markdown · ```sql``` 模板",
+      icon: <FileCode size={14} />,
+      markdownTemplate: "sql",
+    },
+    {
+      id: "journal",
+      noteType: "journal",
       label: "今日日记",
       desc: "一键创建或打开今日日记",
       icon: <Calendar size={14} />,
     },
     {
-      id: "word" as NoteType,
+      id: "word",
+      noteType: "word",
       label: "导入 Word 文档",
       desc: "选择 .docx 转为可编辑笔记",
       icon: <FileType2 size={14} />,
@@ -99,7 +129,8 @@ export default function CreateNoteMenu({ onPick, onClose, anchorRef }: CreateNot
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onPick(it.id);
+              if (it.markdownTemplate) setNextMarkdownNoteTemplate(it.markdownTemplate);
+              onPick(it.noteType);
               onClose();
             }}
             className="w-full flex items-start gap-2 px-3 py-2 text-left text-tx-secondary hover:bg-app-hover hover:text-tx-primary transition-colors"

--- a/frontend/src/components/NavRail.tsx
+++ b/frontend/src/components/NavRail.tsx
@@ -45,6 +45,7 @@ import MigrationModal from "@/components/MigrationModal";
 import { useRailMode, nextRailMode, RailMode } from "@/hooks/useRailMode";
 import { getAppInfo, isDesktop as isDesktopApp, switchDesktopToFull, type AppInfo } from "@/lib/desktopBridge";
 import { clearLocalIdMap, clearQueue, getQueueLength } from "@/lib/offlineQueue";
+import { clearRememberedCredentials } from "@/lib/rememberLogin";
 
 type NavGroup = "workspace" | "modules" | "tools";
 
@@ -391,7 +392,10 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
         </button>
       ) : (
         <button
-          onClick={() => {
+          onClick={async () => {
+            // Android/移动端如果开启“下次自动登录”，必须先清除记住密码凭据；
+            // 否则 reload 后 LoginPage 会读取 SecureStorage 并再次自动登录，表现为“退出不了”。
+            await clearRememberedCredentials();
             // L10: 广播给其他 tab 一起下线，与 Sidebar Footer 保持一致
             broadcastLogout("user_logout");
             window.location.reload();

--- a/frontend/src/lib/newNoteDefaults.ts
+++ b/frontend/src/lib/newNoteDefaults.ts
@@ -1,0 +1,64 @@
+import { api } from "@/lib/api";
+import type { Note } from "@/types";
+
+export type MarkdownNoteTemplate = "heading" | "code" | "sql";
+
+let nextMarkdownNoteTemplate: MarkdownNoteTemplate | null = null;
+let installed = false;
+
+function markdownTemplatePayload(template: MarkdownNoteTemplate): Partial<Note> {
+  if (template === "code") {
+    return {
+      title: "无标题代码笔记",
+      contentFormat: "markdown",
+      content: "```text\n\n```\n",
+      contentText: "",
+    } as Partial<Note>;
+  }
+
+  if (template === "sql") {
+    return {
+      title: "无标题 SQL",
+      contentFormat: "markdown",
+      content: "```sql\n\n```\n",
+      contentText: "",
+    } as Partial<Note>;
+  }
+
+  return {
+    title: "无标题 Markdown",
+    contentFormat: "markdown",
+    content: "# 无标题 Markdown\n\n",
+    contentText: "无标题 Markdown",
+  } as Partial<Note>;
+}
+
+export function setNextMarkdownNoteTemplate(template: MarkdownNoteTemplate): void {
+  nextMarkdownNoteTemplate = template;
+}
+
+export function installNewNoteTemplatePatch(): void {
+  if (installed) return;
+  installed = true;
+
+  const originalCreateNote = api.createNote.bind(api);
+  api.createNote = ((data: Partial<Note>) => {
+    const template = nextMarkdownNoteTemplate;
+    if (template) {
+      // 一次性模板：只影响当前这次新建，避免后续普通 Markdown 笔记被意外污染。
+      nextMarkdownNoteTemplate = null;
+    }
+
+    if (template && data?.contentFormat === "markdown") {
+      return originalCreateNote({
+        ...data,
+        ...markdownTemplatePayload(template),
+        contentFormat: "markdown",
+      });
+    }
+
+    return originalCreateNote(data);
+  }) as typeof api.createNote;
+}
+
+installNewNoteTemplatePatch();


### PR DESCRIPTION
## Summary

Fixes part of #113.

- Add new creation menu entries for Markdown code-block notes and SQL notes.
- Route those entries through a one-shot Markdown template patch so existing note creation flow stays unchanged.
- On mobile/web logout, clear remembered credentials before broadcasting logout to prevent Android auto-login from immediately logging the user back in.

## Notes

The macOS ARM window-control/drag-region report in #113 appears to be a separate Electron window chrome issue and is not changed in this PR.

## Testing

Not run locally in this environment.