### PR TITLE
Validate import target permissions

### DIFF
--- a/backend/src/lib/import-target-permissions.ts
+++ b/backend/src/lib/import-target-permissions.ts
@@ -1,0 +1,104 @@
+import { getDb } from "../db/schema";
+import {
+  getUserWorkspaceRole,
+  hasPermission,
+  hasRole,
+  resolveNotebookPermission,
+} from "../middleware/acl";
+
+export type ImportTargetError = {
+  status: 400 | 403 | 404;
+  body: {
+    error: string;
+    code: string;
+    required?: string;
+    sourceWorkspaceId?: string | null;
+    targetWorkspaceId?: string | null;
+  };
+};
+
+export type WritableNotebookTarget =
+  | { ok: true; notebookId: string; workspaceId: string | null }
+  | ({ ok: false } & ImportTargetError);
+
+export function normalizeImportWorkspaceId(raw: string | null | undefined): string | null {
+  const ws = (raw || "").trim();
+  if (!ws || ws === "personal" || ws === "null") return null;
+  return ws;
+}
+
+export function requireWorkspaceWriteAccess(
+  userId: string,
+  workspaceId: string | null,
+): ImportTargetError | null {
+  if (!workspaceId) return null;
+  const role = getUserWorkspaceRole(workspaceId, userId);
+  if (hasRole(role, "editor")) return null;
+  return {
+    status: 403,
+    body: {
+      error: "您在该工作区无导入权限",
+      code: "FORBIDDEN",
+      required: "editor",
+    },
+  };
+}
+
+export function resolveWritableNotebookTarget(
+  userId: string,
+  notebookId: string,
+  expectedWorkspaceId?: string | null,
+): WritableNotebookTarget {
+  const db = getDb();
+  const nb = db
+    .prepare("SELECT id, workspaceId, isDeleted FROM notebooks WHERE id = ?")
+    .get(notebookId) as
+    | { id: string; workspaceId: string | null; isDeleted: number }
+    | undefined;
+
+  if (!nb) {
+    return {
+      ok: false,
+      status: 404,
+      body: { error: "笔记本不存在", code: "NOTEBOOK_NOT_FOUND" },
+    };
+  }
+
+  if (nb.isDeleted === 1) {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: "笔记本已删除，无法导入", code: "NOTEBOOK_TRASHED" },
+    };
+  }
+
+  const targetWorkspaceId = nb.workspaceId || null;
+  const sourceWorkspaceId = expectedWorkspaceId ?? null;
+  if (expectedWorkspaceId !== undefined && targetWorkspaceId !== sourceWorkspaceId) {
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: "笔记本不属于当前导入工作区",
+        code: "NOTEBOOK_WORKSPACE_MISMATCH",
+        sourceWorkspaceId,
+        targetWorkspaceId,
+      },
+    };
+  }
+
+  const { permission } = resolveNotebookPermission(notebookId, userId);
+  if (!hasPermission(permission, "write")) {
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: "您在该笔记本无导入权限",
+        code: "FORBIDDEN",
+        required: "write",
+      },
+    };
+  }
+
+  return { ok: true, notebookId, workspaceId: targetWorkspaceId };
+}

