### PR TITLE
fix(electron): deny window.open in data windows

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -590,6 +590,8 @@ function createSplash(message) {
       allowRunningInsecureContent: false,
     },
   });
+  // SEC-ELECTRON-01-C-B2-B3: 禁止 data URL 窗口打开新窗口
+  splashWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   const html = `
     <html><head><style>
       html,body{margin:0;height:100%;background:#0D1117;color:#E6EDF3;font-family:system-ui,sans-serif;
@@ -636,6 +638,8 @@ function openAboutWindow() {
       allowRunningInsecureContent: false,
     },
   });
+  // SEC-ELECTRON-01-C-B2-B3: 禁止 data URL 窗口打开新窗口
+  about.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   const html = `
     <html><head><style>
       html,body{margin:0;height:100%;background:#0D1117;color:#E6EDF3;
@@ -1168,6 +1172,8 @@ ipcMain.handle("task:notify-permission", () => {
         webSecurity: true,
       },
     });
+    // SEC-ELECTRON-01-C-B2-B3: 禁止 data URL 窗口打开新窗口
+    offscreen.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
 
     try {
       // 用 data: URL 加载 HTML；base64 编码避免 URL 中特殊字符截断


### PR DESCRIPTION
## 背景

SEC-ELECTRON-01-C-B2-A 审计发现闪屏、关于、PDF 导出窗口未配置 `setWindowOpenHandler`，存在 `data:` 页面通过 `window.open` 打开新 Electron 窗口的风险。

## 修改内容

1. 闪屏窗口添加 `setWindowOpenHandler` deny
2. 关于窗口添加 `setWindowOpenHandler` deny
3. PDF 导出窗口添加 `setWindowOpenHandler` deny

## 风险控制

- 三处 handler 均为默认 deny
- 不调用 `shell.openExternal`
- 不做协议放行
- 不允许任何 URL 新开 Electron 窗口
- 只影响低风险 data URL 窗口
- 不影响主窗口和 Setup 窗口
- 不影响应用启动和核心功能

## 未做内容

- 未修改主窗口 `setWindowOpenHandler`
- 未修改 Setup 窗口 `setWindowOpenHandler`
- 未修改 `will-navigate`
- 未修改 `isAllowedMainWindowNavigation` / `isAllowedExternalUrl`
- 未修改 `sandbox` / `webSecurity` / CSP
- 未修改 `electron/preload.js`
- 未修改 `getLocalAuth` / `resetLocalAuth` / `clearLocalAuth`
- 未修改 frontend / backend
- 未修改数据库 / Repository / PostgreSQL
- 未引入新依赖
- 未修改 `package.json`

## 验证结果

- `SEC-ELECTRON-01-C-B2-B3-RV1` ✅ 通过
- `SEC-ELECTRON-01-C-B2-B3-MERGE-RV` ✅ 通过
- `tsc` exit code 0
- `vite build` exit code 0
- 工作区 clean

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 后续建议

合并后执行轻量 `SEC-ELECTRON-01-C-B2-B3-POST-MERGE-RV`，通过后直接归档本任务。`SEC-ELECTRON-01-C-B2-B4` 统一 helper 暂缓。