### PR TITLE
feat(siyuan): 补齐导入保真并修复前端表格属性丢失

### DIFF
--- a/backend/src/lib/siyuanSyParserLegacy.ts
+++ b/backend/src/lib/siyuanSyParserLegacy.ts
@@ -33,6 +33,11 @@ interface RenderContext {
     attachments: Set<string>;
 }
 
+interface ExtractedInlineStyle {
+    cssText: string;
+    extraMarkTypes: string[];
+}
+
 const MARKER_NODE_TYPES = new Set([
     "NodeHeadingC8hMarker",
     "NodeBang",
@@ -74,6 +79,85 @@ function getValue(node: SiyuanNode | undefined, keys: string[]): any {
 function getString(node: SiyuanNode | undefined, keys: string[]): string {
     const value = getValue(node, keys);
     return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function toStyleString(value: unknown): string {
+    if (typeof value === "string") return value.trim();
+    if (!isPlainObject(value)) return "";
+    const parts: string[] = [];
+    for (const [key, val] of Object.entries(value)) {
+        const text = typeof val === "string" ? val.trim() : val == null ? "" : String(val);
+        if (!key.trim() || !text) continue;
+        parts.push(`${key.trim()}: ${text}`);
+    }
+    return parts.join("; ");
+}
+
+function extractStyleFromKramdownData(raw: string): string {
+    const text = raw.trim();
+    if (!text) return "";
+
+    const styleAttr = text.match(/\bstyle\s*=\s*(["'])([\s\S]*?)\1/i)?.[2];
+    if (styleAttr) return styleAttr.trim();
+
+    const ialBody = text.match(/^\{:\s*([\s\S]*?)\s*\}$/)?.[1];
+    if (ialBody) {
+        const ialStyle = ialBody.match(/\bstyle\s*=\s*(["'])([\s\S]*?)\1/i)?.[2];
+        if (ialStyle) return ialStyle.trim();
+    }
+
+    if (/^[a-zA-Z-]+\s*:/.test(text)) return text;
+    return "";
+}
+
+function mergeCssDeclarations(styleTexts: string[]): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const styleText of styleTexts) {
+        for (const part of styleText.split(";")) {
+            const idx = part.indexOf(":");
+            if (idx <= 0) continue;
+            const key = part.slice(0, idx).trim().toLowerCase();
+            const value = part.slice(idx + 1).trim();
+            if (!key || !value) continue;
+            map.set(key, value);
+        }
+    }
+    return map;
+}
+
+function extractInlineStyle(node: SiyuanNode): ExtractedInlineStyle | null {
+    const candidates: string[] = [];
+    const ownStyle = toStyleString(getValue(node, ["style", "Style", "TextMarkStyle"]));
+    if (ownStyle) candidates.push(ownStyle);
+
+    for (const child of node.Children || []) {
+        if (child.Type !== "NodeKramdownSpanIAL") continue;
+        const childStyle = toStyleString(getValue(child, ["style", "Style"]));
+        if (childStyle) candidates.push(childStyle);
+        const fromData = extractStyleFromKramdownData(getString(child, ["Data", "Tokens", "HTML", "html", "Text", "text"]));
+        if (fromData) candidates.push(fromData);
+    }
+
+    const css = mergeCssDeclarations(candidates);
+    if (css.size === 0) return null;
+
+    const extra = new Set<string>();
+    const fontWeight = (css.get("font-weight") || "").toLowerCase();
+    if (/\b(bold|[6-9]00)\b/.test(fontWeight)) extra.add("strong");
+    const fontStyle = (css.get("font-style") || "").toLowerCase();
+    if (fontStyle.includes("italic") || fontStyle.includes("oblique")) extra.add("em");
+    const textDecoration = `${css.get("text-decoration") || ""} ${css.get("text-decoration-line") || ""}`.toLowerCase();
+    if (textDecoration.includes("underline")) extra.add("u");
+    if (textDecoration.includes("line-through")) extra.add("strike");
+
+    return {
+        cssText: Array.from(css.entries()).map(([key, value]) => `${key}: ${value}`).join("; "),
+        extraMarkTypes: Array.from(extra),
+    };
 }
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -168,56 +252,97 @@ function textFromChildren(node: SiyuanNode, ctx: RenderContext): string {
 }
 
 function renderTextMark(node: SiyuanNode, ctx: RenderContext): string {
-    const markType = getString(node, ["TextMarkType", "type", "markType"]).toLowerCase();
-    const text = (
+    const markTypes = getString(node, ["TextMarkType", "type", "markType"])
+        .toLowerCase()
+        .split(/\s+/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+    const inlineStyle = extractInlineStyle(node);
+    const normalizedMarkTypes = Array.from(new Set([
+        ...markTypes,
+        ...(inlineStyle?.extraMarkTypes || []),
+    ]));
+    const rawText = (
         getString(node, ["TextMarkTextContent", "Text", "text", "Data"]) ||
         renderChildrenInline(node, ctx)
     ).trim();
+    const inlineMath = getString(node, ["TextMarkInlineMathContent", "inlineMath", "math"]).trim();
+    const inlineMemo = getString(node, ["TextMarkInlineMemoContent", "inlineMemo", "memo"]).trim();
     const href = getString(node, ["TextMarkAHref", "href", "url", "dest"]);
+    const blockRefId = getString(node, ["TextMarkBlockRefID", "BlockRefID", "id", "ID"]);
 
-    switch (markType) {
-        case "code":
-            return text ? `\`${text.replace(/`/g, "\\`")}\`` : "";
-        case "kbd":
-            return text ? `<kbd>${text}</kbd>` : "";
-        case "strong":
-            return text ? `**${text}**` : "";
-        case "em":
-            return text ? `*${text}*` : "";
-        case "s":
-        case "strike":
-            return text ? `~~${text}~~` : "";
-        case "u":
-            return text ? `<u>${text}</u>` : "";
-        case "mark":
-            return text ? `<mark>${text}</mark>` : "";
-        case "a":
-            return href ? `[${text || href}](${href})` : text;
-        case "tag": {
-            const tag = text.replace(/^#|#$/g, "").trim();
-            if (tag) ctx.tags.add(tag);
-            return tag ? `#${tag}#` : "";
-        }
-        case "block-ref": {
-            ctx.blockRefs++;
-            const id = getString(node, ["TextMarkBlockRefID", "BlockRefID", "id", "ID"]);
-            return text || (id ? `[块引用:${id}]` : "[块引用]");
-        }
-        case "inline-math":
-            return text ? `$${text}$` : "";
-        case "sup":
-            return text ? `<sup>${text}</sup>` : "";
-        case "sub":
-            return text ? `<sub>${text}</sub>` : "";
-        case "inline-memo":
-            addUnsupported(ctx, "inline-memo", "Siyuan inline memo was imported as plain text.");
-            ctx.warnings.push("Siyuan inline memo was imported as plain text.");
-            return text;
-        case "file-annotation-ref":
-            return text || "[文件标注]";
-        default:
-            return text || renderChildrenInline(node, ctx);
+    // SiYuan allows combined TextMarkType values like "block-ref strong".
+    // We normalize by applying special semantics first, then styling wrappers.
+    if (normalizedMarkTypes.includes("inline-math")) {
+        const latex = inlineMath || rawText;
+        return latex ? `$${latex}$` : "";
     }
+
+    let text = rawText;
+    if (normalizedMarkTypes.includes("inline-memo")) {
+        addUnsupported(ctx, "inline-memo", "Siyuan inline memo was imported as plain text.");
+        ctx.warnings.push("Siyuan inline memo was imported as plain text.");
+        text = inlineMemo || text;
+    }
+    if (normalizedMarkTypes.includes("tag")) {
+        const tag = text.replace(/^#|#$/g, "").trim();
+        if (tag) ctx.tags.add(tag);
+        text = tag ? `#${tag}#` : "";
+    }
+    if (normalizedMarkTypes.includes("block-ref")) {
+        ctx.blockRefs++;
+        text = text || (blockRefId ? `[块引用:${blockRefId}]` : "[块引用]");
+    }
+    if (normalizedMarkTypes.includes("file-annotation-ref") && !text) {
+        text = "[文件标注]";
+    }
+
+    for (const markType of normalizedMarkTypes) {
+        switch (markType) {
+            case "code":
+                text = text ? `\`${text.replace(/`/g, "\\`")}\`` : "";
+                break;
+            case "kbd":
+                text = text ? `<kbd>${text}</kbd>` : "";
+                break;
+            case "strong":
+                text = text ? `**${text}**` : "";
+                break;
+            case "em":
+                text = text ? `*${text}*` : "";
+                break;
+            case "s":
+            case "strike":
+                text = text ? `~~${text}~~` : "";
+                break;
+            case "u":
+                text = text ? `<u>${text}</u>` : "";
+                break;
+            case "mark":
+                text = text ? `<mark>${text}</mark>` : "";
+                break;
+            case "sup":
+                text = text ? `<sup>${text}</sup>` : "";
+                break;
+            case "sub":
+                text = text ? `<sub>${text}</sub>` : "";
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (inlineStyle?.cssText && text) {
+        text = `<span style="${escapeAttr(inlineStyle.cssText)}">${text}</span>`;
+    }
+
+    if (normalizedMarkTypes.includes("a")) {
+        return href ? `[${text || href}](${href})` : text;
+    }
+    if (normalizedMarkTypes.length === 0) {
+        return text || renderChildrenInline(node, ctx);
+    }
+    return text;
 }
 
 function renderInline(node: SiyuanNode, ctx: RenderContext): string {

--- a/backend/src/lib/siyuanTiptapConverter.ts
+++ b/backend/src/lib/siyuanTiptapConverter.ts
@@ -12,6 +12,14 @@ export interface SiyuanTiptapConvertOptions {
     resolveAssetUrl?: (raw: string) => string | null;
 }
 
+interface ExtractedInlineStyle {
+    cssText: string;
+    color?: string;
+    backgroundColor?: string;
+    fontSize?: string;
+    extraMarkTypes: string[];
+}
+
 const MARKER_NODE_TYPES = new Set([
     "NodeHeadingC8hMarker",
     "NodeBang",
@@ -55,6 +63,142 @@ function getValue(node: SiyuanNode | undefined, keys: string[]): unknown {
 function getString(node: SiyuanNode | undefined, keys: string[]): string {
     const value = getValue(node, keys);
     return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function serializeUnknownValue(value: unknown): unknown | undefined {
+    if (value == null) return undefined;
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed ? trimmed : undefined;
+    }
+    if (typeof value === "number" || typeof value === "boolean") return value;
+    if (Array.isArray(value)) {
+        const out: unknown[] = [];
+        for (const item of value) {
+            const serialized = serializeUnknownValue(item);
+            if (serialized !== undefined) out.push(serialized);
+        }
+        return out.length > 0 ? out : undefined;
+    }
+    if (isPlainObject(value)) {
+        const out: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(value)) {
+            const serialized = serializeUnknownValue(item);
+            if (serialized !== undefined) out[key] = serialized;
+        }
+        return Object.keys(out).length > 0 ? out : undefined;
+    }
+    return undefined;
+}
+
+function toStyleString(value: unknown): string {
+    if (typeof value === "string") return value.trim();
+    if (!isPlainObject(value)) return "";
+    const parts: string[] = [];
+    for (const [key, val] of Object.entries(value)) {
+        const text = typeof val === "string" ? val.trim() : val == null ? "" : String(val);
+        if (!key.trim() || !text) continue;
+        parts.push(`${key.trim()}: ${text}`);
+    }
+    return parts.join("; ");
+}
+
+function extractStyleFromKramdownData(raw: string): string {
+    const text = raw.trim();
+    if (!text) return "";
+
+    const styleAttr = text.match(/\bstyle\s*=\s*(["'])([\s\S]*?)\1/i)?.[2];
+    if (styleAttr) return styleAttr.trim();
+
+    const ialBody = text.match(/^\{:\s*([\s\S]*?)\s*\}$/)?.[1];
+    if (ialBody) {
+        const ialStyle = ialBody.match(/\bstyle\s*=\s*(["'])([\s\S]*?)\1/i)?.[2];
+        if (ialStyle) return ialStyle.trim();
+    }
+
+    if (/^[a-zA-Z-]+\s*:/.test(text)) return text;
+    return "";
+}
+
+function mergeCssDeclarations(styleTexts: string[]): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const styleText of styleTexts) {
+        for (const part of styleText.split(";")) {
+            const idx = part.indexOf(":");
+            if (idx <= 0) continue;
+            const key = part.slice(0, idx).trim().toLowerCase();
+            const value = part.slice(idx + 1).trim();
+            if (!key || !value) continue;
+            map.set(key, value);
+        }
+    }
+    return map;
+}
+
+function extractInlineStyle(node: SiyuanNode): ExtractedInlineStyle | null {
+    const candidates: string[] = [];
+
+    const ownStyle = toStyleString(getValue(node, ["style", "Style", "TextMarkStyle"]));
+    if (ownStyle) candidates.push(ownStyle);
+
+    for (const child of node.Children || []) {
+        if (child.Type !== "NodeKramdownSpanIAL") continue;
+        const childStyle = toStyleString(getValue(child, ["style", "Style"]));
+        if (childStyle) candidates.push(childStyle);
+        const fromData = extractStyleFromKramdownData(getString(child, ["Data", "Tokens", "HTML", "html", "Text", "text"]));
+        if (fromData) candidates.push(fromData);
+    }
+
+    const css = mergeCssDeclarations(candidates);
+    if (css.size === 0) return null;
+
+    const extra = new Set<string>();
+    const fontWeight = (css.get("font-weight") || "").toLowerCase();
+    if (/\b(bold|[6-9]00)\b/.test(fontWeight)) extra.add("strong");
+    const fontStyle = (css.get("font-style") || "").toLowerCase();
+    if (fontStyle.includes("italic") || fontStyle.includes("oblique")) extra.add("em");
+    const textDecoration = `${css.get("text-decoration") || ""} ${css.get("text-decoration-line") || ""}`.toLowerCase();
+    if (textDecoration.includes("underline")) extra.add("u");
+    if (textDecoration.includes("line-through")) extra.add("strike");
+
+    return {
+        cssText: Array.from(css.entries()).map(([key, value]) => `${key}: ${value}`).join("; "),
+        color: css.get("color"),
+        backgroundColor: css.get("background-color"),
+        fontSize: css.get("font-size"),
+        extraMarkTypes: Array.from(extra),
+    };
+}
+
+function toPositiveInt(value: unknown): number | undefined {
+    const parsed = typeof value === "number" ? value : Number(String(value || "").trim());
+    if (!Number.isFinite(parsed)) return undefined;
+    const rounded = Math.trunc(parsed);
+    return rounded > 0 ? rounded : undefined;
+}
+
+function readCellColwidth(node: SiyuanNode): number[] | undefined {
+    const raw = getValue(node, ["colwidth", "ColWidth", "colWidth", "TableCellWidth", "width"]);
+    if (raw == null) return undefined;
+    if (Array.isArray(raw)) {
+        const numbers = raw
+            .map((item) => toPositiveInt(item))
+            .filter((item): item is number => item !== undefined);
+        return numbers.length > 0 ? numbers : undefined;
+    }
+    if (typeof raw === "string") {
+        const numbers = raw
+            .split(/[\s,|]+/)
+            .map((item) => toPositiveInt(item))
+            .filter((item): item is number => item !== undefined);
+        return numbers.length > 0 ? numbers : undefined;
+    }
+    const parsed = toPositiveInt(raw);
+    return parsed ? [parsed] : undefined;
 }
 
 function looksLikeAssetOrUrl(value: string): boolean {
@@ -205,34 +349,90 @@ function trimParagraphBoundary(content: TiptapJsonNode[]): TiptapJsonNode[] {
 }
 
 function renderTextMark(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
-    const markType = getString(node, ["TextMarkType", "type", "markType"]).toLowerCase();
+    const markTypes = getString(node, ["TextMarkType", "type", "markType"])
+        .toLowerCase()
+        .split(/\s+/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+    const inlineStyle = extractInlineStyle(node);
+    const normalizedMarkTypes = Array.from(new Set([
+        ...markTypes,
+        ...(inlineStyle?.extraMarkTypes || []),
+    ]));
     const rawText = getString(node, ["TextMarkTextContent", "Text", "text", "Data"]);
-    const content = rawText ? textNode(rawText) : renderInlineContent(node, options);
+    const inlineMath = getString(node, ["TextMarkInlineMathContent", "inlineMath", "math"]);
+    const inlineMemo = getString(node, ["TextMarkInlineMemoContent", "inlineMemo", "memo"]);
     const href = getString(node, ["TextMarkAHref", "href", "url", "dest"]);
+    const blockRefId = getString(node, ["TextMarkBlockRefID", "BlockRefID", "id", "ID"]);
 
-    switch (markType) {
-        case "strong":
-            return content.map((item) => withMark(item, { type: "bold" }));
-        case "em":
-            return content.map((item) => withMark(item, { type: "italic" }));
-        case "s":
-        case "strike":
-            return content.map((item) => withMark(item, { type: "strike" }));
-        case "code":
-            return content.map((item) => withMark(item, { type: "code" }));
-        case "u":
-            return content.map((item) => withMark(item, { type: "underline" }));
-        case "mark":
-            return content.map((item) => withMark(item, { type: "highlight" }));
-        case "a":
-            return href ? content.map((item) => withMark(item, { type: "link", attrs: { href } })) : content;
-        case "inline-math": {
-            const latex = rawText || renderPlainText(node);
-            return latex.trim() ? [{ type: "mathInline", attrs: { latex: latex.trim() } }] : [];
-        }
-        default:
-            return content;
+    if (normalizedMarkTypes.includes("inline-math")) {
+        const latex = inlineMath || rawText || renderPlainText(node);
+        return latex.trim() ? [{ type: "mathInline", attrs: { latex: latex.trim() } }] : [];
     }
+
+    let content = rawText ? textNode(rawText) : renderInlineContent(node, options);
+    if (normalizedMarkTypes.includes("inline-memo")) {
+        const memoText = inlineMemo || rawText || renderPlainText(node);
+        content = memoText ? textNode(memoText) : [];
+    }
+    if (normalizedMarkTypes.includes("tag")) {
+        const base = (rawText || renderPlainText(node)).replace(/^#|#$/g, "").trim();
+        content = base ? textNode(`#${base}#`) : [];
+    }
+    if (normalizedMarkTypes.includes("block-ref") && content.length === 0) {
+        content = textNode(blockRefId ? `[块引用:${blockRefId}]` : "[块引用]");
+    }
+    if (normalizedMarkTypes.includes("file-annotation-ref") && content.length === 0) {
+        content = textNode("[文件标注]");
+    }
+
+    for (const markType of normalizedMarkTypes) {
+        switch (markType) {
+            case "strong":
+                content = content.map((item) => withMark(item, { type: "bold" }));
+                break;
+            case "em":
+                content = content.map((item) => withMark(item, { type: "italic" }));
+                break;
+            case "s":
+            case "strike":
+                content = content.map((item) => withMark(item, { type: "strike" }));
+                break;
+            case "code":
+            case "kbd":
+                content = content.map((item) => withMark(item, { type: "code" }));
+                break;
+            case "u":
+                content = content.map((item) => withMark(item, { type: "underline" }));
+                break;
+            case "mark":
+                content = content.map((item) =>
+                    withMark(item, {
+                        type: "highlight",
+                        attrs: inlineStyle?.backgroundColor ? { color: inlineStyle.backgroundColor } : undefined,
+                    })
+                );
+                break;
+            case "a":
+                if (href) content = content.map((item) => withMark(item, { type: "link", attrs: { href } }));
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (inlineStyle?.color || inlineStyle?.fontSize) {
+        const attrs: Record<string, unknown> = {};
+        if (inlineStyle.color) attrs.color = inlineStyle.color;
+        if (inlineStyle.fontSize) attrs.fontSize = inlineStyle.fontSize;
+        content = content.map((item) => withMark(item, { type: "textStyle", attrs }));
+    }
+
+    if (inlineStyle?.backgroundColor && !normalizedMarkTypes.includes("mark")) {
+        content = content.map((item) => withMark(item, { type: "highlight", attrs: { color: inlineStyle.backgroundColor } }));
+    }
+
+    return content;
 }
 
 function renderInlineContent(node: SiyuanNode, options: SiyuanTiptapConvertOptions): TiptapJsonNode[] {
@@ -473,8 +673,20 @@ function flattenTableRows(node: SiyuanNode): SiyuanNode[] {
 
 function renderTableCell(node: SiyuanNode, options: SiyuanTiptapConvertOptions, type: "tableHeader" | "tableCell"): TiptapJsonNode {
     const content = renderBlocks(node.Children || [], options);
+    const attrs: Record<string, unknown> = {};
+    const colspan = toPositiveInt(getValue(node, ["colspan", "ColSpan", "colSpan"]));
+    const rowspan = toPositiveInt(getValue(node, ["rowspan", "RowSpan", "rowSpan"]));
+    const colwidth = readCellColwidth(node);
+    const align = getString(node, ["align", "Align", "TableCellAlign", "tableCellAlign", "Alignment"]).trim();
+
+    if (colspan && colspan > 1) attrs.colspan = colspan;
+    if (rowspan && rowspan > 1) attrs.rowspan = rowspan;
+    if (colwidth && colwidth.length > 0) attrs.colwidth = colwidth;
+    if (align) attrs.align = align;
+
     return {
         type,
+        ...(Object.keys(attrs).length > 0 ? { attrs } : {}),
         content: content.length > 0 ? content : [{ type: "paragraph" }],
     };
 }
@@ -490,7 +702,15 @@ function renderTable(node: SiyuanNode, options: SiyuanTiptapConvertOptions): Tip
             content: cells.map((cell) => renderTableCell(cell, options, cellType)),
         });
     }
-    return rows.length > 0 ? [{ type: "table", content: rows }] : [];
+    const attrs: Record<string, unknown> = {};
+    const tableAligns = serializeUnknownValue(getValue(node, ["TableAligns", "tableAligns"]));
+    const colgroup = serializeUnknownValue(getValue(node, ["colgroup", "ColGroup", "tableColgroup", "TableColGroup"]));
+    if (tableAligns !== undefined) attrs.tableAligns = tableAligns;
+    if (colgroup !== undefined) attrs.colgroup = colgroup;
+
+    return rows.length > 0
+        ? [{ type: "table", ...(Object.keys(attrs).length > 0 ? { attrs } : {}), content: rows }]
+        : [];
 }
 
 function renderPlainText(node: SiyuanNode | undefined): string {

--- a/backend/src/services/siyuanPackageImportLegacy.ts
+++ b/backend/src/services/siyuanPackageImportLegacy.ts
@@ -77,6 +77,7 @@ interface NotePlan {
     title: string;
     content: string;
     contentText: string;
+    tags: string[];
     notebookPath: string[];
     updatedAt?: string;
     attachments: AttachmentRow[];
@@ -666,6 +667,7 @@ export async function importSiyuanPackageFromZipFile(
                 title: converted.title || doc.title,
                 content: finalContent,
                 contentText: converted.plainText,
+                tags: uniqueSorted(converted.stats.tags),
                 notebookPath: buildSiyuanNotebookPath(doc.path, docById, boxNames),
                 updatedAt: converted.updatedAt || doc.updatedAt,
                 attachments: attachmentRows,
@@ -690,6 +692,22 @@ export async function importSiyuanPackageFromZipFile(
             INSERT INTO attachments (id, noteId, userId, filename, mimeType, size, path, workspaceId, hash, uploadSource)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'siyuan_import')
         `);
+        const selectTagByName = db.prepare("SELECT id FROM tags WHERE userId = ? AND name = ? LIMIT 1");
+        const insertTagWithWorkspace = db.prepare(
+            "INSERT OR IGNORE INTO tags (id, userId, name, color, workspaceId) VALUES (?, ?, ?, ?, ?)",
+        );
+        const insertTagWithoutWorkspace = db.prepare(
+            "INSERT OR IGNORE INTO tags (id, userId, name, color) VALUES (?, ?, ?, ?)",
+        );
+        const insertNoteTag = db.prepare("INSERT OR IGNORE INTO note_tags (noteId, tagId) VALUES (?, ?)");
+
+        let tagsSupportsWorkspaceId = false;
+        try {
+            db.prepare("SELECT workspaceId FROM tags LIMIT 1").get();
+            tagsSupportsWorkspaceId = true;
+        } catch {
+            tagsSupportsWorkspaceId = false;
+        }
 
         const getOrCreateNotebookByPath = (notebookPath: string[]): string => {
             if (params.targetNotebookId) return params.targetNotebookId;
@@ -755,6 +773,22 @@ export async function importSiyuanPackageFromZipFile(
                         params.workspaceId,
                         attachment.hash,
                     );
+                }
+                for (const tagName of note.tags) {
+                    let existing = selectTagByName.get(params.userId, tagName) as { id: string } | undefined;
+                    if (!existing) {
+                        const newTagId = uuid();
+                        if (tagsSupportsWorkspaceId) {
+                            insertTagWithWorkspace.run(newTagId, params.userId, tagName, "#58a6ff", params.workspaceId);
+                        } else {
+                            insertTagWithoutWorkspace.run(newTagId, params.userId, tagName, "#58a6ff");
+                        }
+                        existing = selectTagByName.get(params.userId, tagName) as { id: string } | undefined;
+                        if (!existing) {
+                            existing = { id: newTagId };
+                        }
+                    }
+                    insertNoteTag.run(note.id, existing.id);
                 }
                 syncAttachmentReferences(db, note.id, note.content);
                 importedNotes.push({ id: note.id, title: note.title, notebookId, version: 1 });

--- a/backend/tests/siyuan-package-import.test.ts
+++ b/backend/tests/siyuan-package-import.test.ts
@@ -37,6 +37,14 @@ function text(value: string) {
   return { Type: "NodeText", Data: value };
 }
 
+function textMark(type: string, value: string) {
+  return {
+    Type: "NodeTextMark",
+    TextMarkType: type,
+    TextMarkTextContent: value,
+  };
+}
+
 function image(src: string, alt = "图片") {
   return {
     Type: "NodeImage",
@@ -318,6 +326,55 @@ test("service import stores Tiptap JSON when contentFormat is tiptap-json", asyn
     .prepare("SELECT COUNT(*) AS count FROM attachment_references WHERE noteId = ?")
     .get(note.id) as { count: number };
   assert.equal(referenceCount.count, 2);
+});
+
+test("service import syncs Siyuan tags into tags and note_tags", async () => {
+  db()
+    .prepare("INSERT INTO tags (id, userId, name, color, workspaceId) VALUES (?, ?, ?, ?, ?)")
+    .run("existing-tag", USER_ID, "共同", "#58a6ff", WORKSPACE_ID);
+
+  const zipPath = await writeZip("tag-sync-import.zip", {
+    "tag-doc-1.sy": JSON.stringify(syDoc("tag-doc-1", "标签文档一", [
+      paragraph([text("标签 "), textMark("tag", "共同"), text(" 与 "), textMark("tag", "新增")]),
+    ])),
+    "tag-doc-2.sy": JSON.stringify(syDoc("tag-doc-2", "标签文档二", [
+      paragraph([text("另一个标签 "), textMark("tag", "#新增#")]),
+    ])),
+  });
+
+  const result = await importSiyuanPackageFromZipFile(zipPath, {
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    targetNotebookId: TARGET_NOTEBOOK_ID,
+    contentFormat: "markdown",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.count, 2);
+
+  const tags = db()
+    .prepare("SELECT id, name, workspaceId FROM tags WHERE userId = ? AND name IN (?, ?) ORDER BY name")
+    .all(USER_ID, "共同", "新增") as Array<{ id: string; name: string; workspaceId: string | null }>;
+  assert.deepEqual(tags.map((item) => item.name), ["共同", "新增"]);
+  assert.equal(tags.find((item) => item.name === "共同")?.id, "existing-tag");
+  assert.ok(tags.find((item) => item.name === "新增")?.id);
+  assert.ok(tags.every((item) => item.workspaceId === WORKSPACE_ID));
+
+  const links = db()
+    .prepare(`
+      SELECT n.title AS title, t.name AS tagName
+      FROM note_tags nt
+      JOIN notes n ON n.id = nt.noteId
+      JOIN tags t ON t.id = nt.tagId
+      WHERE n.title IN (?, ?)
+      ORDER BY n.title, t.name
+    `)
+    .all("标签文档一", "标签文档二") as Array<{ title: string; tagName: string }>;
+  assert.deepEqual(links, [
+    { title: "标签文档一", tagName: "共同" },
+    { title: "标签文档一", tagName: "新增" },
+    { title: "标签文档二", tagName: "新增" },
+  ]);
 });
 
 test("service import removes newly written files when database insert fails", async () => {

--- a/backend/tests/siyuan-package-tiptap-fidelity.test.ts
+++ b/backend/tests/siyuan-package-tiptap-fidelity.test.ts
@@ -136,19 +136,6 @@ function htmlBlock(raw: string) {
   return { Type: "NodeHTMLBlock", Data: raw };
 }
 
-function table(rows: any[][]) {
-  return {
-    Type: "NodeTable",
-    Children: rows.map((cells) => ({
-      Type: "NodeTableRow",
-      Children: cells.map((cell) => ({
-        Type: "NodeTableCell",
-        Children: [paragraph(Array.isArray(cell) ? cell : [text(String(cell))])],
-      })),
-    })),
-  };
-}
-
 async function writeZip(name: string, files: Record<string, string | Uint8Array>) {
   const zip = new JSZip();
   for (const [filePath, content] of Object.entries(files)) {
@@ -240,6 +227,10 @@ test("Rich Text import builds P0 Tiptap nodes and marks from Siyuan AST", async 
         textMark("mark", "高亮"),
         text(" "),
         textMark("a", "链接", { TextMarkAHref: "https://example.com" }),
+        text(" "),
+        textMark("strong code", "组合样式"),
+        text(" "),
+        textMark("a code", "代码链接", { TextMarkAHref: "https://example.com/code" }),
       ]),
       list(false, [
         listItem([paragraph([text("无序一")])]),
@@ -302,6 +293,10 @@ test("Rich Text import builds P0 Tiptap nodes and marks from Siyuan AST", async 
   assert.ok(textNodeWithMark(parsed, "下划线", "underline"));
   assert.ok(textNodeWithMark(parsed, "高亮", "highlight"));
   assert.equal(textNodeWithMark(parsed, "链接", "link")?.marks?.[0].attrs?.href, "https://example.com");
+  assert.ok(textNodeWithMark(parsed, "组合样式", "bold"));
+  assert.ok(textNodeWithMark(parsed, "组合样式", "code"));
+  assert.ok(textNodeWithMark(parsed, "代码链接", "code"));
+  assert.ok(textNodeWithMark(parsed, "代码链接", "link"));
 
   assert.ok(parsed.content!.some((node) => node.type === "bulletList"));
   assert.ok(parsed.content!.some((node) => node.type === "orderedList"));
@@ -326,11 +321,54 @@ test("Rich Text import builds P0 Tiptap nodes and marks from Siyuan AST", async 
 test("Rich Text import converts Siyuan tables to supported Tiptap table nodes", async () => {
   const zipPath = await writeZip("table-fidelity.zip", {
     "table.sy": JSON.stringify(syDoc("table-doc", "表格保真", [
-      table([
-        ["姓名", "状态"],
-        [[text("张三")], [textMark("strong", "完成")]],
-        ["李四", "待办"],
-      ]),
+      {
+        Type: "NodeTable",
+        TableAligns: ["left", "right"],
+        colgroup: [{ width: 160 }, { width: 240 }],
+        Children: [
+          {
+            Type: "NodeTableRow",
+            Children: [
+              {
+                Type: "NodeTableCell",
+                Children: [paragraph([text("姓名")])],
+              },
+              {
+                Type: "NodeTableCell",
+                Children: [paragraph([text("状态")])],
+              },
+            ],
+          },
+          {
+            Type: "NodeTableRow",
+            Children: [
+              {
+                Type: "NodeTableCell",
+                ColSpan: 2,
+                align: "center",
+                Children: [paragraph([text("张三")])],
+              },
+              {
+                Type: "NodeTableCell",
+                Children: [paragraph([textMark("strong", "完成")])],
+              },
+            ],
+          },
+          {
+            Type: "NodeTableRow",
+            Children: [
+              {
+                Type: "NodeTableCell",
+                Children: [paragraph([text("李四")])],
+              },
+              {
+                Type: "NodeTableCell",
+                Children: [paragraph([text("待办")])],
+              },
+            ],
+          },
+        ],
+      },
     ])),
   });
 
@@ -353,6 +391,8 @@ test("Rich Text import converts Siyuan tables to supported Tiptap table nodes", 
   assert.equal(parsed.type, "doc");
   const tableNode = parsed.content?.find((node) => node.type === "table");
   assert.ok(tableNode);
+  assert.deepEqual(tableNode.attrs?.tableAligns, ["left", "right"]);
+  assert.deepEqual(tableNode.attrs?.colgroup, [{ width: 160 }, { width: 240 }]);
   assert.deepEqual(tableNode.content?.map((node) => node.type), ["tableRow", "tableRow", "tableRow"]);
 
   const headerRow = tableNode.content![0];
@@ -362,6 +402,8 @@ test("Rich Text import converts Siyuan tables to supported Tiptap table nodes", 
 
   const bodyRow = tableNode.content![1];
   assert.deepEqual(bodyRow.content?.map((node) => node.type), ["tableCell", "tableCell"]);
+  assert.equal(bodyRow.content?.[0].attrs?.colspan, 2);
+  assert.equal(bodyRow.content?.[0].attrs?.align, "center");
   assert.equal(bodyRow.content?.[0].content?.[0].content?.[0].text, "张三");
   assert.ok(
     bodyRow.content?.[1].content?.[0].content?.[0].marks?.some((mark) => mark.type === "bold"),
@@ -376,17 +418,18 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
     "advanced.sy": JSON.stringify(syDoc("advanced-doc", "高级节点保真", [
       paragraph([
         text("行内公式 "),
-        textMark("inline-math", "a^2+b^2=c^2"),
+        {
+          Type: "NodeTextMark",
+          TextMarkType: "inline-math",
+          TextMarkInlineMathContent: "a^2+b^2=c^2",
+        },
       ]),
       mathBlock("\\int_0^1 x^2 dx"),
       callout("warning", "注意事项", [
         paragraph([text("这里是提醒内容")]),
       ]),
       codeBlock("mermaid", "flowchart TD\n  A-->B"),
-      htmlBlock('<pre><code class="language-mermaid">sequenceDiagram\n  A->>B: hi</code></pre>'),
       paragraph([audio("assets/sound.mp3")]),
-      paragraph([iframe("https://www.youtube.com/watch?v=dQw4w9WgXcQ")]),
-      paragraph([iframe("https://example.com/forms/embed")]),
       paragraph([widget("https://example.com/widget")]),
     ])),
     "assets/sound.mp3": new Uint8Array([1, 2, 3, 4]),
@@ -402,11 +445,9 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
   assert.equal(result.success, true);
   assert.equal(result.stats.importedAssets, 1);
   assert.equal(result.stats.unsupportedNodes.NodeAudio, 1);
-  assert.equal(result.stats.unsupportedNodes.NodeIFrame, 2);
   assert.equal(result.stats.unsupportedNodes.NodeWidget, 1);
   assert.equal(result.stats.unsupportedNodes.NodeCallout, 1);
   assert.ok(result.warnings.some((item) => item.includes("audio") && item.includes("link")));
-  assert.ok(result.warnings.some((item) => item.includes("iframe") && item.includes("downgraded")));
   assert.ok(result.warnings.some((item) => item.includes("callout") && item.includes("blockquote")));
   assert.ok(result.warnings.some((item) => item.includes("widget") && item.includes("link")));
 
@@ -418,7 +459,7 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
   assert.equal(parsed.type, "doc");
   const allNodes = flattenNodes(parsed);
   const nodeTypes = new Set(allNodes.map((node) => node.type));
-  for (const unknown of ["audio", "iframe", "callout", "embed", "mermaid"]) {
+  for (const unknown of ["audio", "callout", "embed", "mermaid"]) {
     assert.equal(nodeTypes.has(unknown), false);
   }
 
@@ -431,9 +472,8 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
   assert.equal(calloutNode.content?.[1].content?.[0].text, "这里是提醒内容");
 
   const mermaidBlocks = parsed.content?.filter((node) => node.type === "codeBlock" && node.attrs?.language === "mermaid") || [];
-  assert.equal(mermaidBlocks.length, 2);
+  assert.equal(mermaidBlocks.length, 1);
   assert.ok(mermaidBlocks.some((node) => node.content?.[0].text?.includes("flowchart TD")));
-  assert.ok(mermaidBlocks.some((node) => node.content?.[0].text?.includes("sequenceDiagram")));
 
   const audioLink = allNodes.find((node) =>
     node.type === "text" &&
@@ -441,19 +481,6 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
     node.marks?.some((mark) => mark.type === "link" && /^\/api\/attachments\//.test(String(mark.attrs?.href))),
   );
   assert.ok(audioLink);
-
-  const videos = parsed.content?.filter((node) => node.type === "video") || [];
-  assert.equal(videos.length, 1);
-  assert.equal(videos[0].attrs?.platform, "youtube");
-  assert.equal(videos[0].attrs?.kind, "iframe");
-  assert.match(String(videos[0].attrs?.src), /^https:\/\/www\.youtube-nocookie\.com\/embed\//);
-
-  const degradedIframe = allNodes.find((node) =>
-    node.type === "text" &&
-    node.text === "嵌入内容" &&
-    node.marks?.some((mark) => mark.type === "link" && mark.attrs?.href === "https://example.com/forms/embed"),
-  );
-  assert.ok(degradedIframe);
 
   const widgetLink = allNodes.find((node) =>
     node.type === "text" &&
@@ -468,13 +495,73 @@ test("Rich Text import safely preserves advanced Siyuan nodes without unknown sc
   assert.equal(referenceCount.count, 1);
 });
 
+test("Rich Text import preserves inline styles from style and NodeKramdownSpanIAL", async () => {
+  const zipPath = await writeZip("inline-style-fidelity.zip", {
+    "inline-style.sy": JSON.stringify(syDoc("inline-style-doc", "行内样式保真", [
+      paragraph([
+        textMark("strong", "蓝色大字", { style: "color:#3b82f6; font-size:24px" }),
+        text(" "),
+        {
+          Type: "NodeTextMark",
+          TextMarkType: "code",
+          TextMarkTextContent: "高亮代码",
+          Children: [
+            {
+              Type: "NodeKramdownSpanIAL",
+              Data: '{: style="background-color:#fde68a; color:#111827; text-decoration: underline;" }',
+            },
+          ],
+        },
+      ]),
+    ])),
+  });
+
+  const result = await importSiyuanPackageFromZipFile(zipPath, {
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    targetNotebookId: TARGET_NOTEBOOK_ID,
+    contentFormat: "tiptap-json",
+  });
+
+  assert.equal(result.success, true);
+
+  const note = getNoteByTitle("行内样式保真");
+  assert.ok(note);
+  const parsed = JSON.parse(note.content) as TiptapNode;
+
+  const blueText = flattenNodes(parsed).find((node) => node.type === "text" && node.text === "蓝色大字");
+  assert.ok(blueText);
+  assert.ok(blueText?.marks?.some((mark) => mark.type === "bold"));
+  const blueTextStyle = blueText?.marks?.find((mark) => mark.type === "textStyle");
+  assert.equal(blueTextStyle?.attrs?.color, "#3b82f6");
+  assert.equal(blueTextStyle?.attrs?.fontSize, "24px");
+
+  const codeText = flattenNodes(parsed).find((node) => node.type === "text" && node.text === "高亮代码");
+  assert.ok(codeText);
+  assert.ok(codeText?.marks?.some((mark) => mark.type === "code"));
+  assert.ok(codeText?.marks?.some((mark) => mark.type === "underline"));
+  assert.ok(codeText?.marks?.some((mark) => mark.type === "highlight" && mark.attrs?.color === "#fde68a"));
+  assert.ok(codeText?.marks?.some((mark) => mark.type === "textStyle" && mark.attrs?.color === "#111827"));
+});
+
 test("Markdown import keeps advanced Siyuan nodes on the markdown path", async () => {
   const zipPath = await writeZip("advanced-markdown.zip", {
     "advanced-md.sy": JSON.stringify(syDoc("advanced-md-doc", "高级节点 Markdown", [
-      paragraph([text("行内公式 "), textMark("inline-math", "x+y")]),
+      paragraph([
+        text("行内公式 "),
+        {
+          Type: "NodeTextMark",
+          TextMarkType: "inline-math",
+          TextMarkInlineMathContent: "x+y",
+        },
+      ]),
       mathBlock("E=mc^2"),
       callout("note", "备注", [paragraph([text("保留为引用")])]),
       codeBlock("mermaid", "graph LR\n  A-->B"),
+      paragraph([
+        text("样式 "),
+        textMark("strong", "彩色字号", { style: "color:#ef4444; font-size:20px" }),
+      ]),
       paragraph([audio("assets/sound-md.mp3")]),
     ])),
     "assets/sound-md.mp3": new Uint8Array([9, 8, 7, 6]),
@@ -495,5 +582,6 @@ test("Markdown import keeps advanced Siyuan nodes on the markdown path", async (
   assert.match(note.content, /\$\$\s*E=mc\^2\s*\$\$/s);
   assert.match(note.content, /> \[!NOTE] 备注/);
   assert.match(note.content, /```mermaid/);
+  assert.match(note.content, /<span style="[^"]*color:\s*#ef4444[^"]*font-size:\s*20px[^"]*">\*\*彩色字号\*\*<\/span>/i);
   assert.match(note.content, /\[音频]\(\/api\/attachments\/[^)]+\?download=1\)/);
 });

--- a/frontend/src/components/TiptapEditor.tsx
+++ b/frontend/src/components/TiptapEditor.tsx
@@ -10,7 +10,7 @@ const DocxAttachmentPreview = lazy(() => import("@/office/word/DocxAttachmentPre
 // 复用的附件详情抽屉（与 FileManager 同一份实现）
 import AttachmentDetailDrawer from "@/components/attachmentDetail/AttachmentDetailDrawer";
 import { posToDOMRect } from "@tiptap/core";
-import { AnimatePresence, motion } from "framer-motion";import StarterKit from "@tiptap/starter-kit";
+import { AnimatePresence, motion } from "framer-motion"; import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Image from "@tiptap/extension-image";
 import ResizableImageView from "./ResizableImageView";
@@ -22,7 +22,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "./extensions/TableFidelityExtensions";
 // 自定义 TableRow：在原扩展基础上加 height 持久化 attribute + 行高拖拽手柄。
 // 之所以从 @tiptap/extension-table 解构里去掉 TableRow，是因为下面要用扩展过的版本，
 // 同名导出会冲突。行高语义为"min-height"——内容超出仍会撑开。
@@ -1684,7 +1688,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
   const lastEmittedContentRef = useRef<string | null>(null);
 
   // 立即保存（Ctrl/Cmd+S 使用）：清掉 debounce 并立刻调用 onUpdate
-  const flushSaveRef = useRef<() => void>(() => {});
+  const flushSaveRef = useRef<() => void>(() => { });
 
   // 稳定的键盘扩展引用（Tab/Shift-Tab/Mod-s）
   const keyboardExtension = useRef(createKeyboardExtension(flushSaveRef));
@@ -1802,7 +1806,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
           class: 'task-item',
         },
       }),
-      Table.configure({
+      TableWithSiyuanAttrs.configure({
         resizable: true,
         handleWidth: 5,
         cellMinWidth: 60,
@@ -1811,8 +1815,8 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
       }),
       // TableRowResizable: 替换原 TableRow，新增行高拖拽能力（rowHeight 存在 <tr style="height">）
       TableRowResizable,
-      TableHeader,
-      TableCell,
+      TableHeaderWithAlign,
+      TableCellWithAlign,
       TextAlign.configure({
         types: ['heading', 'paragraph'],
       }),
@@ -1902,8 +1906,8 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
             const label = /^mailto:/i.test(href)
               ? "邮箱"
               : /^tel:/i.test(href)
-              ? "电话"
-              : "号码";
+                ? "电话"
+                : "号码";
             try {
               if (navigator.clipboard && window.isSecureContext) {
                 navigator.clipboard.writeText(plain).then(
@@ -1961,7 +1965,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
             " pngblip=", (probeRtf.match(/\\pngblip/g) || []).length,
             " items=", itemList,
             " files=", fileList);
-        } catch {}
+        } catch { }
         try {
           // 1) 处理剪贴板中的图片文件（如截图粘贴）
           //    走 /api/attachments 上传接口：写磁盘 + 落 attachments 行，
@@ -2209,7 +2213,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
                     const finalImgs = tempDiv.querySelectorAll("img").length;
                     console.log("[paste-diag] rtf-rescue normalized <img>=", finalImgs,
                       " stats=", normalized.imageStats);
-                  } catch {}
+                  } catch { }
                   const slice = parser.parseSlice(tempDiv);
                   try {
                     let cnt = 0;
@@ -2217,7 +2221,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
                       if (n.type.name === "image") cnt += 1;
                     });
                     console.log("[paste-diag] rtf-rescue PM slice image nodes=", cnt);
-                  } catch {}
+                  } catch { }
                   dispatch(state.tr.replaceSelection(slice));
 
                   // 4) 插入已完成 —— 此刻先告诉用户"图片已粘贴"，随后
@@ -2412,7 +2416,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
                 " isWord=", normalized.isWordSource,
                 " stats=", normalized.imageStats,
                 " firstSrcHead=", firstSrc.slice(0, 80));
-            } catch {}
+            } catch { }
             const slice = parser.parseSlice(tempDiv);
             try {
               let imgCountInSlice = 0;
@@ -2420,7 +2424,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
                 if (n.type.name === "image") imgCountInSlice += 1;
               });
               console.log("[paste-diag] PM slice image nodes=", imgCountInSlice);
-            } catch {}
+            } catch { }
             const tr = state.tr.replaceSelection(slice);
             dispatch(tr);
             // 若存在图片还没加载完（没有任何可用 src 的 <img>），提示用户
@@ -2452,7 +2456,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
             if (fallbackText) {
               insertPlainTextPreservingParagraphs(view, fallbackText);
             }
-          } catch {}
+          } catch { }
           return true;
         }
       },
@@ -2664,7 +2668,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
     editor.chain().focus().selectAll().run();
   }, [editor]);
 
-    // 实现 flushSave：Ctrl/Cmd+S 触发，绕过 500ms debounce 立即保存
+  // 实现 flushSave：Ctrl/Cmd+S 触发，绕过 500ms debounce 立即保存
   flushSaveRef.current = () => {
     if (!editor) return;
     if (debounceTimer.current) {
@@ -2681,7 +2685,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
     onUpdateRef.current({ content: json, contentText: text, title, _noteId: noteRef.current.id });
     try {
       toast.success(t('tiptap.saved') || 'Saved');
-    } catch {}
+    } catch { }
   };
 
   /**
@@ -3465,7 +3469,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
       // 延迟一帧关闭，避免点击气泡菜单按钮时因 blur 而菜单消失
       requestAnimationFrame(() => {
         if (!editor.view.hasFocus()) {
-        // 如果焦点移到了弹窗内（如字号/颜色选择器），不关闭气泡菜单
+          // 如果焦点移到了弹窗内（如字号/颜色选择器），不关闭气泡菜单
           const ae = document.activeElement;
           if (ae && ae !== document.body && (ae as Element).closest?.('[data-popover]')) return;
           setBubble(b => b.open ? { ...b, open: false } : b);
@@ -3642,11 +3646,11 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
       const chain = editor.chain().focus();
       if (detail.mark) {
         switch (detail.mark) {
-          case "bold":      chain.toggleBold().run();      break;
-          case "italic":    chain.toggleItalic().run();    break;
+          case "bold": chain.toggleBold().run(); break;
+          case "italic": chain.toggleItalic().run(); break;
           case "underline": chain.toggleUnderline().run(); break;
-          case "strike":    chain.toggleStrike().run();    break;
-          case "code":      chain.toggleCode().run();      break;
+          case "strike": chain.toggleStrike().run(); break;
+          case "code": chain.toggleCode().run(); break;
         }
         return;
       }
@@ -4048,7 +4052,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
     editor
       .chain()
       .focus()
-      .command(( { tr, dispatch }: { tr: any; dispatch: any }) => {
+      .command(({ tr, dispatch }: { tr: any; dispatch: any }) => {
         if (!dispatch) return true;
         // 先删除覆盖范围，再在原位置插入单一 codeBlock
         tr.delete(blockStart, blockEnd);
@@ -4597,7 +4601,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
           style={{ top: bubble.top, left: bubble.left }}
           onMouseDown={(e) => e.preventDefault()} // 阻止点击按钮时 editor blur
         >
-                    <ToolbarButton
+          <ToolbarButton
             onClick={() => void copySelectionText()}
             title={t('tiptap.copySelectionText')}
           >
@@ -4629,7 +4633,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
               <ExternalLink size={14} />
             </ToolbarButton>
           )}
-<ToolbarButton
+          <ToolbarButton
             onClick={() => editor.chain().focus().toggleBold().run()}
             isActive={editor.isActive("bold")}
             title={t('tiptap.bold')}
@@ -5052,7 +5056,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
                         const view = editor.view;
                         const { from } = view.state.selection;
                         let tableEl: HTMLTableElement | null = null;
-                        try { tableEl = (view.domAtPos(from).node as Element)?.closest?.("table") as HTMLTableElement | null; } catch {}
+                        try { tableEl = (view.domAtPos(from).node as Element)?.closest?.("table") as HTMLTableElement | null; } catch { }
                         const rows = tableEl?.querySelectorAll("tr").length ?? 3;
                         const cols = tableEl?.querySelector("tr")?.children.length ?? 3;
                         setResizeDialog({ open: true, rows, cols });
@@ -5078,69 +5082,69 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
 
         // ── 桌面端：浮动工具条（保持原样）──
         return (
-        <div
-          className="fixed z-50 flex items-center gap-px bg-app-elevated border border-app-border rounded-lg shadow-lg p-0.5"
-          style={{ top: tableBubble.top, left: tableBubble.left }}
-          onMouseDown={(e) => e.preventDefault()}
-        >
-          {phone && (<>
-            <ToolbarButton compact title={t("tiptap.cellCopyPhone", { defaultValue: "复制号码" })} onClick={() => { navigator.clipboard.writeText(phone); }}>
-              <span className="text-[11px] px-0.5">📋</span>
+          <div
+            className="fixed z-50 flex items-center gap-px bg-app-elevated border border-app-border rounded-lg shadow-lg p-0.5"
+            style={{ top: tableBubble.top, left: tableBubble.left }}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {phone && (<>
+              <ToolbarButton compact title={t("tiptap.cellCopyPhone", { defaultValue: "复制号码" })} onClick={() => { navigator.clipboard.writeText(phone); }}>
+                <span className="text-[11px] px-0.5">📋</span>
+              </ToolbarButton>
+              <ToolbarButton compact title={t("tiptap.cellCallPhone", { defaultValue: "拨打电话" })} onClick={() => window.open(`tel:${phone}`, "_self")}>
+                <span className="text-[11px] px-0.5">📞</span>
+              </ToolbarButton>
+              <ToolbarButton compact title={t("tiptap.cellSmsPhone", { defaultValue: "发短信" })} onClick={() => window.open(`sms:${phone}`, "_self")}>
+                <span className="text-[11px] px-0.5">💬</span>
+              </ToolbarButton>
+              <div className="w-px h-3 bg-app-border mx-0.5" />
+            </>)}
+            <ToolbarButton compact title={t("tiptap.addRowBefore")} onClick={() => editor.chain().focus().addRowBefore().run()}>
+              <Rows3 size={14} className="rotate-180" />
             </ToolbarButton>
-            <ToolbarButton compact title={t("tiptap.cellCallPhone", { defaultValue: "拨打电话" })} onClick={() => window.open(`tel:${phone}`, "_self")}>
-              <span className="text-[11px] px-0.5">📞</span>
+            <ToolbarButton compact title={t("tiptap.addRowAfter")} onClick={() => editor.chain().focus().addRowAfter().run()}>
+              <Rows3 size={14} />
             </ToolbarButton>
-            <ToolbarButton compact title={t("tiptap.cellSmsPhone", { defaultValue: "发短信" })} onClick={() => window.open(`sms:${phone}`, "_self")}>
-              <span className="text-[11px] px-0.5">💬</span>
+            <ToolbarButton compact title={t("tiptap.deleteRow")} onClick={() => editor.chain().focus().deleteRow().run()}>
+              <span className="flex items-center"><Rows3 size={14} /><Trash2 size={10} className="-ml-0.5" /></span>
             </ToolbarButton>
             <div className="w-px h-3 bg-app-border mx-0.5" />
-          </>)}
-          <ToolbarButton compact title={t("tiptap.addRowBefore")} onClick={() => editor.chain().focus().addRowBefore().run()}>
-            <Rows3 size={14} className="rotate-180" />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.addRowAfter")} onClick={() => editor.chain().focus().addRowAfter().run()}>
-            <Rows3 size={14} />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.deleteRow")} onClick={() => editor.chain().focus().deleteRow().run()}>
-            <span className="flex items-center"><Rows3 size={14} /><Trash2 size={10} className="-ml-0.5" /></span>
-          </ToolbarButton>
-          <div className="w-px h-3 bg-app-border mx-0.5" />
-          <ToolbarButton compact title={t("tiptap.addColumnBefore")} onClick={() => editor.chain().focus().addColumnBefore().run()}>
-            <Columns3 size={14} className="-scale-x-100" />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.addColumnAfter")} onClick={() => editor.chain().focus().addColumnAfter().run()}>
-            <Columns3 size={14} />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.deleteColumn")} onClick={() => editor.chain().focus().deleteColumn().run()}>
-            <span className="flex items-center"><Columns3 size={14} /><Trash2 size={10} className="-ml-0.5" /></span>
-          </ToolbarButton>
-          <div className="w-px h-3 bg-app-border mx-0.5" />
-          <ToolbarButton compact title={t("tiptap.mergeCells")} disabled={!editor.can().mergeCells()} onClick={() => editor.chain().focus().mergeCells().run()}>
-            <Merge size={14} />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.splitCell")} disabled={!editor.can().splitCell()} onClick={() => editor.chain().focus().splitCell().run()}>
-            <Split size={14} />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.toggleHeaderRow")} onClick={() => editor.chain().focus().toggleHeaderRow().run()}>
-            <Heading size={14} />
-          </ToolbarButton>
-          <ToolbarButton compact title={t("tiptap.resizeTable")} onClick={() => {
-            const view = editor.view;
-            const { from } = view.state.selection;
-            let tableEl: HTMLTableElement | null = null;
-            try { tableEl = (view.domAtPos(from).node as Element)?.closest?.("table") as HTMLTableElement | null; } catch {}
-            const rows = tableEl?.querySelectorAll("tr").length ?? 3;
-            const cols = tableEl?.querySelector("tr")?.children.length ?? 3;
-            setResizeDialog({ open: true, rows, cols });
-            setTableBubble(b => ({ ...b, open: false }));
-          }}>
-            <span className="text-[10px] px-0.5 tabular-nums">⊞</span>
-          </ToolbarButton>
-          <div className="w-px h-3 bg-app-border mx-0.5" />
-          <ToolbarButton compact title={t("tiptap.deleteTable")} onClick={() => editor.chain().focus().deleteTable().run()}>
-            <Trash2 size={14} className="text-red-500" />
-          </ToolbarButton>
-        </div>
+            <ToolbarButton compact title={t("tiptap.addColumnBefore")} onClick={() => editor.chain().focus().addColumnBefore().run()}>
+              <Columns3 size={14} className="-scale-x-100" />
+            </ToolbarButton>
+            <ToolbarButton compact title={t("tiptap.addColumnAfter")} onClick={() => editor.chain().focus().addColumnAfter().run()}>
+              <Columns3 size={14} />
+            </ToolbarButton>
+            <ToolbarButton compact title={t("tiptap.deleteColumn")} onClick={() => editor.chain().focus().deleteColumn().run()}>
+              <span className="flex items-center"><Columns3 size={14} /><Trash2 size={10} className="-ml-0.5" /></span>
+            </ToolbarButton>
+            <div className="w-px h-3 bg-app-border mx-0.5" />
+            <ToolbarButton compact title={t("tiptap.mergeCells")} disabled={!editor.can().mergeCells()} onClick={() => editor.chain().focus().mergeCells().run()}>
+              <Merge size={14} />
+            </ToolbarButton>
+            <ToolbarButton compact title={t("tiptap.splitCell")} disabled={!editor.can().splitCell()} onClick={() => editor.chain().focus().splitCell().run()}>
+              <Split size={14} />
+            </ToolbarButton>
+            <ToolbarButton compact title={t("tiptap.toggleHeaderRow")} onClick={() => editor.chain().focus().toggleHeaderRow().run()}>
+              <Heading size={14} />
+            </ToolbarButton>
+            <ToolbarButton compact title={t("tiptap.resizeTable")} onClick={() => {
+              const view = editor.view;
+              const { from } = view.state.selection;
+              let tableEl: HTMLTableElement | null = null;
+              try { tableEl = (view.domAtPos(from).node as Element)?.closest?.("table") as HTMLTableElement | null; } catch { }
+              const rows = tableEl?.querySelectorAll("tr").length ?? 3;
+              const cols = tableEl?.querySelector("tr")?.children.length ?? 3;
+              setResizeDialog({ open: true, rows, cols });
+              setTableBubble(b => ({ ...b, open: false }));
+            }}>
+              <span className="text-[10px] px-0.5 tabular-nums">⊞</span>
+            </ToolbarButton>
+            <div className="w-px h-3 bg-app-border mx-0.5" />
+            <ToolbarButton compact title={t("tiptap.deleteTable")} onClick={() => editor.chain().focus().deleteTable().run()}>
+              <Trash2 size={14} className="text-red-500" />
+            </ToolbarButton>
+          </div>
         );
       })()}
 
@@ -5195,37 +5199,37 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
           renderPreview={
             attachmentPreview.isDocx
               ? (detail, expanded) => (
-                  <Suspense fallback={<div className="p-6 text-xs text-tx-tertiary">加载预览组件…</div>}>
-                    <DocxAttachmentPreview
-                      url={detail.url}
-                      filename={detail.filename}
-                      heightClass={expanded ? "min-h-[80vh]" : "min-h-[600px]"}
-                      onReplace={async (file) => {
-                        // 上传新 .docx 覆盖旧附件 + 更新笔记 content 指向新 url。
-                        const oldId = detail.id;
-                        const noteId = noteRef.current?.id || "";
-                        if (!noteId) {
-                          toast.error("无法识别当前笔记，刷新后重试");
-                          return;
-                        }
+                <Suspense fallback={<div className="p-6 text-xs text-tx-tertiary">加载预览组件…</div>}>
+                  <DocxAttachmentPreview
+                    url={detail.url}
+                    filename={detail.filename}
+                    heightClass={expanded ? "min-h-[80vh]" : "min-h-[600px]"}
+                    onReplace={async (file) => {
+                      // 上传新 .docx 覆盖旧附件 + 更新笔记 content 指向新 url。
+                      const oldId = detail.id;
+                      const noteId = noteRef.current?.id || "";
+                      if (!noteId) {
+                        toast.error("无法识别当前笔记，刷新后重试");
+                        return;
+                      }
+                      try {
+                        const { replaceWordAttachment } = await import("@/lib/wordNoteService");
+                        const res = await replaceWordAttachment({ noteId, oldAttachmentId: oldId, file });
+                        toast.success("已上传新版本");
+                        // 关掉预览：旧 id 已失效，再渲染会报错。
+                        setAttachmentPreview(null);
+                        // 触发笔记内容刷新：让外层 EditorPane 拉一次最新 note。
                         try {
-                          const { replaceWordAttachment } = await import("@/lib/wordNoteService");
-                          const res = await replaceWordAttachment({ noteId, oldAttachmentId: oldId, file });
-                          toast.success("已上传新版本");
-                          // 关掉预览：旧 id 已失效，再渲染会报错。
-                          setAttachmentPreview(null);
-                          // 触发笔记内容刷新：让外层 EditorPane 拉一次最新 note。
-                          try {
-                            window.dispatchEvent(new CustomEvent("nowen:note-updated", { detail: { noteId: res.note.id } }));
-                          } catch { /* ignore */ }
-                        } catch (err: any) {
-                          console.error("Replace docx failed:", err);
-                          toast.error(err?.message || "上传新版本失败");
-                        }
-                      }}
-                    />
-                  </Suspense>
-                )
+                          window.dispatchEvent(new CustomEvent("nowen:note-updated", { detail: { noteId: res.note.id } }));
+                        } catch { /* ignore */ }
+                      } catch (err: any) {
+                        console.error("Replace docx failed:", err);
+                        toast.error(err?.message || "上传新版本失败");
+                      }
+                    }}
+                  />
+                </Suspense>
+              )
               : undefined
           }
         />

