### PR TITLE
refactor(db): move note_versions insert into repository

### DIFF
--- a/backend/src/repositories/noteVersionsRepository.ts
+++ b/backend/src/repositories/noteVersionsRepository.ts
@@ -2,14 +2,13 @@
  * Note Versions Repository
  *
  * 职责：
- * - 封装 note_versions 表的查询类数据库操作
+ * - 封装 note_versions 表的数据库操作
  * - 提供类型安全的接口
  * - 保持现有 SQLite 行为不变
  *
  * 注意：
- * - 本次只迁移查询类 SQL（B2-B1）
- * - 创建版本 INSERT / 删除版本 DELETE / pruneOldVersions / 恢复版本事务
- *   留在后续批次迁移
+ * - 已迁移：查询类 SQL（B2-B1）、创建版本 INSERT（B2-B2）
+ * - 未迁移：删除版本 DELETE / pruneOldVersions / 恢复版本事务
  * - 不涉及 notes 主表 CRUD
  */
 
@@ -117,5 +116,40 @@ export const noteVersionsRepository = {
          LIMIT 1`,
       )
       .get(noteId) as { createdAt: string } | undefined;
+  },
+
+  /**
+   * 创建版本记录。
+   *
+   * 用于：
+   * - 编辑保存时记录修改前状态（changeType='edit'）
+   * - 访客编辑时记录修改前状态（changeType='guest_edit'）
+   * - 恢复版本前备份当前状态（changeType='restore'）
+   *
+   * @param input 版本数据
+   */
+  create(input: {
+    id: string;
+    noteId: string;
+    userId: string;
+    title: string;
+    content: string;
+    contentText: string;
+    version: number;
+    changeType: 'edit' | 'guest_edit' | 'restore';
+    changeSummary?: string;
+  }): void {
+    const db = getDb();
+    if (input.changeSummary !== undefined) {
+      db.prepare(
+        `INSERT INTO note_versions (id, noteId, userId, title, content, contentText, version, changeType, changeSummary)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(input.id, input.noteId, input.userId, input.title, input.content, input.contentText, input.version, input.changeType, input.changeSummary);
+    } else {
+      db.prepare(
+        `INSERT INTO note_versions (id, noteId, userId, title, content, contentText, version, changeType)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(input.id, input.noteId, input.userId, input.title, input.content, input.contentText, input.version, input.changeType);
+    }
   },
 };

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -643,10 +643,16 @@ app.put("/:id", async (c) => {
         if (shouldInsert) {
           const versionId = uuid();
           // 版本历史里记录实际编辑者（可能与笔记所有者不同）
-          db.prepare(`
-            INSERT INTO note_versions (id, noteId, userId, title, content, contentText, version, changeType)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'edit')
-          `).run(versionId, id, userId, currentNote.title, currentNote.content, currentNote.contentText, currentNote.version);
+          noteVersionsRepository.create({
+            id: versionId,
+            noteId: id,
+            userId,
+            title: currentNote.title,
+            content: currentNote.content,
+            contentText: currentNote.contentText,
+            version: currentNote.version,
+            changeType: 'edit',
+          });
         }
       }
     }

--- a/backend/src/routes/shares.ts
+++ b/backend/src/routes/shares.ts
@@ -505,19 +505,17 @@ sharedRouter.put("/:token/content", async (c) => {
       || (title !== undefined && title !== share.noteTitle);
     if (hasContentChange) {
       const versionId = uuid();
-      db.prepare(`
-        INSERT INTO note_versions (id, noteId, userId, title, content, contentText, version, changeType, changeSummary)
-        VALUES (?, ?, ?, ?, ?, ?, ?, 'guest_edit', ?)
-      `).run(
-        versionId,
-        share.noteId,
-        share.noteUserId,
-        share.noteTitle,
-        share.noteContent,
-        share.noteContentText,
-        share.noteVersion,
-        `访客 ${trimmedName} 编辑`,
-      );
+      noteVersionsRepository.create({
+        id: versionId,
+        noteId: share.noteId,
+        userId: share.noteUserId,
+        title: share.noteTitle,
+        content: share.noteContent,
+        contentText: share.noteContentText,
+        version: share.noteVersion,
+        changeType: 'guest_edit',
+        changeSummary: `访客 ${trimmedName} 编辑`,
+      });
     }
   }
 
@@ -601,10 +599,17 @@ sharesRouter.post("/note/:noteId/versions/:versionId/restore", (c) => {
 
   const updated = db.transaction(() => {
     const currentVersionId = uuid();
-    db.prepare(`
-      INSERT INTO note_versions (id, noteId, userId, title, content, contentText, version, changeType, changeSummary)
-      VALUES (?, ?, ?, ?, ?, ?, ?, 'restore', ?)
-    `).run(currentVersionId, noteId, userId, note.title, note.content, note.contentText, note.version, "恢复前自动备份");
+    noteVersionsRepository.create({
+      id: currentVersionId,
+      noteId,
+      userId,
+      title: note.title,
+      content: note.content,
+      contentText: note.contentText,
+      version: note.version,
+      changeType: 'restore',
+      changeSummary: "恢复前自动备份",
+    });
 
     db.prepare(`
       UPDATE notes


### PR DESCRIPTION
## 概述

迁移 `note_versions` 的创建版本 INSERT 路径到 Repository 层，为后续 SQLite → PostgreSQL 做前置准备。

## 变更

- 新增 `noteVersionsRepository.create(input)`
- `notes.ts` 创建版本 INSERT 改为 Repository 调用
- `shares.ts` 创建版本 INSERT 改为 Repository 调用

## 范围控制

- 只迁移 `note_versions` INSERT
- 不改变业务行为
- 不接入 PostgreSQL
- 不新增 `DATABASE_URL`
- 不新增 `DB_DRIVER`
- 不改 Docker
- 不改 `package.json`
- 不改前端 UI
- 不改 Electron

## FAST-RV 结果

- 分支：`db/note-versions-insert-repository`
- commit：`db51d49`
- 修改文件：
  - `backend/src/repositories/noteVersionsRepository.ts`
  - `backend/src/routes/notes.ts`
  - `backend/src/routes/shares.ts`
- `shares.ts` 只替换 `note_versions` INSERT，未改分享权限 / 公开分享 / 协作权限 / API 返回 / HTTP status / 鉴权逻辑
- PostgreSQL 禁区未触碰
- `typecheck` 仍受既有 `sanitize-html` 缺失影响，与本次修改无关

## 当前迁移状态

`note_versions` 仍是部分迁移表。本次仅补充 INSERT 路径；后续建议继续 `DB-REPOSITORY-NEXT-CANDIDATES-01-B2-B3`，迁移删除 / 清理路径。

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 合并前校验

必须确认：

```text
PR head_sha == db51d49
```