### PR TITLE
refactor(db): move task metadata tables into repositories

### DIFF
--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -17,6 +17,9 @@ export { aiCustomPromptsRepository } from "./aiCustomPromptsRepository";
 export { noteVersionsRepository } from "./noteVersionsRepository";
 export { favoritesRepository } from "./favoritesRepository";
 export { userSessionsRepository } from "./userSessionsRepository";
+export { taskRemindersRepository } from "./taskRemindersRepository";
+export { taskProjectsRepository } from "./taskProjectsRepository";
+export { taskTemplatesRepository } from "./taskTemplatesRepository";
 
 // 类型导出
 export type {

--- a/backend/src/repositories/taskProjectsRepository.ts
+++ b/backend/src/repositories/taskProjectsRepository.ts
@@ -1,0 +1,158 @@
+/**
+ * Task Projects Repository
+ *
+ * 职责：
+ * - 封装 task_projects 表的数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ */
+
+import { getDb } from "../db/schema";
+
+/** task_projects 记录 */
+export interface TaskProjectRecord {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  icon: string | null;
+  color: string | null;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** task_projects 列表项（含统计） */
+export interface TaskProjectWithStats extends TaskProjectRecord {
+  taskCount: number;
+  completedCount: number;
+  progress: number;
+}
+
+export const taskProjectsRepository = {
+  /**
+   * 获取项目列表（含任务统计）。
+   *
+   * @param userId 用户 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   * @returns 项目列表
+   */
+  listByUser(userId: string, workspaceId: string | null): TaskProjectWithStats[] {
+    const db = getDb();
+    if (workspaceId) {
+      return db.prepare(
+        "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
+        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
+        "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 THEN " +
+        "ROUND(100.0 * (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) / " +
+        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
+        "FROM task_projects p WHERE p.workspaceId = ? ORDER BY p.sortOrder ASC, p.createdAt ASC"
+      ).all(workspaceId) as TaskProjectWithStats[];
+    } else {
+      return db.prepare(
+        "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
+        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
+        "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 THEN " +
+        "ROUND(100.0 * (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) / " +
+        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
+        "FROM task_projects p WHERE p.userId = ? AND p.workspaceId IS NULL ORDER BY p.sortOrder ASC, p.createdAt ASC"
+      ).all(userId) as TaskProjectWithStats[];
+    }
+  },
+
+  /**
+   * 获取项目详情。
+   *
+   * @param projectId 项目 ID
+   * @returns 项目记录，或 undefined
+   */
+  getById(projectId: string): TaskProjectRecord | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM task_projects WHERE id = ?")
+      .get(projectId) as TaskProjectRecord | undefined;
+  },
+
+  /**
+   * 获取项目详情（含统计）。
+   *
+   * @param projectId 项目 ID
+   * @returns 项目记录（含统计），或 undefined
+   */
+  getByIdWithStats(projectId: string): TaskProjectWithStats | undefined {
+    const db = getDb();
+    return db.prepare(
+      "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
+      "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
+      "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 THEN " +
+      "ROUND(100.0 * (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) / " +
+      "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
+      "FROM task_projects p WHERE p.id = ?"
+    ).get(projectId) as TaskProjectWithStats | undefined;
+  },
+
+  /**
+   * 创建项目。
+   *
+   * @param input 项目数据
+   */
+  create(input: {
+    id: string;
+    userId: string;
+    workspaceId: string | null;
+    name: string;
+    icon: string | null;
+    color: string | null;
+    sortOrder: number;
+  }): void {
+    const db = getDb();
+    db.prepare(
+      "INSERT INTO task_projects (id, userId, workspaceId, name, icon, color, sortOrder) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(input.id, input.userId, input.workspaceId, input.name, input.icon, input.color, input.sortOrder);
+  },
+
+  /**
+   * 更新项目。
+   *
+   * @param projectId 项目 ID
+   * @param input 更新数据
+   */
+  update(projectId: string, input: {
+    name: string;
+    icon: string | null;
+    color: string | null;
+    sortOrder: number;
+  }): void {
+    const db = getDb();
+    db.prepare(
+      "UPDATE task_projects SET name = ?, icon = ?, color = ?, sortOrder = ?, updatedAt = datetime('now') WHERE id = ?"
+    ).run(input.name, input.icon, input.color, input.sortOrder, projectId);
+  },
+
+  /**
+   * 删除项目。
+   *
+   * @param projectId 项目 ID
+   */
+  delete(projectId: string): void {
+    const db = getDb();
+    db.prepare("UPDATE tasks SET projectId = NULL WHERE projectId = ?").run(projectId);
+    db.prepare("DELETE FROM task_projects WHERE id = ?").run(projectId);
+  },
+
+  /**
+   * 批量更新项目排序。
+   *
+   * @param items 排序数据
+   */
+  updateSortOrder(items: Array<{ id: string; sortOrder: number }>): void {
+    const db = getDb();
+    const stmt = db.prepare("UPDATE task_projects SET sortOrder = ?, updatedAt = datetime('now') WHERE id = ?");
+    const tx = db.transaction(() => {
+      for (const item of items) {
+        stmt.run(item.sortOrder, item.id);
+      }
+    });
+    tx();
+  },
+};

--- a/backend/src/repositories/taskRemindersRepository.ts
+++ b/backend/src/repositories/taskRemindersRepository.ts
@@ -1,0 +1,191 @@
+/**
+ * Task Reminders Repository
+ *
+ * 职责：
+ * - 封装 task_reminders 表的数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ */
+
+import { getDb } from "../db/schema";
+
+/** task_reminders 记录 */
+export interface TaskReminderRecord {
+  id: string;
+  taskId: string;
+  userId: string;
+  offsetMinutes: number;
+  enabled: number;
+  snoozedUntil: string | null;
+  lastNotifiedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const taskRemindersRepository = {
+  /**
+   * 获取任务的提醒列表。
+   *
+   * @param taskId 任务 ID
+   * @param userId 用户 ID
+   * @returns 提醒列表
+   */
+  listByTaskId(taskId: string, userId: string): TaskReminderRecord[] {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM task_reminders WHERE taskId = ? AND userId = ? ORDER BY offsetMinutes ASC")
+      .all(taskId, userId) as TaskReminderRecord[];
+  },
+
+  /**
+   * 获取提醒详情。
+   *
+   * @param reminderId 提醒 ID
+   * @returns 提醒记录，或 undefined
+   */
+  getById(reminderId: string): TaskReminderRecord | undefined {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM task_reminders WHERE id = ?")
+      .get(reminderId) as TaskReminderRecord | undefined;
+  },
+
+  /**
+   * 创建提醒。
+   *
+   * @param input 提醒数据
+   */
+  create(input: {
+    id: string;
+    taskId: string;
+    userId: string;
+    offsetMinutes: number;
+  }): void {
+    const db = getDb();
+    db.prepare(
+      "INSERT INTO task_reminders (id, taskId, userId, offsetMinutes, enabled) VALUES (?, ?, ?, ?, 1)"
+    ).run(input.id, input.taskId, input.userId, input.offsetMinutes);
+  },
+
+  /**
+   * 更新提醒。
+   *
+   * @param reminderId 提醒 ID
+   * @param input 更新数据
+   */
+  update(reminderId: string, input: {
+    offsetMinutes: number;
+    enabled: boolean;
+    snoozedUntil: string | null;
+  }): void {
+    const db = getDb();
+    db.prepare(
+      "UPDATE task_reminders SET offsetMinutes = ?, enabled = ?, snoozedUntil = ?, updatedAt = datetime('now') WHERE id = ?"
+    ).run(input.offsetMinutes, input.enabled ? 1 : 0, input.snoozedUntil, reminderId);
+  },
+
+  /**
+   * 删除提醒。
+   *
+   * @param reminderId 提醒 ID
+   */
+  delete(reminderId: string): void {
+    const db = getDb();
+    db.prepare("DELETE FROM task_reminders WHERE id = ?").run(reminderId);
+  },
+
+  /**
+   * 获取用户的活跃提醒列表（带任务信息）。
+   *
+   * @param userId 用户 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   * @returns 提醒列表（含任务信息）
+   */
+  listActiveByUser(userId: string, workspaceId: string | null): Array<TaskReminderRecord & {
+    title: string;
+    isCompleted: number;
+    dueDate: string | null;
+    dueAt: string | null;
+  }> {
+    const db = getDb();
+    if (workspaceId) {
+      return db.prepare(`
+        SELECT r.*, t.title, t.isCompleted, t.dueDate, t.dueAt
+        FROM task_reminders r
+        JOIN tasks t ON t.id = r.taskId
+        WHERE r.userId = ? AND t.workspaceId = ?
+        ORDER BY r.createdAt DESC
+      `).all(userId, workspaceId) as any[];
+    } else {
+      return db.prepare(`
+        SELECT r.*, t.title, t.isCompleted, t.dueDate, t.dueAt
+        FROM task_reminders r
+        JOIN tasks t ON t.id = r.taskId
+        WHERE r.userId = ? AND t.workspaceId IS NULL
+        ORDER BY r.createdAt DESC
+      `).all(userId) as any[];
+    }
+  },
+
+  /**
+   * 获取待触发的提醒列表（用于通知）。
+   *
+   * @returns 待触发提醒列表
+   */
+  listPendingNotifications(): Array<TaskReminderRecord & {
+    title: string;
+    isCompleted: number;
+  }> {
+    const db = getDb();
+    return db.prepare(`
+      SELECT r.*, t.title, t.isCompleted
+      FROM task_reminders r
+      JOIN tasks t ON t.id = r.taskId
+      WHERE r.enabled = 1
+        AND t.isCompleted = 0
+        AND (r.snoozedUntil IS NULL OR datetime(r.snoozedUntil) <= datetime('now'))
+        AND (r.lastNotifiedAt IS NULL OR datetime(r.lastNotifiedAt) < datetime('now', '-' || r.offsetMinutes || ' minutes'))
+      ORDER BY r.createdAt ASC
+    `).all() as any[];
+  },
+
+  /**
+   * 更新提醒的通知状态。
+   *
+   * @param reminderId 提醒 ID
+   */
+  markNotified(reminderId: string): void {
+    const db = getDb();
+    db.prepare(
+      "UPDATE task_reminders SET lastNotifiedAt = datetime('now'), snoozedUntil = NULL WHERE id = ?"
+    ).run(reminderId);
+  },
+
+  /**
+   * 获取任务的提醒（用于复制任务时）。
+   *
+   * @param taskId 任务 ID
+   * @returns 提醒列表
+   */
+  listByTaskIdForCopy(taskId: string): TaskReminderRecord[] {
+    const db = getDb();
+    return db
+      .prepare("SELECT * FROM task_reminders WHERE taskId = ?")
+      .all(taskId) as TaskReminderRecord[];
+  },
+
+  /**
+   * 复制提醒到新任务。
+   *
+   * @param sourceReminder 源提醒
+   * @param newTaskId 新任务 ID
+   */
+  copyReminder(sourceReminder: TaskReminderRecord, newTaskId: string): void {
+    const db = getDb();
+    const crypto = require("crypto");
+    const rId = crypto.randomUUID();
+    db.prepare(
+      "INSERT INTO task_reminders (id, taskId, userId, offsetMinutes, enabled, lastNotifiedAt, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, NULL, datetime('now'), datetime('now'))"
+    ).run(rId, newTaskId, sourceReminder.userId, sourceReminder.offsetMinutes, sourceReminder.enabled);
+  },
+};

--- a/backend/src/repositories/taskTemplatesRepository.ts
+++ b/backend/src/repositories/taskTemplatesRepository.ts
@@ -1,0 +1,148 @@
+/**
+ * Task Templates Repository
+ *
+ * 职责：
+ * - 封装 task_templates 表的数据库操作
+ * - 提供类型安全的接口
+ * - 保持现有 SQLite 行为不变
+ */
+
+import { getDb } from "../db/schema";
+
+/** task_templates 记录 */
+export interface TaskTemplateRecord {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  items: string; // JSON 字符串
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const taskTemplatesRepository = {
+  /**
+   * 获取模板列表。
+   *
+   * @param userId 用户 ID
+   * @param workspaceId 工作区 ID（null = 个人空间）
+   * @returns 模板列表
+   */
+  listByUser(userId: string, workspaceId: string | null): TaskTemplateRecord[] {
+    const db = getDb();
+    if (workspaceId) {
+      return db
+        .prepare('SELECT * FROM task_templates WHERE workspaceId = ? ORDER BY createdAt DESC')
+        .all(workspaceId) as TaskTemplateRecord[];
+    } else {
+      return db
+        .prepare('SELECT * FROM task_templates WHERE userId = ? AND workspaceId IS NULL ORDER BY createdAt DESC')
+        .all(userId) as TaskTemplateRecord[];
+    }
+  },
+
+  /**
+   * 获取模板详情。
+   *
+   * @param templateId 模板 ID
+   * @returns 模板记录，或 undefined
+   */
+  getById(templateId: string): TaskTemplateRecord | undefined {
+    const db = getDb();
+    return db
+      .prepare('SELECT * FROM task_templates WHERE id = ?')
+      .get(templateId) as TaskTemplateRecord | undefined;
+  },
+
+  /**
+   * 创建模板。
+   *
+   * @param input 模板数据
+   */
+  create(input: {
+    id: string;
+    userId: string;
+    workspaceId: string | null;
+    name: string;
+    description: string | null;
+    icon: string | null;
+    color: string | null;
+    items: any[];
+  }): void {
+    const db = getDb();
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO task_templates (id, userId, workspaceId, name, description, icon, color, items, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(
+      input.id,
+      input.userId,
+      input.workspaceId,
+      input.name.trim(),
+      input.description || null,
+      input.icon || null,
+      input.color || null,
+      JSON.stringify(input.items),
+      now,
+      now
+    );
+  },
+
+  /**
+   * 更新模板。
+   *
+   * @param templateId 模板 ID
+   * @param input 更新数据
+   */
+  update(templateId: string, input: {
+    name?: string;
+    description?: string | null;
+    icon?: string | null;
+    color?: string | null;
+    items?: any[];
+  }): void {
+    const db = getDb();
+    const updates: string[] = [];
+    const params: any[] = [];
+
+    if (input.name !== undefined) {
+      updates.push('name = ?');
+      params.push(input.name.trim());
+    }
+    if (input.description !== undefined) {
+      updates.push('description = ?');
+      params.push(input.description || null);
+    }
+    if (input.icon !== undefined) {
+      updates.push('icon = ?');
+      params.push(input.icon || null);
+    }
+    if (input.color !== undefined) {
+      updates.push('color = ?');
+      params.push(input.color || null);
+    }
+    if (input.items !== undefined) {
+      updates.push('items = ?');
+      params.push(JSON.stringify(input.items));
+    }
+
+    if (updates.length === 0) return;
+
+    updates.push("updatedAt = datetime('now')");
+    params.push(templateId);
+
+    db.prepare(`UPDATE task_templates SET ${updates.join(', ')} WHERE id = ?`).run(...params);
+  },
+
+  /**
+   * 删除模板。
+   *
+   * @param templateId 模板 ID
+   */
+  delete(templateId: string): void {
+    const db = getDb();
+    db.prepare('DELETE FROM task_templates WHERE id = ?').run(templateId);
+  },
+};

--- a/backend/src/routes/task-projects.ts
+++ b/backend/src/routes/task-projects.ts
@@ -5,6 +5,7 @@ import {
   getUserWorkspaceRole,
   canManageResource,
 } from "../middleware/acl";
+import { taskProjectsRepository } from "../repositories";
 
 const taskProjects = new Hono();
 
@@ -19,29 +20,11 @@ function resolveScope(c: any, userId: string) {
 
 // List projects
 taskProjects.get("/", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const scope = resolveScope(c, userId);
   if (scope.error) return c.json({ error: scope.error }, 403);
 
-  const rows = scope.workspaceId
-    ? db.prepare(
-        "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
-        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
-        "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 " +
-        "THEN ROUND((SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) * 100.0 / " +
-        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
-        "FROM task_projects p WHERE p.workspaceId = ? ORDER BY p.sortOrder ASC, p.createdAt ASC"
-      ).all(scope.workspaceId)
-    : db.prepare(
-        "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
-        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
-        "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 " +
-        "THEN ROUND((SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) * 100.0 / " +
-        "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
-        "FROM task_projects p WHERE p.userId = ? AND p.workspaceId IS NULL ORDER BY p.sortOrder ASC, p.createdAt ASC"
-      ).all(userId);
-
+  const rows = taskProjectsRepository.listByUser(userId, scope.workspaceId);
   return c.json(rows);
 });
 
@@ -70,23 +53,17 @@ taskProjects.post("/", async (c) => {
   const color = body.color || "#6366f1";
   const sortOrder = body.sortOrder ?? 0;
 
-  db.prepare(
-    "INSERT INTO task_projects (id, userId, workspaceId, name, icon, color, sortOrder) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(id, userId, scope.workspaceId, name, icon, color, sortOrder);
-
-  const project = db.prepare(
-    "SELECT p.*, 0 AS taskCount, 0 AS completedCount, 0 AS progress FROM task_projects p WHERE p.id = ?"
-  ).get(id);
+  taskProjectsRepository.create({ id, userId, workspaceId: scope.workspaceId, name, icon, color, sortOrder });
+  const project = taskProjectsRepository.getByIdWithStats(id);
   return c.json(project, 201);
 });
 
 // Update project
 taskProjects.put("/:id", async (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const id = c.req.param("id");
 
-  const existing = db.prepare("SELECT * FROM task_projects WHERE id = ?").get(id) as any;
+  const existing = taskProjectsRepository.getById(id);
   if (!existing) return c.json({ error: "Project not found" }, 404);
   if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
     return c.json({ error: "Forbidden", code: "FORBIDDEN" }, 403);
@@ -98,42 +75,28 @@ taskProjects.put("/:id", async (c) => {
   const color = body.color ?? existing.color;
   const sortOrder = body.sortOrder ?? existing.sortOrder;
 
-  db.prepare(
-    "UPDATE task_projects SET name = ?, icon = ?, color = ?, sortOrder = ?, updatedAt = datetime('now') WHERE id = ?"
-  ).run(name, icon, color, sortOrder, id);
-
-  const updated = db.prepare(
-    "SELECT p.*, (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) AS taskCount, " +
-    "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) AS completedCount, " +
-    "CASE WHEN (SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id) > 0 " +
-    "THEN ROUND((SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id AND t.isCompleted = 1) * 100.0 / " +
-    "(SELECT COUNT(*) FROM tasks t WHERE t.projectId = p.id)) ELSE 0 END AS progress " +
-    "FROM task_projects p WHERE p.id = ?"
-  ).get(id);
+  taskProjectsRepository.update(id, { name, icon, color, sortOrder });
+  const updated = taskProjectsRepository.getByIdWithStats(id);
   return c.json(updated);
 });
 
 // Delete project (tasks are NOT deleted, just unlinked)
 taskProjects.delete("/:id", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const id = c.req.param("id");
 
-  const existing = db.prepare("SELECT * FROM task_projects WHERE id = ?").get(id) as any;
+  const existing = taskProjectsRepository.getById(id);
   if (!existing) return c.json({ error: "Project not found" }, 404);
   if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
     return c.json({ error: "Forbidden", code: "FORBIDDEN" }, 403);
   }
 
-  // Unlink tasks from this project
-  db.prepare("UPDATE tasks SET projectId = NULL WHERE projectId = ?").run(id);
-  db.prepare("DELETE FROM task_projects WHERE id = ?").run(id);
+  taskProjectsRepository.delete(id);
   return c.json({ success: true });
 });
 
 // Reorder projects
 taskProjects.put("/reorder/batch", async (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const body = await c.req.json();
   const items = body.items as { id: string; sortOrder: number }[];
@@ -146,21 +109,14 @@ taskProjects.put("/reorder/batch", async (c) => {
 
   // Fix 3: validate permissions for every project
   for (const item of safeItems) {
-    const project = db.prepare("SELECT userId, workspaceId FROM task_projects WHERE id = ?").get(item.id) as any;
+    const project = taskProjectsRepository.getById(item.id);
     if (!project) return c.json({ error: `Project ${item.id} not found`, code: "NOT_FOUND" }, 404);
     if (!canManageResource(project.userId, project.workspaceId, userId)) {
       return c.json({ error: "No permission to reorder project " + item.id, code: "FORBIDDEN" }, 403);
     }
   }
 
-  const stmt = db.prepare("UPDATE task_projects SET sortOrder = ?, updatedAt = datetime('now') WHERE id = ?");
-  const tx = db.transaction(() => {
-    for (const item of safeItems) {
-      stmt.run(item.sortOrder, item.id);
-    }
-  });
-  tx();
-
+  taskProjectsRepository.updateSortOrder(safeItems);
   return c.json({ success: true });
 });
 

--- a/backend/src/routes/task-reminders.ts
+++ b/backend/src/routes/task-reminders.ts
@@ -6,6 +6,7 @@ import {
   getUserWorkspaceRole,
   canManageResource,
 } from "../middleware/acl";
+import { taskRemindersRepository } from "../repositories";
 
 const taskReminders = new Hono();
 
@@ -148,10 +149,7 @@ taskReminders.get("/:taskId", (c) => {
   const task = db.prepare("SELECT id, userId, workspaceId FROM tasks WHERE id = ?").get(taskId) as any;
   if (!task) return c.json({ error: "Task not found" }, 404);
 
-  const rows = db.prepare(
-    "SELECT * FROM task_reminders WHERE taskId = ? AND userId = ? ORDER BY offsetMinutes ASC"
-  ).all(taskId, userId);
-
+  const rows = taskRemindersRepository.listByTaskId(taskId, userId);
   return c.json(rows);
 });
 
@@ -168,12 +166,8 @@ taskReminders.post("/:taskId", async (c) => {
   const offsetMinutes = body.offsetMinutes ?? 30;
   const id = crypto.randomUUID();
 
-  db.prepare(`
-    INSERT INTO task_reminders (id, taskId, userId, offsetMinutes, enabled)
-    VALUES (?, ?, ?, ?, 1)
-  `).run(id, taskId, userId, offsetMinutes);
-
-  const reminder = db.prepare("SELECT * FROM task_reminders WHERE id = ?").get(id);
+  taskRemindersRepository.create({ id, taskId, userId, offsetMinutes });
+  const reminder = taskRemindersRepository.getById(id);
   return c.json(reminder, 201);
 });
 
@@ -183,7 +177,7 @@ taskReminders.put("/:reminderId", async (c) => {
   const userId = c.req.header("X-User-Id")!;
   const reminderId = c.req.param("reminderId");
 
-  const existing = db.prepare("SELECT * FROM task_reminders WHERE id = ?").get(reminderId) as any;
+  const existing = taskRemindersRepository.getById(reminderId);
   if (!existing) return c.json({ error: "Reminder not found" }, 404);
   if (existing.userId !== userId) return c.json({ error: "无权修改", code: "FORBIDDEN" }, 403);
 
@@ -193,26 +187,21 @@ taskReminders.put("/:reminderId", async (c) => {
   const hasSnoozedUntil = Object.prototype.hasOwnProperty.call(body, "snoozedUntil");
   const snoozedUntil = hasSnoozedUntil ? body.snoozedUntil : existing.snoozedUntil;
 
-  db.prepare(`
-    UPDATE task_reminders SET offsetMinutes = ?, enabled = ?, snoozedUntil = ?, updatedAt = datetime('now')
-    WHERE id = ?
-  `).run(offsetMinutes, enabled ? 1 : 0, snoozedUntil, reminderId);
-
-  const updated = db.prepare("SELECT * FROM task_reminders WHERE id = ?").get(reminderId);
+  taskRemindersRepository.update(reminderId, { offsetMinutes, enabled: !!enabled, snoozedUntil });
+  const updated = taskRemindersRepository.getById(reminderId);
   return c.json(updated);
 });
 
 // 删除提醒
 taskReminders.delete("/:reminderId", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const reminderId = c.req.param("reminderId");
 
-  const existing = db.prepare("SELECT * FROM task_reminders WHERE id = ?").get(reminderId) as any;
+  const existing = taskRemindersRepository.getById(reminderId);
   if (!existing) return c.json({ error: "Reminder not found" }, 404);
   if (existing.userId !== userId) return c.json({ error: "无权删除", code: "FORBIDDEN" }, 403);
 
-  db.prepare("DELETE FROM task_reminders WHERE id = ?").run(reminderId);
+  taskRemindersRepository.delete(reminderId);
   return c.json({ success: true });
 });
 
@@ -323,10 +312,7 @@ export function scanDueReminders(): PendingReminder[] {
  * 标记提醒已通知。
  */
 export function markReminderNotified(reminderId: string) {
-  const db = getDb();
-  db.prepare(
-    "UPDATE task_reminders SET lastNotifiedAt = datetime('now'), snoozedUntil = NULL WHERE id = ?"
-  ).run(reminderId);
+  taskRemindersRepository.markNotified(reminderId);
 }
 
 export default taskReminders;

--- a/backend/src/routes/task-templates.ts
+++ b/backend/src/routes/task-templates.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { getDb } from '../db/schema';
 import crypto from 'crypto';
 import { getUserWorkspaceRole, canManageResource } from '../middleware/acl';
+import { taskTemplatesRepository } from '../repositories';
 
 const taskTemplates = new Hono();
 
@@ -26,24 +27,15 @@ function resolveScope(c: any, userId: string) {
 }
 
 taskTemplates.get('/', (c) => {
-  const db = getDb();
   const userId = c.req.header('X-User-Id')!;
   const scope = resolveScope(c, userId);
   if (scope.error) return c.json({ error: scope.error }, 403);
 
-  const rows = scope.workspaceId
-    ? db.prepare(
-        'SELECT * FROM task_templates WHERE workspaceId = ? ORDER BY createdAt DESC'
-      ).all(scope.workspaceId)
-    : db.prepare(
-        'SELECT * FROM task_templates WHERE userId = ? AND workspaceId IS NULL ORDER BY createdAt DESC'
-      ).all(userId);
-
+  const rows = taskTemplatesRepository.listByUser(userId, scope.workspaceId);
   return c.json(rows.map((r: any) => ({ ...r, items: JSON.parse(r.items || '[]') })));
 });
 
 taskTemplates.post('/', async (c) => {
-  const db = getDb();
   const userId = c.req.header('X-User-Id')!;
   const scope = resolveScope(c, userId);
   if (scope.error) return c.json({ error: scope.error }, 403);
@@ -55,20 +47,25 @@ taskTemplates.post('/', async (c) => {
   const items = normalizeTemplateItems(body.items);
 
   const id = crypto.randomUUID();
-  const now = new Date().toISOString();
-  db.prepare(
-    'INSERT INTO task_templates (id, userId, workspaceId, name, description, icon, color, items, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-  ).run(id, userId, scope.workspaceId, body.name.trim(), body.description || null, body.icon || null, body.color || null, JSON.stringify(items), now, now);
+  taskTemplatesRepository.create({
+    id,
+    userId,
+    workspaceId: scope.workspaceId,
+    name: body.name.trim(),
+    description: body.description || null,
+    icon: body.icon || null,
+    color: body.color || null,
+    items,
+  });
 
-  const row = db.prepare('SELECT * FROM task_templates WHERE id = ?').get(id) as any;
-  return c.json({ ...row, items: JSON.parse(row.items || '[]') }, 201);
+  const row = taskTemplatesRepository.getById(id);
+  return c.json({ ...row, items: JSON.parse(row?.items || '[]') }, 201);
 });
 
 taskTemplates.put('/:id', async (c) => {
-  const db = getDb();
   const userId = c.req.header('X-User-Id')!;
   const id = c.req.param('id');
-  const row = db.prepare('SELECT * FROM task_templates WHERE id = ?').get(id) as any;
+  const row = taskTemplatesRepository.getById(id);
   if (!row) return c.json({ error: 'Not found' }, 404);
 
   if (row.workspaceId) {
@@ -82,40 +79,30 @@ taskTemplates.put('/:id', async (c) => {
   }
 
   const body = await c.req.json();
-  const updates: string[] = [];
-  const params: any[] = [];
+  const updates: any = {};
 
   if (body.name !== undefined) {
     if (!body.name || typeof body.name !== 'string' || !body.name.trim()) {
       return c.json({ error: 'Name is required', code: 'INVALID_NAME' }, 400);
     }
-    updates.push('name = ?');
-    params.push(body.name.trim());
+    updates.name = body.name.trim();
   }
-  if (body.description !== undefined) { updates.push('description = ?'); params.push(body.description || null); }
-  if (body.icon !== undefined) { updates.push('icon = ?'); params.push(body.icon || null); }
-  if (body.color !== undefined) { updates.push('color = ?'); params.push(body.color || null); }
-  if (body.items !== undefined) {
-    updates.push('items = ?');
-    params.push(JSON.stringify(normalizeTemplateItems(body.items)));
-  }
+  if (body.description !== undefined) updates.description = body.description || null;
+  if (body.icon !== undefined) updates.icon = body.icon || null;
+  if (body.color !== undefined) updates.color = body.color || null;
+  if (body.items !== undefined) updates.items = normalizeTemplateItems(body.items);
 
-  if (updates.length === 0) return c.json({ ...row, items: JSON.parse(row.items || '[]') });
+  if (Object.keys(updates).length === 0) return c.json({ ...row, items: JSON.parse(row.items || '[]') });
 
-  updates.push('updatedAt = ?');
-  params.push(new Date().toISOString());
-  params.push(id);
-
-  db.prepare('UPDATE task_templates SET ' + updates.join(', ') + ' WHERE id = ?').run(...params);
-  const updated = db.prepare('SELECT * FROM task_templates WHERE id = ?').get(id) as any;
-  return c.json({ ...updated, items: JSON.parse(updated.items || '[]') });
+  taskTemplatesRepository.update(id, updates);
+  const updated = taskTemplatesRepository.getById(id);
+  return c.json({ ...updated, items: JSON.parse(updated?.items || '[]') });
 });
 
 taskTemplates.delete('/:id', (c) => {
-  const db = getDb();
   const userId = c.req.header('X-User-Id')!;
   const id = c.req.param('id');
-  const row = db.prepare('SELECT * FROM task_templates WHERE id = ?').get(id) as any;
+  const row = taskTemplatesRepository.getById(id);
   if (!row) return c.json({ error: 'Not found' }, 404);
 
   if (row.workspaceId) {
@@ -128,7 +115,7 @@ taskTemplates.delete('/:id', (c) => {
     return c.json({ error: 'Not allowed' }, 403);
   }
 
-  db.prepare('DELETE FROM task_templates WHERE id = ?').run(id);
+  taskTemplatesRepository.delete(id);
   return c.json({ success: true });
 });
 


### PR DESCRIPTION
## 概述

批量迁移任务元数据相关低风险表到 Repository 层，为后续 SQLite → PostgreSQL 做前置准备。

## 变更

- 新增 `taskRemindersRepository`
- 新增 `taskProjectsRepository`
- 新增 `taskTemplatesRepository`
- `task-reminders.ts` 中 `task_reminders` SQL 改为 Repository 调用
- `task-projects.ts` 中 `task_projects` SQL 改为 Repository 调用
- `task-templates.ts` 中 `task_templates` 常规 CRUD SQL 改为 Repository 调用

## 范围控制

- 只迁移 `task_reminders + task_projects + task_templates` 的低风险单表路径
- 不迁移 `tasks` 主表
- 不迁移 `task_dependencies`
- 不迁移 `task_attachments`
- 不改变业务行为
- 不接入 PostgreSQL
- 不新增 `DATABASE_URL`
- 不新增 `DB_DRIVER`
- 不改 Docker
- 不改 `package.json`
- 不改前端 UI
- 不改 Electron

## FAST-RV 结果

- 分支：`db/task-meta-repositories`
- commit：`9dec2e3`
- 修改文件：
  - `backend/src/repositories/taskRemindersRepository.ts`
  - `backend/src/repositories/taskProjectsRepository.ts`
  - `backend/src/repositories/taskTemplatesRepository.ts`
  - `backend/src/repositories/index.ts`
  - `backend/src/routes/task-reminders.ts`
  - `backend/src/routes/task-projects.ts`
  - `backend/src/routes/task-templates.ts`
- `taskRemindersRepository`：10 个方法
- `taskProjectsRepository`：7 个方法
- `taskTemplatesRepository`：5 个方法
- `task-reminders.ts` 中本次范围内无直连 SQL
- `task-projects.ts` 中本次范围内无直连 SQL
- `task-templates.ts` 中常规 CRUD 已迁移；`apply` 功能保留 1 处多表直连 SQL，涉及 `task_templates + task_projects + tasks`，不纳入本次单表迁移范围
- PostgreSQL 禁区未触碰
- `typecheck/build` 仍受既有 `sanitize-html` 缺失影响，与本次修改无关

## 进度说明

如按“常规 CRUD 路径”口径，合并后 Repository 前置迁移进度可更新为：

```text
13/43 = 30.2%
```

但 `task_templates.apply` 仍有 1 处多表直连 SQL，若按“全表零直连 SQL”严格口径，`task_templates` 应标记为：

```text
常规 CRUD 完成，多表 apply 专项待处理
```

PostgreSQL 实际接入仍为：

```text
0%
```

## 回滚方案

```bash
git revert <merge-commit-hash>
```

## 合并前校验

必须确认：

```text
PR head_sha == 9dec2e3
```