### PR TITLE
refactor(db): move favorites and user_sessions into repositories

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,6 +52,7 @@ import releasesRouter from "./routes/releases";
 import { seedDatabase } from "./db/seed";
 import { initApiTokensTable, looksLikeApiToken, resolveApiToken } from "./lib/api-tokens";
 import { getDb, closeDb } from "./db/schema";
+import { userSessionsRepository } from "./repositories";
 import { generateOpenAPISpec } from "./services/openapi";
 import { getBackupManager } from "./services/backup";
 import { attachRealtimeServer, getRealtimeStats, shutdownRealtime } from "./services/realtime";
@@ -359,9 +360,7 @@ function touchSessionLastSeen(sessionId: string) {
   if (now - last < SESSION_TOUCH_INTERVAL_MS) return;
   sessionLastTouched.set(sessionId, now);
   try {
-    getDb()
-      .prepare("UPDATE user_sessions SET lastSeenAt = datetime('now') WHERE id = ?")
-      .run(sessionId);
+    userSessionsRepository.updateLastSeen(sessionId);
   } catch {
     /* 更新失败不阻塞请求 */
   }
@@ -442,10 +441,7 @@ app.use("/api/*", async (c, next) => {
   //   - 旧 token 没有 jti（升级前签发的）→ 按兼容路径放行，但不更新 lastSeenAt；
   //   - lastSeenAt 每 60 秒内同用户同 session 只更新一次，避免高频写 DB。
   if (payload.jti) {
-    const db = getDb();
-    const sess = db
-      .prepare("SELECT id, revokedAt FROM user_sessions WHERE id = ? AND userId = ?")
-      .get(payload.jti, payload.userId) as { id: string; revokedAt: string | null } | undefined;
+    const sess = userSessionsRepository.getByIdAndUser(payload.jti, payload.userId);
     if (!sess) {
       // 签发时有 jti，但 DB 里找不到对应 session（可能被 factory-reset 清库） → 视为吊销
       return c.json({ error: "会话已失效，请重新登录", code: "TOKEN_REVOKED" }, 401);

--- a/backend/src/repositories/favoritesRepository.ts
+++ b/backend/src/repositories/favoritesRepository.ts
@@ -1,0 +1,131 @@
+/**
+ * Favorites Repository
+ *
+ * 职责：
+ * - 封装 favorites 表的数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ *
+ * favorites 表结构：
+ * - userId TEXT NOT NULL
+ * - noteId TEXT NOT NULL
+ * - workspaceId TEXT (nullable, NULL=个人空间)
+ * - createdAt TEXT NOT NULL
+ * - PRIMARY KEY (userId, noteId)
+ */
+
+import { getDb } from "../db/schema";
+
+/** favorites 记录 */
+export interface FavoriteRecord {
+  userId: string;
+  noteId: string;
+  workspaceId: string | null;
+  createdAt: string;
+}
+
+export const favoritesRepository = {
+  /**
+   * 检查用户是否收藏了某笔记。
+   *
+   * @param userId 用户 ID
+   * @param noteId 笔记 ID
+   * @returns 是否收藏
+   */
+  isFavorited(userId: string, noteId: string): boolean {
+    const db = getDb();
+    const row = db
+      .prepare("SELECT 1 FROM favorites WHERE userId = ? AND noteId = ?")
+      .get(userId, noteId);
+    return !!row;
+  },
+
+  /**
+   * 添加收藏。
+   *
+   * @param userId 用户 ID
+   * @param noteId 笔记 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   */
+  addFavorite(userId: string, noteId: string, workspaceId: string | null): void {
+    const db = getDb();
+    db.prepare(
+      "INSERT OR IGNORE INTO favorites (userId, noteId, workspaceId, createdAt) VALUES (?, ?, ?, datetime('now'))"
+    ).run(userId, noteId, workspaceId);
+  },
+
+  /**
+   * 取消收藏。
+   *
+   * @param userId 用户 ID
+   * @param noteId 笔记 ID
+   */
+  removeFavorite(userId: string, noteId: string): void {
+    const db = getDb();
+    db.prepare("DELETE FROM favorites WHERE userId = ? AND noteId = ?").run(userId, noteId);
+  },
+
+  /**
+   * 切换收藏状态。
+   *
+   * @param userId 用户 ID
+   * @param noteId 笔记 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   * @returns 新的收藏状态
+   */
+  toggleFavorite(userId: string, noteId: string, workspaceId: string | null): boolean {
+    if (this.isFavorited(userId, noteId)) {
+      this.removeFavorite(userId, noteId);
+      return false;
+    } else {
+      this.addFavorite(userId, noteId, workspaceId);
+      return true;
+    }
+  },
+
+  /**
+   * 获取用户的收藏笔记 ID 列表。
+   *
+   * @param userId 用户 ID
+   * @param workspaceId 工作区 ID（null = 个人空间，undefined = 所有空间）
+   * @returns 收藏的笔记 ID 列表
+   */
+  listFavoriteNoteIds(userId: string, workspaceId?: string | null): string[] {
+    const db = getDb();
+    if (workspaceId !== undefined) {
+      const rows = db
+        .prepare("SELECT noteId FROM favorites WHERE userId = ? AND workspaceId = ? ORDER BY createdAt DESC")
+        .all(userId, workspaceId) as { noteId: string }[];
+      return rows.map((r) => r.noteId);
+    } else {
+      const rows = db
+        .prepare("SELECT noteId FROM favorites WHERE userId = ? ORDER BY createdAt DESC")
+        .all(userId) as { noteId: string }[];
+      return rows.map((r) => r.noteId);
+    }
+  },
+
+  /**
+   * 删除笔记的所有收藏记录。
+   *
+   * @param noteId 笔记 ID
+   * @returns 删除的行数
+   */
+  deleteByNoteId(noteId: string): number {
+    const db = getDb();
+    const result = db.prepare("DELETE FROM favorites WHERE noteId = ?").run(noteId);
+    return result.changes;
+  },
+
+  /**
+   * 删除用户的所有收藏记录。
+   *
+   * @param userId 用户 ID
+   * @returns 删除的行数
+   */
+  deleteByUserId(userId: string): number {
+    const db = getDb();
+    const result = db.prepare("DELETE FROM favorites WHERE userId = ?").run(userId);
+    return result.changes;
+  },
+};

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -15,6 +15,8 @@ export { tagsRepository } from "./tagsRepository";
 export { noteTagsRepository } from "./noteTagsRepository";
 export { aiCustomPromptsRepository } from "./aiCustomPromptsRepository";
 export { noteVersionsRepository } from "./noteVersionsRepository";
+export { favoritesRepository } from "./favoritesRepository";
+export { userSessionsRepository } from "./userSessionsRepository";
 
 // 类型导出
 export type {

--- a/backend/src/repositories/userSessionsRepository.ts
+++ b/backend/src/repositories/userSessionsRepository.ts
@@ -1,0 +1,231 @@
+/**
+ * User Sessions Repository
+ *
+ * 职责：
+ * - 封装 user_sessions 表的数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ *
+ * user_sessions 表结构：
+ * - id TEXT PRIMARY KEY
+ * - userId TEXT NOT NULL
+ * - createdAt TEXT NOT NULL
+ * - lastSeenAt TEXT NOT NULL
+ * - expiresAt TEXT (nullable)
+ * - ip TEXT DEFAULT ''
+ * - userAgent TEXT DEFAULT ''
+ * - deviceLabel TEXT (nullable)
+ * - revokedAt TEXT (nullable)
+ * - revokedReason TEXT (nullable)
+ */
+
+import { getDb } from "../db/schema";
+
+/** user_sessions 记录 */
+export interface UserSessionRecord {
+  id: string;
+  userId: string;
+  createdAt: string;
+  lastSeenAt: string;
+  expiresAt: string | null;
+  ip: string;
+  userAgent: string;
+  deviceLabel: string | null;
+  revokedAt: string | null;
+  revokedReason: string | null;
+}
+
+/** 会话列表项（不含敏感信息） */
+export interface SessionListItem {
+  id: string;
+  createdAt: string;
+  lastSeenAt: string;
+  expiresAt: string | null;
+  ip: string;
+  userAgent: string;
+  deviceLabel: string | null;
+}
+
+export const userSessionsRepository = {
+  /**
+   * 创建新会话。
+   *
+   * @param input 会话数据
+   * @returns 创建的会话 ID
+   */
+  create(input: {
+    id: string;
+    userId: string;
+    ip: string;
+    userAgent: string;
+    deviceLabel?: string;
+    expiresAt?: string;
+  }): string {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO user_sessions (id, userId, ip, userAgent, deviceLabel, expiresAt)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(
+      input.id,
+      input.userId,
+      input.ip || "",
+      input.userAgent || "",
+      input.deviceLabel || null,
+      input.expiresAt || null
+    );
+    return input.id;
+  },
+
+  /**
+   * 查找现有设备会话（用于复用）。
+   *
+   * @param userId 用户 ID
+   * @param deviceLabel 设备标签
+   * @returns 现有会话，或 undefined
+   */
+  findByDevice(userId: string, deviceLabel: string): { id: string } | undefined {
+    const db = getDb();
+    return db
+      .prepare(
+        `SELECT id FROM user_sessions
+         WHERE userId = ? AND deviceLabel = ? AND revokedAt IS NULL
+           AND (expiresAt IS NULL OR datetime(expiresAt) > datetime('now'))
+         ORDER BY lastSeenAt DESC LIMIT 1`
+      )
+      .get(userId, deviceLabel) as { id: string } | undefined;
+  },
+
+  /**
+   * 更新会话的最后活跃时间和 IP。
+   *
+   * @param sessionId 会话 ID
+   * @param ip IP 地址
+   * @param expiresAt 过期时间（可选）
+   */
+  updateLastSeen(sessionId: string, ip?: string, expiresAt?: string): void {
+    const db = getDb();
+    if (ip !== undefined && expiresAt !== undefined) {
+      db.prepare(
+        `UPDATE user_sessions
+         SET lastSeenAt = datetime('now'), ip = ?, expiresAt = ?
+         WHERE id = ?`
+      ).run(ip || "", expiresAt, sessionId);
+    } else {
+      db.prepare(
+        "UPDATE user_sessions SET lastSeenAt = datetime('now') WHERE id = ?"
+      ).run(sessionId);
+    }
+  },
+
+  /**
+   * 获取会话信息（用于 JWT 验证）。
+   *
+   * @param sessionId 会话 ID
+   * @param userId 用户 ID
+   * @returns 会话信息，或 undefined
+   */
+  getByIdAndUser(sessionId: string, userId: string): { id: string; revokedAt: string | null } | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT id, revokedAt FROM user_sessions WHERE id = ? AND userId = ?")
+      .get(sessionId, userId) as { id: string; revokedAt: string | null } | undefined;
+  },
+
+  /**
+   * 获取会话详情（用于会话管理）。
+   *
+   * @param sessionId 会话 ID
+   * @returns 会话信息，或 undefined
+   */
+  getById(sessionId: string): { id: string; userId: string; revokedAt: string | null } | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT id, userId, revokedAt FROM user_sessions WHERE id = ?")
+      .get(sessionId) as { id: string; userId: string; revokedAt: string | null } | undefined;
+  },
+
+  /**
+   * 吊销会话。
+   *
+   * @param sessionId 会话 ID
+   * @param reason 吊销原因
+   */
+  revoke(sessionId: string, reason?: string): void {
+    const db = getDb();
+    db.prepare(
+      `UPDATE user_sessions
+       SET revokedAt = datetime('now'), revokedReason = ?
+       WHERE id = ? AND revokedAt IS NULL`
+    ).run(reason || null, sessionId);
+  },
+
+  /**
+   * 批量吊销用户的所有其他会话。
+   *
+   * @param userId 用户 ID
+   * @param currentSessionId 当前会话 ID（不吊销）
+   * @returns 吊销的行数
+   */
+  revokeAllOther(userId: string, currentSessionId: string): number {
+    const db = getDb();
+    const result = db.prepare(
+      `UPDATE user_sessions
+       SET revokedAt = datetime('now'), revokedReason = 'user_bulk_revoked'
+       WHERE userId = ? AND revokedAt IS NULL AND id != ?`
+    ).run(userId, currentSessionId);
+    return result.changes;
+  },
+
+  /**
+   * 批量吊销用户的所有会话。
+   *
+   * @param userId 用户 ID
+   * @returns 吊销的行数
+   */
+  revokeAll(userId: string): number {
+    const db = getDb();
+    const result = db.prepare(
+      `UPDATE user_sessions
+       SET revokedAt = datetime('now'), revokedReason = 'user_bulk_revoked'
+       WHERE userId = ? AND revokedAt IS NULL`
+    ).run(userId);
+    return result.changes;
+  },
+
+  /**
+   * 清理过期和已撤销的会话。
+   *
+   * @param userId 用户 ID
+   * @returns 删除的行数
+   */
+  cleanupExpired(userId: string): number {
+    const db = getDb();
+    const result = db.prepare(
+      `DELETE FROM user_sessions
+       WHERE userId = ? AND (
+         revokedAt IS NOT NULL
+         OR (expiresAt IS NOT NULL AND datetime(expiresAt) <= datetime('now'))
+       )`
+    ).run(userId);
+    return result.changes;
+  },
+
+  /**
+   * 列出用户的活跃会话。
+   *
+   * @param userId 用户 ID
+   * @returns 活跃会话列表
+   */
+  listActiveByUser(userId: string): SessionListItem[] {
+    const db = getDb();
+    return db
+      .prepare(
+        `SELECT id, createdAt, lastSeenAt, expiresAt, ip, userAgent, deviceLabel
+         FROM user_sessions
+         WHERE userId = ? AND revokedAt IS NULL
+           AND (expiresAt IS NULL OR datetime(expiresAt) > datetime('now'))
+         ORDER BY lastSeenAt DESC`
+      )
+      .all(userId) as SessionListItem[];
+  },
+};

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Hono, type Context } from "hono";
 import { getDb } from "../db/schema";
+import { userSessionsRepository } from "../repositories";
 import { v4 as uuid } from "uuid";
 import bcrypt from "bcryptjs";
 import {
@@ -62,48 +63,31 @@ function createSession(params: {
 
   // 若有 deviceId，尝试复用已有活跃 session
   if (params.deviceId) {
-    const existing = db.prepare(
-      `SELECT id FROM user_sessions
-       WHERE userId = ? AND deviceLabel = ? AND revokedAt IS NULL
-         AND (expiresAt IS NULL OR datetime(expiresAt) > datetime('now'))
-       ORDER BY lastSeenAt DESC LIMIT 1`,
-    ).get(params.userId, `device:${params.deviceId}`) as { id: string } | undefined;
+    const existing = userSessionsRepository.findByDevice(params.userId, `device:${params.deviceId}`);
 
     if (existing) {
       // 复用：更新 lastSeenAt、IP、expiresAt
-      db.prepare(
-        `UPDATE user_sessions
-         SET lastSeenAt = datetime('now'), ip = ?, expiresAt = ?
-         WHERE id = ?`,
-      ).run(params.ip || "", expiresAt, existing.id);
+      userSessionsRepository.updateLastSeen(existing.id, params.ip || "", expiresAt);
       return existing.id;
     }
   }
 
   // 新建 session
   const id = uuid();
-  db.prepare(
-    `INSERT INTO user_sessions (id, userId, ip, userAgent, deviceLabel, expiresAt)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-  ).run(
+  userSessionsRepository.create({
     id,
-    params.userId,
-    params.ip || "",
-    params.userAgent || "",
-    params.deviceId ? `device:${params.deviceId}` : null,
+    userId: params.userId,
+    ip: params.ip || "",
+    userAgent: params.userAgent || "",
+    deviceLabel: params.deviceId ? `device:${params.deviceId}` : undefined,
     expiresAt,
-  );
+  });
   return id;
 }
 
 /** 标记 session 为已吊销。适用于"单端下线"，不提升 tokenVersion，其它端不受影响。 */
 function revokeSession(sessionId: string, reason: string) {
-  const db = getDb();
-  db.prepare(
-    `UPDATE user_sessions
-     SET revokedAt = datetime('now'), revokedReason = ?
-     WHERE id = ? AND revokedAt IS NULL`,
-  ).run(reason, sessionId);
+  userSessionsRepository.revoke(sessionId, reason);
 }
 
 // ========== 工具 ==========
@@ -1096,34 +1080,10 @@ auth.get("/sessions", (c) => {
   const payload = token ? verifyLoginToken(token) : null;
   const currentSessionId = payload?.jti || null;
 
-  const db = getDb();
-
   // 清理过期和已撤销的 session（每次查询时顺带清理，避免无限膨胀）
-  db.prepare(
-    `DELETE FROM user_sessions
-     WHERE userId = ? AND (
-       revokedAt IS NOT NULL
-       OR (expiresAt IS NOT NULL AND datetime(expiresAt) <= datetime('now'))
-     )`,
-  ).run(userId);
+  userSessionsRepository.cleanupExpired(userId);
 
-  const rows = db
-    .prepare(
-      `SELECT id, createdAt, lastSeenAt, expiresAt, ip, userAgent, deviceLabel
-       FROM user_sessions
-       WHERE userId = ? AND revokedAt IS NULL
-         AND (expiresAt IS NULL OR datetime(expiresAt) > datetime('now'))
-       ORDER BY lastSeenAt DESC`,
-    )
-    .all(userId) as Array<{
-      id: string;
-      createdAt: string;
-      lastSeenAt: string;
-      expiresAt: string | null;
-      ip: string;
-      userAgent: string;
-      deviceLabel: string | null;
-    }>;
+  const rows = userSessionsRepository.listActiveByUser(userId);
 
   return c.json({
     sessions: rows.map((r) => ({
@@ -1138,10 +1098,7 @@ auth.delete("/sessions/:id", (c) => {
   const userId = extractUserId(c);
   if (!userId) return c.json({ error: "未授权" }, 401);
   const sessionId = c.req.param("id");
-  const db = getDb();
-  const sess = db
-    .prepare("SELECT id, userId, revokedAt FROM user_sessions WHERE id = ?")
-    .get(sessionId) as { id: string; userId: string; revokedAt: string | null } | undefined;
+  const sess = userSessionsRepository.getById(sessionId);
   if (!sess || sess.userId !== userId) {
     return c.json({ error: "会话不存在" }, 404);
   }
@@ -1167,30 +1124,17 @@ auth.delete("/sessions", (c) => {
   const payload = token ? verifyLoginToken(token) : null;
   const currentSessionId = payload?.jti || null;
 
-  const db = getDb();
-  let info;
+  let revokedCount: number;
   if (keepCurrent && currentSessionId) {
-    info = db
-      .prepare(
-        `UPDATE user_sessions
-         SET revokedAt = datetime('now'), revokedReason = 'user_bulk_revoked'
-         WHERE userId = ? AND revokedAt IS NULL AND id != ?`,
-      )
-      .run(userId, currentSessionId);
+    revokedCount = userSessionsRepository.revokeAllOther(userId, currentSessionId);
   } else {
-    info = db
-      .prepare(
-        `UPDATE user_sessions
-         SET revokedAt = datetime('now'), revokedReason = 'user_bulk_revoked'
-         WHERE userId = ? AND revokedAt IS NULL`,
-      )
-      .run(userId);
+    revokedCount = userSessionsRepository.revokeAll(userId);
   }
-  logAudit(userId, "auth", "session_bulk_revoked", { count: info.changes, keepCurrent }, {
+  logAudit(userId, "auth", "session_bulk_revoked", { count: revokedCount, keepCurrent }, {
     ip: extractClientIp(c),
     userAgent: c.req.header("user-agent") || "",
   });
-  return c.json({ success: true, revoked: info.changes });
+  return c.json({ success: true, revoked: revokedCount });
 });
 
 // ========== 登出（吊销当前会话） ==========

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -15,7 +15,7 @@ import { yFlush, yDestroyDoc, yReplaceContentAsUpdate } from "../services/yjs";
 import { deleteAttachmentFilesByNoteIds, extractInlineBase64Images } from "./attachments";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { syncNoteLinks, getBacklinks } from "../lib/noteLinks";
-import { noteLinksRepository, noteTagsRepository, noteVersionsRepository } from "../repositories";
+import { noteLinksRepository, noteTagsRepository, noteVersionsRepository, favoritesRepository } from "../repositories";
 import { reclaimSpace } from "../lib/reclaimSpace";
 import { buildFtsSearchTerm } from "../lib/searchQuery";
 
@@ -701,12 +701,9 @@ app.put("/:id", async (c) => {
       | undefined;
     const favWsId = favRow?.workspaceId ?? null;
     if (body.isFavorite) {
-      db.prepare(`
-        INSERT OR IGNORE INTO favorites (userId, noteId, workspaceId, createdAt)
-        VALUES (?, ?, ?, datetime('now'))
-      `).run(userId, id, favWsId);
+      favoritesRepository.addFavorite(userId, id, favWsId);
     } else {
-      db.prepare("DELETE FROM favorites WHERE userId = ? AND noteId = ?").run(userId, id);
+      favoritesRepository.removeFavorite(userId, id);
     }
   }
   if (body.isLocked !== undefined) { fields.push("isLocked = ?"); params.push(body.isLocked); }


### PR DESCRIPTION
## 概述

批量迁移 `favorites` 和 `user_sessions` 两张低风险表到 Repository 层，为后续 SQLite → PostgreSQL 做前置准备。

## 变更

- 新增 `favoritesRepository`
- 新增 `userSessionsRepository`
- `notes.ts` 中 favorites 相关 SQL 改为 Repository 调用
- `auth.ts` 中 user_sessions 相关 SQL 改为 Repository 调用
- `index.ts` 中 session cleanup 改为 Repository 调用

## 范围控制

- 只迁移 `favorites + user_sessions`
- 不改变业务行为
- 不接入 PostgreSQL
- 不新增 `DATABASE_URL`
- 不新增 `DB_DRIVER`
- 不改 Docker
- 不改 `package.json`
- 不改前端 UI
- 不改 Electron

## FAST-RV 结果

- 分支：`db/favorites-user-sessions-repository`
- commit：`90bddd7`
- 修改文件：
  - `backend/src/repositories/favoritesRepository.ts`
  - `backend/src/repositories/userSessionsRepository.ts`
  - `backend/src/repositories/index.ts`
  - `backend/src/routes/notes.ts`
  - `backend/src/routes/auth.ts`
  - `backend/src/index.ts`
- `notes.ts` 只替换 favorites 相关 SQL，未改 notes 主表核心 CRUD
- `auth.ts` 只替换 user_sessions 相关 SQL，未改登录 / 登出 / JWT / Cookie / 鉴权语义
- `index.ts` 只替换 session cleanup 为 Repository 调用
- PostgreSQL 禁区未触碰
- `typecheck/build` 仍受既有 `sanitize-html` 缺失影响，与本次修改无关

## 当前迁移状态

合并后 Repository 前置迁移进度可更新为：

```text
10/43 = 23.3%
```

PostgreSQL 实际接入仍为：

```text
0%
```

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 合并前校验

必须确认：

```text
PR head_sha == 90bddd7
```