### PR TITLE
fix(electron): validate external URL protocols

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -21,6 +21,17 @@ const {
 } = require("./credentials");
 const folderSync = require("./folder-sync");
 
+// SEC-ELECTRON-01-B1: 验证外部 URL 协议是否允许通过 shell.openExternal 打开
+// 只允许 http/https/mailto，禁止 file/javascript/data/vbscript 等危险协议
+function isAllowedExternalUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    return ["http:", "https:", "mailto:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
 // 日志 & 崩溃上报需尽早初始化（crashReporter.start 建议在 ready 之前）
 initLogger({
   // 如需接入外部崩溃上报服务（如 Sentry/Bugsnag/自建 collector），填入 URL 并设置 uploadCrashes=true
@@ -754,7 +765,12 @@ function createWindow() {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith("http")) shell.openExternal(url);
+    // SEC-ELECTRON-01-B1: 使用 URL parser 验证协议，只允许安全协议
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+    } else {
+      console.warn("[main] blocked external URL with unsafe protocol:", url);
+    }
     return { action: "deny" };
   });
 


### PR DESCRIPTION
## 背景

SEC-ELECTRON-01-A 审计发现 `shell.openExternal` 只检查 `startsWith("http")`，存在协议绕过风险。

## 修改内容

1. 新增 `isAllowedExternalUrl` helper 函数
2. 使用 URL parser 验证协议
3. 只允许 `http` / `https` / `mailto`
4. 拒绝 `file` / `javascript` / `data` / `vbscript` / `about` / `chrome` / `devtools` / 未知协议

## 未做内容

- 未修改 `electron/preload.js`
- 未修改 `getLocalAuth`
- 未修改 `resetLocalAuth`
- 未修改 `sandbox` / `webSecurity`
- 未修改 `shell.openPath`
- 未修改附件预览
- 未修改文件导入
- 未修改 PDF 导出
- 未修改数据库 / Repository / PostgreSQL 相关代码
- 未引入新依赖
- 未修改 `package.json`

## 风险控制

- URL 解析失败时拒绝打开
- 拒绝时只记录日志，不导致应用崩溃
- `http` / `https` / `mailto` 保持可打开
- `shell.openExternal` 只在校验通过后调用
- 不改变 IPC channel 名称
- 不改变 API 返回结构

## 验证结果

- `SEC-ELECTRON-01-B1-RV1` ✅ 通过
- `SEC-ELECTRON-01-B1-MERGE-RV` ✅ 通过
- typecheck ✅ 通过
- build ✅ 通过
- 工作区 clean（忽略本地 `.claude/settings.json`）

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `SEC-ELECTRON-01-B1-POST-MERGE-RV`。不要直接进入 `B2`，`getLocalAuth / resetLocalAuth` 放到 `SEC-ELECTRON-01-B2-A` 单独审计。