### PR TITLE
refactor(db): move note version reads to repository

### DIFF
--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -14,6 +14,7 @@ export { noteLinksRepository } from "./noteLinksRepository";
 export { tagsRepository } from "./tagsRepository";
 export { noteTagsRepository } from "./noteTagsRepository";
 export { aiCustomPromptsRepository } from "./aiCustomPromptsRepository";
+export { noteVersionsRepository } from "./noteVersionsRepository";
 
 // 类型导出
 export type {
@@ -36,3 +37,4 @@ export type {
   UpdateTagInput,
 } from "./types";
 export type { AiCustomPromptRecord } from "./aiCustomPromptsRepository";
+export type { NoteVersionListItem, NoteVersionRecord } from "./noteVersionsRepository";

--- a/backend/src/repositories/noteVersionsRepository.ts
+++ b/backend/src/repositories/noteVersionsRepository.ts
@@ -1,0 +1,121 @@
+/**
+ * Note Versions Repository
+ *
+ * 职责：
+ * - 封装 note_versions 表的查询类数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ *
+ * 注意：
+ * - 本次只迁移查询类 SQL（B2-B1）
+ * - 创建版本 INSERT / 删除版本 DELETE / pruneOldVersions / 恢复版本事务
+ *   留在后续批次迁移
+ * - 不涉及 notes 主表 CRUD
+ */
+
+import { getDb } from "../db/schema";
+
+/** note_versions 记录（列表视图，不含 content/contentText） */
+export interface NoteVersionListItem {
+  id: string;
+  noteId: string;
+  userId: string;
+  title: string | null;
+  version: number;
+  changeType: string;
+  changeSummary: string | null;
+  createdAt: string;
+  username: string | null;
+}
+
+/** note_versions 完整记录 */
+export interface NoteVersionRecord {
+  id: string;
+  noteId: string;
+  userId: string;
+  title: string | null;
+  content: string | null;
+  contentText: string | null;
+  version: number;
+  changeType: string;
+  changeSummary: string | null;
+  createdAt: string;
+}
+
+export const noteVersionsRepository = {
+  /**
+   * 列出某笔记的版本历史（分页）。
+   *
+   * 保持原 SQL：JOIN users 获取 username，按 version DESC 排序。
+   *
+   * @param noteId 笔记 ID
+   * @param limit 每页条数
+   * @param offset 偏移量
+   * @returns 版本列表
+   */
+  listByNoteId(noteId: string, limit: number, offset: number): NoteVersionListItem[] {
+    const db = getDb();
+    return db
+      .prepare(
+        `SELECT nv.id, nv.noteId, nv.userId, nv.title, nv.version, nv.changeType, nv.changeSummary, nv.createdAt,
+                u.username
+         FROM note_versions nv
+         LEFT JOIN users u ON nv.userId = u.id
+         WHERE nv.noteId = ?
+         ORDER BY nv.version DESC
+         LIMIT ? OFFSET ?`,
+      )
+      .all(noteId, limit, offset) as NoteVersionListItem[];
+  },
+
+  /**
+   * 统计某笔记的版本总数。
+   *
+   * @param noteId 笔记 ID
+   * @returns 版本总数
+   */
+  countByNoteId(noteId: string): number {
+    const db = getDb();
+    const row = db
+      .prepare("SELECT COUNT(*) as count FROM note_versions WHERE noteId = ?")
+      .get(noteId) as { count: number };
+    return row.count;
+  },
+
+  /**
+   * 获取单个版本（按 id + noteId）。
+   *
+   * 用于查看单个版本和恢复前读取版本。
+   *
+   * @param id 版本 ID
+   * @param noteId 笔记 ID
+   * @returns 版本记录，或 undefined
+   */
+  getByIdAndNoteId(id: string, noteId: string): NoteVersionRecord | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM note_versions WHERE id = ? AND noteId = ?")
+      .get(id, noteId) as NoteVersionRecord | undefined;
+  },
+
+  /**
+   * 获取某笔记最近一条 edit 类型版本的 createdAt。
+   *
+   * 用于 notes.ts 中 5 分钟窗口判断。只迁移 SELECT 查询，
+   * 5 分钟窗口判断逻辑仍留在 route。
+   *
+   * @param noteId 笔记 ID
+   * @returns 最近 edit 版本的 createdAt，或 undefined
+   */
+  getLastEditByNoteId(noteId: string): { createdAt: string } | undefined {
+    const db = getDb();
+    return db
+      .prepare(
+        `SELECT createdAt FROM note_versions
+         WHERE noteId = ? AND changeType = 'edit'
+         ORDER BY version DESC
+         LIMIT 1`,
+      )
+      .get(noteId) as { createdAt: string } | undefined;
+  },
+};

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -15,7 +15,7 @@ import { yFlush, yDestroyDoc, yReplaceContentAsUpdate } from "../services/yjs";
 import { deleteAttachmentFilesByNoteIds, extractInlineBase64Images } from "./attachments";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { syncNoteLinks, getBacklinks } from "../lib/noteLinks";
-import { noteLinksRepository, noteTagsRepository } from "../repositories";
+import { noteLinksRepository, noteTagsRepository, noteVersionsRepository } from "../repositories";
 import { reclaimSpace } from "../lib/reclaimSpace";
 import { buildFtsSearchTerm } from "../lib/searchQuery";
 
