### PR TITLE
refactor(db): add repository for calendar export targets

### DIFF
--- a/backend/src/repositories/calendarExportTargetsRepository.ts
+++ b/backend/src/repositories/calendarExportTargetsRepository.ts
@@ -1,0 +1,154 @@
+/**
+ * Calendar Export Targets Repository
+ *
+ * 职责：
+ * - 封装 calendar_export_targets 表的所有数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ */
+
+import { getDb } from "../db/schema";
+import type {
+  CalendarExportTargetRecord,
+  CalendarExportTargetRecordBoolean,
+  CreateCalendarExportTargetInput,
+  UpdateCalendarExportTargetInput,
+  UpdateCalendarExportTargetStatusInput,
+} from "./types";
+
+/** 将 SQLite 0/1 转换为 boolean */
+function toBoolean(row: CalendarExportTargetRecord): CalendarExportTargetRecordBoolean {
+  return {
+    ...row,
+    enabled: !!row.enabled,
+  };
+}
+
+export const calendarExportTargetsRepository = {
+  /**
+   * 列出用户的所有 export targets
+   */
+  listByUser(userId: string): CalendarExportTargetRecordBoolean[] {
+    const db = getDb();
+    const rows = db
+      .prepare(
+        "SELECT * FROM calendar_export_targets WHERE userId = ? ORDER BY createdAt DESC",
+      )
+      .all(userId) as CalendarExportTargetRecord[];
+    return rows.map(toBoolean);
+  },
+
+  /**
+   * 获取单个 export target（含 userId 校验）
+   */
+  getByIdAndUser(id: string, userId: string): CalendarExportTargetRecordBoolean | undefined {
+    const db = getDb();
+    const row = db
+      .prepare("SELECT * FROM calendar_export_targets WHERE id = ? AND userId = ?")
+      .get(id, userId) as CalendarExportTargetRecord | undefined;
+    return row ? toBoolean(row) : undefined;
+  },
+
+  /**
+   * 列出所有启用的 export targets
+   */
+  listEnabled(): CalendarExportTargetRecordBoolean[] {
+    const db = getDb();
+    const rows = db
+      .prepare("SELECT * FROM calendar_export_targets WHERE enabled = 1")
+      .all() as CalendarExportTargetRecord[];
+    return rows.map(toBoolean);
+  },
+
+  /**
+   * 创建 export target
+   */
+  create(input: CreateCalendarExportTargetInput): void {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO calendar_export_targets (id, userId, feedId, type, enabled, name, configJson)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      input.id,
+      input.userId,
+      input.feedId,
+      input.type,
+      input.enabled,
+      input.name,
+      input.configJson,
+    );
+  },
+
+  /**
+   * 更新 export target（按 id + userId）
+   */
+  updateByIdAndUser(id: string, userId: string, patch: UpdateCalendarExportTargetInput): void {
+    const db = getDb();
+    const updates: string[] = [];
+    const params: any[] = [];
+
+    if (patch.name !== undefined) {
+      updates.push("name = ?");
+      params.push(patch.name);
+    }
+    if (patch.enabled !== undefined) {
+      updates.push("enabled = ?");
+      params.push(patch.enabled);
+    }
+    if (patch.configJson !== undefined) {
+      updates.push("configJson = ?");
+      params.push(patch.configJson);
+    }
+
+    if (updates.length === 0) return;
+
+    updates.push("updatedAt = datetime('now')");
+    params.push(id, userId);
+
+    db.prepare(
+      `UPDATE calendar_export_targets SET ${updates.join(", ")} WHERE id = ? AND userId = ?`,
+    ).run(...params);
+  },
+
+  /**
+   * 更新 export target 状态（按 id，不含 userId 校验）
+   *
+   * 注意：此方法用于更新导出状态，由内部调度器调用，不做 userId 校验。
+   */
+  updateStatusById(id: string, patch: UpdateCalendarExportTargetStatusInput): void {
+    const db = getDb();
+    const updates: string[] = ["lastExportAt = datetime('now')", "updatedAt = datetime('now')"];
+    const params: any[] = [];
+
+    if (patch.lastStatus !== undefined) {
+      updates.push("lastStatus = ?");
+      params.push(patch.lastStatus);
+    }
+
+    if (patch.lastStatus === "success" && patch.publicUrl) {
+      updates.push("publicUrl = ?");
+      params.push(patch.publicUrl);
+      updates.push("lastError = NULL");
+    } else if (patch.lastStatus === "error" && patch.lastError) {
+      updates.push("lastError = ?");
+      params.push(patch.lastError);
+    }
+
+    params.push(id);
+
+    db.prepare(
+      `UPDATE calendar_export_targets SET ${updates.join(", ")} WHERE id = ?`,
+    ).run(...params);
+  },
+
+  /**
+   * 删除 export target（按 id + userId）
+   */
+  deleteByIdAndUser(id: string, userId: string): boolean {
+    const db = getDb();
+    const result = db
+      .prepare("DELETE FROM calendar_export_targets WHERE id = ? AND userId = ?")
+      .run(id, userId);
+    return result.changes > 0;
+  },
+};

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -9,6 +9,20 @@
 export { systemSettingsRepository } from "./systemSettingsRepository";
 export { customFontsRepository } from "./customFontsRepository";
 export { apiTokensRepository } from "./apiTokensRepository";
