### PR TITLE
refactor(db): add repository for tag list query

### DIFF
--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -11,6 +11,7 @@ export { customFontsRepository } from "./customFontsRepository";
 export { apiTokensRepository } from "./apiTokensRepository";
 export { calendarExportTargetsRepository } from "./calendarExportTargetsRepository";
 export { noteLinksRepository } from "./noteLinksRepository";
+export { tagsRepository } from "./tagsRepository";
 
 // 类型导出
 export type {
@@ -28,4 +29,5 @@ export type {
   UpdateCalendarExportTargetStatusInput,
   BacklinkItem,
   NoteLinkEntry,
+  TagWithCount,
 } from "./types";

--- a/backend/src/repositories/tagsRepository.ts
+++ b/backend/src/repositories/tagsRepository.ts
@@ -1,0 +1,74 @@
+/**
+ * Tags Repository
+ *
+ * 职责：
+ * - 封装 tags 表的只读查询操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ *
+ * 注意：
+ * - D1-A 阶段只迁移 GET /tags 列表查询
+ * - 创建/更新/删除标签暂不迁移
+ * - note_tags 绑定/解绑暂不迁移
+ * - 导入导出/用户迁移暂不迁移
+ */
+
+import { getDb } from "../db/schema";
+import type { TagWithCount } from "./types";
+
+export const tagsRepository = {
+  /**
+   * 列出当前空间的标签 + 笔记数。
+   *
+   * 笔记数采用空间内口径：只统计与该 tag 关联、且笔记同样落在该空间的笔记。
+   *
+   * @param userId 用户 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   * @param includeEmpty 是否包含未使用的标签
+   */
+  listByUser(
+    userId: string,
+    workspaceId: string | null = null,
+    includeEmpty: boolean = false,
+  ): TagWithCount[] {
+    const db = getDb();
+    const havingClause = includeEmpty ? "" : "HAVING COUNT(nt.noteId) > 0";
+
+    if (workspaceId) {
+      // 工作区视角
+      return db
+        .prepare(
+          `
+          SELECT t.*, COUNT(nt.noteId) AS noteCount
+          FROM tags t
+          LEFT JOIN note_tags nt ON nt.tagId = t.id
+          LEFT JOIN notes n ON n.id = nt.noteId AND n.workspaceId = ? AND n.isTrashed = 0
+          WHERE t.workspaceId = ?
+          GROUP BY t.id
+          ${havingClause}
+          ORDER BY t.name ASC
+          `,
+        )
+        .all(workspaceId, workspaceId) as TagWithCount[];
+    } else {
+      // 个人空间：仅看自己的、且 workspaceId IS NULL 的标签
+      return db
+        .prepare(
+          `
+          SELECT t.*, COUNT(nt.noteId) AS noteCount
+          FROM tags t
+          LEFT JOIN note_tags nt ON nt.tagId = t.id
+          LEFT JOIN notes n ON n.id = nt.noteId
+                            AND (n.workspaceId IS NULL)
+                            AND n.userId = ?
+                            AND n.isTrashed = 0
+          WHERE t.userId = ? AND t.workspaceId IS NULL
+          GROUP BY t.id
+          ${havingClause}
+          ORDER BY t.name ASC
+          `,
+        )
+        .all(userId, userId) as TagWithCount[];
+    }
+  },
+};

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -145,3 +145,16 @@ export interface NoteLinkEntry {
   linkText: string | null;
   excerpt: string | null;
 }
+
+// ===== Tags =====
+
+/** 标签条目（含笔记数） */
+export interface TagWithCount {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  color: string;
+  createdAt: string;
+  noteCount: number;
+}

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { getDb } from "../db/schema";
 import { v4 as uuid } from "uuid";
 import { getUserWorkspaceRole, hasRole } from "../middleware/acl";
+import { tagsRepository } from "../repositories";
 
 /**
  * Tags 路由 —— 支持工作区隔离
@@ -63,53 +64,17 @@ function canWriteTag(
  *   传 includeEmpty=true 可返回所有标签（用于标签管理页）。
  */
 app.get("/", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id") || "demo";
   const ws = normalizeWorkspaceId(c.req.query("workspaceId"));
   const includeEmpty = c.req.query("includeEmpty") === "true";
 
-  let rows: any[];
+  // 工作区视角：成员校验
   if (ws) {
-    // 工作区视角：成员校验
     const role = getUserWorkspaceRole(ws, userId);
     if (!role) return c.json({ error: "无权访问该工作区" }, 403);
-
-    const havingClause = includeEmpty ? "" : "HAVING COUNT(nt.noteId) > 0";
-    rows = db
-      .prepare(
-        `
-        SELECT t.*, COUNT(nt.noteId) AS noteCount
-        FROM tags t
-        LEFT JOIN note_tags nt ON nt.tagId = t.id
-        LEFT JOIN notes n ON n.id = nt.noteId AND n.workspaceId = ? AND n.isTrashed = 0
-        WHERE t.workspaceId = ?
-        GROUP BY t.id
-        ${havingClause}
-        ORDER BY t.name ASC
-      `,
-      )
-      .all(ws, ws);
-  } else {
-    // 个人空间：仅看自己的、且 workspaceId IS NULL 的标签
-    const havingClause = includeEmpty ? "" : "HAVING COUNT(nt.noteId) > 0";
-    rows = db
-      .prepare(
-        `
-        SELECT t.*, COUNT(nt.noteId) AS noteCount
-        FROM tags t
-        LEFT JOIN note_tags nt ON nt.tagId = t.id
-        LEFT JOIN notes n ON n.id = nt.noteId
-                          AND (n.workspaceId IS NULL)
-                          AND n.userId = ?
-                          AND n.isTrashed = 0
-        WHERE t.userId = ? AND t.workspaceId IS NULL
-        GROUP BY t.id
-        ${havingClause}
-        ORDER BY t.name ASC
-      `,
-      )
-      .all(userId, userId);
   }
+
+  const rows = tagsRepository.listByUser(userId, ws, includeEmpty);
   return c.json(rows);
 });
 


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `GET /tags` 标签列表只读查询从 `routes/tags.ts` 中的直接 SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `tagsRepository.ts`
   - 封装 `listByUser(userId, workspaceId?, includeEmpty?)` 方法
2. 更新 `repositories/types.ts`
   - 新增 `TagWithCount` 类型
3. 更新 `repositories/index.ts`
   - 导出 Repository 和类型
4. 更新 `routes/tags.ts`
   - `GET /tags` 改为调用 Repository

## 未做内容

- 未迁移创建标签 `POST /tags`
- 未迁移更新标签 `PUT /tags/:id`
- 未迁移删除标签 `DELETE /tags/:id`
- 未迁移 `note_tags` 绑定 / 解绑
- 未修改 `routes/notes.ts`
- 未修改导入导出
- 未修改用户迁移
- 未修改 `schema.ts` / `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL

## 风险控制

- 只迁移 `GET /tags` 只读查询
- `tagsRepository` 只包含 `listByUser` 一个方法
- SQL 语义保持不变
- API 返回结构保持不变
- `userId` / `workspaceId` / `includeEmpty` 行为保持不变
- 标签计数和排序保持不变
- 创建 / 更新 / 删除标签逻辑保持不变
- `note_tags` 绑定 / 解绑逻辑保持不变
- 导入导出和用户迁移保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-D1-A-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-D1-A-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后观察一轮，再考虑 `D1-B`。`D1-B` 只迁移 `getTagById` / 单个标签只读查询，不要碰创建 / 更新 / 删除 / `note_tags` / 导入导出 / 用户迁移。