### PR TITLE
refactor(db): add repository for single tag queries

### DIFF
--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -29,5 +29,6 @@ export type {
   UpdateCalendarExportTargetStatusInput,
   BacklinkItem,
   NoteLinkEntry,
+  Tag,
   TagWithCount,
 } from "./types";

--- a/backend/src/repositories/tagsRepository.ts
+++ b/backend/src/repositories/tagsRepository.ts
@@ -14,7 +14,7 @@
  */
 
 import { getDb } from "../db/schema";
-import type { TagWithCount } from "./types";
+import type { Tag, TagWithCount } from "./types";
 
 export const tagsRepository = {
   /**
@@ -70,5 +70,50 @@ export const tagsRepository = {
         )
         .all(userId, userId) as TagWithCount[];
     }
+  },
+
+  /**
+   * 获取单个标签的所有者信息（用于 ACL 校验）。
+   *
+   * @param tagId 标签 ID
+   * @returns 标签所有者信息，或 undefined（标签不存在）
+   */
+  getOwner(tagId: string): { userId: string; workspaceId: string | null } | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT userId, workspaceId FROM tags WHERE id = ?")
+      .get(tagId) as { userId: string; workspaceId: string | null } | undefined;
+  },
+
+  /**
+   * 获取单个标签（按 ID）。
+   *
+   * @param tagId 标签 ID
+   * @returns 标签信息，或 undefined（标签不存在）
+   */
+  getById(tagId: string): Tag | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM tags WHERE id = ?")
+      .get(tagId) as Tag | undefined;
+  },
+
+  /**
+   * 获取单个标签（按 ID，含笔记数）。
+   *
+   * @param tagId 标签 ID
+   * @returns 标签信息（含笔记数），或 undefined（标签不存在）
+   */
+  getByIdWithCount(tagId: string): TagWithCount | undefined {
+    const db = getDb();
+    return db
+      .prepare(
+        `
+        SELECT t.*, COUNT(nt.noteId) AS noteCount
+        FROM tags t LEFT JOIN note_tags nt ON t.id = nt.tagId
+        WHERE t.id = ? GROUP BY t.id
+        `,
+      )
+      .get(tagId) as TagWithCount | undefined;
   },
 };

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -148,13 +148,17 @@ export interface NoteLinkEntry {
 
 // ===== Tags =====
 
-/** 标签条目（含笔记数） */
-export interface TagWithCount {
+/** 标签条目 */
+export interface Tag {
   id: string;
   userId: string;
   workspaceId: string | null;
   name: string;
   color: string;
   createdAt: string;
+}
+
+/** 标签条目（含笔记数） */
+export interface TagWithCount extends Tag {
   noteCount: number;
 }

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -34,10 +34,7 @@ function normalizeWorkspaceId(raw: string | null | undefined): string | null {
 function getTagOwner(
   tagId: string,
 ): { userId: string; workspaceId: string | null } | undefined {
-  const db = getDb();
-  return db
-    .prepare("SELECT userId, workspaceId FROM tags WHERE id = ?")
-    .get(tagId) as { userId: string; workspaceId: string | null } | undefined;
+  return tagsRepository.getOwner(tagId);
 }
 
 /**
@@ -123,7 +120,7 @@ app.post("/", async (c) => {
     }
     throw err;
   }
-  const tag = db.prepare("SELECT * FROM tags WHERE id = ?").get(id);
+  const tag = tagsRepository.getById(id);
   return c.json(tag, 201);
 });
 
@@ -163,15 +160,7 @@ app.put("/:id", async (c) => {
   if (fields.length === 0) return c.json({ error: "No fields to update" }, 400);
   values.push(id);
   db.prepare(`UPDATE tags SET ${fields.join(", ")} WHERE id = ?`).run(...values);
-  const tag = db
-    .prepare(
-      `
-    SELECT t.*, COUNT(nt.noteId) AS noteCount
-    FROM tags t LEFT JOIN note_tags nt ON t.id = nt.tagId
-    WHERE t.id = ? GROUP BY t.id
-  `,
-    )
-    .get(id);
+  const tag = tagsRepository.getByIdWithCount(id);
   return c.json(tag);
 });
 


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `routes/tags.ts` 中单个标签相关只读查询迁移到独立 Repository 层。

## 修改内容

1. 新增 `tagsRepository.getOwner(tagId)` 方法
2. 新增 `tagsRepository.getById(tagId)` 方法
3. 新增 `tagsRepository.getByIdWithCount(tagId)` 方法
4. 在 `types.ts` 中添加 `Tag` 类型
5. 修改 `routes/tags.ts` 调用 Repository

## 未做内容

- 未迁移创建标签 `POST /tags`
- 未迁移更新标签 `PUT /tags/:id`
- 未迁移删除标签 `DELETE /tags/:id`
- 未迁移 `note_tags` 绑定 / 解绑
- 未修改 `routes/notes.ts`
- 未修改导入导出
- 未修改用户迁移
- 未修改 `schema.ts` / `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL

## 风险控制

- 本 PR 只迁移 tags 单个标签相关只读查询
- `tagsRepository` 当前只包含只读方法：`listByUser`、`getOwner`、`getById`、`getByIdWithCount`
- SQL 语义保持不变
- 权限校验保持不变
- 找不到标签时行为保持不变
- 错误返回结构保持不变
- API 成功返回结构保持不变
- `GET /tags` 列表查询保持不变
- 创建 / 更新 / 删除标签逻辑保持不变
- `note_tags` 绑定 / 解绑逻辑保持不变
- 导入导出和用户迁移保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-D1-B-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-D1-B-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean（忽略本地 `.claude/settings.json`）

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `DB-REPOSITORY-PILOT-NEXT-D1-B-POST-MERGE-RV`，再观察一轮。不要直接进入写操作迁移；如继续推进，D1-C 也必须单独拆分，不要碰 `note_tags`、导入导出、用户迁移。