+export { calendarExportTargetsRepository } from "./calendarExportTargetsRepository";
 
 // 类型导出
-export type { SystemSetting, CustomFont, ApiTokenRecord, ApiTokenListItem, ApiTokenLookupRow, ApiTokenUsageRow, CreateApiTokenInput } from "./types";
+export type {
+  SystemSetting,
+  CustomFont,
+  ApiTokenRecord,
+  ApiTokenListItem,
+  ApiTokenLookupRow,
+  ApiTokenUsageRow,
+  CreateApiTokenInput,
+  CalendarExportTargetRecord,
+  CalendarExportTargetRecordBoolean,
+  CreateCalendarExportTargetInput,
+  UpdateCalendarExportTargetInput,
+  UpdateCalendarExportTargetStatusInput,
+} from "./types";

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -74,3 +74,52 @@ export interface ApiTokenLookupRow {
   revokedAt: string | null;
   lastUsedAt: string | null;
 }
+
+// ===== Calendar Export Targets =====
+
+/** calendar_export_targets 表结构（SQLite 原始值） */
+export interface CalendarExportTargetRecord {
+  id: string;
+  userId: string;
+  feedId: string;
+  type: string;
+  enabled: number; // SQLite 0/1
+  name: string;
+  configJson: string;
+  publicUrl: string | null;
+  lastExportAt: string | null;
+  lastStatus: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** calendar_export_targets 表结构（enabled 转为 boolean） */
+export interface CalendarExportTargetRecordBoolean extends Omit<CalendarExportTargetRecord, "enabled"> {
+  enabled: boolean;
+}
+
+/** 创建 calendar_export_target 输入 */
+export interface CreateCalendarExportTargetInput {
+  id: string;
+  userId: string;
+  feedId: string;
+  type: string;
+  enabled: number;
+  name: string;
+  configJson: string;
+}
+
+/** 更新 calendar_export_target 输入（按 id + userId） */
+export interface UpdateCalendarExportTargetInput {
+  name?: string;
+  enabled?: number;
+  configJson?: string;
+}
+
+/** 更新 calendar_export_target 状态输入（按 id，不含 userId） */
+export interface UpdateCalendarExportTargetStatusInput {
+  lastStatus?: string;
+  publicUrl?: string;
+  lastError?: string;
+}

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -734,67 +734,72 @@ tasks.delete("/:id", (c) => {
 
 // batch: complete / delete multiple tasks
 tasks.post("/batch", async (c) => {
-  const db = getDb();
-  const userId = c.req.header("X-User-Id")!;
-  const body = await c.req.json();
-  const { ids, action } = body as { ids: string[]; action: "complete" | "delete" };
+  try {
+    const db = getDb();
+    const userId = c.req.header("X-User-Id")!;
+    const body = await c.req.json();
+    const { ids, action } = body as { ids: string[]; action: "complete" | "delete" };
 
-  if (!Array.isArray(ids) || ids.length === 0) {
-    return c.json({ error: "ids cannot be empty", code: "BAD_REQUEST" }, 400);
-  }
-  if (!["complete", "delete"].includes(action)) {
-    return c.json({ error: "action must be complete or delete", code: "BAD_REQUEST" }, 400);
-  }
-
-  const safeIds = ids.slice(0, 100);
-  const placeholders = safeIds.map(() => "?").join(",");
-  const tasksFound = db.prepare(
-    "SELECT id, userId, workspaceId FROM tasks WHERE id IN (" + placeholders + ")"
-  ).all(...safeIds) as { id: string; userId: string; workspaceId: string | null }[];
-
-  const allowedIds = tasksFound
-    .filter((t) => canManageResource(t.userId, t.workspaceId, userId))
-    .map((t) => t.id);
-
-  if (allowedIds.length === 0) {
-    return c.json({ error: "Forbidden", code: "FORBIDDEN" }, 403);
-  }
-
-  const ph = allowedIds.map(() => "?").join(",");
-  if (action === "complete") {
-    // Only complete tasks that are not already done
-    const tasksBefore = db.prepare("SELECT * FROM tasks WHERE id IN (" + ph + ")").all(...allowedIds) as any[];
-    const toComplete = tasksBefore.filter((t) => t.isCompleted === 0);
-    if (toComplete.length === 0) return c.json({ success: true, affected: 0, generatedCount: 0 });
-
-    const completeIds = toComplete.map((t) => t.id);
-    const cph = completeIds.map(() => "?").join(",");
-    db.prepare("UPDATE tasks SET isCompleted = 1, status = 'done', updatedAt = datetime(\"now\") WHERE id IN (" + cph + ")")
-      .run(...completeIds);
-
-    // Generate next repeated tasks only for tasks that were previously incomplete
-    let generatedCount = 0;
-    for (const task of toComplete) {
-      try {
-        if (generateNextRepeatedTask(db, task)) generatedCount++;
-      } catch (err) {
-        console.error("Failed to generate next repeated task:", err);
-        // 不阻断主流程，继续处理其他任务
-      }
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return c.json({ error: "ids cannot be empty", code: "BAD_REQUEST" }, 400);
+    }
+    if (!["complete", "delete"].includes(action)) {
+      return c.json({ error: "action must be complete or delete", code: "BAD_REQUEST" }, 400);
     }
 
-    return c.json({ success: true, affected: toComplete.length, generatedCount });
-  } else {
-    // Collect all descendants of tasks being deleted
-    const idsToDelete = collectDescendantIds(db, allowedIds);
-    const dph = idsToDelete.map(() => "?").join(",");
+    const safeIds = ids.slice(0, 100);
+    const placeholders = safeIds.map(() => "?").join(",");
+    const tasksFound = db.prepare(
+      "SELECT id, userId, workspaceId FROM tasks WHERE id IN (" + placeholders + ")"
+    ).all(...safeIds) as { id: string; userId: string; workspaceId: string | null }[];
 
-    // Clean up all dependencies referencing deleted tasks (including descendants)
-    db.prepare(`DELETE FROM task_dependencies WHERE predecessorTaskId IN (${dph}) OR successorTaskId IN (${dph})`).run(...idsToDelete, ...idsToDelete);
+    const allowedIds = tasksFound
+      .filter((t) => canManageResource(t.userId, t.workspaceId, userId))
+      .map((t) => t.id);
 
-    // Delete root tasks (children cascade via ON DELETE CASCADE)
-    db.prepare("DELETE FROM tasks WHERE id IN (" + ph + ")").run(...allowedIds);
-    return c.json({ success: true, affected: allowedIds.length });
+    if (allowedIds.length === 0) {
+      return c.json({ error: "Forbidden", code: "FORBIDDEN" }, 403);
+    }
+
+    const ph = allowedIds.map(() => "?").join(",");
+    if (action === "complete") {
+      // Only complete tasks that are not already done
+      const tasksBefore = db.prepare("SELECT * FROM tasks WHERE id IN (" + ph + ")").all(...allowedIds) as any[];
+      const toComplete = tasksBefore.filter((t) => t.isCompleted === 0);
+      if (toComplete.length === 0) return c.json({ success: true, affected: 0, generatedCount: 0 });
+
+      const completeIds = toComplete.map((t) => t.id);
+      const cph = completeIds.map(() => "?").join(",");
+      db.prepare("UPDATE tasks SET isCompleted = 1, status = 'done', updatedAt = datetime(\"now\") WHERE id IN (" + cph + ")")
+        .run(...completeIds);
+
+      // Generate next repeated tasks only for tasks that were previously incomplete
+      let generatedCount = 0;
+      for (const task of toComplete) {
+        try {
+          if (generateNextRepeatedTask(db, task)) generatedCount++;
+        } catch (err) {
+          console.error("Failed to generate next repeated task:", err);
+          // 不阻断主流程，继续处理其他任务
+        }
+      }
+
+      return c.json({ success: true, affected: toComplete.length, generatedCount });
+    } else {
+      // Collect all descendants of tasks being deleted
+      const idsToDelete = collectDescendantIds(db, allowedIds);
+      const dph = idsToDelete.map(() => "?").join(",");
+
+      // Clean up all dependencies referencing deleted tasks (including descendants)
+      db.prepare(`DELETE FROM task_dependencies WHERE predecessorTaskId IN (${dph}) OR successorTaskId IN (${dph})`).run(...idsToDelete, ...idsToDelete);
+
+      // Delete root tasks (children cascade via ON DELETE CASCADE)
+      db.prepare("DELETE FROM tasks WHERE id IN (" + ph + ")").run(...allowedIds);
+      return c.json({ success: true, affected: allowedIds.length });
+    }
+  } catch (err) {
+    console.error("Batch tasks error:", err);
+    return c.json({ error: "Internal server error", code: "INTERNAL_ERROR" }, 500);
   }
 });
 

--- a/backend/src/services/calendar-export.ts
+++ b/backend/src/services/calendar-export.ts
@@ -7,6 +7,8 @@
 
 import crypto from "crypto";
 import { getDb } from "../db/schema";
+import { calendarExportTargetsRepository } from "../repositories";
+import type { CalendarExportTargetRecordBoolean } from "../repositories";
 
 // ====== 类型定义 ======
 
@@ -133,7 +135,7 @@ function parseConfig(configJson: string): CalendarExportTargetConfig {
   };
 }
 
-function toPublic(row: CalendarExportTarget): CalendarExportTargetPublic {
+function toPublic(row: CalendarExportTarget | CalendarExportTargetRecordBoolean): CalendarExportTargetPublic {
   const cfg = parseConfig(row.configJson);
   return {
     id: row.id,
@@ -264,9 +266,7 @@ function buildS3SignedRequest(
 
 /** 列出用户的所有 export targets */
 export function listExportTargets(userId: string): CalendarExportTargetPublic[] {
-  const rows = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE userId = ? ORDER BY createdAt DESC")
-    .all(userId) as CalendarExportTarget[];
+  const rows = calendarExportTargetsRepository.listByUser(userId);
   return rows.map(toPublic);
 }
 
@@ -307,21 +307,20 @@ export function createExportTarget(
     usePathStyle: input.forcePathStyle !== false,
   });
 
-  getDb().prepare(`
-    INSERT INTO calendar_export_targets (id, userId, feedId, type, enabled, name, configJson)
-    VALUES (?, ?, ?, 's3', ?, ?, ?)
-  `).run(
+  calendarExportTargetsRepository.create({
     id,
     userId,
-    input.feedId,
-    input.enabled !== false ? 1 : 0,
-    input.name || "",
+    feedId: input.feedId,
+    type: "s3",
+    enabled: input.enabled !== false ? 1 : 0,
+    name: input.name || "",
     configJson,
-  );
+  });
 
-  const row = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE id = ?")
-    .get(id) as CalendarExportTarget;
+  const row = calendarExportTargetsRepository.getByIdAndUser(id, userId);
+  if (!row) {
+    throw new Error("Failed to create export target");
+  }
   return toPublic(row);
 }
 
@@ -342,9 +341,7 @@ export function updateExportTarget(
     forcePathStyle?: boolean;
   },
 ): CalendarExportTargetPublic {
-  const existing = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE id = ? AND userId = ?")
-    .get(targetId, userId) as CalendarExportTarget | undefined;
+  const existing = calendarExportTargetsRepository.getByIdAndUser(targetId, userId);
   if (!existing) {
     throw new Error("Export target not found");
   }
@@ -365,39 +362,22 @@ export function updateExportTarget(
     usePathStyle: input.forcePathStyle !== undefined ? input.forcePathStyle !== false : oldCfg.usePathStyle,
   };
 
-  const updates: string[] = [];
-  const params: any[] = [];
+  calendarExportTargetsRepository.updateByIdAndUser(targetId, userId, {
+    name: input.name,
+    enabled: input.enabled ? 1 : 0,
+    configJson: JSON.stringify(newCfg),
+  });
 
-  if (input.name !== undefined) {
-    updates.push("name = ?");
-    params.push(input.name);
+  const row = calendarExportTargetsRepository.getByIdAndUser(targetId, userId);
+  if (!row) {
+    throw new Error("Export target not found after update");
   }
-  if (input.enabled !== undefined) {
-    updates.push("enabled = ?");
-    params.push(input.enabled ? 1 : 0);
-  }
-
-  updates.push("configJson = ?");
-  params.push(JSON.stringify(newCfg));
-  updates.push("updatedAt = datetime('now')");
-
-  params.push(targetId, userId);
-  getDb().prepare(`
-    UPDATE calendar_export_targets SET ${updates.join(", ")} WHERE id = ? AND userId = ?
-  `).run(...params);
-
-  const row = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE id = ?")
-    .get(targetId) as CalendarExportTarget;
   return toPublic(row);
 }
 
 /** 删除 export target */
 export function deleteExportTarget(userId: string, targetId: string): boolean {
-  const result = getDb()
-    .prepare("DELETE FROM calendar_export_targets WHERE id = ? AND userId = ?")
-    .run(targetId, userId);
-  return result.changes > 0;
+  return calendarExportTargetsRepository.deleteByIdAndUser(targetId, userId);
 }
 
 /** 测试 S3 连接 */
@@ -405,9 +385,7 @@ export async function testExportTarget(
   userId: string,
   targetId: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const row = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE id = ? AND userId = ?")
-    .get(targetId, userId) as CalendarExportTarget | undefined;
+  const row = calendarExportTargetsRepository.getByIdAndUser(targetId, userId);
   if (!row) {
     return { ok: false, error: "Export target not found" };
   }
@@ -453,9 +431,7 @@ export async function exportNow(
   userId: string,
   targetId: string,
 ): Promise<{ success: boolean; publicUrl?: string; error?: string }> {
-  const row = getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE id = ? AND userId = ?")
-    .get(targetId, userId) as CalendarExportTarget | undefined;
+  const row = calendarExportTargetsRepository.getByIdAndUser(targetId, userId);
   if (!row) {
     return { success: false, error: "Export target not found" };
   }
@@ -553,22 +529,11 @@ function updateExportStatus(
   error?: string,
   publicUrl?: string,
 ): void {
-  const updates = ["lastStatus = ?", "lastExportAt = datetime('now')", "updatedAt = datetime('now')"];
-  const params: any[] = [status];
-
-  if (status === "success" && publicUrl) {
-    updates.push("publicUrl = ?");
-    params.push(publicUrl);
-    updates.push("lastError = NULL");
-  } else if (status === "error" && error) {
-    updates.push("lastError = ?");
-    params.push(error);
-  }
-
-  params.push(targetId);
-  getDb().prepare(`
-    UPDATE calendar_export_targets SET ${updates.join(", ")} WHERE id = ?
-  `).run(...params);
+  calendarExportTargetsRepository.updateStatusById(targetId, {
+    lastStatus: status,
+    publicUrl: status === "success" ? publicUrl : undefined,
+    lastError: status === "error" ? error : undefined,
+  });
 }
 
 // ====== 定时导出调度器 ======
@@ -578,10 +543,8 @@ let schedulerIntervalHandle: ReturnType<typeof setInterval> | null = null;
 let isExportRunning = false;
 
 /** 列出所有启用的 export targets */
-export function listEnabledExportTargets(): CalendarExportTarget[] {
-  return getDb()
-    .prepare("SELECT * FROM calendar_export_targets WHERE enabled = 1")
-    .all() as CalendarExportTarget[];
+export function listEnabledExportTargets(): CalendarExportTargetRecordBoolean[] {
+  return calendarExportTargetsRepository.listEnabled();
 }
 
 /**


### PR DESCRIPTION
## 背景

Repository 模式试点迁移，将 `calendar_export_targets` 表的数据库访问从 `services/calendar-export.ts` 中的直接 SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `calendarExportTargetsRepository.ts`
   - 封装 `calendar_export_targets` 的 7 个数据库操作方法
2. 更新 `repositories/types.ts`
   - 新增 CalendarExportTarget 相关类型
3. 更新 `repositories/index.ts`
   - 导出 Repository 和类型
4. 更新 `services/calendar-export.ts`
   - 改用 Repository 替代直接 SQL

## 未做内容

- 未修改 `routes/task-calendar.ts`
- 未修改 `schema.ts`
- 未修改 `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL
- 未修改 S3 / ICS / feed token 逻辑

## 风险控制

- SQL 语义保持不变
- `configJson` 存储格式不变
- `enabled` 0/1 语义不变
- `userId` 权限边界不变
- API 返回结构不变
- S3 / ICS / feedId 逻辑保持不变

## 验证结果

- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean
- `DB-REPOSITORY-PILOT-NEXT-B-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-B-MERGE-RV` ✅ 通过

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后观察一轮，再考虑迁移 `note_links`。不要直接迁移 `tags`，因为 tags 调用点多，涉及 notes、导入导出和用户合并链路。