### PR TITLE
feat(import): improve Siyuan rich-text tiptap fidelity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bt-detail.json
 bt-pkgs.json
 node-procs.txt
 vs-list.json
+*.err
 
 # 鸿蒙构建产物
 nowen-harmony/.hvigor/

--- a/backend/src/lib/siyuanTiptapConverter.ts
+++ b/backend/src/lib/siyuanTiptapConverter.ts
@@ -1,0 +1,395 @@
+import type { SiyuanNode } from "./siyuanSyParser";
+
+export interface TiptapJsonNode {
+    type: string;
+    attrs?: Record<string, unknown>;
+    content?: TiptapJsonNode[];
+    text?: string;
+    marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+}
+
+export interface SiyuanTiptapConvertOptions {
+    resolveAssetUrl?: (raw: string) => string | null;
+}
+
+const MARKER_NODE_TYPES = new Set([
+    "NodeHeadingC8hMarker",
+    "NodeBang",
+    "NodeOpenBracket",
+    "NodeCloseBracket",
+    "NodeOpenParen",
+    "NodeCloseParen",
+    "NodeOpenBrace",
+    "NodeCloseBrace",
+    "NodeKramdownSpanIAL",
+    "NodeBlockquoteMarker",
+    "NodeCodeBlockFenceOpenMarker",
+    "NodeCodeBlockFenceCloseMarker",
+    "NodeCodeBlockFenceInfoMarker",
+    "NodeMathBlockOpenMarker",
+    "NodeMathBlockCloseMarker",
+    "NodeSuperBlockOpenMarker",
+    "NodeSuperBlockLayoutMarker",
+    "NodeSuperBlockCloseMarker",
+    "NodeTaskListItemMarker",
+]);
+
+function getValue(node: SiyuanNode | undefined, keys: string[]): unknown {
+    if (!node) return undefined;
+    for (const key of keys) {
+        if (node[key] !== undefined) return node[key];
+        if (node.Properties?.[key] !== undefined) return node.Properties[key];
+    }
+    const lowerKeys = new Set(keys.map((key) => key.toLowerCase()));
+    for (const [key, value] of Object.entries(node.Properties || {})) {
+        if (lowerKeys.has(key.toLowerCase())) return value;
+    }
+    for (const [key, value] of Object.entries(node)) {
+        if (lowerKeys.has(key.toLowerCase())) return value;
+    }
+    return undefined;
+}
+
+function getString(node: SiyuanNode | undefined, keys: string[]): string {
+    const value = getValue(node, keys);
+    return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function looksLikeAssetOrUrl(value: string): boolean {
+    return /^(https?:|data:|blob:|file:|\/|\.\/|\.\.\/|assets\/)/i.test(value.trim()) ||
+        /\.(png|jpe?g|gif|webp|svg|bmp|ico|avif|mp4|webm|ogg|ogv|m4v|mov|mp3|wav|m4a|flac|aac)([?#].*)?$/i.test(value);
+}
+
+function extractSrc(text: string): string {
+    return text.match(/\bsrc=["']([^"']+)["']/i)?.[1] || text.match(/\(([^)]+)\)/)?.[1] || text.trim();
+}
+
+function getHeadingLevel(node: SiyuanNode): number {
+    const raw =
+        getString(node, ["HeadingLevel", "headingLevel", "level", "Level"]) ||
+        getString((node.Children || []).find((child) => child.Type === "NodeHeadingC8hMarker"), ["Data"]);
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return 1;
+    return Math.min(3, Math.max(1, parsed));
+}
+
+function isTaskItem(node: SiyuanNode): boolean {
+    return (node.Children || []).some((child) => child.Type === "NodeTaskListItemMarker") ||
+        getString(node, ["TaskChecked", "checked", "Checked"]).trim() !== "";
+}
+
+function isCheckedTask(node: SiyuanNode): boolean {
+    const data = [
+        getString(node, ["Data"]),
+        getString(node, ["TaskChecked", "checked", "Checked"]),
+        ...(node.Children || []).map((child) => getString(child, ["Data"])),
+    ]
+        .join(" ")
+        .toLowerCase();
+    return data.includes("[x]") || data.includes("checked") || data.includes("done") || data.includes("true");
+}
+
+function isOrderedList(node: SiyuanNode): boolean {
+    const hint = [
+        node.Type,
+        getString(node, ["ListData", "SubType", "subType", "listType", "type"]),
+        getString(node, ["Data"]),
+    ].join(" ").toLowerCase();
+    return /\b(ordered|order|ol|number)\b/.test(hint);
+}
+
+function withMark(node: TiptapJsonNode, mark: { type: string; attrs?: Record<string, unknown> }): TiptapJsonNode {
+    if (node.type !== "text") return node;
+    return { ...node, marks: [...(node.marks || []), mark] };
+}
+
+function textNode(text: string, marks?: TiptapJsonNode["marks"]): TiptapJsonNode[] {
+    if (!text) return [];
+    return [{ type: "text", text, ...(marks?.length ? { marks } : {}) }];
+}
+
+function trimParagraphBoundary(content: TiptapJsonNode[]): TiptapJsonNode[] {
+    const next = content.map((item) => ({ ...item }));
+    while (next[0]?.type === "text" && !next[0].marks?.length) {
+        next[0].text = (next[0].text || "").replace(/^\s+/, "");
+        if (next[0].text) break;
+        next.shift();
+    }
+    while (next[next.length - 1]?.type === "text" && !next[next.length - 1].marks?.length) {
+        const last = next[next.length - 1];
+        last.text = (last.text || "").replace(/\s+$/, "");
+        if (last.text) break;
+        next.pop();
+    }
+    return next;
+}
+
+function renderTextMark(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const markType = getString(node, ["TextMarkType", "type", "markType"]).toLowerCase();
+    const rawText = getString(node, ["TextMarkTextContent", "Text", "text", "Data"]);
+    const content = rawText ? textNode(rawText) : renderInlineContent(node, options);
+    const href = getString(node, ["TextMarkAHref", "href", "url", "dest"]);
+
+    switch (markType) {
+        case "strong":
+            return content.map((item) => withMark(item, { type: "bold" }));
+        case "em":
+            return content.map((item) => withMark(item, { type: "italic" }));
+        case "s":
+        case "strike":
+            return content.map((item) => withMark(item, { type: "strike" }));
+        case "code":
+            return content.map((item) => withMark(item, { type: "code" }));
+        case "u":
+            return content.map((item) => withMark(item, { type: "underline" }));
+        case "mark":
+            return content.map((item) => withMark(item, { type: "highlight" }));
+        case "a":
+            return href ? content.map((item) => withMark(item, { type: "link", attrs: { href } })) : content;
+        default:
+            return content;
+    }
+}
+
+function renderInlineContent(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const out: TiptapJsonNode[] = [];
+    for (const child of node.Children || []) {
+        out.push(...renderInline(child, options));
+    }
+    return out;
+}
+
+function renderInline(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    if (MARKER_NODE_TYPES.has(node.Type)) return [];
+
+    switch (node.Type) {
+        case "NodeText":
+        case "NodeCodeBlockCode":
+        case "NodeMathBlockContent":
+        case "NodeLinkText":
+        case "NodeLinkDest":
+            return textNode(getString(node, ["Data"]));
+        case "NodeTextMark":
+            return renderTextMark(node, options);
+        case "NodeBr":
+            return [{ type: "hardBreak" }];
+        case "NodeBackslash":
+        case "NodeBlockRef":
+        case "NodeInlineHTML":
+            return textNode(getString(node, ["Data", "Text", "text", "Tokens", "HTML", "html"]) || renderPlainText(node));
+        default:
+            return textNode(getString(node, ["Data"]) || renderPlainText(node));
+    }
+}
+
+function renderParagraphLike(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const blocks: TiptapJsonNode[] = [];
+    let inline: TiptapJsonNode[] = [];
+    const flushParagraph = () => {
+        const content = trimParagraphBoundary(inline);
+        inline = [];
+        if (content.length > 0) {
+            blocks.push({ type: "paragraph", content });
+        }
+    };
+
+    for (const child of node.Children || []) {
+        if (MARKER_NODE_TYPES.has(child.Type)) continue;
+        if (child.Type === "NodeImage" || child.Type === "NodeVideo") {
+            flushParagraph();
+            blocks.push(...renderBlock(child, options));
+            continue;
+        }
+        inline.push(...renderInline(child, options));
+    }
+
+    flushParagraph();
+    if (blocks.length === 0) {
+        const data = getString(node, ["Data"]);
+        blocks.push(data ? { type: "paragraph", content: textNode(data) } : { type: "paragraph" });
+    }
+    return blocks;
+}
+
+function renderListItemContent(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const content: TiptapJsonNode[] = [];
+    for (const child of node.Children || []) {
+        if (MARKER_NODE_TYPES.has(child.Type)) continue;
+        if (child.Type === "NodeParagraph") {
+            const paragraph = renderParagraphLike(child, options).filter((item) => item.type === "paragraph");
+            content.push(...paragraph);
+            continue;
+        }
+        content.push(...renderBlock(child, options));
+    }
+    return content.length > 0 ? content : [{ type: "paragraph" }];
+}
+
+function renderList(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const items = (node.Children || []).filter((child) => child.Type === "NodeListItem");
+    if (items.length === 0) return [];
+
+    const taskList = items.some(isTaskItem);
+    if (taskList) {
+        return [{
+            type: "taskList",
+            content: items.map((item) => ({
+                type: "taskItem",
+                attrs: { checked: isCheckedTask(item) },
+                content: renderListItemContent(item, options),
+            })),
+        }];
+    }
+
+    return [{
+        type: isOrderedList(node) ? "orderedList" : "bulletList",
+        content: items.map((item) => ({
+            type: "listItem",
+            content: renderListItemContent(item, options),
+        })),
+    }];
+}
+
+function resolveMediaSrc(raw: string, options: SiyuanTiptapConvertOptions): string {
+    return options.resolveAssetUrl?.(raw) || raw;
+}
+
+function renderImage(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const childDest = getString((node.Children || []).find((child) => child.Type === "NodeLinkDest"), ["Data"]);
+    const explicitSrc = getString(node, ["src", "href", "url"]);
+    const data = getString(node, ["Data"]);
+    const src = childDest || explicitSrc || (looksLikeAssetOrUrl(data) ? data : "");
+    const alt =
+        getString(node, ["alt", "title"]) ||
+        getString((node.Children || []).find((child) => child.Type === "NodeLinkText"), ["Data"]) ||
+        renderPlainText((node.Children || []).find((child) => child.Type === "NodeLinkText"));
+    const title = getString((node.Children || []).find((child) => child.Type === "NodeLinkTitle"), ["Data"]);
+    if (!src) return alt ? [{ type: "paragraph", content: textNode(alt) }] : [];
+    return [{
+        type: "image",
+        attrs: {
+            src: resolveMediaSrc(src, options),
+            alt: alt || null,
+            title: title || null,
+        },
+    }];
+}
+
+function renderVideo(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const raw = getString(node, ["src", "href", "url", "Data", "Tokens", "HTML", "html"]) || renderPlainText(node);
+    const src = extractSrc(raw);
+    if (!src) return [];
+    const resolved = resolveMediaSrc(src, options);
+    return [{
+        type: "video",
+        attrs: {
+            src: resolved,
+            platform: "file",
+            kind: "file",
+            originalUrl: resolved,
+        },
+    }];
+}
+
+function renderCodeBlock(node: SiyuanNode): TiptapJsonNode[] {
+    const language =
+        getString(node, ["CodeBlockInfo", "language", "lang"]) ||
+        getString((node.Children || []).find((child) => child.Type === "NodeCodeBlockFenceInfoMarker"), ["Data"]);
+    const code =
+        getString(node, ["CodeBlockCode", "code", "Data"]) ||
+        (node.Children || [])
+            .filter((child) => child.Type === "NodeCodeBlockCode")
+            .map((child) => getString(child, ["Data"]))
+            .join("\n");
+    return [{
+        type: "codeBlock",
+        attrs: { language: language.trim() || null },
+        content: code ? [{ type: "text", text: code.replace(/\n$/, "") }] : undefined,
+    }];
+}
+
+function renderBlockquote(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    const content = renderBlocks(node.Children || [], options);
+    return [{ type: "blockquote", content: content.length > 0 ? content : [{ type: "paragraph" }] }];
+}
+
+function renderPlainText(node: SiyuanNode | undefined): string {
+    if (!node) return "";
+    const data = getString(node, ["Data", "Text", "text", "Tokens", "HTML", "html"]);
+    if (data) return data;
+    return (node.Children || []).map(renderPlainText).join("");
+}
+
+function renderDeferredMedia(node: SiyuanNode, options: SiyuanTiptapConvertOptions, label: string): TiptapJsonNode[] {
+    const raw = getString(node, ["src", "href", "url", "Data", "Tokens", "HTML", "html"]) || renderPlainText(node);
+    const src = extractSrc(raw);
+    const text = src ? label : renderPlainText(node);
+    if (!src) return text ? [{ type: "paragraph", content: textNode(text) }] : [];
+    return [{
+        type: "paragraph",
+        content: [{
+            type: "text",
+            text: label,
+            marks: [{ type: "link", attrs: { href: resolveMediaSrc(src, options) } }],
+        }],
+    }];
+}
+
+function renderBlock(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    if (MARKER_NODE_TYPES.has(node.Type)) return [];
+
+    switch (node.Type) {
+        case "NodeDocument":
+        case "NodeSuperBlock":
+            return renderBlocks(node.Children || [], options);
+        case "NodeHeading": {
+            const content = renderInlineContent(node, options);
+            return [{
+                type: "heading",
+                attrs: { level: getHeadingLevel(node) },
+                content: content.length > 0 ? content : undefined,
+            }];
+        }
+        case "NodeParagraph":
+            return renderParagraphLike(node, options);
+        case "NodeText":
+        case "NodeTextMark":
+        case "NodeBr":
+            return [{ type: "paragraph", content: renderInline(node, options) }];
+        case "NodeList":
+            return renderList(node, options);
+        case "NodeBlockquote":
+            return renderBlockquote(node, options);
+        case "NodeCodeBlock":
+            return renderCodeBlock(node);
+        case "NodeThematicBreak":
+            return [{ type: "horizontalRule" }];
+        case "NodeImage":
+            return renderImage(node, options);
+        case "NodeVideo":
+            return renderVideo(node, options);
+        case "NodeAudio":
+            return renderDeferredMedia(node, options, "音频附件");
+        case "NodeIFrame":
+        case "NodeWidget":
+            return renderDeferredMedia(node, options, "嵌入内容");
+        default: {
+            const childBlocks = renderBlocks(node.Children || [], options);
+            if (childBlocks.length > 0) return childBlocks;
+            const text = getString(node, ["Data"]) || renderPlainText(node);
+            return text ? [{ type: "paragraph", content: textNode(text) }] : [];
+        }
+    }
+}
+
+function renderBlocks(nodes: SiyuanNode[], options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
+    return nodes.flatMap((node) => renderBlock(node, options));
+}
+
+export function siyuanSyToTiptapJson(doc: SiyuanNode, options: SiyuanTiptapConvertOptions = {}): string {
+    const content = renderBlock(doc, options);
+    return JSON.stringify({
+        type: "doc",
+        content: content.length > 0 ? content : [{ type: "paragraph" }],
+    });
+}

--- a/backend/src/services/siyuanPackageImport.ts
+++ b/backend/src/services/siyuanPackageImport.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from "uuid";
 import { getDb } from "../db/schema";
 import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
 import { siyuanSyToMarkdown, type SiyuanNode } from "../lib/siyuanSyParser";
+import { siyuanSyToTiptapJson } from "../lib/siyuanTiptapConverter";
 import {
     deleteAttachmentObject,
     getUploadMonthPath,
@@ -81,13 +82,6 @@ interface NotePlan {
     attachments: AttachmentRow[];
 }
 
-interface TiptapJsonNode {
-    type: string;
-    attrs?: Record<string, unknown>;
-    content?: TiptapJsonNode[];
-    text?: string;
-}
-
 const SIYUAN_SY_EXT_RE = /\.sy$/i;
 const SIYUAN_CONF_RE = /(^|\/)\.siyuan\/conf\.json$/i;
 const ASSETS_SEGMENT_RE = /(^|\/)assets\//i;
@@ -125,90 +119,6 @@ export class SiyuanZipBudgetError extends Error {
 
 function normalizeZipPath(value: string): string {
     return String(value || "").replace(/\\/g, "/").replace(/^\/+/, "");
-}
-
-function cleanInlineMarkdownText(value: string): string {
-    return value
-        .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
-        .replace(/[*_~`]/g, "")
-        .replace(/<[^>]+>/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
-}
-
-function addParagraph(content: TiptapJsonNode[], text: string) {
-    const cleaned = cleanInlineMarkdownText(text);
-    if (!cleaned) return;
-    content.push({ type: "paragraph", content: [{ type: "text", text: cleaned }] });
-}
-
-function appendMarkdownBlockAsTiptap(content: TiptapJsonNode[], block: string) {
-    const heading = block.match(/^(#{1,6})\s+(.+)$/);
-    if (heading && !block.includes("\n")) {
-        const text = cleanInlineMarkdownText(heading[2]);
-        if (text) {
-            content.push({
-                type: "heading",
-                attrs: { level: Math.min(6, heading[1].length) },
-                content: [{ type: "text", text }],
-            });
-        }
-        return;
-    }
-
-    const mediaRe = /!\[([^\]]*)]\(([^)\s]+)(?:\s+"([^"]*)")?\)|@\[video]\(([^)]+)\)/g;
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = mediaRe.exec(block)) !== null) {
-        addParagraph(content, block.slice(lastIndex, match.index));
-        if (match[2]) {
-            content.push({
-                type: "image",
-                attrs: {
-                    src: match[2],
-                    alt: match[1] || null,
-                    title: match[3] || null,
-                },
-            });
-        } else if (match[4]) {
-            content.push({
-                type: "video",
-                attrs: {
-                    src: match[4],
-                    platform: "file",
-                    kind: "file",
-                    originalUrl: match[4],
-                },
-            });
-        }
-        lastIndex = match.index + match[0].length;
-    }
-    addParagraph(content, block.slice(lastIndex));
-}
-
-function markdownToBasicTiptapJson(markdown: string): string {
-    const content: TiptapJsonNode[] = [];
-    for (const block of markdown.replace(/\r\n/g, "\n").split(/\n{2,}/)) {
-        const trimmed = block.trim();
-        if (!trimmed) continue;
-
-        const code = trimmed.match(/^```([^\n]*)\n([\s\S]*?)\n```$/);
-        if (code) {
-            content.push({
-                type: "codeBlock",
-                attrs: { language: code[1].trim() || null },
-                content: code[2] ? [{ type: "text", text: code[2] }] : undefined,
-            });
-            continue;
-        }
-
-        appendMarkdownBlockAsTiptap(content, trimmed);
-    }
-
-    if (content.length === 0) {
-        content.push({ type: "paragraph" });
-    }
-    return JSON.stringify({ type: "doc", content });
 }
 
 function isSafeZipPath(value: string): boolean {
@@ -750,7 +660,7 @@ export async function importSiyuanPackageFromZipFile(
             const rewritten = rewriteAssetRefs(markdown, urlMap);
             const finalContent = targetContentFormat === "markdown"
                 ? rewriteMarkdownAttachmentRender(rewritten, urlMimeMap)
-                : markdownToBasicTiptapJson(rewritten);
+                : siyuanSyToTiptapJson(doc.ast, { resolveAssetUrl: (raw) => resolveAssetUrl(urlMap, raw) });
             notePlans.push({
                 id: noteId,
                 title: converted.title || doc.title,

--- a/backend/tests/siyuan-package-tiptap-fidelity.test.ts
+++ b/backend/tests/siyuan-package-tiptap-fidelity.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import JSZip from "jszip";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-siyuan-tiptap-fidelity-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+const USER_ID = "siyuan-tiptap-fidelity-user";
+const WORKSPACE_ID = "siyuan-tiptap-fidelity-workspace";
+const TARGET_NOTEBOOK_ID = "siyuan-tiptap-fidelity-notebook";
+
+let closeDb: () => void;
+let getDb: () => import("better-sqlite3").Database;
+let importSiyuanPackageFromZipFile: typeof import("../src/services/siyuanPackageImport").importSiyuanPackageFromZipFile;
+
+type TiptapNode = {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TiptapNode[];
+  text?: string;
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+};
+
+function syDoc(id: string, title: string, children: any[] = []) {
+  return {
+    ID: id,
+    Type: "NodeDocument",
+    Properties: { title },
+    updated: "20260102030405",
+    Children: children,
+  };
+}
+
+function heading(level: number, children: any[]) {
+  return { Type: "NodeHeading", HeadingLevel: String(level), Children: children };
+}
+
+function paragraph(children: any[]) {
+  return { Type: "NodeParagraph", Children: children };
+}
+
+function text(value: string) {
+  return { Type: "NodeText", Data: value };
+}
+
+function textMark(type: string, value: string, attrs: Record<string, string> = {}) {
+  return {
+    Type: "NodeTextMark",
+    TextMarkType: type,
+    TextMarkTextContent: value,
+    ...attrs,
+  };
+}
+
+function hardBreak() {
+  return { Type: "NodeBr" };
+}
+
+function list(ordered: boolean, items: any[]) {
+  return {
+    Type: "NodeList",
+    SubType: ordered ? "ordered" : "bullet",
+    Children: items,
+  };
+}
+
+function listItem(children: any[], checked?: boolean) {
+  return {
+    Type: "NodeListItem",
+    TaskChecked: checked === undefined ? undefined : String(checked),
+    Children: checked === undefined
+      ? children
+      : [{ Type: "NodeTaskListItemMarker", Data: checked ? "[x]" : "[ ]" }, ...children],
+  };
+}
+
+function blockquote(children: any[]) {
+  return { Type: "NodeBlockquote", Children: children };
+}
+
+function codeBlock(language: string, code: string) {
+  return { Type: "NodeCodeBlock", CodeBlockInfo: language, CodeBlockCode: code };
+}
+
+function horizontalRule() {
+  return { Type: "NodeThematicBreak" };
+}
+
+function image(src: string, alt = "图片") {
+  return {
+    Type: "NodeImage",
+    Children: [
+      { Type: "NodeLinkText", Data: alt },
+      { Type: "NodeLinkDest", Data: src },
+    ],
+  };
+}
+
+function video(src: string) {
+  return { Type: "NodeVideo", Data: `<video src="${src}"></video>` };
+}
+
+async function writeZip(name: string, files: Record<string, string | Uint8Array>) {
+  const zip = new JSZip();
+  for (const [filePath, content] of Object.entries(files)) {
+    zip.file(filePath, content);
+  }
+  const zipPath = path.join(tmpDir, name);
+  fs.writeFileSync(zipPath, await zip.generateAsync({ type: "nodebuffer" }));
+  return zipPath;
+}
+
+function db() {
+  return getDb();
+}
+
+function seedBaseData() {
+  db()
+    .prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+  db()
+    .prepare("INSERT INTO workspaces (id, name, ownerId) VALUES (?, ?, ?)")
+    .run(WORKSPACE_ID, "思源保真测试工作区", USER_ID);
+  db()
+    .prepare("INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)")
+    .run(WORKSPACE_ID, USER_ID, "editor");
+  db()
+    .prepare("INSERT INTO notebooks (id, userId, parentId, name, icon, workspaceId) VALUES (?, ?, NULL, ?, ?, ?)")
+    .run(TARGET_NOTEBOOK_ID, USER_ID, "指定导入", "📥", WORKSPACE_ID);
+}
+
+function getNoteByTitle(title: string) {
+  return db()
+    .prepare("SELECT id, title, content, contentFormat FROM notes WHERE title = ?")
+    .get(title) as { id: string; title: string; content: string; contentFormat: string } | undefined;
+}
+
+function flattenNodes(node: TiptapNode): TiptapNode[] {
+  return [node, ...(node.content || []).flatMap((child) => flattenNodes(child))];
+}
+
+function textNodeWithMark(doc: TiptapNode, textValue: string, markType: string) {
+  return flattenNodes(doc).find(
+    (node) => node.type === "text" && node.text === textValue && node.marks?.some((mark) => mark.type === markType),
+  );
+}
+
+test.before(async () => {
+  const [serviceModule, schemaModule] = await Promise.all([
+    import("../src/services/siyuanPackageImport"),
+    import("../src/db/schema"),
+  ]);
+  importSiyuanPackageFromZipFile = serviceModule.importSiyuanPackageFromZipFile;
+  closeDb = schemaModule.closeDb;
+  getDb = schemaModule.getDb;
+  seedBaseData();
+});
+
+test.after(async () => {
+  closeDb();
+  for (let i = 0; i < 5; i++) {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    } catch (err: any) {
+      if (err?.code !== "EBUSY" && err?.code !== "ENOTEMPTY") throw err;
+      if (i === 4) return;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+});
+
+test("Rich Text import builds P0 Tiptap nodes and marks from Siyuan AST", async () => {
+  const zipPath = await writeZip("p0-fidelity.zip", {
+    "doc.sy": JSON.stringify(syDoc("doc", "P0 保真", [
+      heading(1, [text("一级标题")]),
+      heading(4, [text("四级标题")]),
+      paragraph([
+        text("普通"),
+        hardBreak(),
+        textMark("strong", "加粗"),
+        text(" "),
+        textMark("em", "斜体"),
+        text(" "),
+        textMark("s", "删除线"),
+        text(" "),
+        textMark("code", "inlineCode"),
+        text(" "),
+        textMark("u", "下划线"),
+        text(" "),
+        textMark("mark", "高亮"),
+        text(" "),
+        textMark("a", "链接", { TextMarkAHref: "https://example.com" }),
+      ]),
+      list(false, [
+        listItem([paragraph([text("无序一")])]),
+        listItem([paragraph([text("无序二")])]),
+      ]),
+      list(true, [
+        listItem([paragraph([text("有序一")])]),
+        listItem([paragraph([text("有序二")])]),
+      ]),
+      list(false, [
+        listItem([paragraph([text("任务完成")])], true),
+        listItem([paragraph([text("任务待办")])], false),
+      ]),
+      blockquote([paragraph([text("引用内容")])]),
+      codeBlock("ts", "const answer = 42;"),
+      horizontalRule(),
+      paragraph([image("assets/pic.png", "配图")]),
+      paragraph([video("assets/demo.mp4")]),
+      paragraph([image("assets/missing.png", "缺失图")]),
+      { Type: "NodeAttributeView" },
+    ])),
+    "assets/pic.png": new Uint8Array([1, 2, 3]),
+    "assets/demo.mp4": new Uint8Array([4, 5, 6, 7]),
+  });
+
+  const result = await importSiyuanPackageFromZipFile(zipPath, {
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    targetNotebookId: TARGET_NOTEBOOK_ID,
+    contentFormat: "tiptap-json",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.stats.importedAssets, 2);
+  assert.equal(result.stats.unresolvedAssets, 1);
+  assert.equal(result.stats.unsupportedNodes.NodeAttributeView, 1);
+  assert.ok(result.warnings.some((item) => item.includes("Siyuan asset not found: assets/missing.png")));
+  assert.ok(result.warnings.some((item) => item.includes("attribute view")));
+
+  const note = getNoteByTitle("P0 保真");
+  assert.ok(note);
+  assert.equal(note.contentFormat, "tiptap-json");
+  assert.doesNotMatch(note.content, /!\[[^\]]*]\(/);
+  assert.doesNotMatch(note.content, /@\[video]\(/);
+
+  const parsed = JSON.parse(note.content) as TiptapNode;
+  assert.equal(parsed.type, "doc");
+  assert.ok(Array.isArray(parsed.content));
+
+  const headings = parsed.content!.filter((node) => node.type === "heading");
+  assert.deepEqual(headings.map((node) => node.attrs?.level), [1, 3]);
+  assert.equal(headings[0].content?.[0].text, "一级标题");
+  assert.equal(headings[1].content?.[0].text, "四级标题");
+
+  assert.ok(flattenNodes(parsed).some((node) => node.type === "hardBreak"));
+  assert.ok(textNodeWithMark(parsed, "加粗", "bold"));
+  assert.ok(textNodeWithMark(parsed, "斜体", "italic"));
+  assert.ok(textNodeWithMark(parsed, "删除线", "strike"));
+  assert.ok(textNodeWithMark(parsed, "inlineCode", "code"));
+  assert.ok(textNodeWithMark(parsed, "下划线", "underline"));
+  assert.ok(textNodeWithMark(parsed, "高亮", "highlight"));
+  assert.equal(textNodeWithMark(parsed, "链接", "link")?.marks?.[0].attrs?.href, "https://example.com");
+
+  assert.ok(parsed.content!.some((node) => node.type === "bulletList"));
+  assert.ok(parsed.content!.some((node) => node.type === "orderedList"));
+  const taskList = parsed.content!.find((node) => node.type === "taskList");
+  assert.ok(taskList);
+  assert.deepEqual(taskList.content?.map((node) => node.attrs?.checked), [true, false]);
+  assert.ok(parsed.content!.some((node) => node.type === "blockquote"));
+  assert.ok(parsed.content!.some((node) => node.type === "codeBlock" && node.attrs?.language === "ts"));
+  assert.ok(parsed.content!.some((node) => node.type === "horizontalRule"));
+
+  const imageNode = parsed.content!.find((node) => node.type === "image");
+  const videoNode = parsed.content!.find((node) => node.type === "video");
+  assert.match(String(imageNode?.attrs?.src), /^\/api\/attachments\//);
+  assert.match(String(videoNode?.attrs?.src), /^\/api\/attachments\//);
+
+  const referenceCount = db()
+    .prepare("SELECT COUNT(*) AS count FROM attachment_references WHERE noteId = ?")
+    .get(note.id) as { count: number };
+  assert.equal(referenceCount.count, 2);
+});


### PR DESCRIPTION
## Summary

增强思源 `.sy` 包导入 Rich Text 模式下的 Tiptap JSON 保真度。

本 PR 在 #173 已合并的安全导入链路基础上，新增后端受限 Tiptap JSON builder，使 `contentFormat=tiptap-json` 不再依赖基础 Markdown 转换器，而是从 Siyuan AST 生成更接近前端 schema 的合法 Tiptap JSON。

覆盖内容：

- heading 1/2/3，heading 4-6 clamp 到 3
- paragraph / hardBreak
- bold / italic / strike / code / underline / highlight / link
- bulletList / orderedList / taskList / taskItem
- blockquote / codeBlock / horizontalRule
- image / video 附件 URL rewrite
- attachment_references、missing asset warnings、unsupportedNodes 不回退

附带清理：

- 将开发期错误日志文件加入 `.gitignore`，避免 `backend-dev.err` / `frontend-dev-5173.err` 进入工作区噪音

## Scope

本 PR 不包含：

- table
- audio 独立节点
- 任意 iframe
- math / callout / mermaid / embed
- 上传限制 / ZIP budget / 路径安全边界调整

这些保留到后续 P1/P2。

## Validation

```bash
cd backend
node --import tsx --test tests/siyuan-package-tiptap-fidelity.test.ts
node --import tsx --test tests/siyuan-package-import.test.ts
node --import tsx --test tests/siyuan-package-upload-limit.test.ts
node --import tsx --test tests/siyuan-package-zip-budget.test.ts
npm run build
npm run build:tsc

cd ../frontend
npm run build
```

前端 build 有既有 Vite chunk/CSS warning，但 exit 0。