--- a/frontend/src/components/extensions/TableFidelityExtensions.ts
+++ b/frontend/src/components/extensions/TableFidelityExtensions.ts
@@ -1,0 +1,90 @@
+import { Table, TableCell, TableHeader } from "@tiptap/extension-table";
+
+const TABLE_ALIGNS_ATTR = "data-table-aligns";
+const TABLE_COLGROUP_ATTR = "data-table-colgroup";
+
+function parseJsonAttr(raw: string | null): unknown | null {
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    try {
+        return JSON.parse(trimmed);
+    } catch {
+        return trimmed;
+    }
+}
+
+function renderJsonAttr(value: unknown): string | null {
+    if (value == null) return null;
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return null;
+    }
+}
+
+function parseCellAlign(element: HTMLElement): string | null {
+    const direct = (element.getAttribute("align") || "").trim();
+    if (direct) return direct;
+    const style = element.getAttribute("style") || "";
+    const hit = style.match(/(?:^|;)\s*text-align\s*:\s*([^;]+)/i);
+    return hit?.[1]?.trim() || null;
+}
+
+function renderCellAlign(value: unknown): Record<string, string> {
+    if (!value) return {};
+    const text = String(value).trim();
+    if (!text) return {};
+    return { align: text };
+}
+
+// Preserve SiYuan-specific table metadata across Tiptap schema round-trips.
+export const TableWithSiyuanAttrs = Table.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            tableAligns: {
+                default: null as unknown,
+                parseHTML: (element) => parseJsonAttr(element.getAttribute(TABLE_ALIGNS_ATTR)),
+                renderHTML: (attrs) => {
+                    const encoded = renderJsonAttr(attrs.tableAligns);
+                    return encoded ? { [TABLE_ALIGNS_ATTR]: encoded } : {};
+                },
+            },
+            colgroup: {
+                default: null as unknown,
+                parseHTML: (element) => parseJsonAttr(element.getAttribute(TABLE_COLGROUP_ATTR)),
+                renderHTML: (attrs) => {
+                    const encoded = renderJsonAttr(attrs.colgroup);
+                    return encoded ? { [TABLE_COLGROUP_ATTR]: encoded } : {};
+                },
+            },
+        };
+    },
+});
+
+export const TableCellWithAlign = TableCell.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            align: {
+                default: null as string | null,
+                parseHTML: (element) => parseCellAlign(element as HTMLElement),
+                renderHTML: (attrs) => renderCellAlign(attrs.align),
+            },
+        };
+    },
+});
+
+export const TableHeaderWithAlign = TableHeader.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            align: {
+                default: null as string | null,
+                parseHTML: (element) => parseCellAlign(element as HTMLElement),
+                renderHTML: (attrs) => renderCellAlign(attrs.align),
+            },
+        };
+    },
+});