--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -14,6 +14,10 @@ import {
 import { getUserWorkspaceRole } from "../middleware/acl";
 import { callAIChat, callAIChatStream, extractTextFromChatCompletion, sanitizeError } from "../services/ai-client";
 import { aiCustomPromptsRepository } from "../repositories";
+import {
+  requireWorkspaceWriteAccess,
+  resolveWritableNotebookTarget,
+} from "../lib/import-target-permissions";
 
 const ai = new Hono();
 
@@ -848,6 +852,13 @@ ai.post("/parse-document", async (c) => {
       return c.json({ error: "文件内容为空或无法解析" }, 400);
     }
 
+    let targetWorkspaceId: string | null = null;
+    if (notebookId) {
+      const target = resolveWritableNotebookTarget(userId, notebookId);
+      if (!target.ok) return c.json(target.body, target.status as any);
+      targetWorkspaceId = target.workspaceId;
+    }
+
     // 使用 AI 将内容转换为规范的 Markdown 格式
     const aiPrompt = formatMode === "note"
       ? "请将以下文档内容整理为结构化的笔记格式（Markdown），合理使用标题层级、列表、表格、代码块等元素，保留原始信息不丢失，使内容清晰易读："
@@ -893,9 +904,9 @@ ai.post("/parse-document", async (c) => {
       const contentText = markdownContent.replace(/[#*`>\-|_\[\]()]/g, "").replace(/\n{2,}/g, "\n").trim();
 
       db.prepare(`
-        INSERT INTO notes (id, title, content, contentText, notebookId, userId, isFavorite, isPinned, isTrashed, isLocked, version, createdAt, updatedAt)
-        VALUES (?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 1, datetime('now'), datetime('now'))
-      `).run(noteId, title, JSON.stringify({ type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: markdownContent }] }] }), contentText, notebookId, userId);
+        INSERT INTO notes (id, title, content, contentText, notebookId, userId, workspaceId, isFavorite, isPinned, isTrashed, isLocked, version, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 1, datetime('now'), datetime('now'))
+      `).run(noteId, title, JSON.stringify({ type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: markdownContent }] }] }), contentText, notebookId, userId, targetWorkspaceId);
 
       return c.json({
         success: true,
@@ -1381,6 +1392,11 @@ ai.post("/import-to-knowledge", async (c) => {
     // 如果没有指定 notebookId，自动查找/创建一个"知识库文档"笔记本（按 scope 隔离）
     let targetNotebookId = notebookId;
     if (!targetNotebookId) {
+      const deniedWorkspace = requireWorkspaceWriteAccess(userId, workspaceId);
+      if (deniedWorkspace) {
+        return c.json(deniedWorkspace.body, deniedWorkspace.status as any);
+      }
+
       let existing: { id: string } | undefined;
       if (workspaceId === null) {
         // 个人空间：按 (userId, workspaceId IS NULL) 匹配
@@ -1403,22 +1419,10 @@ ai.post("/import-to-knowledge", async (c) => {
         ).run(targetNotebookId, userId, workspaceId);
       }
     } else {
-      // 用户显式传了 notebookId：必须确保它在当前 scope 内，避免把工作区文档塞到
-      // 个人空间笔记本（或反之），同时阻断越权写入。
-      const nb = db.prepare(
-        "SELECT id, userId, workspaceId FROM notebooks WHERE id = ?",
-      ).get(targetNotebookId) as { id: string; userId: string; workspaceId: string | null } | undefined;
-      if (!nb) {
-        return c.json({ error: "笔记本不存在" }, 404);
-      }
-      const nbWs = nb.workspaceId || null;
-      if (nbWs !== workspaceId) {
-        return c.json({ error: "笔记本不属于当前工作区" }, 403);
-      }
-      // 个人空间下还要确保是当前用户自己的笔记本
-      if (workspaceId === null && nb.userId !== userId) {
-        return c.json({ error: "无权写入该笔记本" }, 403);
-      }
+      // 用户显式传了 notebookId：必须确保它在当前 scope 内且当前用户可写。
+      const target = resolveWritableNotebookTarget(userId, targetNotebookId, workspaceId);
+      if (!target.ok) return c.json(target.body, target.status as any);
+      targetNotebookId = target.notebookId;
     }
 
     const results: { fileName: string; success: boolean; noteId?: string; error?: string }[] = [];
@@ -2527,5 +2531,4 @@ ai.post("/notebook-mermaid", async (c) => {
   }
 });
 export default ai;
-
 

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -4,6 +4,11 @@ import { extractInlineBase64Images } from "./attachments";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { broadcastToUser } from "../services/realtime";
 import { isSystemAdmin } from "../middleware/acl";
+import {
+  normalizeImportWorkspaceId,
+  requireWorkspaceWriteAccess,
+  resolveWritableNotebookTarget,
+} from "../lib/import-target-permissions";
 
 const app = new Hono();
 
@@ -123,9 +128,10 @@ app.post("/import", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const wsRaw = c.req.query("workspaceId") ?? undefined;
-  // 工作区参数：personal/空 → null（写库时也是 NULL），否则保持字符串
-  const targetWs: string | null =
-    !wsRaw || wsRaw.trim() === "" || wsRaw.trim() === "personal" ? null : wsRaw.trim();
+  const wsWasExplicit = wsRaw !== undefined && wsRaw.trim() !== "";
+  // 工作区参数：personal/空 → null（写库时也是 NULL），否则保持字符串。
+  // 显式 notebookId 会在解析后以笔记本所属 workspace 为准。
+  let targetWs: string | null = normalizeImportWorkspaceId(wsRaw);
 
   // 闸门：个人空间导入——按当前用户的 users.personalImportEnabled 判定（方案 B）
   const denied = denyIfPersonalFeatureDisabled(
@@ -152,6 +158,23 @@ app.post("/import", async (c) => {
 
   if (!notes || !Array.isArray(notes) || notes.length === 0) {
     return c.json({ error: "No notes provided" }, 400);
+  }
+
+  let explicitNotebookId: string | null = null;
+  if (notebookId) {
+    const target = resolveWritableNotebookTarget(
+      userId,
+      notebookId,
+      wsWasExplicit ? targetWs : undefined,
+    );
+    if (!target.ok) return c.json(target.body, target.status as any);
+    explicitNotebookId = target.notebookId;
+    targetWs = target.workspaceId;
+  } else {
+    const deniedWorkspace = requireWorkspaceWriteAccess(userId, targetWs);
+    if (deniedWorkspace) {
+      return c.json(deniedWorkspace.body, deniedWorkspace.status as any);
+    }
   }
 
   const { v4: uuid } = require("uuid");
@@ -227,11 +250,11 @@ app.post("/import", async (c) => {
 
   // 决定"默认笔记本 id"：
   // - 若前端传了 notebookId，则所有笔记都归到该 id（覆盖 note.notebookName）
-  //   注意：调用方有责任保证该 id 属于目标 workspace；后端不强校验。
+  //   后端会校验该 notebook 可写，并从 notebook 继承 workspaceId。
   // - 否则若传了全局 notebookName，按该名找/建（限定在 targetWs 域）
   // - 否则每条 note 若带 notebookName 就按各自名找/建，没带的归到"导入的笔记"
   const explicitFallbackId =
-    notebookId ||
+    explicitNotebookId ||
     (notebookName && notebookName.trim() ? getOrCreateNotebookByName(notebookName.trim()) : null);
 
   // INSERT 时显式带 workspaceId，确保新笔记落到指定工作区。
@@ -397,12 +420,19 @@ app.post("/import/nowen-package", async (c) => {
 
   // 解析 workspaceId
   const wsRaw = c.req.query("workspaceId") ?? undefined;
+  const wsWasExplicit = wsRaw !== undefined && wsRaw.trim() !== "";
   const { sql: wsSql, param: wsParam } = workspaceFilter(wsRaw);
 
   // 闸门检查
   const isPersonalScope = wsParam === null;
   const denied = denyIfPersonalFeatureDisabled(userId, isPersonalScope, "personalImportEnabled");
   if (denied) return c.json(denied, 403);
+  if (!(importMode === "into-target" && targetNotebookId)) {
+    const deniedWorkspace = requireWorkspaceWriteAccess(userId, wsParam);
+    if (deniedWorkspace) {
+      return c.json(deniedWorkspace.body, deniedWorkspace.status as any);
+    }
+  }
 
   try {
     // 解析 multipart form data
@@ -421,7 +451,7 @@ app.post("/import/nowen-package", async (c) => {
     const { importNowenPackage } = await import("../services/nowenPackageImport");
     const result = await importNowenPackage(zipBuffer, {
       userId,
-      workspaceId: wsParam,
+      workspaceId: wsWasExplicit ? wsParam : undefined,
       targetNotebookId,
       importMode,
       dryRun,

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -133,14 +133,6 @@ app.post("/import", async (c) => {
   // 显式 notebookId 会在解析后以笔记本所属 workspace 为准。
   let targetWs: string | null = normalizeImportWorkspaceId(wsRaw);
 
-  // 闸门：个人空间导入——按当前用户的 users.personalImportEnabled 判定（方案 B）
-  const denied = denyIfPersonalFeatureDisabled(
-    userId,
-    targetWs === null,
-    "personalImportEnabled",
-  );
-  if (denied) return c.json(denied, 403);
-
   const body = await c.req.json();
   const { notes, notebookId, notebookName } = body as {
     notes: {
@@ -176,6 +168,14 @@ app.post("/import", async (c) => {
       return c.json(deniedWorkspace.body, deniedWorkspace.status as any);
     }
   }
+
+  // 闸门：个人空间导入——按解析后的最终 target scope 判定。
+  const denied = denyIfPersonalFeatureDisabled(
+    userId,
+    targetWs === null,
+    "personalImportEnabled",
+  );
+  if (denied) return c.json(denied, 403);
 
   const { v4: uuid } = require("uuid");
 

--- a/backend/src/routes/micloud.ts
+++ b/backend/src/routes/micloud.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { resolveWritableNotebookTarget } from "../lib/import-target-permissions";
 
 const app = new Hono();
 
@@ -338,6 +339,20 @@ app.post("/import", async (c) => {
     return c.json({ error: "请选择要导入的笔记" }, 400);
   }
 
+  const { getDb } = await import("../db/schema");
+  const db = getDb();
+  const userId = c.req.header("X-User-Id")!;
+  let targetNotebookId: string | null =
+    typeof notebookId === "string" && notebookId.trim() ? notebookId : null;
+  let targetWorkspaceId: string | null = null;
+
+  if (targetNotebookId) {
+    const target = resolveWritableNotebookTarget(userId, targetNotebookId);
+    if (!target.ok) return c.json(target.body, target.status as any);
+    targetNotebookId = target.notebookId;
+    targetWorkspaceId = target.workspaceId;
+  }
+
   const results: { id: string; title: string; content: string; contentText: string; createDate?: number; modifyDate?: number }[] = [];
   const errors: string[] = [];
 
@@ -384,16 +399,11 @@ app.post("/import", async (c) => {
     return c.json({ error: "没有成功获取任何笔记", errors }, 500);
   }
 
-  const { getDb } = await import("../db/schema");
-  const db = getDb();
-  const userId = c.req.header("X-User-Id")!;
-
   // 确定目标笔记本
-  let targetNotebookId = notebookId;
   if (!targetNotebookId) {
     const existing = db
       .prepare(
-        "SELECT id FROM notebooks WHERE userId = ? AND name = '小米云笔记'"
+        "SELECT id FROM notebooks WHERE userId = ? AND name = '小米云笔记' AND workspaceId IS NULL"
       )
       .get(userId) as { id: string } | undefined;
 
@@ -403,14 +413,14 @@ app.post("/import", async (c) => {
       const { v4: uuid } = require("uuid");
       targetNotebookId = uuid();
       db.prepare(
-        "INSERT INTO notebooks (id, userId, name, icon) VALUES (?, ?, '小米云笔记', '📱')"
+        "INSERT INTO notebooks (id, userId, name, icon, workspaceId) VALUES (?, ?, '小米云笔记', '📱', NULL)"
       ).run(targetNotebookId, userId);
     }
   }
 
   const insert = db.prepare(`
-    INSERT INTO notes (id, userId, notebookId, title, content, contentText, createdAt, updatedAt)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO notes (id, userId, workspaceId, notebookId, title, content, contentText, createdAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const { v4: uuid } = require("uuid");
@@ -443,6 +453,7 @@ app.post("/import", async (c) => {
       insert.run(
         id,
         userId,
+        targetWorkspaceId,
         targetNotebookId,
         note.title,
         note.content,

--- a/backend/src/routes/url-import.ts
+++ b/backend/src/routes/url-import.ts
@@ -7,6 +7,11 @@ import { getDb } from "../db/schema";
 import { createDeduplicatedAttachmentRow, ensureAttachmentsDir, MIME_TO_EXT } from "./attachments";
 import { deleteAttachmentObject, writeAttachmentObject } from "../services/attachment-storage";
 import { sanitizeForImport } from "../lib/sanitizeHtml";
+import {
+  normalizeImportWorkspaceId,
+  requireWorkspaceWriteAccess,
+  resolveWritableNotebookTarget,
+} from "../lib/import-target-permissions";
 
 const app = new Hono();
 
@@ -387,7 +392,9 @@ app.post("/", async (c) => {
   }
 
   const userId = c.req.header("X-User-Id")!;
-  const workspaceId = c.req.query("workspaceId") || null;
+  const wsRaw = c.req.query("workspaceId") ?? undefined;
+  const wsWasExplicit = wsRaw !== undefined && wsRaw.trim() !== "";
+  let workspaceId = normalizeImportWorkspaceId(wsRaw);
 
   let html: string;
   try {
@@ -432,16 +439,33 @@ app.post("/", async (c) => {
 
   // 确定目标笔记本：未指定 → "导入的文章"
   let targetNotebookId = notebookId;
-  if (!targetNotebookId) {
-    const exist = db
-      .prepare("SELECT id FROM notebooks WHERE userId = ? AND name = ?")
-      .get(userId, "导入的文章") as { id: string } | undefined;
+  if (targetNotebookId) {
+    const target = resolveWritableNotebookTarget(
+      userId,
+      targetNotebookId,
+      wsWasExplicit ? workspaceId : undefined,
+    );
+    if (!target.ok) return c.json(target.body, target.status as any);
+    workspaceId = target.workspaceId;
+  } else {
+    const deniedWorkspace = requireWorkspaceWriteAccess(userId, workspaceId);
+    if (deniedWorkspace) {
+      return c.json(deniedWorkspace.body, deniedWorkspace.status as any);
+    }
+
+    const exist = workspaceId
+      ? (db
+          .prepare("SELECT id FROM notebooks WHERE userId = ? AND name = ? AND workspaceId = ?")
+          .get(userId, "导入的文章", workspaceId) as { id: string } | undefined)
+      : (db
+          .prepare("SELECT id FROM notebooks WHERE userId = ? AND name = ? AND workspaceId IS NULL")
+          .get(userId, "导入的文章") as { id: string } | undefined);
     if (exist) {
       targetNotebookId = exist.id;
     } else {
       targetNotebookId = uuid();
-      db.prepare("INSERT INTO notebooks (id, userId, name, icon) VALUES (?, ?, ?, ?)")
-        .run(targetNotebookId, userId, "导入的文章", "📄");
+      db.prepare("INSERT INTO notebooks (id, userId, name, icon, workspaceId) VALUES (?, ?, ?, ?, ?)")
+        .run(targetNotebookId, userId, "导入的文章", "📄", workspaceId);
     }
   }
 

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -11,6 +11,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 import JSZip from "jszip";
+import { resolveWritableNotebookTarget } from "../lib/import-target-permissions";
 
 // ====== 类型定义 ======
 
@@ -364,15 +365,9 @@ export async function importNowenPackage(zipBuffer: Buffer, params: ImportParams
   let resolvedWorkspaceId: string | null = workspaceId ?? null;
 
   if (importMode === "into-target" && targetNotebookId) {
-    const target = db.prepare(
-      "SELECT id, userId, isDeleted, workspaceId FROM notebooks WHERE id = ? AND userId = ?"
-    ).get(targetNotebookId, userId) as { id: string; userId: string; isDeleted: number; workspaceId: string | null } | undefined;
-
-    if (!target) {
-      return { success: false, dryRun, warnings, errors: ["Target notebook not found or not owned by user"] };
-    }
-    if (target.isDeleted === 1) {
-      return { success: false, dryRun, warnings, errors: ["Target notebook is deleted"] };
+    const target = resolveWritableNotebookTarget(userId, targetNotebookId, workspaceId);
+    if (!target.ok) {
+      return { success: false, dryRun, warnings, errors: [target.body.error] };
     }
     // 以 target notebook 的 workspaceId 为准
     resolvedWorkspaceId = target.workspaceId;

--- a/backend/tests/import-target-permissions.test.ts
+++ b/backend/tests/import-target-permissions.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-import-targets-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+const originalFetch = globalThis.fetch;
+
+function db() {
+  return getDb();
+}
+
+function seedBase() {
+  db().exec(`
+    INSERT INTO users (id, username, passwordHash)
+    VALUES
+      ('owner', 'owner', 'hash'),
+      ('editor', 'editor', 'hash'),
+      ('viewer', 'viewer', 'hash'),
+      ('intruder', 'intruder', 'hash');
+
+    INSERT INTO workspaces (id, name, ownerId)
+    VALUES ('ws-1', 'Workspace', 'owner');
+
+    INSERT INTO workspace_members (workspaceId, userId, role)
+    VALUES
+      ('ws-1', 'owner', 'owner'),
+      ('ws-1', 'editor', 'editor'),
+      ('ws-1', 'viewer', 'viewer');
+
+    INSERT INTO notebooks (id, userId, workspaceId, name)
+    VALUES
+      ('nb-ws', 'owner', 'ws-1', 'Workspace notebook'),
+      ('nb-owner-personal', 'owner', NULL, 'Owner personal');
+
+    INSERT INTO system_settings (key, value)
+    VALUES
+      ('ai_provider', 'ollama'),
+      ('ai_api_url', 'http://ai.test'),
+      ('ai_model', 'test-model');
+  `);
+}
+
+function resetDb() {
+  db().exec(`
+    DELETE FROM notes;
+    DELETE FROM notebook_members;
+    DELETE FROM notebooks;
+    DELETE FROM workspace_members;
+    DELETE FROM workspaces;
+    DELETE FROM system_settings;
+    DELETE FROM users;
+  `);
+  seedBase();
+}
+
+function importBody(extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    notes: [
+      {
+        title: "Imported note",
+        content: "{}",
+        contentText: "Imported note",
+      },
+    ],
+    ...extra,
+  });
+}
+
+test.before(async () => {
+  const [exportModule, aiModule, schemaModule] = await Promise.all([
+    import("../src/routes/export"),
+    import("../src/routes/ai"),
+    import("../src/db/schema"),
+  ]);
+  app = new Hono();
+  app.route("/export", exportModule.default);
+  app.route("/ai", aiModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+  resetDb();
+});
+
+test.beforeEach(() => {
+  resetDb();
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({ choices: [{ message: { content: "Formatted markdown" } }] }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("export import rejects workspace writes from non-editor members", async () => {
+  const res = await app.request("/export/import?workspaceId=ws-1", {
+    method: "POST",
+    headers: {
+      "X-User-Id": "viewer",
+      "Content-Type": "application/json",
+    },
+    body: importBody(),
+  });
+
+  assert.equal(res.status, 403);
+  const count = db().prepare("SELECT COUNT(*) AS count FROM notes").get() as { count: number };
+  assert.equal(count.count, 0);
+});
+
+test("export import inherits workspace from an explicit writable notebook", async () => {
+  const res = await app.request("/export/import", {
+    method: "POST",
+    headers: {
+      "X-User-Id": "editor",
+      "Content-Type": "application/json",
+    },
+    body: importBody({ notebookId: "nb-ws" }),
+  });
+
+  assert.equal(res.status, 201);
+  const note = db()
+    .prepare("SELECT userId, notebookId, workspaceId FROM notes WHERE title = ?")
+    .get("Imported note") as
+    | { userId: string; notebookId: string; workspaceId: string | null }
+    | undefined;
+  assert.deepEqual(note, {
+    userId: "editor",
+    notebookId: "nb-ws",
+    workspaceId: "ws-1",
+  });
+});
+
+test("AI parse-document rejects notebooks the caller cannot write", async () => {
+  const form = new FormData();
+  form.set("file", new File(["plain text"], "sample.txt", { type: "text/plain" }));
+  form.set("notebookId", "nb-owner-personal");
+
+  const res = await app.request("/ai/parse-document", {
+    method: "POST",
+    headers: { "X-User-Id": "intruder" },
+    body: form,
+  });
+
+  assert.equal(res.status, 403);
+  const count = db().prepare("SELECT COUNT(*) AS count FROM notes").get() as { count: number };
+  assert.equal(count.count, 0);
+});

--- a/backend/tests/import-target-permissions.test.ts
+++ b/backend/tests/import-target-permissions.test.ts
@@ -119,7 +119,11 @@ test("export import rejects workspace writes from non-editor members", async () 
   assert.equal(count.count, 0);
 });
 
-test("export import inherits workspace from an explicit writable notebook", async () => {
+test("export import inherits workspace from an explicit writable notebook before personal gate", async () => {
+  db()
+    .prepare("UPDATE users SET personalImportEnabled = 0 WHERE id = ?")
+    .run("editor");
+
   const res = await app.request("/export/import", {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary

- Add a shared import-target permission helper for workspace and notebook write checks.
- Apply it to note import, AI document imports, URL/Xiaomi imports, and Nowen package target imports.
- Ensure explicit notebook imports inherit the notebook's workspace instead of trusting caller-supplied workspace state.
- Add route-level regression coverage for workspace import permissions, explicit notebook workspace inheritance, and AI parse-document write authorization.

## Root cause

Several import-style write paths accepted caller-provided `workspaceId` or `notebookId` targets without reusing the same write checks and workspace inheritance used by normal note creation.

## Why it matters

Bulk import and document import paths should preserve the same notebook/workspace boundaries as regular CRUD paths. This keeps imported notes attached only to targets the requester can write to, and keeps `notes.workspaceId` aligned with the target notebook.

## Validation

- `npx tsx --test tests/import-target-permissions.test.ts` passes.
- `git diff --check` passes.

Known existing blockers while running broader local checks:

- `npm run build:tsc` fails in unrelated files: missing `sanitize-html` type/module resolution, `data-file.ts` string/path typing, and `task-calendar.ts` existing strictness errors.
- `npm run build` also fails before this patch's changed code due to unresolved `sanitize-html` from `src/lib/sanitizeHtml.ts`.