### PR TITLE
fix(electron): guard main window navigation

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -22,6 +22,7 @@ const {
 const folderSync = require("./folder-sync");
 const {
   isAllowedExternalUrl,
+  isAllowedMainWindowNavigation,
   isTrustedMainWindowSender,
   isTrustedSetupWindowSender,
   assertMainWindowSender,
@@ -772,6 +773,25 @@ function createWindow() {
   // 首次加载完成后，冲刷待送的文件关联打开请求
   mainWindow.webContents.on("did-finish-load", () => {
     flushPending(mainWindow);
+  });
+
+  // SEC-ELECTRON-01-C-B1: 主窗口 navigation 拦截
+  // 防止 renderer 通过 window.location、恶意链接、脚本跳转等方式把主窗口导航到非应用页面
+  mainWindow.webContents.on("will-navigate", (event, navigationUrl) => {
+    const currentUrl = mainWindow.webContents.getURL();
+    if (isAllowedMainWindowNavigation(navigationUrl, currentUrl)) {
+      return; // 允许内部导航
+    }
+
+    // 阻止主窗口跳转
+    event.preventDefault();
+
+    // 外部 http/https/mailto 走安全外链打开
+    if (isAllowedExternalUrl(navigationUrl)) {
+      shell.openExternal(navigationUrl);
+    } else {
+      console.warn("[main] blocked main window navigation to unsafe URL:", navigationUrl);
+    }
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {

--- a/electron/security.js
+++ b/electron/security.js
@@ -64,27 +64,34 @@ function assertMainWindowSender(event) {
 
 /**
  * 判断主窗口导航是否允许。
- * 允许：同源导航、hash 路由、file:// 本地页面、data: 页面。
- * 拒绝：外部 http/https、mailto、javascript/data/vbscript 等危险协议。
+ *
+ * 安全策略：
+ *   - 只允许同源 http/https 导航和 hash 路由变化
+ *   - 拒绝 data: / javascript: / vbscript: / chrome: / devtools: / mailto: / about: 等
+ *   - file:// 不泛允许，避免任意本地文件进入主窗口
+ *   - origin 为 "null" 的 URL 不因 origin 相同被误放行
  */
 function isAllowedMainWindowNavigation(targetUrl, currentUrl) {
   try {
     const target = new URL(targetUrl);
     const current = new URL(currentUrl);
 
-    // 同源导航允许
-    if (target.origin === current.origin) return true;
+    // http/https 协议：只允许同源导航
+    if (target.protocol === "http:" || target.protocol === "https:") {
+      return target.origin === current.origin;
+    }
 
-    // file:// 协议：只允许本地文件（生产环境）
-    if (target.protocol === "file:" && current.protocol === "file:") return true;
+    // file:// 协议：不泛允许，避免任意本地文件进入主窗口
+    // 生产环境主窗口通过 loadFile 加载本地文件，但不允许跨文件导航
+    if (target.protocol === "file:") {
+      return false;
+    }
 
-    // data: 协议：允许（错误页面等）
-    if (target.protocol === "data:") return true;
+    // hash 路由变化：允许（同源页面内的 hash 变化）
+    // 注意：URL 解析后 hash 变化不会改变 origin，上面的 http/https 同源判断已覆盖
 
-    // about:blank 允许
-    if (target.protocol === "about:") return true;
-
-    // 其他协议拒绝
+    // 以下协议一律拒绝，不允许加载进主窗口
+    // data: / javascript: / vbscript: / chrome: / devtools: / mailto: / about:
     return false;
   } catch {
     // URL 解析失败拒绝

--- a/electron/security.js
+++ b/electron/security.js
@@ -62,8 +62,39 @@ function assertMainWindowSender(event) {
   return null;
 }
 
+/**
+ * 判断主窗口导航是否允许。
+ * 允许：同源导航、hash 路由、file:// 本地页面、data: 页面。
+ * 拒绝：外部 http/https、mailto、javascript/data/vbscript 等危险协议。
+ */
+function isAllowedMainWindowNavigation(targetUrl, currentUrl) {
+  try {
+    const target = new URL(targetUrl);
+    const current = new URL(currentUrl);
+
+    // 同源导航允许
+    if (target.origin === current.origin) return true;
+
+    // file:// 协议：只允许本地文件（生产环境）
+    if (target.protocol === "file:" && current.protocol === "file:") return true;
+
+    // data: 协议：允许（错误页面等）
+    if (target.protocol === "data:") return true;
+
+    // about:blank 允许
+    if (target.protocol === "about:") return true;
+
+    // 其他协议拒绝
+    return false;
+  } catch {
+    // URL 解析失败拒绝
+    return false;
+  }
+}
+
 module.exports = {
   isAllowedExternalUrl,
+  isAllowedMainWindowNavigation,
   isTrustedMainWindowSender,
   isTrustedSetupWindowSender,
   assertMainWindowSender,


### PR DESCRIPTION
## 背景

SEC-ELECTRON-01-C-A 审计发现主窗口缺少 `will-navigate` 拦截，存在 renderer 通过 `window.location`、恶意链接、脚本跳转等方式把主窗口导航到非应用页面的风险。

## 修改内容

1. 在 `electron/security.js` 中新增 `isAllowedMainWindowNavigation` helper 函数
2. 在 `electron/main.js` 中为主窗口添加 `will-navigate` 监听
3. 允许同源 `http` / `https` 导航和 hash 路由
4. 阻止外部 `http` / `https` / `mailto` 加载进主窗口
5. 拒绝 `javascript` / `data` / `vbscript` / `chrome` / `devtools` / `about` / `file` / 非法 URL
6. 修正 `data` / `about` / `file` / `origin=null` 误放行问题

## 未做内容

- 未修改 `setWindowOpenHandler`
- 未修改 `sandbox` / `webSecurity` / CSP
- 未修改 `electron/preload.js`
- 未修改 `getLocalAuth` / `resetLocalAuth` / `clearLocalAuth`
- 未修改 frontend / backend
- 未修改数据库 / Repository / PostgreSQL
- 未引入新依赖
- 未修改 `package.json`

## 风险控制

- 只影响主窗口，不影响其他窗口
- 不影响应用内路由跳转
- 不影响开发环境 HMR
- 不影响生产包启动
- 外部 URL 不会获得主窗口 preload API 暴露面
- 未新增裸 `shell.openExternal`
- 未放宽 `isAllowedExternalUrl`

## 验证结果

- `SEC-ELECTRON-01-C-B1-RV1`：发现 navigation helper 判断过宽
- `SEC-ELECTRON-01-C-B1-FIX1`：已修正 `data:` / `about:` / `file://` / `origin=null` 问题
- `SEC-ELECTRON-01-C-B1-RV2` ✅ 通过
- `SEC-ELECTRON-01-C-B1-MERGE-RV2` ✅ 通过
- `tsc` exit code 0
- `vite build` exit code 0
- 工作区 clean

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行 `SEC-ELECTRON-01-C-B1-POST-MERGE-RV`。不要直接进入 `C-B2`。