### PR TITLE
refactor(db): add repository for note links

### DIFF
--- a/backend/src/lib/noteLinks.ts
+++ b/backend/src/lib/noteLinks.ts
@@ -31,15 +31,7 @@
 import type Database from "better-sqlite3";
 import { v4 as uuid } from "uuid";
 import { noteLinksRepository } from "../repositories";
-
-// BLOCK-LINKS-01: 引用链接条目
-export interface NoteLinkEntry {
-  targetNoteId: string;
-  targetBlockId: string | null;
-  linkType: "note" | "block";
-  linkText: string | null;
-  excerpt: string | null;
-}
+import type { NoteLinkEntry } from "../repositories";
 
 // 匹配 [[note:UUID|标题]] 和 [[note:UUID#blk:BLOCK_ID|标题 > 摘要]] 格式（纯文本形式）
 // UUID 支持大小写十六进制
@@ -116,60 +108,22 @@ export function extractNoteLinksFromContent(content: string): NoteLinkEntry[] {
  * 失败仅打日志，不阻断保存（与 attachmentReferences 一致）。
  */
 export function syncNoteLinks(
-  db: Database.Database,
+  _db: Database.Database,
   userId: string,
   sourceNoteId: string,
   content: string,
 ): void {
   try {
-    // 1. 清除旧的引用关系
-    db.prepare(
-      "DELETE FROM note_links WHERE userId = ? AND sourceNoteId = ?"
-    ).run(userId, sourceNoteId);
-
-    // 2. 解析新的引用（含笔记级和块级）
+    // 1. 解析新的引用（含笔记级和块级）
     const links = extractNoteLinksFromContent(content);
 
-    // 3. 排除笔记级自引用（块级自引用允许：引用自己的某个 heading）
+    // 2. 排除笔记级自引用（块级自引用允许：引用自己的某个 heading）
     const filteredLinks = links.filter(
       (link) => !(link.targetNoteId === sourceNoteId.toLowerCase() && !link.targetBlockId)
     );
 
-    if (filteredLinks.length === 0) return;
-
-    // 4. 过滤掉不存在的 target note（简单校验）
-    const validEntries: NoteLinkEntry[] = [];
-    const checkStmt = db.prepare("SELECT id FROM notes WHERE id = ?");
-    for (const link of filteredLinks) {
-      const exists = checkStmt.get(link.targetNoteId);
-      if (exists) validEntries.push(link);
-    }
-
-    if (validEntries.length === 0) return;
-
-    // 5. 批量插入新的引用关系
-    //    使用 INSERT OR IGNORE + 部分唯一约束去重
-    const insertStmt = db.prepare(`
-      INSERT OR IGNORE INTO note_links (id, userId, sourceNoteId, targetNoteId, targetBlockId, linkType, linkText, excerpt, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-    `);
-
-    const insertMany = db.transaction((entries: NoteLinkEntry[]) => {
-      for (const link of entries) {
-        insertStmt.run(
-          uuid(),
-          userId,
-          sourceNoteId,
-          link.targetNoteId,
-          link.targetBlockId,
-          link.linkType,
-          link.linkText,
-          link.excerpt,
-        );
-      }
-    });
-
-    insertMany(validEntries);
+    // 3. 调用 Repository 执行 DELETE + INSERT（保持现有事务边界）
+    noteLinksRepository.replaceLinksForSource(userId, sourceNoteId, filteredLinks);
   } catch (e) {
     console.warn("[syncNoteLinks] failed:", e instanceof Error ? e.message : e);
   }

--- a/backend/src/lib/noteLinks.ts
+++ b/backend/src/lib/noteLinks.ts
@@ -30,6 +30,7 @@
 
 import type Database from "better-sqlite3";
 import { v4 as uuid } from "uuid";
+import { noteLinksRepository } from "../repositories";
 
 // BLOCK-LINKS-01: 引用链接条目
 export interface NoteLinkEntry {
@@ -191,7 +192,7 @@ export function syncNoteLinks(
  *   - 无权限的来源笔记（调用方应已做过权限校验）
  */
 export function getBacklinks(
-  db: Database.Database,
+  _db: Database.Database,
   userId: string,
   targetNoteId: string,
   limit: number = 50,
@@ -204,36 +205,5 @@ export function getBacklinks(
   targetBlockId: string | null;
   excerpt: string | null;
 }> {
-  try {
-    const rows = db.prepare(`
-      SELECT
-        nl.sourceNoteId,
-        n.title,
-        n.updatedAt,
-        nl.linkText,
-        nl.linkType,
-        nl.targetBlockId,
-        nl.excerpt
-      FROM note_links nl
-      JOIN notes n ON n.id = nl.sourceNoteId
-      WHERE nl.userId = ?
-        AND nl.targetNoteId = ?
-        AND n.isTrashed = 0
-      ORDER BY n.updatedAt DESC
-      LIMIT ?
-    `).all(userId, targetNoteId, limit) as Array<{
-      sourceNoteId: string;
-      title: string;
-      updatedAt: string;
-      linkText: string | null;
-      linkType: string;
-      targetBlockId: string | null;
-      excerpt: string | null;
-    }>;
-
-    return rows;
-  } catch (e) {
-    console.warn("[getBacklinks] failed:", e instanceof Error ? e.message : e);
-    return [];
-  }
+  return noteLinksRepository.getBacklinks(userId, targetNoteId, limit);
 }

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -27,4 +27,5 @@ export type {
   UpdateCalendarExportTargetInput,
   UpdateCalendarExportTargetStatusInput,
   BacklinkItem,
+  NoteLinkEntry,
 } from "./types";

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -10,6 +10,7 @@ export { systemSettingsRepository } from "./systemSettingsRepository";
 export { customFontsRepository } from "./customFontsRepository";
 export { apiTokensRepository } from "./apiTokensRepository";
 export { calendarExportTargetsRepository } from "./calendarExportTargetsRepository";
+export { noteLinksRepository } from "./noteLinksRepository";
 
 // 类型导出
 export type {
@@ -25,4 +26,5 @@ export type {
   CreateCalendarExportTargetInput,
   UpdateCalendarExportTargetInput,
   UpdateCalendarExportTargetStatusInput,
+  BacklinkItem,
 } from "./types";

--- a/backend/src/repositories/noteLinksRepository.ts
+++ b/backend/src/repositories/noteLinksRepository.ts
@@ -129,4 +129,17 @@ export const noteLinksRepository = {
 
     insertMany(validEntries);
   },
+
+  /**
+   * 删除笔记时清理 note_links 引用关系。
+   *
+   * 清理作为来源或目标的引用记录，避免孤儿数据残留。
+   * SQL 保持与原 routes/notes.ts 中的直连 SQL 完全等价。
+   */
+  deleteByNoteId(noteId: string): void {
+    const db = getDb();
+    db.prepare(
+      "DELETE FROM note_links WHERE sourceNoteId = ? OR targetNoteId = ?",
+    ).run(noteId, noteId);
+  },
 };

--- a/backend/src/repositories/noteLinksRepository.ts
+++ b/backend/src/repositories/noteLinksRepository.ts
@@ -2,18 +2,19 @@
  * Note Links Repository
  *
  * 职责：
- * - 封装 note_links 表的只读查询操作
+ * - 封装 note_links 表的数据库操作
  * - 提供类型安全的接口
  * - 保持现有 SQLite 行为不变
  *
  * 注意：
- * - C1 阶段只迁移 getBacklinks 只读查询
- * - syncNoteLinks 的 DELETE + INSERT 事务暂不迁移
+ * - C1: getBacklinks 只读查询
+ * - C2: syncNoteLinks 写入操作（保持现有事务边界）
  * - routes/notes.ts 中的删除清理暂不迁移
  */
 
 import { getDb } from "../db/schema";
-import type { BacklinkItem } from "./types";
+import { v4 as uuid } from "uuid";
+import type { BacklinkItem, NoteLinkEntry } from "./types";
 
 export const noteLinksRepository = {
   /**
@@ -64,5 +65,68 @@ export const noteLinksRepository = {
       console.warn("[noteLinksRepository.getBacklinks] failed:", e instanceof Error ? e.message : e);
       return [];
     }
+  },
+
+  /**
+   * 全量替换 sourceNoteId 的引用关系。
+   *
+   * 行为保持现有 syncNoteLinks 的数据库行为：
+   *   1. 先 DELETE 旧引用
+   *   2. 如果 links 为空，直接 return
+   *   3. 对每个 link 执行 target note 存在性校验
+   *   4. 过滤掉不存在的 target note
+   *   5. 如果 validEntries 为空，直接 return
+   *   6. 使用 db.transaction() 包裹批量 INSERT
+   *
+   * 注意：DELETE 和 INSERT 不在同一个事务中，保持现有行为。
+   */
+  replaceLinksForSource(
+    userId: string,
+    sourceNoteId: string,
+    links: NoteLinkEntry[],
+  ): void {
+    const db = getDb();
+
+    // 1. 清除旧的引用关系
+    db.prepare(
+      "DELETE FROM note_links WHERE userId = ? AND sourceNoteId = ?",
+    ).run(userId, sourceNoteId);
+
+    // 2. 如果 links 为空，直接 return
+    if (links.length === 0) return;
+
+    // 3. 过滤掉不存在的 target note
+    const validEntries: NoteLinkEntry[] = [];
+    const checkStmt = db.prepare("SELECT id FROM notes WHERE id = ?");
+    for (const link of links) {
+      const exists = checkStmt.get(link.targetNoteId);
+      if (exists) validEntries.push(link);
+    }
+
+    // 4. 如果 validEntries 为空，直接 return
+    if (validEntries.length === 0) return;
+
+    // 5. 批量插入新的引用关系（使用事务）
+    const insertStmt = db.prepare(`
+      INSERT OR IGNORE INTO note_links (id, userId, sourceNoteId, targetNoteId, targetBlockId, linkType, linkText, excerpt, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+    `);
+
+    const insertMany = db.transaction((entries: NoteLinkEntry[]) => {
+      for (const link of entries) {
+        insertStmt.run(
+          uuid(),
+          userId,
+          sourceNoteId,
+          link.targetNoteId,
+          link.targetBlockId,
+          link.linkType,
+          link.linkText,
+          link.excerpt,
+        );
+      }
+    });
+
+    insertMany(validEntries);
   },
 };

--- a/backend/src/repositories/noteLinksRepository.ts
+++ b/backend/src/repositories/noteLinksRepository.ts
@@ -1,0 +1,68 @@
+/**
+ * Note Links Repository
+ *
+ * 职责：
+ * - 封装 note_links 表的只读查询操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ *
+ * 注意：
+ * - C1 阶段只迁移 getBacklinks 只读查询
+ * - syncNoteLinks 的 DELETE + INSERT 事务暂不迁移
+ * - routes/notes.ts 中的删除清理暂不迁移
+ */
+
+import { getDb } from "../db/schema";
+import type { BacklinkItem } from "./types";
+
+export const noteLinksRepository = {
+  /**
+   * 获取目标笔记的所有反向链接（来源笔记）。
+   *
+   * 返回结构：
+   *   - sourceNoteId: 来源笔记 ID
+   *   - title: 来源笔记标题
+   *   - updatedAt: 来源笔记更新时间
+   *   - linkText: 引用时的显示文本（可选）
+   *   - linkType: 'note' 或 'block'
+   *   - targetBlockId: 被引用的块 ID（可选）
+   *   - excerpt: 块级引用摘要（可选）
+   *
+   * 排除规则：
+   *   - isTrashed = 1 的来源笔记
+   *   - 无权限的来源笔记（调用方应已做过权限校验）
+   */
+  getBacklinks(
+    userId: string,
+    targetNoteId: string,
+    limit: number = 50,
+  ): BacklinkItem[] {
+    try {
+      const db = getDb();
+      const rows = db
+        .prepare(
+          `SELECT
+            nl.sourceNoteId,
+            n.title,
+            n.updatedAt,
+            nl.linkText,
+            nl.linkType,
+            nl.targetBlockId,
+            nl.excerpt
+          FROM note_links nl
+          JOIN notes n ON n.id = nl.sourceNoteId
+          WHERE nl.userId = ?
+            AND nl.targetNoteId = ?
+            AND n.isTrashed = 0
+          ORDER BY n.updatedAt DESC
+          LIMIT ?`,
+        )
+        .all(userId, targetNoteId, limit) as BacklinkItem[];
+
+      return rows;
+    } catch (e) {
+      console.warn("[noteLinksRepository.getBacklinks] failed:", e instanceof Error ? e.message : e);
+      return [];
+    }
+  },
+};

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -136,3 +136,12 @@ export interface BacklinkItem {
   targetBlockId: string | null;
   excerpt: string | null;
 }
+
+/** 笔记引用链接条目（用于 syncNoteLinks） */
+export interface NoteLinkEntry {
+  targetNoteId: string;
+  targetBlockId: string | null;
+  linkType: "note" | "block";
+  linkText: string | null;
+  excerpt: string | null;
+}

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -123,3 +123,16 @@ export interface UpdateCalendarExportTargetStatusInput {
   publicUrl?: string;
   lastError?: string;
 }
+
+// ===== Note Links =====
+
+/** 反向链接条目 */
+export interface BacklinkItem {
+  sourceNoteId: string;
+  title: string;
+  updatedAt: string;
+  linkText: string | null;
+  linkType: string;
+  targetBlockId: string | null;
+  excerpt: string | null;
+}

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -15,6 +15,7 @@ import { yFlush, yDestroyDoc, yReplaceContentAsUpdate } from "../services/yjs";
 import { deleteAttachmentFilesByNoteIds, extractInlineBase64Images } from "./attachments";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { syncNoteLinks, getBacklinks } from "../lib/noteLinks";
+import { noteLinksRepository } from "../repositories";
 import { reclaimSpace } from "../lib/reclaimSpace";
 import { buildFtsSearchTerm } from "../lib/searchQuery";
 
@@ -1111,7 +1112,7 @@ app.delete("/:id", (c) => {
   // BACKLINKS-02-RV1: 永久删除笔记前清理 note_links 引用关系
   // 作为 source 或 target 的引用记录都需要清除，避免孤儿数据残留
   try {
-    db.prepare("DELETE FROM note_links WHERE sourceNoteId = ? OR targetNoteId = ?").run(id, id);
+    noteLinksRepository.deleteByNoteId(id);
   } catch (e) {
     console.warn("[notes.delete] cleanup note_links failed:", e);
   }


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `note_links` 表的数据库访问从 `lib/noteLinks.ts` 和 `routes/notes.ts` 中的直接 SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `noteLinksRepository.ts`
   - 封装 `note_links` 的 3 个数据库操作方法：
     - `getBacklinks(userId, targetNoteId, limit)`
     - `replaceLinksForSource(userId, sourceNoteId, links)`
     - `deleteByNoteId(noteId)`
2. 更新 `repositories/types.ts`
   - 新增 `BacklinkItem` 和 `NoteLinkEntry` 类型
3. 更新 `repositories/index.ts`
   - 导出 Repository 和类型
4. 更新 `lib/noteLinks.ts`
   - 改用 Repository 替代直接 SQL
5. 更新 `routes/notes.ts`
   - 删除笔记时改用 Repository 清理 `note_links`

## 未做内容

- 未修改 `schema.ts`
- 未修改 `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL
- 未修改 `tags` / `shares` / import / export
- 未修改 FTS5 / sqlite-vec
- 未改变 `syncNoteLinks` 的失败语义
- 未把 DELETE + INSERT 改成整体事务

## 风险控制

- SQL 语义保持不变
- `getBacklinks` 返回字段保持不变
- `syncNoteLinks` 函数签名保持不变
- `syncNoteLinks` 失败仍不阻断保存流程
- DELETE + INSERT 事务边界保持不变
- 删除笔记 API 权限校验保持不变
- 删除笔记 API 返回结构保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-C1-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-C2-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-C3-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-C-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后观察一轮，再考虑迁移 `tags`。`tags` 调用点多，涉及 notes、导入导出和用户合并链路，需要单独审计和拆分。