### PR TITLE
refactor(db): move tag deletion to repository

### DIFF
--- a/backend/src/repositories/tagsRepository.ts
+++ b/backend/src/repositories/tagsRepository.ts
@@ -163,4 +163,24 @@ export const tagsRepository = {
     values.push(tagId);
     db.prepare(`UPDATE tags SET ${fields.join(", ")} WHERE id = ?`).run(...values);
   },
+
+  /**
+   * 删除标签与笔记的关联（note_tags）。
+   *
+   * @param tagId 标签 ID
+   */
+  deleteTagLinks(tagId: string): void {
+    const db = getDb();
+    db.prepare("DELETE FROM note_tags WHERE tagId = ?").run(tagId);
+  },
+
+  /**
+   * 删除标签本身。
+   *
+   * @param tagId 标签 ID
+   */
+  deleteById(tagId: string): void {
+    const db = getDb();
+    db.prepare("DELETE FROM tags WHERE id = ?").run(tagId);
+  },
 };

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -174,8 +174,8 @@ app.delete("/:id", (c) => {
   if (!owner) return c.json({ error: "tag not found" }, 404);
   if (!canWriteTag(owner, userId)) return c.json({ error: "forbidden" }, 403);
 
-  db.prepare("DELETE FROM note_tags WHERE tagId = ?").run(id);
-  db.prepare("DELETE FROM tags WHERE id = ?").run(id);
+  tagsRepository.deleteTagLinks(id);
+  tagsRepository.deleteById(id);
   return c.json({ success: true });
 });
 


### PR DESCRIPTION
## 背景

Repository 模式迁移，将 `DELETE /tags/:id` 删除标签相关 SQL 迁移到独立 Repository 层。

## 修改内容

1. 新增 `tagsRepository.deleteTagLinks()` 方法
2. 新增 `tagsRepository.deleteById()` 方法
3. 修改 `routes/tags.ts` 调用 Repository

## 未做内容

- 未迁移 `note_tags` 绑定 / 解绑
- 未修改 `routes/notes.ts`
- 未修改导入导出
- 未修改用户迁移
- 未修改 `schema.ts` / `migrations.ts`
- 未修改 `docker-compose.yml`
- 未修改 `package.json`
- 未引入 PostgreSQL
- 未引入 DB_DRIVER
- 未引入 DATABASE_URL
- 未引入事务
- 未新增 `deleteWithLinks`

## 风险控制

- 本 PR 只迁移 `DELETE /tags/:id` 删除标签相关 SQL
- `deleteTagLinks` 只删除 `note_tags`
- `deleteById` 只删除 `tags`
- 删除顺序保持不变：先 `note_tags`，后 `tags`
- `getOwner` 归属查询保持不变
- `userId` / `workspaceId` 权限校验保持不变
- 找不到标签 `404` 保持不变
- forbidden `403` 保持不变
- 成功返回 `c.json({ success: true })` 保持不变
- 不引入事务，保持原无事务行为
- `GET /tags` 列表查询保持不变
- 单个标签只读查询保持不变
- `POST /tags` 创建标签保持不变
- `PUT /tags/:id` 更新标签保持不变
- `note_tags` 绑定 / 解绑逻辑保持不变
- 导入导出和用户迁移保持不变

## 验证结果

- `DB-REPOSITORY-PILOT-NEXT-D1-C3-RV1` ✅ 通过
- `DB-REPOSITORY-PILOT-NEXT-D1-C3-MERGE-RV` ✅ 通过
- `npx tsc -b --noEmit` ✅ exit code 0
- `npx vite build` ✅ exit code 0
- `git status` ✅ clean（忽略本地 `.claude/settings.json`）

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `DB-REPOSITORY-PILOT-NEXT-D1-C3-POST-MERGE-RV`，再观察一轮。不要继续迁移 `note_tags` 绑定 / 解绑，也不要进入 `routes/notes.ts`。