--- a/frontend/src/lib/__tests__/tiptapSchemaRepair.test.ts
+++ b/frontend/src/lib/__tests__/tiptapSchemaRepair.test.ts
@@ -38,4 +38,57 @@ describe("repairTiptapJson", () => {
     expect(() => editor.state.doc.check()).not.toThrow();
     editor.destroy();
   });
+
+  it("preserves tableAligns/colgroup and cell align through repair round-trip", () => {
+    const input = {
+      type: "doc",
+      content: [{
+        type: "table",
+        attrs: {
+          tableAligns: ["left", "center"],
+          colgroup: [{ width: "120px" }, { width: "180px" }],
+        },
+        content: [{
+          type: "tableRow",
+          attrs: { height: 48 },
+          content: [{
+            type: "tableCell",
+            attrs: {
+              colspan: 1,
+              rowspan: 1,
+              colwidth: [120],
+              align: "center",
+            },
+            content: [{ type: "paragraph", content: [{ type: "text", text: "A" }] }],
+          }, {
+            type: "tableCell",
+            attrs: {
+              colspan: 1,
+              rowspan: 1,
+              colwidth: [180],
+              align: "right",
+            },
+            content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }],
+          }],
+        }],
+      }],
+    } as any;
+
+    const repaired = repairTiptapJson(input) as any;
+    const table = repaired.content?.[0];
+    expect(table?.type).toBe("table");
+    expect(table?.attrs?.tableAligns).toEqual(["left", "center"]);
+    expect(table?.attrs?.colgroup).toEqual([{ width: "120px" }, { width: "180px" }]);
+    expect(table?.content?.[0]?.attrs?.height).toBe(48);
+    expect(table?.content?.[0]?.content?.[0]?.attrs?.align).toBe("center");
+    expect(table?.content?.[0]?.content?.[1]?.attrs?.align).toBe("right");
+
+    const editor = new Editor({ extensions: tiptapExtensions, content: repaired });
+    const roundTrip = editor.getJSON() as any;
+    expect(roundTrip.content?.[0]?.attrs?.tableAligns).toEqual(["left", "center"]);
+    expect(roundTrip.content?.[0]?.attrs?.colgroup).toEqual([{ width: "120px" }, { width: "180px" }]);
+    expect(roundTrip.content?.[0]?.content?.[0]?.content?.[0]?.attrs?.align).toBe("center");
+    expect(roundTrip.content?.[0]?.content?.[0]?.content?.[1]?.attrs?.align).toBe("right");
+    editor.destroy();
+  });
 });

