### PR TITLE
fix(tasks): 已完成任务的日期标签不再显示"已逾期"

### DIFF
--- a/frontend/src/components/tasks/DateBadge.tsx
+++ b/frontend/src/components/tasks/DateBadge.tsx
@@ -35,7 +35,15 @@ export function isTaskDateOverdue(dueDate: string, dueAt?: string | null): boole
 }
 
 /* ===== 日期胶囊 ===== */
-export function DateBadge({ dateStr, dueAt }: { dateStr: string | null; dueAt?: string | null }) {
+export function DateBadge({
+  dateStr,
+  dueAt,
+  isCompleted = false,
+}: {
+  dateStr: string | null;
+  dueAt?: string | null;
+  isCompleted?: boolean;
+}) {
   const { t, i18n } = useTranslation();
   const dateLocale = i18n.language === "zh-CN" ? zhCN : enUS;
   if (!dateStr) return null;
@@ -44,7 +52,11 @@ export function DateBadge({ dateStr, dueAt }: { dateStr: string | null; dueAt?: 
 
   let label: string;
   let cls: string;
-  if (isToday(d)) {
+  if (isCompleted) {
+    // 已完成任务只展示日期本身，不再标红"已逾期"
+    label = formatted;
+    cls = "bg-app-hover text-tx-tertiary";
+  } else if (isToday(d)) {
     label = t('tasks.today');
     cls = "bg-indigo-500/10 text-indigo-500";
   } else if (isTomorrow(d)) {

--- a/frontend/src/components/tasks/FlatTaskRow.tsx
+++ b/frontend/src/components/tasks/FlatTaskRow.tsx
@@ -132,7 +132,7 @@ export const FlatTaskRow = React.forwardRef<HTMLDivElement, {
           )}
           {(task.dueDate || showCreator) && (
             <div className="md:hidden flex items-center flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
-              <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} />
+              <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} isCompleted={isCompleted} />
               {showCreator && (
                 <span
                   className="flex items-center gap-1 text-[10px] text-tx-tertiary min-w-0"
@@ -167,7 +167,7 @@ export const FlatTaskRow = React.forwardRef<HTMLDivElement, {
             </button>
           )}
           <span className="hidden md:inline-flex">
-            <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} />
+            <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} isCompleted={isCompleted} />
           </span>
           {hasEnabledReminder(task) && <span title={t("tasks.reminder.title")}><Bell size={12} className="text-accent-primary/70" /></span>}
           {isRepeatingTask(task) && <span title={t(`tasks.repeat.${task.repeatRule}`)}><Repeat size={12} className="text-accent-primary/60" /></span>}

--- a/frontend/src/components/tasks/TaskBoardView.tsx
+++ b/frontend/src/components/tasks/TaskBoardView.tsx
@@ -168,7 +168,7 @@ export function TaskBoardView({
                     {/* Meta row */}
                     <div className="flex items-center gap-2 flex-wrap">
                       {(task.dueDate || task.dueAt) && (
-                        <DateBadge dateStr={task.dueDate || (task.dueAt ? task.dueAt.split("T")[0] : null)} dueAt={task.dueAt} />
+                        <DateBadge dateStr={task.dueDate || (task.dueAt ? task.dueAt.split("T")[0] : null)} dueAt={task.dueAt} isCompleted={task.isCompleted === 1} />
                       )}
                       {task.parentId && (
                         <span className="text-[10px] text-tx-tertiary px-1 py-0.5 rounded bg-app-hover">{t("tasks.subtaskShort")}</span>

--- a/frontend/src/components/tasks/TaskTreeRow.tsx
+++ b/frontend/src/components/tasks/TaskTreeRow.tsx
@@ -120,7 +120,7 @@ export const TaskTreeRow = React.forwardRef<HTMLDivElement, {
           )}
           {(task.dueDate || showCreator) && (
             <div className="md:hidden flex items-center flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
-              <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} />
+              <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} isCompleted={isCompleted} />
               {showCreator && (
                 <span
                   className="flex items-center gap-1 text-[10px] text-tx-tertiary min-w-0"
@@ -171,7 +171,7 @@ export const TaskTreeRow = React.forwardRef<HTMLDivElement, {
             </div>
           )}
           <span className="hidden md:inline-flex">
-            <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} />
+            <DateBadge dateStr={task.dueDate} dueAt={task.dueAt} isCompleted={isCompleted} />
           </span>
           {hasEnabledReminder(task) && <span title={t("tasks.reminder.title")}><Bell size={12} className="text-accent-primary/70" /></span>}
           {isRepeatingTask(task) && <span title={t(`tasks.repeat.${task.repeatRule}`)}><Repeat size={12} className="text-accent-primary/60" /></span>}


### PR DESCRIPTION
DateBadge 之前只看 dueDate 是否早于今天来决定是否标红"已逾期"，
未接收任务完成状态。导致已打勾完成、但截止日已过的任务依旧显示
红色"已逾期"，与"已完成"语义冲突。

新增可选 isCompleted prop，已完成任务统一走灰色普通日期分支，
跳过今天/明天/已逾期/本周等高亮判断。FlatTaskRow、TaskTreeRow、
TaskBoardView 三个调用方补传 isCompleted。