### PR TITLE
refactor(db): move tag creation to repository

### DIFF
--- a/backend/src/repositories/tagsRepository.ts
+++ b/backend/src/repositories/tagsRepository.ts
@@ -116,4 +116,22 @@ export const tagsRepository = {
       )
       .get(tagId) as TagWithCount | undefined;
   },
+
+  /**
+   * 创建标签。
+   *
+   * @param input 创建标签的输入
+   */
+  create(input: {
+    id: string;
+    userId: string;
+    workspaceId: string | null;
+    name: string;
+    color: string;
+  }): void {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO tags (id, userId, workspaceId, name, color) VALUES (?, ?, ?, ?, ?)`,
+    ).run(input.id, input.userId, input.workspaceId, input.name, input.color);
+  },
 };

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -104,9 +104,13 @@ app.post("/", async (c) => {
 
   const id = uuid();
   try {
-    db.prepare(
-      `INSERT INTO tags (id, userId, workspaceId, name, color) VALUES (?, ?, ?, ?, ?)`,
-    ).run(id, userId, ws, name, body.color || "#58a6ff");
+    tagsRepository.create({
+      id,
+      userId,
+      workspaceId: ws,
+      name,
+      color: body.color || "#58a6ff",
+    });
   } catch (err: any) {
     // UNIQUE(userId, name) 冲突 → 当前账号已有同名标签（可能在其他空间）
     if (String(err?.message || err).includes("UNIQUE")) {


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `POST /tags` 创建标签的 `INSERT` SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `tagsRepository.create()` 方法
2. 修改 `routes/tags.ts` 调用 Repository

## 未做内容

- 未迁移 `PUT /tags/:id`
- 未迁移 `DELETE /tags/:id`
- 未迁移 `note_tags` 绑定 / 解绑
- 未修改 `routes/notes.ts`
- 未修改导入导出
- 未修改用户迁移
- 未修改 `schema.ts` / `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL

## 风险控制

- 本 PR 只迁移 `POST /tags` 创建标签 `INSERT`
- `uuid` 生成仍在 `routes/tags.ts`
- `color` 默认值逻辑保持不变
- `workspaceId` 写入行为保持不变
- `createdAt` / `updatedAt` 仍依赖数据库默认值
- `UNIQUE(userId, name)` 冲突处理保持不变
- 重名标签 `409` 保持不变
- `409` 错误结构保持不变
- 成功返回 `c.json(tag, 201)` 保持不变
- `GET /tags` 列表查询保持不变
- 单个标签只读查询保持不变
- 更新 / 删除标签逻辑保持不变
- `note_tags` 绑定 / 解绑逻辑保持不变
- 导入导出和用户迁移保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-D1-C1-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-D1-C1-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean（忽略本地 `.claude/settings.json`）

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `DB-REPOSITORY-PILOT-NEXT-D1-C1-POST-MERGE-RV`，再观察一轮。不要直接进入 D1-C2；D1-C2 只迁移更新标签 `UPDATE`，D1-C3 涉及 `note_tags` 清理，继续暂缓。