### PR TITLE
refactor(db): move tag update to repository

### DIFF
--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -31,4 +31,5 @@ export type {
   NoteLinkEntry,
   Tag,
   TagWithCount,
+  UpdateTagInput,
 } from "./types";

--- a/backend/src/repositories/tagsRepository.ts
+++ b/backend/src/repositories/tagsRepository.ts
@@ -134,4 +134,33 @@ export const tagsRepository = {
       `INSERT INTO tags (id, userId, workspaceId, name, color) VALUES (?, ?, ?, ?, ?)`,
     ).run(input.id, input.userId, input.workspaceId, input.name, input.color);
   },
+
+  /**
+   * 更新标签（按 ID）。
+   *
+   * 只更新传入的字段，保持与原 routes/tags.ts 中 PUT /tags/:id 行为一致。
+   * 注意：不显式更新 updatedAt，保持原代码行为。
+   *
+   * @param tagId 标签 ID
+   * @param patch 更新字段
+   */
+  updateById(tagId: string, patch: { name?: string; color?: string }): void {
+    const db = getDb();
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (patch.name !== undefined) {
+      fields.push("name = ?");
+      values.push(patch.name);
+    }
+    if (patch.color !== undefined) {
+      fields.push("color = ?");
+      values.push(patch.color);
+    }
+
+    if (fields.length === 0) return;
+
+    values.push(tagId);
+    db.prepare(`UPDATE tags SET ${fields.join(", ")} WHERE id = ?`).run(...values);
+  },
 };

--- a/backend/src/repositories/types.ts
+++ b/backend/src/repositories/types.ts
@@ -162,3 +162,9 @@ export interface Tag {
 export interface TagWithCount extends Tag {
   noteCount: number;
 }
+
+/** 更新标签输入 */
+export interface UpdateTagInput {
+  name?: string;
+  color?: string;
+}

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -151,19 +151,16 @@ app.put("/:id", async (c) => {
   if (!owner) return c.json({ error: "tag not found" }, 404);
   if (!canWriteTag(owner, userId)) return c.json({ error: "forbidden" }, 403);
 
-  const fields: string[] = [];
-  const values: any[] = [];
+  const patch: { name?: string; color?: string } = {};
   if (body.name !== undefined) {
-    fields.push("name = ?");
-    values.push(body.name);
+    patch.name = body.name;
   }
   if (body.color !== undefined) {
-    fields.push("color = ?");
-    values.push(body.color);
+    patch.color = body.color;
   }
-  if (fields.length === 0) return c.json({ error: "No fields to update" }, 400);
-  values.push(id);
-  db.prepare(`UPDATE tags SET ${fields.join(", ")} WHERE id = ?`).run(...values);
+  if (Object.keys(patch).length === 0) return c.json({ error: "No fields to update" }, 400);
+
+  tagsRepository.updateById(id, patch);
   const tag = tagsRepository.getByIdWithCount(id);
   return c.json(tag);
 });


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `PUT /tags/:id` 更新标签的 `UPDATE` SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `tagsRepository.updateById()` 方法
2. 在 `types.ts` 中添加 `UpdateTagInput` 类型
3. 在 `index.ts` 中导出 `UpdateTagInput` 类型
4. 修改 `routes/tags.ts` 调用 Repository

## 未做内容

- 未迁移 `DELETE /tags/:id`
- 未迁移 `note_tags` 绑定 / 解绑
- 未修改 `routes/notes.ts`
- 未修改导入导出
- 未修改用户迁移
- 未修改 `schema.ts` / `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL

## 风险控制

- 本 PR 只迁移 `PUT /tags/:id` 更新标签 `UPDATE`
- 动态 fields 逻辑保持不变
- `getOwner` 归属查询保持不变
- `getByIdWithCount` 返回查询保持不变
- `userId` / `workspaceId` 权限校验保持不变
- `name` / `color` 更新行为保持不变
- `updatedAt` 行为保持，不新增显式 `updatedAt`
- `UNIQUE(userId, name)` 冲突处理保持不变
- 找不到标签 `404` 保持不变
- forbidden `403` 保持不变
- 重名冲突错误结构保持不变
- 成功返回 `c.json(tag)` 保持不变
- `GET /tags` 列表查询保持不变
- 单个标签只读查询保持不变
- `POST /tags` 创建标签保持不变
- `DELETE /tags/:id` 删除标签保持不变
- `note_tags` 绑定 / 解绑逻辑保持不变
- 导入导出和用户迁移保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-D1-C2-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-D1-C2-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean（忽略本地 `.claude/settings.json`）

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `DB-REPOSITORY-PILOT-NEXT-D1-C2-POST-MERGE-RV`，再观察一轮。不要直接进入 D1-C3；D1-C3 涉及删除标签和 `note_tags` 清理，风险中等，继续暂缓。