### PR TITLE
refactor(db): move note tag filtering to repository

### DIFF
--- a/backend/src/repositories/noteTagsRepository.ts
+++ b/backend/src/repositories/noteTagsRepository.ts
@@ -59,4 +59,43 @@ export const noteTagsRepository = {
       )
       .all(noteId) as Tag[];
   },
+
+  /**
+   * 按标签筛选笔记 ID 列表。
+   *
+   * 支持单标签、多标签 OR、多标签 AND 三种模式。
+   *
+   * @param tagIds 标签 ID 列表
+   * @param mode 筛选模式："and"（默认）或 "or"
+   * @returns 笔记 ID 列表
+   */
+  listNoteIdsByTagFilter(tagIds: string[], mode: "and" | "or" = "and"): string[] {
+    if (tagIds.length === 0) return [];
+
+    const db = getDb();
+
+    if (mode === "and" && tagIds.length > 1) {
+      // AND 逻辑：笔记必须同时拥有所有已选标签
+      // 使用 GROUP BY + HAVING COUNT 确保每个 tagId 都命中
+      const placeholders = tagIds.map(() => "?").join(",");
+      const rows = db
+        .prepare(
+          `SELECT noteId FROM note_tags
+           WHERE tagId IN (${placeholders})
+           GROUP BY noteId
+           HAVING COUNT(DISTINCT tagId) >= ?`,
+        )
+        .all(...tagIds, tagIds.length) as { noteId: string }[];
+      return rows.map((r) => r.noteId);
+    } else {
+      // OR 逻辑 或 单标签：只要命中任一标签即可
+      const placeholders = tagIds.map(() => "?").join(",");
+      const rows = db
+        .prepare(
+          `SELECT DISTINCT noteId FROM note_tags WHERE tagId IN (${placeholders})`,
+        )
+        .all(...tagIds) as { noteId: string }[];
+      return rows.map((r) => r.noteId);
+    }
+  },
 };

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -121,23 +121,14 @@ app.get("/", (c) => {
     params.push(userId);
   } else if (tagIds.length > 0) {
     query += " AND notes.isTrashed = 0";
-    if (tagMode === "and" && tagIds.length > 1) {
-      // AND 逻辑：笔记必须同时拥有所有已选标签
-      // 使用 GROUP BY + HAVING COUNT 确保每个 tagId 都命中
-      const placeholders = tagIds.map(() => "?").join(",");
-      query += ` AND notes.id IN (
-        SELECT noteId FROM note_tags
-        WHERE tagId IN (${placeholders})
-        GROUP BY noteId
-        HAVING COUNT(DISTINCT tagId) >= ?
-      )`;
-      params.push(...tagIds, tagIds.length);
-    } else {
-      // OR 逻辑 或 单标签：只要命中任一标签即可
-      const placeholders = tagIds.map(() => "?").join(",");
-      query += ` AND notes.id IN (SELECT noteId FROM note_tags WHERE tagId IN (${placeholders}))`;
-      params.push(...tagIds);
+    const filteredNoteIds = noteTagsRepository.listNoteIdsByTagFilter(tagIds, tagMode as "and" | "or");
+    if (filteredNoteIds.length === 0) {
+      // 无匹配标签，直接返回空
+      return c.json([]);
     }
+    const placeholders = filteredNoteIds.map(() => "?").join(",");
+    query += ` AND notes.id IN (${placeholders})`;
+    params.push(...filteredNoteIds);
   } else if (notebookId) {
     // 递归收集 notebookId 自身 + 全部后代笔记本，使笔记列表能展示子笔记本下的笔记
     // 用 SQLite 的递归 CTE：从给定 id 出发沿 parentId 反向向下展开


### PR DESCRIPTION
## 背景

tags Repository 迁移，将 `routes/notes.ts` 中“按标签筛选笔记”的 `note_tags` 直接 SQL 迁移到独立 Repository 层。

## 修改内容

1. 扩展 `noteTagsRepository`
2. 新增 `listNoteIdsByTagFilter` 方法
3. 迁移 `routes/notes.ts` 标签筛选 `note_tags` 直接 SQL

## 风险控制

- 保留单标签筛选行为
- 保留多标签 OR 筛选行为
- 保留多标签 AND 筛选行为
- 保留返回 `noteId` 列表结构
- 保留参数绑定，避免 SQL 注入
- 不修改 notes 主查询结构
- 不修改分页 / 排序 / 搜索 / notebookId / workspaceId / 权限过滤逻辑

## 未做内容

- 未迁移 notes 主表整体 CRUD
- 未修改分页逻辑
- 未修改排序逻辑
- 未修改搜索逻辑
- 未修改 notebookId 过滤
- 未修改 workspaceId 过滤
- 未修改权限过滤
- 未引入 `pg`
- 未新增 `DATABASE_URL` / `DB_DRIVER`
- 未修改 Docker
- 未修改 `package.json`
- 未修改 frontend
- 未修改 Electron

## 验证结果

- `DB-REPOSITORY-TAGS-COMPLETE-01-B2-FAST-RV` ✅ 通过
- 不带标签筛选 `GET /notes` 正常
- 单标签筛选正常
- 多标签 OR 筛选正常
- 多标签 AND 筛选正常
- 标签筛选 + 搜索正常
- 标签筛选 + 分页正常
- 标签筛选 + 排序正常
- 标签筛选 + notebookId 正常
- 跨用户 / 跨 workspace 不串数据
- `GET /tags` 正常
- 添加标签正常
- 移除标签正常
- 笔记详情 `tags` 返回正常
- 更新笔记后 `tags` 返回正常
- `tsc` exit code 0
- `vite build` exit code 0
- 工作区 clean

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## PR head 校验

创建后必须确认：

```text
PR head_sha == e119b38
```

如果不一致，关闭 PR，不允许合并。