### PR TITLE
fix(import): route siyuan zip by suffix

### DIFF
--- a/frontend/src/components/DataManager.tsx
+++ b/frontend/src/components/DataManager.tsx
@@ -556,7 +556,9 @@ export default function DataManager() {
 
     try {
       if (zipFile) {
-        if (activeImportMethod === "siyuan") {
+        const lowerZipName = zipFile.name.toLowerCase();
+        const isSiyuanSyZip = lowerZipName.endsWith(".sy.zip");
+        if (activeImportMethod === "siyuan" && isSiyuanSyZip) {
           setServerSiyuanFile(zipFile);
           result = [{
             name: zipFile.name,


### PR DESCRIPTION
Summary
修复思源导入时 ZIP 包导入通道判断过于宽泛的问题。

此前在“思源导入”入口下，文件就会走后端 .sy 导入通道，导致 Markdown ZIP 也被当作 .sy 数据包处理，并报错：

No importable Siyuan .sy document found

本 PR 在前端导入分流逻辑中增加后缀判定：

仅当文件名后缀为 [.sy.zip]时，走思源后端导入通道
其它 ZIP走通用 Markdown ZIP 导入通道
变更文件：

frontend/src/components/DataManager.tsx
Scope
本 PR 仅包含导入分流条件修复，不包含：

后端思源解析逻辑调整
导入文案/i18n 文本调整
上传限制与 ZIP 预算策略
其它导入格式行为变更
Validation
 在“思源导入”入口导入 [xxx.sy.zip]，确认走后端 .sy 导入通道
 在“思源导入”入口导入 [xxx.md.zip]，确认走通用 Markdown ZIP 导入通道
 导入 [xxx.md.zip]不再出现 No importable Siyuan .sy document found
 回归检查普通 [.zip]（非 [.sy.zip]导入行为正常