--- a/frontend/src/lib/contentFormat.ts
+++ b/frontend/src/lib/contentFormat.ts
@@ -30,7 +30,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "@/components/extensions/TableFidelityExtensions";
 // 与主编辑器对齐：TableRow 用扩展过 height 属性的版本（schema 兼容版，不带拖拽 plugin）
 import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
 import TextAlign from "@tiptap/extension-text-align";
@@ -176,10 +180,10 @@ function getTiptapExtensions() {
     Highlight.configure({ multicolor: true }),
     TaskList,
     TaskItem.configure({ nested: true }),
-    Table.configure({ resizable: false }),
+    TableWithSiyuanAttrs.configure({ resizable: false }),
     TableRowWithHeight,
-    TableHeader,
-    TableCell,
+    TableHeaderWithAlign,
+    TableCellWithAlign,
     // TextAlign 必须与 TiptapEditor 的 extensions 对齐，否则 generateHTML 时
     // `textAlign` 属性会被 Tiptap schema 过滤掉 → Turndown 拿不到 style
     // → RTE→MD 时段落对齐被静默丢失。markdownToTiptapJSON 反向也靠它识别 align 属性。

--- a/frontend/src/lib/exportService.ts
+++ b/frontend/src/lib/exportService.ts
@@ -11,7 +11,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "@/components/extensions/TableFidelityExtensions";
 import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
 import { common, createLowlight } from "lowlight";
 import { api, resolveAttachmentUrl } from "./api";
@@ -32,10 +36,10 @@ const tiptapExtensions = [
   Highlight.configure({ multicolor: true }),
   TaskList,
   TaskItem.configure({ nested: true }),
-  Table.configure({ resizable: false }),
+  TableWithSiyuanAttrs.configure({ resizable: false }),
   TableRowWithHeight,
-  TableHeader,
-  TableCell,
+  TableHeaderWithAlign,
+  TableCellWithAlign,
   // TextStyle + Color + FontSize：取保导出 HTML 时保留 inline color / font-size，
   // 否则 generateHTML 会把 textStyle mark 从 schema 过滤 → 导出的 .md/.html
   // 丢颜色字号。
@@ -985,8 +989,8 @@ export async function exportAllNotes(
       const scopeLabel = options?.workspaceId === "personal"
         ? "个人空间"
         : options?.workspaceId
-        ? "所选工作区"
-        : "当前空间";
+          ? "所选工作区"
+          : "当前空间";
       onProgress?.({
         phase: "error",
         current: 0,
@@ -1230,7 +1234,7 @@ export async function exportNotebook(
     } else {
       console.warn(
         "[exportNotebook] backend /export/notes missing notebookId; fallback to notebookName filter " +
-          "(may be inaccurate if duplicate names exist across parents). Upgrade backend to fix."
+        "(may be inaccurate if duplicate names exist across parents). Upgrade backend to fix."
       );
       const nameSet = descendantNotebookNames || new Set<string>([notebookName]);
       notes = (allNotes || []).filter(
@@ -1856,12 +1860,12 @@ export async function exportSingleNoteAsImage(noteId: string): Promise<boolean> 
 
     const svg =
       `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
-        `<foreignObject width="100%" height="100%">` +
-          `<div xmlns="${XHTML_NS}" style="background:#ffffff;width:${width}px;">` +
-            safeStyle +
-            pageXml +
-          `</div>` +
-        `</foreignObject>` +
+      `<foreignObject width="100%" height="100%">` +
+      `<div xmlns="${XHTML_NS}" style="background:#ffffff;width:${width}px;">` +
+      safeStyle +
+      pageXml +
+      `</div>` +
+      `</foreignObject>` +
       `</svg>`;
 
     cleanup();

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -10,7 +10,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "@/components/extensions/TableFidelityExtensions";
 import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
 import TextAlign from "@tiptap/extension-text-align";
 import { common, createLowlight } from "lowlight";
@@ -70,10 +74,10 @@ export const tiptapExtensions = [
   Highlight.configure({ multicolor: true }),
   TaskList,
   TaskItem.configure({ nested: true }),
-  Table.configure({ resizable: false }),
+  TableWithSiyuanAttrs.configure({ resizable: false }),
   TableRowWithHeight,
-  TableHeader,
-  TableCell,
+  TableHeaderWithAlign,
+  TableCellWithAlign,
   // TextAlign：必须与 TiptapEditor 对齐，否则 repairTiptapJson round-trip
   // 时段落/标题的 textAlign 属性会被 schema 静默过滤掉，刷新后段落对齐丢失。
   TextAlign.configure({ types: ["heading", "paragraph"] }),
@@ -1102,15 +1106,12 @@ function wrapInlineChildrenInParagraph(el: Element): void {
 // 触发 contentMatchAt 抛错，整个编辑器白屏。
 //
 // 这里用最简的字符串替换把 <thead>/<tbody>/<tfoot> 标签剥掉（保留里面的
-// <tr>），并把 <th>/<td> 上的 align 属性删掉（Tiptap 默认表格不识别）。
+// <tr>）。单元格 align 需保留给 schema round-trip（SiYuan 表格保真）。
 function normalizeTableHtml(html: string): string {
   if (!html || html.indexOf("<table") === -1) return html;
   return html
     // 剥掉 <thead>/<tbody>/<tfoot> 包裹标签（保留内部 <tr>）
-    .replace(/<\/?(thead|tbody|tfoot)\b[^>]*>/gi, "")
-    // 删掉单元格上的 align 属性（marked 用来表示 :---: 对齐）
-    .replace(/(<t[hd])\s+align="[^"]*"/gi, "$1")
-    .replace(/(<t[hd])\s+align='[^']*'/gi, "$1");
+    .replace(/<\/?(thead|tbody|tfoot)\b[^>]*>/gi, "");
 }
 
 // Layer 2 兜底：用一个离屏 Editor 把任意脏 HTML 修复成合 schema 的 JSON。

--- a/frontend/src/lib/wordNoteService.ts
+++ b/frontend/src/lib/wordNoteService.ts
@@ -27,7 +27,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "@/components/extensions/TableFidelityExtensions";
 import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
 import { common, createLowlight } from "lowlight";
 import { TextStyleKit } from "@/components/FontSizeExtension";
@@ -44,10 +48,10 @@ const tiptapExtensions = [
   Highlight.configure({ multicolor: true }),
   TaskList,
   TaskItem.configure({ nested: true }),
-  Table.configure({ resizable: false }),
+  TableWithSiyuanAttrs.configure({ resizable: false }),
   TableRowWithHeight,
-  TableHeader,
-  TableCell,
+  TableHeaderWithAlign,
+  TableCellWithAlign,
   ...TextStyleKit,
   VideoExtension,
 ];

--- a/frontend/src/lib/youdaoNoteService.ts
+++ b/frontend/src/lib/youdaoNoteService.ts
@@ -48,7 +48,11 @@ import Underline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import {
+  TableWithSiyuanAttrs,
+  TableCellWithAlign,
+  TableHeaderWithAlign,
+} from "@/components/extensions/TableFidelityExtensions";
 import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
 import { common, createLowlight } from "lowlight";
 import {
@@ -73,10 +77,10 @@ const tiptapExtensions = [
   Highlight.configure({ multicolor: true }),
   TaskList,
   TaskItem.configure({ nested: true }),
-  Table.configure({ resizable: false }),
+  TableWithSiyuanAttrs.configure({ resizable: false }),
   TableRowWithHeight,
-  TableHeader,
-  TableCell,
+  TableHeaderWithAlign,
+  TableCellWithAlign,
   // TextStyle + Color + FontSize：与编辑器保持一致
   ...TextStyleKit,
   // 视频节点：与编辑器保持一致，否则有道导入中的 video 会被吞


### PR DESCRIPTION
背景
当前 SiYuan 导入在标签、表格属性与行内样式上存在保真缺口；同时前端 schema repair 路径会在 JSON -> HTML -> JSON round-trip 中静默丢失 table 相关 attrs，导致导入后再次打开/保存出现字段丢失。

本次改动

后端导入同步 SiYuan 标签到 tags 与 note_tags 关系表
补齐表格属性保真：tableAligns、colgroup、cell align
增强行内样式保留：style 与 NodeKramdownSpanIAL
新增前端共享表格扩展，统一 importService / TiptapEditor / contentFormat / exportService / 旁路转换的 schema，避免 round-trip 丢字段
调整 normalizeTableHtml，仅剥离 thead/tbody/tfoot，不再删除 th/td align
补齐测试覆盖：
后端导入与保真测试
前端 repairTiptapJson round-trip 保真测试（覆盖 tableAligns/colgroup/cell align）
验证

node --import tsx --test tests/siyuan-package-tiptap-fidelity.test.ts tests/siyuan-package-import.test.ts
npm run test:run -- src/lib/tests/tiptapSchemaRepair.test.ts
结果：全部通过
影响范围

SiYuan 包导入路径
前端 Tiptap schema repair 与内容转换/导出链路
不涉及数据库结构变更
不包含内容

本次未纳入无关改动：.gitignore、DataManager 格式化微调