@@ -627,12 +627,7 @@ app.put("/:id", async (c) => {
       const hasContentChange = (body.content !== undefined && body.content !== currentNote.content)
         || (body.title !== undefined && body.title !== currentNote.title);
       if (hasContentChange) {
-        const lastEdit = db.prepare(`
-          SELECT createdAt FROM note_versions
-          WHERE noteId = ? AND changeType = 'edit'
-          ORDER BY version DESC
-          LIMIT 1
-        `).get(id) as { createdAt: string } | undefined;
+        const lastEdit = noteVersionsRepository.getLastEditByNoteId(id);
 
         let shouldInsert = true;
         if (lastEdit) {

--- a/backend/src/routes/shares.ts
+++ b/backend/src/routes/shares.ts
@@ -10,6 +10,7 @@ import { broadcastNoteUpdated, broadcastToUser } from "../services/realtime";
 import { yDestroyDoc } from "../services/yjs";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { logAudit } from "../services/audit";
+import { noteVersionsRepository } from "../repositories";
 
 // H3: 使用密码学安全的随机源生成分享 token。
 //     原实现用 Math.random()，理论上可被预测；改用 crypto.randomBytes。
@@ -557,17 +558,8 @@ sharesRouter.get("/note/:noteId/versions", (c) => {
   const note = db.prepare("SELECT id FROM notes WHERE id = ? AND userId = ?").get(noteId, userId) as any;
   if (!note) return c.json({ error: "笔记不存在或无权操作" }, 404);
 
-  const versions = db.prepare(`
-    SELECT nv.id, nv.noteId, nv.userId, nv.title, nv.version, nv.changeType, nv.changeSummary, nv.createdAt,
-           u.username
-    FROM note_versions nv
-    LEFT JOIN users u ON nv.userId = u.id
-    WHERE nv.noteId = ?
-    ORDER BY nv.version DESC
-    LIMIT ? OFFSET ?
-  `).all(noteId, limit, offset) as any[];
-
-  const total = (db.prepare("SELECT COUNT(*) as count FROM note_versions WHERE noteId = ?").get(noteId) as any).count;
+  const versions = noteVersionsRepository.listByNoteId(noteId, limit, offset);
+  const total = noteVersionsRepository.countByNoteId(noteId);
 
   return c.json({ versions, total });
 });
@@ -582,7 +574,7 @@ sharesRouter.get("/note/:noteId/versions/:versionId", (c) => {
   const note = db.prepare("SELECT id FROM notes WHERE id = ? AND userId = ?").get(noteId, userId) as any;
   if (!note) return c.json({ error: "笔记不存在或无权操作" }, 404);
 
-  const version = db.prepare("SELECT * FROM note_versions WHERE id = ? AND noteId = ?").get(versionId, noteId) as any;
+  const version = noteVersionsRepository.getByIdAndNoteId(versionId, noteId);
   if (!version) return c.json({ error: "版本不存在" }, 404);
 
   return c.json(version);
@@ -604,7 +596,7 @@ sharesRouter.post("/note/:noteId/versions/:versionId/restore", (c) => {
   if (!note) return c.json({ error: "笔记不存在或无权操作" }, 404);
   if (note.isLocked) return c.json({ error: "笔记已锁定" }, 403);
 
-  const version = db.prepare("SELECT * FROM note_versions WHERE id = ? AND noteId = ?").get(versionId, noteId) as any;
+  const version = noteVersionsRepository.getByIdAndNoteId(versionId, noteId);
   if (!version) return c.json({ error: "版本不存在" }, 404);
 
   const updated = db.transaction(() => {


### PR DESCRIPTION
## 概述

新增 `noteVersionsRepository`，迁移 `note_versions` 查询类 SQL。

## 变更

- 新增 `backend/src/repositories/noteVersionsRepository.ts`
- 导出 `noteVersionsRepository` 到 `repositories/index.ts`
- 迁移 `shares.ts` 版本列表查询 → `noteVersionsRepository.listByNoteId`
- 迁移 `shares.ts` 版本总数 COUNT → `noteVersionsRepository.countByNoteId`
- 迁移 `shares.ts` 单版本查询 → `noteVersionsRepository.getByIdAndNoteId`
- 迁移 `notes.ts` 最近 edit 版本查询 → `noteVersionsRepository.getLastEditByNoteId`

## 保持不变

- note 权限校验
- `resolveNotePermission` / `hasPermission` 逻辑
- 接口路径、HTTP status、错误消息、响应结构
- 分页结构、排序行为
- 创建版本 INSERT（`notes.ts` + `shares.ts`）
- 删除版本 DELETE
- 恢复版本事务（INSERT + UPDATE + DELETE + 广播）
- `pruneOldVersions`
- 导入导出版本 SQL
- 用户迁移 UPDATE
- notes 主表 UPDATE
- `yDestroyDoc` / `broadcastNoteUpdated`
- 前端 UI / Electron

## 未引入

- `pg` / PostgreSQL
- `DATABASE_URL` / `DB_DRIVER`
- Docker 修改
- `package.json` 修改
- frontend 修改
- Electron 修改

## 验证结果

- `DB-REPOSITORY-NEXT-CANDIDATES-01-B2-B1-FAST-RV-FIX1` ✅ 通过
- 工作区 clean
- frontend/electron 残留已清理
- 分支已 rebase 到最新 `origin/main`
- PR 预期 head commit：`efe04bd`
- `typecheck/build` 如失败，属于既有 `sanitize-html` 缺失问题，与本次迁移无关

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## PR head 校验

创建后必须确认：

```text
PR head_sha == efe04bd
```

如果不一致，关闭 PR，不允许合并。