### PR TITLE
fix(export): 修复 NAS 环境下 Markdown、PDF 和 Word 导出卡住

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "nowen-note-backend",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nowen-note-backend",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@types/ws": "^8.18.1",
+        "archiver": "^7.0.1",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.7.0",
         "bonjour-service": "^1.2.1",
@@ -33,6 +34,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.4",
         "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.12",
         "@types/jsonwebtoken": "^9.0.10",
@@ -865,11 +867,48 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmmirror.com/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmmirror.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/archiver": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/archiver/-/archiver-6.0.4.tgz",
+      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
     },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
@@ -917,6 +956,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmmirror.com/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sanitize-html": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
@@ -950,12 +999,291 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://mirrors.tencent.com/npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmmirror.com/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmmirror.com/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmmirror.com/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmmirror.com/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmmirror.com/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -1021,6 +1349,15 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/buffer": {
@@ -1113,9 +1450,144 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.21",
@@ -1292,12 +1764,24 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -1370,6 +1854,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
@@ -1381,6 +1892,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fd-slicer": {
@@ -1395,6 +1912,22 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -1443,6 +1976,26 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -1512,6 +2065,15 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -1521,9 +2083,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
@@ -1533,6 +2113,21 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmmirror.com/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jsonfile": {
@@ -1627,6 +2222,48 @@
         "dayjs": "^1.11.7"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/lib0": {
       "version": "0.2.117",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
@@ -1654,6 +2291,12 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -1693,6 +2336,12 @@
         "option": "~0.2.1",
         "underscore": "^1.13.1"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/lunar-javascript": {
       "version": "1.7.7",
@@ -1734,11 +2383,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -1800,6 +2473,15 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
@@ -1812,6 +2494,12 @@
       "resolved": "https://mirrors.tencent.com/npm/option/-/option-0.2.4.tgz",
       "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -1829,6 +2517,31 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pend": {
@@ -2023,6 +2736,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmmirror.com/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -2058,6 +2780,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2164,6 +2907,39 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-concat": {
@@ -2325,11 +3101,118 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmmirror.com/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2361,6 +3244,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thunky": {
@@ -2482,6 +3383,21 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/word-extractor": {
       "version": "1.0.4",
       "resolved": "https://mirrors.tencent.com/npm/word-extractor/-/word-extractor-1.0.4.tgz",
@@ -2490,6 +3406,97 @@
       "dependencies": {
         "saxes": "^5.0.1",
         "yauzl": "^2.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -2585,6 +3592,60 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "@types/ws": "^8.18.1",
+    "archiver": "^7.0.1",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^11.7.0",
     "bonjour-service": "^1.2.1",
@@ -39,6 +40,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.4",
     "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.12",
     "@types/jsonwebtoken": "^9.0.10",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -80,7 +80,7 @@ app.use("*", cors({
     return resolveCorsOrigin({ origin, isProd, corsOrigins });
   },
   allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  allowHeaders: ["Content-Type", "X-User-Id", "Authorization", "X-Sudo-Token", "X-Connection-Id", "X-Requested-With", "X-Request-Id"],
+  allowHeaders: ["Content-Type", "X-User-Id", "Authorization", "X-Sudo-Token", "X-Connection-Id", "X-Requested-With", "X-Request-Id", "X-Export-Filename"],
   credentials: true,
 }));
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import tagsRouter from "./routes/tags";
 import searchRouter from "./routes/search";
 import tasksRouter from "./routes/tasks";
 import exportRouter from "./routes/export";
+import { handleMarkdownExportDownload } from "./services/markdownExportJobs";
 import dataFileRouter from "./routes/data-file";
 import settingsRouter from "./routes/settings";
 import fontsRouter from "./routes/fonts";
@@ -303,6 +304,11 @@ app.get("/api/fonts/file/:id", (c) => {
 //     走 JWT 中间件必然 401。和字体一样把下载 handler 注册在 JWT 中间件之前。
 //   - 授权靠附件 id 不可枚举（uuid）保护；详细权衡见 routes/attachments.ts 顶部注释。
 app.get("/api/attachments/:id", handleDownloadAttachment);
+
+// 导出任务生成的 ZIP 使用随机 256-bit capability token 下载。
+// 浏览器原生下载请求无法携带 localStorage 中的 Authorization header，因此必须在
+// JWT 中间件之前注册；token 不可枚举、30 分钟过期，且响应禁止缓存。
+app.get("/api/export/download/:token", handleMarkdownExportDownload);
 
 // 任务附件下载（无需 JWT），与 attachments 同款"id 不可枚举"授权模型。
 // 任务列表里的图片缩略图通过 <img src="/api/task-attachments/<id>"> 拉取。

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -13,6 +13,7 @@ import {
   createMarkdownExportJob,
   getMarkdownExportJob,
   MarkdownExportBusyError,
+  stageGeneratedExport,
   type PreparedMarkdownNote,
 } from "../services/markdownExportJobs";
 
@@ -328,6 +329,45 @@ app.get("/markdown-package/jobs/:id", (c) => {
   const job = getMarkdownExportJob(c.req.param("id"), userId);
   if (!job) return c.json({ error: "导出任务不存在或已过期", code: "EXPORT_JOB_NOT_FOUND" }, 404);
   return c.json({ job });
+});
+
+// PDF / DOCX 依赖浏览器端排版生成，但不能继续用 about:blank Blob 下载，否则
+// Chrono 等下载扩展可能在字节收满后无法完成。这里把生成结果流式落到临时文件，
+// 再复用真实 HTTP 下载地址。
+app.post("/download-jobs", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const encodedFilename = c.req.header("X-Export-Filename") || "export.bin";
+  let filename: string;
+  try {
+    filename = decodeURIComponent(encodedFilename);
+  } catch {
+    return c.json({ error: "导出文件名无效", code: "INVALID_EXPORT_FILENAME" }, 400);
+  }
+  const contentType = (c.req.header("Content-Type") || "application/octet-stream").split(";")[0].trim();
+  const allowedTypes = new Set([
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ]);
+  if (!allowedTypes.has(contentType)) {
+    return c.json({ error: "仅支持 PDF 和 DOCX 导出中转", code: "UNSUPPORTED_EXPORT_TYPE" }, 415);
+  }
+  if (!c.req.raw.body) return c.json({ error: "导出文件为空", code: "EMPTY_EXPORT_FILE" }, 400);
+
+  try {
+    const result = await stageGeneratedExport({
+      userId,
+      filename,
+      contentType,
+      body: c.req.raw.body,
+      contentLength: Number(c.req.header("Content-Length") || "") || undefined,
+    });
+    return c.json(result, 201);
+  } catch (error) {
+    return c.json({
+      error: error instanceof Error ? error.message : "准备导出文件失败",
+      code: "EXPORT_STAGE_FAILED",
+    }, 400);
+  }
 });
 
 // 导入笔记（批量）

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -279,6 +279,8 @@ app.post("/markdown-package/jobs", async (c) => {
   const body = await c.req.json().catch(() => null) as {
     notes?: PreparedMarkdownNote[];
     inlineImages?: boolean;
+    layout?: "notebooks" | "flat";
+    filenameBase?: string;
   } | null;
   const notes = body?.notes;
   if (!Array.isArray(notes) || notes.length === 0) {
@@ -309,6 +311,8 @@ app.post("/markdown-package/jobs", async (c) => {
       userId,
       notes,
       inlineImages: body?.inlineImages === true,
+      layout: body?.layout === "flat" ? "flat" : "notebooks",
+      filenameBase: typeof body?.filenameBase === "string" ? body.filenameBase : undefined,
     });
     return c.json({ job }, 202);
   } catch (error) {

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -9,6 +9,12 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { Readable } from "stream";
+import {
+  createMarkdownExportJob,
+  getMarkdownExportJob,
+  MarkdownExportBusyError,
+  type PreparedMarkdownNote,
+} from "../services/markdownExportJobs";
 
 const Busboy = require("busboy");
 
@@ -258,6 +264,66 @@ app.get("/notes", (c) => {
   const notes = wsParam === null ? stmt.all(userId) : stmt.all(userId, wsParam);
 
   return c.json(notes);
+});
+
+// 前端保留富文本 -> Markdown 的格式转换，后端负责把结果和附件流式写入临时 ZIP。
+// POST 只创建异步任务并立即返回，避免 NAS 反向代理因长时间无响应而超时。
+app.post("/markdown-package/jobs", async (c) => {
+  const db = getDb();
+  const userId = c.req.header("X-User-Id")!;
+  const wsRaw = c.req.query("workspaceId") ?? undefined;
+  const { sql: wsSql, param: wsParam } = workspaceFilter(wsRaw);
+  const denied = denyIfPersonalFeatureDisabled(userId, wsParam === null, "personalExportEnabled");
+  if (denied) return c.json(denied, 403);
+
+  const body = await c.req.json().catch(() => null) as {
+    notes?: PreparedMarkdownNote[];
+    inlineImages?: boolean;
+  } | null;
+  const notes = body?.notes;
+  if (!Array.isArray(notes) || notes.length === 0) {
+    return c.json({ error: "没有可导出的笔记", code: "NO_NOTES" }, 400);
+  }
+
+  const noteIds = notes.map((note) => note?.id).filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (noteIds.length !== notes.length || new Set(noteIds).size !== noteIds.length) {
+    return c.json({ error: "导出笔记列表包含无效或重复 ID", code: "INVALID_NOTE_IDS" }, 400);
+  }
+
+  const stmt = db.prepare(`
+    SELECT n.id
+      FROM notes n
+     WHERE n.userId = ? AND n.isTrashed = 0
+       ${wsSql}
+  `);
+  const rows = (wsParam === null
+    ? stmt.all(userId)
+    : stmt.all(userId, wsParam)) as Array<{ id: string }>;
+  const allowedIds = new Set(rows.map((row) => row.id));
+  if (noteIds.some((id) => !allowedIds.has(id))) {
+    return c.json({ error: "部分笔记不存在或不属于当前导出空间", code: "NOTE_SCOPE_MISMATCH" }, 403);
+  }
+
+  try {
+    const job = createMarkdownExportJob({
+      userId,
+      notes,
+      inlineImages: body?.inlineImages === true,
+    });
+    return c.json({ job }, 202);
+  } catch (error) {
+    if (error instanceof MarkdownExportBusyError) {
+      return c.json({ error: error.message, code: error.code }, 409);
+    }
+    throw error;
+  }
+});
+
+app.get("/markdown-package/jobs/:id", (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const job = getMarkdownExportJob(c.req.param("id"), userId);
+  if (!job) return c.json({ error: "导出任务不存在或已过期", code: "EXPORT_JOB_NOT_FOUND" }, 404);
+  return c.json({ job });
 });
 
 // 导入笔记（批量）

--- a/backend/src/services/markdownExportJobs.ts
+++ b/backend/src/services/markdownExportJobs.ts
@@ -3,7 +3,8 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { Readable } from "stream";
+import { Readable, Transform } from "stream";
+import { pipeline } from "stream/promises";
 import type { Context } from "hono";
 import { getDb } from "../db/schema";
 import {
@@ -16,6 +17,8 @@ const EXPORT_TMP_PREFIX = "nowen-markdown-export-";
 const EXPORT_TTL_MS = 30 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 const MAX_INLINE_ASSET_BYTES = 128 * 1024 * 1024;
+const MAX_STAGED_EXPORT_BYTES = 512 * 1024 * 1024;
+const MAX_STAGED_EXPORTS_PER_USER = 5;
 
 export interface PreparedMarkdownAsset {
   relPath: string;
@@ -53,7 +56,9 @@ export class MarkdownExportBusyError extends Error {
 }
 
 interface MarkdownExportJob extends MarkdownExportJobSnapshot {
+  kind: "markdown" | "staged";
   userId: string;
+  contentType: string;
   tmpDir: string;
   tmpPath: string;
   createdAt: number;
@@ -357,7 +362,9 @@ export function createMarkdownExportJob(params: {
   const date = new Date().toISOString().slice(0, 10);
   const job: MarkdownExportJob = {
     id,
+    kind: "markdown",
     userId: params.userId,
+    contentType: "application/zip",
     state: "queued",
     current: 0,
     total: params.notes.length,
@@ -383,6 +390,79 @@ export function createMarkdownExportJob(params: {
   return publicSnapshot(job);
 }
 
+export async function stageGeneratedExport(params: {
+  userId: string;
+  filename: string;
+  contentType: string;
+  body: ReadableStream<Uint8Array>;
+  contentLength?: number;
+}): Promise<{ downloadToken: string; filename: string; size: number }> {
+  cleanupExpiredJobs();
+  if (params.contentLength && params.contentLength > MAX_STAGED_EXPORT_BYTES) {
+    throw new Error("导出文件超过 512MB，无法通过临时下载中转");
+  }
+
+  const stagedJobs = Array.from(jobs.values())
+    .filter((job) => job.userId === params.userId && job.kind === "staged")
+    .sort((a, b) => a.createdAt - b.createdAt);
+  while (stagedJobs.length >= MAX_STAGED_EXPORTS_PER_USER) {
+    const old = stagedJobs.shift()!;
+    jobs.delete(old.id);
+    if (old.downloadToken) downloadTokens.delete(old.downloadToken);
+    safeRemove(old.tmpDir);
+  }
+
+  const id = crypto.randomUUID();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), EXPORT_TMP_PREFIX));
+  const tmpPath = path.join(tmpDir, "export.bin");
+  let size = 0;
+  const limiter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      size += chunk.length;
+      if (size > MAX_STAGED_EXPORT_BYTES) {
+        callback(new Error("导出文件超过 512MB，无法通过临时下载中转"));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+
+  try {
+    await pipeline(
+      Readable.fromWeb(params.body as unknown as Parameters<typeof Readable.fromWeb>[0]),
+      limiter,
+      fs.createWriteStream(tmpPath),
+    );
+    if (size === 0) throw new Error("导出文件为空");
+  } catch (error) {
+    safeRemove(tmpDir);
+    throw error;
+  }
+
+  const downloadToken = crypto.randomBytes(32).toString("hex");
+  const filename = sanitizeFilename(params.filename);
+  const job: MarkdownExportJob = {
+    id,
+    kind: "staged",
+    userId: params.userId,
+    contentType: params.contentType,
+    state: "ready",
+    current: 1,
+    total: 1,
+    message: "导出文件已准备完成",
+    filename,
+    downloadToken,
+    warnings: 0,
+    tmpDir,
+    tmpPath,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + EXPORT_TTL_MS,
+  };
+  jobs.set(id, job);
+  downloadTokens.set(downloadToken, id);
+  return { downloadToken, filename, size };
+}
+
 export function getMarkdownExportJob(jobId: string, userId: string): MarkdownExportJobSnapshot | null {
   cleanupExpiredJobs();
   const job = jobs.get(jobId);
@@ -406,7 +486,7 @@ export function handleMarkdownExportDownload(c: Context): Response {
   const stream = fs.createReadStream(job.tmpPath);
   return new Response(Readable.toWeb(stream) as ReadableStream, {
     headers: {
-      "Content-Type": "application/zip",
+      "Content-Type": job.contentType,
       "Content-Length": String(stat.size),
       "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(job.filename || "nowen-note.zip")}`,
       "Cache-Control": "private, no-store",

--- a/backend/src/services/markdownExportJobs.ts
+++ b/backend/src/services/markdownExportJobs.ts
@@ -186,6 +186,7 @@ async function buildArchive(
   job: MarkdownExportJob,
   notes: PreparedMarkdownNote[],
   inlineImages: boolean,
+  layout: "notebooks" | "flat",
 ): Promise<void> {
   job.state = "building";
   job.message = "正在生成 ZIP";
@@ -221,15 +222,16 @@ async function buildArchive(
 
   for (let index = 0; index < notes.length; index++) {
     const note = notes[index];
-    const folder = sanitizeFilename(note.notebookName || "未分类");
-    folderCounts.set(folder, (folderCounts.get(folder) || 0) + 1);
+    const folder = layout === "flat" ? "" : sanitizeFilename(note.notebookName || "未分类");
+    const zipPrefix = folder ? `${folder}/` : "";
+    if (folder) folderCounts.set(folder, (folderCounts.get(folder) || 0) + 1);
     const baseName = sanitizeFilename(note.title);
     let noteName = baseName;
     let suffix = 2;
-    while (usedNotePaths.has(`${folder}/${noteName}.md`)) {
+    while (usedNotePaths.has(`${zipPrefix}${noteName}.md`)) {
       noteName = `${baseName}_${suffix++}`;
     }
-    usedNotePaths.add(`${folder}/${noteName}.md`);
+    usedNotePaths.add(`${zipPrefix}${noteName}.md`);
     let markdown = note.markdown || "";
 
     for (const attachmentId of attachmentIdsInMarkdown(markdown)) {
@@ -255,7 +257,7 @@ async function buildArchive(
 
       const assetName = `att-${sanitizeFilename(row.id)}-${sanitizeFilename(row.filename)}`;
       const relPath = `assets/${assetName}`;
-      const zipPath = `${folder}/${relPath}`;
+      const zipPath = `${zipPrefix}${relPath}`;
       if (writtenAttachments.has(zipPath)) {
         markdown = replaceAttachmentUrl(markdown, attachmentId, `./${relPath}`);
         continue;
@@ -275,7 +277,7 @@ async function buildArchive(
         warnings.push({ type: "inline_asset_invalid_path", noteId: note.id, path: asset.relPath });
         continue;
       }
-      const zipPath = `${folder}/${relPath}`;
+      const zipPath = `${zipPrefix}${relPath}`;
       if (writtenAttachments.has(zipPath)) continue;
       const estimatedBytes = Math.ceil((asset.base64.length * 3) / 4);
       if (estimatedBytes > MAX_INLINE_ASSET_BYTES) {
@@ -302,7 +304,7 @@ async function buildArchive(
       "---",
       "",
     ].join("\n");
-    archive.append(frontmatter + markdown, { name: `${folder}/${noteName}.md` });
+    archive.append(frontmatter + markdown, { name: `${zipPrefix}${noteName}.md` });
     job.current = index + 1;
     job.message = `正在打包：${note.title}`;
   }
@@ -336,6 +338,8 @@ export function createMarkdownExportJob(params: {
   userId: string;
   notes: PreparedMarkdownNote[];
   inlineImages: boolean;
+  layout?: "notebooks" | "flat";
+  filenameBase?: string;
 }): MarkdownExportJobSnapshot {
   cleanupExpiredJobs();
   for (const [jobId, job] of jobs) {
@@ -358,7 +362,9 @@ export function createMarkdownExportJob(params: {
     current: 0,
     total: params.notes.length,
     message: "等待生成 ZIP",
-    filename: `nowen-note_backup_${date}.zip`,
+    filename: params.filenameBase
+      ? `${sanitizeFilename(params.filenameBase)}.zip`
+      : `nowen-note_backup_${date}.zip`,
     warnings: 0,
     tmpDir,
     tmpPath: path.join(tmpDir, "export.zip"),
@@ -367,7 +373,7 @@ export function createMarkdownExportJob(params: {
   };
   jobs.set(id, job);
 
-  void buildArchive(job, params.notes, params.inlineImages).catch((error) => {
+  void buildArchive(job, params.notes, params.inlineImages, params.layout || "notebooks").catch((error) => {
     console.error("[markdown-export] build failed:", error);
     safeRemove(job.tmpDir);
     job.state = "error";

--- a/backend/src/services/markdownExportJobs.ts
+++ b/backend/src/services/markdownExportJobs.ts
@@ -1,0 +1,417 @@
+import archiver from "archiver";
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Readable } from "stream";
+import type { Context } from "hono";
+import { getDb } from "../db/schema";
+import {
+  getAttachmentStorageInfo,
+  getLocalAttachmentPath,
+  readAttachmentObject,
+} from "./attachment-storage";
+
+const EXPORT_TMP_PREFIX = "nowen-markdown-export-";
+const EXPORT_TTL_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_INLINE_ASSET_BYTES = 128 * 1024 * 1024;
+
+export interface PreparedMarkdownAsset {
+  relPath: string;
+  base64: string;
+}
+
+export interface PreparedMarkdownNote {
+  id: string;
+  title: string;
+  notebookName: string | null;
+  createdAt: string;
+  updatedAt: string;
+  contentFormat?: string;
+  markdown: string;
+  inlineAssets?: PreparedMarkdownAsset[];
+}
+
+export interface MarkdownExportJobSnapshot {
+  id: string;
+  state: "queued" | "building" | "ready" | "error";
+  current: number;
+  total: number;
+  message: string;
+  filename?: string;
+  downloadToken?: string;
+  warnings: number;
+}
+
+export class MarkdownExportBusyError extends Error {
+  code = "EXPORT_JOB_BUSY";
+
+  constructor() {
+    super("已有导出任务正在生成，请等待当前任务完成");
+  }
+}
+
+interface MarkdownExportJob extends MarkdownExportJobSnapshot {
+  userId: string;
+  tmpDir: string;
+  tmpPath: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+interface AttachmentRow {
+  id: string;
+  noteId: string;
+  filename: string;
+  mimeType: string;
+  path: string;
+}
+
+const jobs = new Map<string, MarkdownExportJob>();
+const downloadTokens = new Map<string, string>();
+let lastCleanupAt = 0;
+
+function sanitizeFilename(value: string): string {
+  return value
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[. ]+$/g, "") || "未命名";
+}
+
+function normalizeAssetRelPath(value: string): string | null {
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\//, "");
+  if (!normalized || normalized.startsWith("/") || normalized.includes("../")) return null;
+  return normalized
+    .split("/")
+    .filter(Boolean)
+    .map(sanitizeFilename)
+    .join("/");
+}
+
+function safeRemove(target: string): void {
+  try {
+    fs.rmSync(target, { recursive: true, force: true });
+  } catch {
+    /* 临时文件清理由下一轮兜底 */
+  }
+}
+
+function cleanupExpiredJobs(force = false): void {
+  const now = Date.now();
+  if (!force && now - lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+  lastCleanupAt = now;
+
+  for (const [id, job] of jobs) {
+    if (job.expiresAt > now) continue;
+    jobs.delete(id);
+    if (job.downloadToken) downloadTokens.delete(job.downloadToken);
+    safeRemove(job.tmpDir);
+  }
+
+  try {
+    for (const entry of fs.readdirSync(os.tmpdir(), { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(EXPORT_TMP_PREFIX)) continue;
+      const abs = path.join(os.tmpdir(), entry.name);
+      try {
+        const stat = fs.statSync(abs);
+        if (now - stat.mtimeMs > EXPORT_TTL_MS * 2) safeRemove(abs);
+      } catch {
+        safeRemove(abs);
+      }
+    }
+  } catch {
+    /* 系统临时目录不可读时不阻断导出 */
+  }
+}
+
+function publicSnapshot(job: MarkdownExportJob): MarkdownExportJobSnapshot {
+  return {
+    id: job.id,
+    state: job.state,
+    current: job.current,
+    total: job.total,
+    message: job.message,
+    filename: job.filename,
+    downloadToken: job.downloadToken,
+    warnings: job.warnings,
+  };
+}
+
+function attachmentIdsInMarkdown(markdown: string): string[] {
+  const ids = new Set<string>();
+  const re = /\/api\/attachments\/([^/?#\s)"'<>]+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(markdown)) !== null) {
+    try {
+      ids.add(decodeURIComponent(match[1]));
+    } catch {
+      ids.add(match[1]);
+    }
+  }
+  return Array.from(ids);
+}
+
+function replaceAttachmentUrl(markdown: string, attachmentId: string, replacement: string): string {
+  const escaped = attachmentId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return markdown.replace(
+    new RegExp(`(?:https?:\\/\\/[^\\s)"'<>]+)?\\/api\\/attachments\\/${escaped}(?:\\?[^\\s)"'<>]*)?`, "gi"),
+    replacement,
+  );
+}
+
+async function appendAttachment(
+  archive: archiver.Archiver,
+  row: AttachmentRow,
+  zipPath: string,
+): Promise<boolean> {
+  const storage = getAttachmentStorageInfo();
+  if (storage.driver === "local") {
+    const abs = getLocalAttachmentPath(row.path);
+    if (!fs.existsSync(abs)) return false;
+    // 图片、视频、PDF 等附件通常已经压缩；直接 STORE 可显著降低 NAS CPU 占用。
+    archive.file(abs, { name: zipPath, store: true } as archiver.ZipEntryData);
+    return true;
+  }
+
+  const buffer = await readAttachmentObject(row.path);
+  if (!buffer) return false;
+  archive.append(buffer, { name: zipPath, store: true } as archiver.ZipEntryData);
+  return true;
+}
+
+async function buildArchive(
+  job: MarkdownExportJob,
+  notes: PreparedMarkdownNote[],
+  inlineImages: boolean,
+): Promise<void> {
+  job.state = "building";
+  job.message = "正在生成 ZIP";
+  const warnings: Array<Record<string, unknown>> = [];
+  const output = fs.createWriteStream(job.tmpPath);
+  const archive = archiver("zip", {
+    zlib: { level: 6 },
+    forceZip64: true,
+  });
+  const completion = new Promise<void>((resolve, reject) => {
+    output.once("close", resolve);
+    output.once("error", reject);
+    archive.once("error", reject);
+  });
+  archive.on("warning", (error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      warnings.push({ type: "archive_source_missing", message: error.message });
+      return;
+    }
+    archive.emit("error", error);
+  });
+  archive.pipe(output);
+
+  const db = getDb();
+  const getAttachment = db.prepare(
+    `SELECT id, noteId, filename, mimeType, path
+       FROM attachments
+      WHERE id = ? AND userId = ?`,
+  );
+  const folderCounts = new Map<string, number>();
+  const usedNotePaths = new Set<string>();
+  const writtenAttachments = new Set<string>();
+
+  for (let index = 0; index < notes.length; index++) {
+    const note = notes[index];
+    const folder = sanitizeFilename(note.notebookName || "未分类");
+    folderCounts.set(folder, (folderCounts.get(folder) || 0) + 1);
+    const baseName = sanitizeFilename(note.title);
+    let noteName = baseName;
+    let suffix = 2;
+    while (usedNotePaths.has(`${folder}/${noteName}.md`)) {
+      noteName = `${baseName}_${suffix++}`;
+    }
+    usedNotePaths.add(`${folder}/${noteName}.md`);
+    let markdown = note.markdown || "";
+
+    for (const attachmentId of attachmentIdsInMarkdown(markdown)) {
+      const row = getAttachment.get(attachmentId, job.userId) as AttachmentRow | undefined;
+      if (!row) {
+        warnings.push({ type: "attachment_missing", noteId: note.id, attachmentId });
+        continue;
+      }
+
+      if (inlineImages && row.mimeType.startsWith("image/")) {
+        const buffer = await readAttachmentObject(row.path);
+        if (!buffer) {
+          warnings.push({ type: "attachment_file_missing", noteId: note.id, attachmentId });
+          continue;
+        }
+        markdown = replaceAttachmentUrl(
+          markdown,
+          attachmentId,
+          `data:${row.mimeType};base64,${buffer.toString("base64")}`,
+        );
+        continue;
+      }
+
+      const assetName = `att-${sanitizeFilename(row.id)}-${sanitizeFilename(row.filename)}`;
+      const relPath = `assets/${assetName}`;
+      const zipPath = `${folder}/${relPath}`;
+      if (writtenAttachments.has(zipPath)) {
+        markdown = replaceAttachmentUrl(markdown, attachmentId, `./${relPath}`);
+        continue;
+      }
+
+      if (await appendAttachment(archive, row, zipPath)) {
+        writtenAttachments.add(zipPath);
+        markdown = replaceAttachmentUrl(markdown, attachmentId, `./${relPath}`);
+      } else {
+        warnings.push({ type: "attachment_file_missing", noteId: note.id, attachmentId });
+      }
+    }
+
+    for (const asset of note.inlineAssets || []) {
+      const relPath = normalizeAssetRelPath(asset.relPath);
+      if (!relPath) {
+        warnings.push({ type: "inline_asset_invalid_path", noteId: note.id, path: asset.relPath });
+        continue;
+      }
+      const zipPath = `${folder}/${relPath}`;
+      if (writtenAttachments.has(zipPath)) continue;
+      const estimatedBytes = Math.ceil((asset.base64.length * 3) / 4);
+      if (estimatedBytes > MAX_INLINE_ASSET_BYTES) {
+        warnings.push({ type: "inline_asset_too_large", noteId: note.id, path: relPath });
+        continue;
+      }
+      try {
+        archive.append(
+          Buffer.from(asset.base64, "base64"),
+          { name: zipPath, store: true } as archiver.ZipEntryData,
+        );
+        writtenAttachments.add(zipPath);
+      } catch {
+        warnings.push({ type: "inline_asset_invalid", noteId: note.id, path: relPath });
+      }
+    }
+
+    const frontmatter = [
+      "---",
+      `title: "${note.title.replace(/"/g, '\\"')}"`,
+      `contentFormat: "${note.contentFormat || "tiptap-json"}"`,
+      `created: ${note.createdAt}`,
+      `updated: ${note.updatedAt}`,
+      "---",
+      "",
+    ].join("\n");
+    archive.append(frontmatter + markdown, { name: `${folder}/${noteName}.md` });
+    job.current = index + 1;
+    job.message = `正在打包：${note.title}`;
+  }
+
+  archive.append(JSON.stringify({
+    version: "2.0",
+    app: "nowen-note",
+    exportedAt: new Date().toISOString(),
+    totalNotes: notes.length,
+    notebooks: Array.from(folderCounts.entries()).map(([name, count]) => ({ name, count })),
+    warnings: warnings.length,
+  }, null, 2), { name: "metadata.json" });
+  if (warnings.length > 0) {
+    archive.append(JSON.stringify({ version: "1.0", items: warnings }, null, 2), {
+      name: "export-warnings.json",
+    });
+  }
+
+  job.message = "正在完成 ZIP 文件";
+  await archive.finalize();
+  await completion;
+  job.warnings = warnings.length;
+  job.state = "ready";
+  job.current = job.total;
+  job.message = warnings.length > 0 ? `导出完成，${warnings.length} 个附件需要检查` : "导出完成";
+  job.downloadToken = crypto.randomBytes(32).toString("hex");
+  downloadTokens.set(job.downloadToken, job.id);
+}
+
+export function createMarkdownExportJob(params: {
+  userId: string;
+  notes: PreparedMarkdownNote[];
+  inlineImages: boolean;
+}): MarkdownExportJobSnapshot {
+  cleanupExpiredJobs();
+  for (const [jobId, job] of jobs) {
+    if (job.userId !== params.userId) continue;
+    if (job.state === "queued" || job.state === "building") {
+      throw new MarkdownExportBusyError();
+    }
+    // 每个用户只保留最近一个已完成包，避免连续导出把 NAS 临时盘占满。
+    jobs.delete(jobId);
+    if (job.downloadToken) downloadTokens.delete(job.downloadToken);
+    safeRemove(job.tmpDir);
+  }
+  const id = crypto.randomUUID();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), EXPORT_TMP_PREFIX));
+  const date = new Date().toISOString().slice(0, 10);
+  const job: MarkdownExportJob = {
+    id,
+    userId: params.userId,
+    state: "queued",
+    current: 0,
+    total: params.notes.length,
+    message: "等待生成 ZIP",
+    filename: `nowen-note_backup_${date}.zip`,
+    warnings: 0,
+    tmpDir,
+    tmpPath: path.join(tmpDir, "export.zip"),
+    createdAt: Date.now(),
+    expiresAt: Date.now() + EXPORT_TTL_MS,
+  };
+  jobs.set(id, job);
+
+  void buildArchive(job, params.notes, params.inlineImages).catch((error) => {
+    console.error("[markdown-export] build failed:", error);
+    safeRemove(job.tmpDir);
+    job.state = "error";
+    job.message = error instanceof Error ? error.message : "生成 ZIP 失败";
+    job.expiresAt = Date.now() + EXPORT_TTL_MS;
+  });
+  return publicSnapshot(job);
+}
+
+export function getMarkdownExportJob(jobId: string, userId: string): MarkdownExportJobSnapshot | null {
+  cleanupExpiredJobs();
+  const job = jobs.get(jobId);
+  if (!job || job.userId !== userId) return null;
+  return publicSnapshot(job);
+}
+
+export function handleMarkdownExportDownload(c: Context): Response {
+  cleanupExpiredJobs();
+  const token = c.req.param("token");
+  const jobId = downloadTokens.get(token);
+  const job = jobId ? jobs.get(jobId) : undefined;
+  if (!job || job.state !== "ready" || job.downloadToken !== token || !fs.existsSync(job.tmpPath)) {
+    return new Response(JSON.stringify({ error: "下载链接无效或已过期" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
+  }
+
+  const stat = fs.statSync(job.tmpPath);
+  const stream = fs.createReadStream(job.tmpPath);
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Length": String(stat.size),
+      "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(job.filename || "nowen-note.zip")}`,
+      "Cache-Control": "private, no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+export const markdownExportTestUtils = {
+  attachmentIdsInMarkdown,
+  normalizeAssetRelPath,
+  replaceAttachmentUrl,
+  sanitizeFilename,
+};

--- a/backend/tests/markdown-export-jobs.test.ts
+++ b/backend/tests/markdown-export-jobs.test.ts
@@ -147,10 +147,46 @@ test("single-note flat export keeps the note and assets at ZIP root", async () =
   assert.equal(zip.file("未分类/资料分析模块.md"), null);
 });
 
+test("generated PDF can be staged and downloaded from a real HTTP response", async () => {
+  const service = await import("../src/services/markdownExportJobs");
+  const source = new TextEncoder().encode("pdf-content");
+  const body = new Response(source).body;
+  assert.ok(body);
+  const staged = await service.stageGeneratedExport({
+    userId: "user-export",
+    filename: "资料分析模块.pdf",
+    contentType: "application/pdf",
+    body,
+    contentLength: source.byteLength,
+  });
+
+  const app = new Hono();
+  app.get("/download/:token", service.handleMarkdownExportDownload);
+  const response = await app.request(`/download/${staged.downloadToken}`);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/pdf");
+  assert.match(response.headers.get("content-disposition") || "", /\.pdf/i);
+  assert.equal(await response.text(), "pdf-content");
+});
+
 test("markdown export route validates note ownership and exposes asynchronous status", async () => {
   const exportRouter = (await import("../src/routes/export")).default;
   const app = new Hono();
   app.route("/export", exportRouter);
+  const stagedPdf = await app.request("/export/download-jobs", {
+    method: "POST",
+    headers: {
+      "X-User-Id": "user-export",
+      "X-Export-Filename": encodeURIComponent("资料分析模块.pdf"),
+      "Content-Type": "application/pdf",
+    },
+    body: "pdf-route-content",
+  });
+  assert.equal(stagedPdf.status, 201, await stagedPdf.clone().text());
+  const stagedBody = await stagedPdf.json() as { filename: string; downloadToken: string };
+  assert.equal(stagedBody.filename, "资料分析模块.pdf");
+  assert.ok(stagedBody.downloadToken);
+
   const payload = {
     notes: [{
       id: "note-1",

--- a/backend/tests/markdown-export-jobs.test.ts
+++ b/backend/tests/markdown-export-jobs.test.ts
@@ -111,6 +111,42 @@ test("markdown export writes attachments to a ZIP file and keeps duplicate note 
   );
 });
 
+test("single-note flat export keeps the note and assets at ZIP root", async () => {
+  const service = await import("../src/services/markdownExportJobs");
+  const created = service.createMarkdownExportJob({
+    userId: "user-export",
+    inlineImages: false,
+    layout: "flat",
+    filenameBase: "资料分析模块",
+    notes: [{
+      id: "note-1",
+      title: "资料分析模块",
+      notebookName: null,
+      createdAt: "2026-07-11 10:00:00",
+      updatedAt: "2026-07-11 10:00:00",
+      contentFormat: "markdown",
+      markdown: "![图](./assets/image.png)",
+      inlineAssets: [{ relPath: "assets/image.png", base64: Buffer.from("image").toString("base64") }],
+    }],
+  });
+
+  let snapshot = created;
+  for (let i = 0; i < 200 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    snapshot = service.getMarkdownExportJob(created.id, "user-export")!;
+  }
+  assert.equal(snapshot.state, "ready", snapshot.message);
+  assert.equal(snapshot.filename, "资料分析模块.zip");
+
+  const app = new Hono();
+  app.get("/download/:token", service.handleMarkdownExportDownload);
+  const response = await app.request(`/download/${snapshot.downloadToken}`);
+  const zip = await JSZip.loadAsync(await response.arrayBuffer());
+  assert.ok(zip.file("资料分析模块.md"));
+  assert.equal(await zip.file("assets/image.png")!.async("string"), "image");
+  assert.equal(zip.file("未分类/资料分析模块.md"), null);
+});
+
 test("markdown export route validates note ownership and exposes asynchronous status", async () => {
   const exportRouter = (await import("../src/routes/export")).default;
   const app = new Hono();

--- a/backend/tests/markdown-export-jobs.test.ts
+++ b/backend/tests/markdown-export-jobs.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import JSZip from "jszip";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-markdown-export-test-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+let closeDb: typeof import("../src/db/schema").closeDb;
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("export helpers reject traversal and rewrite attachment URLs", async () => {
+  const { markdownExportTestUtils } = await import("../src/services/markdownExportJobs");
+  assert.equal(markdownExportTestUtils.normalizeAssetRelPath("../secret.txt"), null);
+  assert.equal(markdownExportTestUtils.normalizeAssetRelPath("assets\\图片.png"), "assets/图片.png");
+  assert.deepEqual(
+    markdownExportTestUtils.attachmentIdsInMarkdown(
+      "![a](/api/attachments/att-1?download=0) [b](https://note.test/api/attachments/att-2)",
+    ),
+    ["att-1", "att-2"],
+  );
+  assert.equal(
+    markdownExportTestUtils.replaceAttachmentUrl(
+      "![a](https://note.test/api/attachments/att-1?download=0)",
+      "att-1",
+      "./assets/a.png",
+    ),
+    "![a](./assets/a.png)",
+  );
+});
+
+test("markdown export writes attachments to a ZIP file and keeps duplicate note titles", async () => {
+  const schema = await import("../src/db/schema");
+  const service = await import("../src/services/markdownExportJobs");
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run("user-export", "user-export", "hash");
+  db.prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run("nb-export", "user-export", "笔记本");
+  for (const id of ["note-1", "note-2"]) {
+    db.prepare("INSERT INTO notes (id, userId, notebookId, title) VALUES (?, ?, ?, ?)")
+      .run(id, "user-export", "nb-export", "同名笔记");
+  }
+  const attachmentsDir = path.join(tmpDir, "attachments");
+  fs.mkdirSync(attachmentsDir, { recursive: true });
+  fs.writeFileSync(path.join(attachmentsDir, "asset.bin"), Buffer.from("streamed attachment"));
+  db.prepare(
+    `INSERT INTO attachments (id, noteId, userId, filename, mimeType, size, path)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run("att-1", "note-1", "user-export", "附件.bin", "application/octet-stream", 19, "asset.bin");
+
+  const created = service.createMarkdownExportJob({
+    userId: "user-export",
+    inlineImages: false,
+    notes: [
+      {
+        id: "note-1",
+        title: "同名笔记",
+        notebookName: "笔记本",
+        createdAt: "2026-07-11 10:00:00",
+        updatedAt: "2026-07-11 10:00:00",
+        contentFormat: "markdown",
+        markdown: "[附件](/api/attachments/att-1?download=0)",
+      },
+      {
+        id: "note-2",
+        title: "同名笔记",
+        notebookName: "笔记本",
+        createdAt: "2026-07-11 10:00:00",
+        updatedAt: "2026-07-11 10:00:00",
+        contentFormat: "markdown",
+        markdown: "第二篇",
+      },
+    ],
+  });
+
+  let snapshot = created;
+  for (let i = 0; i < 200 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    snapshot = service.getMarkdownExportJob(created.id, "user-export")!;
+  }
+  assert.equal(snapshot.state, "ready", snapshot.message);
+  assert.ok(snapshot.downloadToken);
+
+  const app = new Hono();
+  app.get("/download/:token", service.handleMarkdownExportDownload);
+  const response = await app.request(`/download/${snapshot.downloadToken}`);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/zip");
+  assert.ok(Number(response.headers.get("content-length")) > 0);
+
+  const zip = await JSZip.loadAsync(await response.arrayBuffer());
+  assert.ok(zip.file("笔记本/同名笔记.md"));
+  assert.ok(zip.file("笔记本/同名笔记_2.md"));
+  assert.equal(
+    await zip.file("笔记本/assets/att-att-1-附件.bin")!.async("string"),
+    "streamed attachment",
+  );
+  assert.match(
+    await zip.file("笔记本/同名笔记.md")!.async("string"),
+    /\[附件\]\(\.\/assets\/att-att-1-附件\.bin\)/,
+  );
+});
+
+test("markdown export route validates note ownership and exposes asynchronous status", async () => {
+  const exportRouter = (await import("../src/routes/export")).default;
+  const app = new Hono();
+  app.route("/export", exportRouter);
+  const payload = {
+    notes: [{
+      id: "note-1",
+      title: "路由导出",
+      notebookName: "笔记本",
+      createdAt: "2026-07-11 10:00:00",
+      updatedAt: "2026-07-11 10:00:00",
+      contentFormat: "markdown",
+      markdown: "正文",
+    }],
+  };
+
+  const forbidden = await app.request("/export/markdown-package/jobs", {
+    method: "POST",
+    headers: { "X-User-Id": "another-user", "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  assert.equal(forbidden.status, 403);
+
+  const created = await app.request("/export/markdown-package/jobs", {
+    method: "POST",
+    headers: { "X-User-Id": "user-export", "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (created.status !== 202) assert.equal(created.status, 202, await created.text());
+  const createdBody = await created.json() as { job: { id: string } };
+
+  let state = "queued";
+  for (let i = 0; i < 200 && state !== "ready" && state !== "error"; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const status = await app.request(`/export/markdown-package/jobs/${createdBody.job.id}`, {
+      headers: { "X-User-Id": "user-export" },
+    });
+    assert.equal(status.status, 200);
+    state = ((await status.json()) as { job: { state: string } }).job.state;
+  }
+  assert.equal(state, "ready");
+});

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -496,7 +496,7 @@ export default function ContextMenu({
         const { exportNoteAsDocx, downloadDocxBlob } = await import("@/lib/wordNoteService");
         const title = fresh.title || t("common.untitledNote") || "未命名笔记";
         const blob = await exportNoteAsDocx(fresh.content || "", title);
-        downloadDocxBlob(blob, title);
+        await downloadDocxBlob(blob, title);
         toast.dismiss(toastId);
         toast.success(t("export.exportComplete"));
       } catch (err: any) {

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -2467,7 +2467,7 @@ export default function NoteList() {
           const fresh = await api.getNote(targetId);
           const { exportNoteAsDocx, downloadDocxBlob } = await import("@/lib/wordNoteService");
           const blob = await exportNoteAsDocx(fresh.content || "", fresh.title || "未命名笔记");
-          downloadDocxBlob(blob, fresh.title || "未命名笔记");
+          await downloadDocxBlob(blob, fresh.title || "未命名笔记");
           toast.dismiss(toastId);
           toast.success(t('export.exportComplete'));
         } catch (err: any) {

--- a/frontend/src/lib/__tests__/exportService.test.ts
+++ b/frontend/src/lib/__tests__/exportService.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { noteContentToExportHtml } from "@/lib/exportService";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { exportSingleNote, noteContentToExportHtml } from "@/lib/exportService";
+import { api } from "@/lib/api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("noteContentToExportHtml", () => {
   it("renders native Markdown notes to HTML for image export", () => {
@@ -33,5 +38,46 @@ describe("noteContentToExportHtml", () => {
     expect(html).toContain("<pre><code");
     expect(html).toContain("<table>");
     expect(html).not.toContain("# 一级标题");
+  });
+});
+
+describe("exportSingleNote", () => {
+  it("routes a note with attachments through the flat server ZIP job", async () => {
+    vi.spyOn(api, "getNote").mockResolvedValue({
+      id: "note-1",
+      title: "资料分析模块",
+      content: JSON.stringify({
+        type: "doc",
+        content: [{
+          type: "image",
+          attrs: { src: "/api/attachments/att-1", alt: "图" },
+        }],
+      }),
+      contentText: "图",
+      contentFormat: "tiptap-json",
+      createdAt: "2026-07-11 10:00:00",
+      updatedAt: "2026-07-11 10:00:00",
+    } as Awaited<ReturnType<typeof api.getNote>>);
+    const createJob = vi.spyOn(api, "createMarkdownExportJob").mockResolvedValue({
+      job: {
+        id: "job-1",
+        state: "ready",
+        current: 1,
+        total: 1,
+        message: "导出完成",
+        filename: "资料分析模块.zip",
+        downloadToken: "token-1",
+        warnings: 0,
+      },
+    });
+    const download = vi.spyOn(api, "downloadMarkdownExport").mockImplementation(() => {});
+
+    await expect(exportSingleNote("note-1")).resolves.toBe(true);
+
+    expect(createJob).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: "note-1", title: "资料分析模块" })],
+      expect.objectContaining({ layout: "flat", filenameBase: "资料分析模块" }),
+    );
+    expect(download).toHaveBeenCalledWith("token-1", "资料分析模块.zip");
   });
 });

--- a/frontend/src/lib/__tests__/wordNoteDownload.test.ts
+++ b/frontend/src/lib/__tests__/wordNoteDownload.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import { downloadDocxBlob } from "@/lib/wordNoteService";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("downloadDocxBlob", () => {
+  it("stages DOCX on the server before triggering a real HTTP download", async () => {
+    const blob = new Blob(["docx"], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    const stage = vi.spyOn(api, "stageGeneratedExport").mockResolvedValue({
+      downloadToken: "docx-token",
+      filename: "资料分析模块.docx",
+      size: 4,
+    });
+    const download = vi.spyOn(api, "downloadMarkdownExport").mockImplementation(() => {});
+
+    await downloadDocxBlob(blob, "资料分析模块");
+
+    expect(stage).toHaveBeenCalledWith(blob, "资料分析模块.docx");
+    expect(download).toHaveBeenCalledWith("docx-token", "资料分析模块.docx");
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1920,6 +1920,24 @@ export const api = {
     a.click();
     document.body.removeChild(a);
   },
+  stageGeneratedExport: async (blob: Blob, filename: string) => {
+    const token = getToken();
+    const res = await fetch(`${getBaseUrl()}/export/download-jobs`, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": blob.type || "application/octet-stream",
+        "X-Export-Filename": encodeURIComponent(filename),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: blob,
+    });
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+      throw new Error(error.error || `HTTP ${res.status}`);
+    }
+    return res.json() as Promise<{ downloadToken: string; filename: string; size: number }>;
+  },
   /** 导出 Nowen 数据包（.nowen.zip） */
   downloadNowenPackage: async (opts?: { notebookId?: string; includeSubNotebooks?: boolean; includeTrashed?: boolean }) => {
     const ws = getCurrentWorkspace();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1865,7 +1865,12 @@ export const api = {
       markdown: string;
       inlineAssets?: Array<{ relPath: string; base64: string }>;
     }>,
-    options?: { inlineImages?: boolean; workspaceId?: string },
+    options?: {
+      inlineImages?: boolean;
+      workspaceId?: string;
+      layout?: "notebooks" | "flat";
+      filenameBase?: string;
+    },
   ) => {
     const params = new URLSearchParams();
     if (options?.workspaceId && options.workspaceId !== "personal") {
@@ -1885,7 +1890,12 @@ export const api = {
       };
     }>(`/export/markdown-package/jobs${qs}`, {
       method: "POST",
-      body: JSON.stringify({ notes, inlineImages: options?.inlineImages === true }),
+      body: JSON.stringify({
+        notes,
+        inlineImages: options?.inlineImages === true,
+        layout: options?.layout,
+        filenameBase: options?.filenameBase,
+      }),
     });
   },
   getMarkdownExportJob: (jobId: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1854,6 +1854,62 @@ export const api = {
     const qs = ws && ws !== "personal" ? `?workspaceId=${encodeURIComponent(ws)}` : "";
     return request<any[]>(`/export/notes${qs}`);
   },
+  createMarkdownExportJob: (
+    notes: Array<{
+      id: string;
+      title: string;
+      notebookName: string | null;
+      createdAt: string;
+      updatedAt: string;
+      contentFormat?: string;
+      markdown: string;
+      inlineAssets?: Array<{ relPath: string; base64: string }>;
+    }>,
+    options?: { inlineImages?: boolean; workspaceId?: string },
+  ) => {
+    const params = new URLSearchParams();
+    if (options?.workspaceId && options.workspaceId !== "personal") {
+      params.set("workspaceId", options.workspaceId);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    return request<{
+      job: {
+        id: string;
+        state: "queued" | "building" | "ready" | "error";
+        current: number;
+        total: number;
+        message: string;
+        filename?: string;
+        downloadToken?: string;
+        warnings: number;
+      };
+    }>(`/export/markdown-package/jobs${qs}`, {
+      method: "POST",
+      body: JSON.stringify({ notes, inlineImages: options?.inlineImages === true }),
+    });
+  },
+  getMarkdownExportJob: (jobId: string) =>
+    request<{
+      job: {
+        id: string;
+        state: "queued" | "building" | "ready" | "error";
+        current: number;
+        total: number;
+        message: string;
+        filename?: string;
+        downloadToken?: string;
+        warnings: number;
+      };
+    }>(`/export/markdown-package/jobs/${encodeURIComponent(jobId)}`),
+  downloadMarkdownExport: (downloadToken: string, filename?: string) => {
+    const a = document.createElement("a");
+    a.href = `${getBaseUrl()}/export/download/${encodeURIComponent(downloadToken)}`;
+    a.download = filename || "nowen-note.zip";
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  },
   /** 导出 Nowen 数据包（.nowen.zip） */
   downloadNowenPackage: async (opts?: { notebookId?: string; includeSubNotebooks?: boolean; includeTrashed?: boolean }) => {
     const ws = getCurrentWorkspace();
@@ -4144,4 +4200,3 @@ export async function fetchRegisterConfig(baseUrlOverride?: string): Promise<{ a
     return { allowRegistration: true };
   }
 }
-

--- a/frontend/src/lib/exportService.ts
+++ b/frontend/src/lib/exportService.ts
@@ -1682,7 +1682,8 @@ export async function exportSingleNoteAsPDF(noteId: string): Promise<ExportPdfRe
     // —— Web 直接下载 PDF ——
     const blob = await renderPrintableHtmlToPdfBlob(docHtml);
     const filename = `${sanitizeFilename(note.title) || "note"}.pdf`;
-    saveAs(blob, filename);
+    const staged = await api.stageGeneratedExport(blob, filename);
+    api.downloadMarkdownExport(staged.downloadToken, staged.filename);
     return { ok: true, mode: "web" };
   } catch (error) {
     console.error("导出 PDF 失败:", error);

--- a/frontend/src/lib/exportService.ts
+++ b/frontend/src/lib/exportService.ts
@@ -999,21 +999,21 @@ export async function exportAllNotes(
     }
 
     const total = notes.length;
-    const zip = new JSZip();
     const td = createTurndown();
 
-    // 2. 转换并打包
-    const folderCounts = new Map<string, number>();
+    // 2. 只在前端做依赖 DOM/Tiptap 的格式转换；ZIP 和附件均交给后端流式处理。
     // 每个笔记本目录独立的 hash->相对路径 注册表，保证 md 中 ./assets/xxx 一定存在于同级目录
     const perFolderRegistry = new Map<string, Map<string, string>>();
-    // 已写入 zip 的图片相对路径，避免重复写
-    const writtenImages = new Set<string>();
-    // 远程图片下载计数（成功 / 失败），最终给用户做个汇总
-    // P0-2：同时收集失败明细（src + noteId + error），供 zip 根目录写出 export-warnings.json
-    const imgStats: ImgStats = { ok: 0, failed: 0, failures: [] };
-
-    // 格式统计
-    const formatStats = { markdown: 0, richText: 0, html: 0 };
+    const preparedNotes: Array<{
+      id: string;
+      title: string;
+      notebookName: string | null;
+      createdAt: string;
+      updatedAt: string;
+      contentFormat?: string;
+      markdown: string;
+      inlineAssets: ExtractedImage[];
+    }> = [];
 
     for (let i = 0; i < notes.length; i++) {
       const note = notes[i];
@@ -1025,29 +1025,9 @@ export async function exportAllNotes(
       let markdown: string;
       let extractedImages: ExtractedImage[] = [];
 
-      // 统计格式
-      if (note.contentFormat === "markdown") formatStats.markdown++;
-      else if (note.contentFormat === "html") formatStats.html++;
-      else formatStats.richText++;
-
       // P0: Markdown 原生笔记直接导出 content 原文，不走 HTML → Markdown 转换
       if (note.contentFormat === "markdown") {
         markdown = note.content || note.contentText || "";
-
-        // Markdown 笔记中的附件引用需要处理
-        if (!inlineImages && markdown) {
-          let registry = perFolderRegistry.get(folder);
-          if (!registry) {
-            registry = new Map();
-            perFolderRegistry.set(folder, registry);
-          }
-          // 处理 Markdown 语法中的 ![alt](/api/attachments/<id>) 和 [text](/api/attachments/<id>)
-          const r = await processMarkdownAttachments(markdown, registry, imgStats, { noteId: note.id, noteTitle: note.title });
-          markdown = r.content;
-          extractedImages = r.images;
-        } else if (inlineImages && markdown) {
-          markdown = await inlineRemoteImages(markdown, imgStats, { noteId: note.id, noteTitle: note.title });
-        }
       } else {
         // 富文本笔记：Tiptap JSON → HTML → Markdown
         let html = noteContentToHtml(note.content, note.contentText);
@@ -1061,117 +1041,47 @@ export async function exportAllNotes(
           const r = await extractDataImages(html, registry);
           html = r.html;
           extractedImages = r.images;
-
-          const r2 = await fetchRemoteImages(html, registry, imgStats, { noteId: note.id, noteTitle: note.title });
-          html = r2.html;
-          extractedImages = extractedImages.concat(r2.images);
-
-          const r3 = await fetchRemoteAttachments(html, registry, imgStats, { noteId: note.id, noteTitle: note.title });
-          html = r3.html;
-          extractedImages = extractedImages.concat(r3.assets);
-        } else if (inlineImages && html) {
-          html = await inlineRemoteImages(html, imgStats, { noteId: note.id, noteTitle: note.title });
         }
 
         markdown = html ? postProcessMarkdown(td.turndown(html)) : "";
       }
 
-      // 添加 YAML frontmatter
-      const frontmatter = [
-        "---",
-        `title: "${note.title.replace(/"/g, '\\"')}"`,
-        `contentFormat: "${note.contentFormat || 'tiptap-json'}"`,
-        `created: ${note.createdAt}`,
-        `updated: ${note.updatedAt}`,
-        "---",
-        "",
-      ].join("\n");
-
-      const fullContent = frontmatter + markdown;
-
-      // 确定文件路径（folder 在抽图前已计算）
-      const count = folderCounts.get(folder) || 0;
-      folderCounts.set(folder, count + 1);
-
-      let fileName = sanitizeFilename(note.title);
-      // 避免同名文件冲突
-      const testPath = `${folder}/${fileName}.md`;
-      if (zip.file(testPath)) {
-        fileName = `${fileName}_${count + 1}`;
-      }
-
-      zip.file(`${folder}/${fileName}.md`, fullContent);
-
-      // 把本笔记抽出的图片写入 zip（同一 hash 在同目录只写一次）
-      for (const img of extractedImages) {
-        const fullPath = `${folder}/${img.relPath}`;
-        if (writtenImages.has(fullPath)) continue;
-        writtenImages.add(fullPath);
-        zip.file(fullPath, img.base64, { base64: true });
-      }
-    }
-
-    // 3. 添加元数据
-    zip.file(
-      "metadata.json",
-      JSON.stringify({
-        version: "1.0",
-        app: "nowen-note",
-        exportedAt: new Date().toISOString(),
-        totalNotes: total,
-        notebooks: Array.from(folderCounts.entries()).map(([name, count]) => ({ name, count })),
-        // P0-2：汇总在 metadata 里，快速看总体；明细看 export-warnings.json
-        imageStats: { ok: imgStats.ok, failed: imgStats.failed },
-        formatStats,
-      }, null, 2)
-    );
-
-    // 3.1 如果有图片处理失败，写明细信息到 export-warnings.json，让用户能看到
-    // “哪些笔记的哪些图”失败了，而不是只看到一个“失败 N 张”的总数。
-    if (imgStats.failures.length > 0) {
-      zip.file(
-        "export-warnings.json",
-        JSON.stringify({
-          version: "1.0",
-          app: "nowen-note",
-          generatedAt: new Date().toISOString(),
-          summary: { ok: imgStats.ok, failed: imgStats.failed },
-          failures: imgStats.failures,
-          hint: "请检查：原始附件是否仍在（/api/attachments/<id>）、网络是否可用。导入到其它实例时可能出现这些图加载失败。",
-        }, null, 2)
-      );
-    }
-
-    // 4. 生成 ZIP
-    onProgress?.({ phase: "packing", current: total, total, message: i18n.t('export.generatingZip') });
-    const blob = await zip.generateAsync(
-      {
-        type: "blob",
-        compression: "DEFLATE",
-        compressionOptions: { level: 6 },
-      },
-      (meta) => {
-        onProgress?.({
-          phase: "packing",
-          current: Math.round(meta.percent),
-          total: 100,
-          message: i18n.t('export.compressing', { percent: Math.round(meta.percent) }),
-        });
-      }
-    );
-
-    // 5. 触发下载
-    const date = new Date().toISOString().slice(0, 10);
-    saveAs(blob, `nowen-note_backup_${date}.zip`);
-
-    // 若有图片下载失败，给用户一个非阻塞警告（done 前多 emit 一条 error 消息）
-    if (imgStats.failed > 0) {
-      onProgress?.({
-        phase: "error",
-        current: imgStats.failed,
-        total: imgStats.ok + imgStats.failed,
-        message: i18n.t('export.someImagesFailed', { count: imgStats.failed }),
+      preparedNotes.push({
+        id: note.id,
+        title: note.title,
+        notebookName: note.notebookName,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+        contentFormat: note.contentFormat,
+        markdown,
+        inlineAssets: extractedImages,
       });
+    }
+
+    // 3. 后端异步流式打包。轮询任务状态不会占用一个长连接，也不会触发 NAS 代理超时。
+    onProgress?.({ phase: "packing", current: 0, total: 100, message: i18n.t('export.generatingZip') });
+    const created = await api.createMarkdownExportJob(preparedNotes, {
+      inlineImages,
+      workspaceId: options?.workspaceId,
+    });
+    // 服务端已接收任务后立即释放转换结果和原始列表，避免轮询期间继续占用浏览器内存。
+    preparedNotes.length = 0;
+    notes.length = 0;
+    let job = created.job;
+    const deadline = Date.now() + 30 * 60 * 1000;
+    while (job.state === "queued" || job.state === "building") {
+      if (Date.now() > deadline) throw new Error("导出任务超时，请缩小导出范围后重试");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      job = (await api.getMarkdownExportJob(job.id)).job;
+      const percent = job.total > 0 ? Math.min(99, Math.round((job.current / job.total) * 95)) : 0;
+      onProgress?.({ phase: "packing", current: percent, total: 100, message: job.message });
+    }
+    if (job.state === "error") throw new Error(job.message || "生成 ZIP 失败");
+    if (!job.downloadToken) throw new Error("导出任务完成但没有生成下载链接");
+    api.downloadMarkdownExport(job.downloadToken, job.filename);
+
+    if (job.warnings > 0) {
+      onProgress?.({ phase: "error", current: job.warnings, total: job.warnings, message: job.message });
     }
     onProgress?.({ phase: "done", current: total, total, message: i18n.t('export.exportComplete') });
     return true;

--- a/frontend/src/lib/exportService.ts
+++ b/frontend/src/lib/exportService.ts
@@ -1344,15 +1344,6 @@ export async function exportSingleNote(
       const r = await extractDataImages(html, registry);
       html = r.html;
       extractedImages = r.images;
-
-      // 同样把 /api/attachments/<id> 的图片一起拉下来
-      const stats: ImgStats = { ok: 0, failed: 0, failures: [] };
-      const r2 = await fetchRemoteImages(html, registry, stats, { noteId: note.id, noteTitle: note.title });
-      html = r2.html;
-      extractedImages = extractedImages.concat(r2.images);
-      if (stats.failed > 0) {
-        console.warn(`[exportSingleNote] ${stats.failed} image(s) failed to download; keeping original <img src>.`);
-      }
     } else if (inlineImages && html) {
       // inline 模式：把附件内嵌成 data URI，让二次导入时后端自动重建附件
       const stats: ImgStats = { ok: 0, failed: 0, failures: [] };
@@ -1375,20 +1366,35 @@ export async function exportSingleNote(
 
     const fullContent = frontmatter + markdown;
     const safeTitle = sanitizeFilename(note.title);
+    const hasServerAssets = extractedImages.length > 0 || /\/api\/attachments\//i.test(markdown);
 
-    if (extractedImages.length > 0) {
-      // 打成 zip：根目录放 md + assets/
-      const zip = new JSZip();
-      zip.file(`${safeTitle}.md`, fullContent);
-      for (const img of extractedImages) {
-        zip.file(img.relPath, img.base64, { base64: true });
-      }
-      const blob = await zip.generateAsync({
-        type: "blob",
-        compression: "DEFLATE",
-        compressionOptions: { level: 6 },
+    if (!inlineImages && hasServerAssets) {
+      // 单篇含附件时也交给后端流式打包，避免 Blob 下载被 Chrono 等扩展卡在完成状态。
+      const created = await api.createMarkdownExportJob([{
+        id: note.id,
+        title: note.title,
+        notebookName: null,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+        contentFormat: note.contentFormat,
+        markdown,
+        inlineAssets: extractedImages,
+      }], {
+        inlineImages: false,
+        layout: "flat",
+        filenameBase: safeTitle,
       });
-      saveAs(blob, `${safeTitle}.zip`);
+      let job = created.job;
+      const deadline = Date.now() + 30 * 60 * 1000;
+      while (job.state === "queued" || job.state === "building") {
+        if (Date.now() > deadline) throw new Error("导出任务超时，请稍后重试");
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        job = (await api.getMarkdownExportJob(job.id)).job;
+      }
+      if (job.state === "error") throw new Error(job.message || "生成 ZIP 失败");
+      if (!job.downloadToken) throw new Error("导出任务完成但没有生成下载链接");
+      api.downloadMarkdownExport(job.downloadToken, job.filename);
+      if (job.warnings > 0) console.warn(`[exportSingleNote] ${job.message}`);
     } else {
       const blob = new Blob([fullContent], { type: "text/markdown;charset=utf-8" });
       saveAs(blob, `${safeTitle}.md`);

--- a/frontend/src/lib/wordNoteService.ts
+++ b/frontend/src/lib/wordNoteService.ts
@@ -349,20 +349,13 @@ export async function exportNoteAsDocx(
 }
 
 /**
- * 触发浏览器下载一个 .docx Blob。
- * 抽出来是因为下载链路三段（Blob URL → a 标签 → revoke）很容易写错。
+ * 把浏览器生成的 DOCX 暂存到服务端，再从真实 HTTP 地址触发下载。
+ * 避免 Chrono 等下载扩展接管 about:blank Blob 后无法完成。
  */
-export function downloadDocxBlob(blob: Blob, filename: string): void {
+export async function downloadDocxBlob(blob: Blob, filename: string): Promise<void> {
   const safeName = /\.docx$/i.test(filename) ? filename : `${filename}.docx`;
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = safeName;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  // 给浏览器一点时间走下载握手再释放（直接 revoke 部分浏览器会取消下载）
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  const staged = await api.stageGeneratedExport(blob, safeName);
+  api.downloadMarkdownExport(staged.downloadToken, staged.filename);
 }
 
 // ===== 导入 Word 文档 =====


### PR DESCRIPTION
## 背景

在 NAS（极空间）部署环境中，从笔记本导出单篇文档时存在两类卡住问题：

- Markdown 导出在下载进度接近完成（约 99%）后不再结束。
- PDF / Word 虽然已经在浏览器端生成完整文件，但下载工具看到的来源是 `about:blank`，进度显示文件大小已完成后仍无法收尾。

该问题在极空间的 Chrono 下载工具中可以稳定复现。Markdown、PDF、DOCX 三种格式均受浏览器 Blob 下载链路影响，只是表现略有不同。

## 根因

1. Markdown 导出原先在前端收集笔记与附件并一次性生成 ZIP，导出过程占用浏览器内存，最终通过 Blob URL 触发下载。
2. PDF 和 DOCX 仍然直接使用浏览器生成的 Blob URL 下载。NAS 下载工具接管请求后只能看到 `about:blank`，缺少稳定的 HTTP 响应、文件长度及附件响应头，因此可能在收到全部字节后仍无法正确结束任务。

## 修改内容

### 1. Markdown 改为后端异步流式导出

- 新增 Markdown 导出任务服务与接口。
- 后端校验当前用户对笔记的访问权限后，流式写入 ZIP 临时文件，避免在浏览器内一次性聚合全部内容。
- 前端仅负责创建任务、轮询状态，并通过真实 HTTP 下载地址获取完成的 ZIP。
- 单篇笔记导出使用扁平 ZIP 结构：Markdown 文件和附件位于压缩包根目录，同时继续重写文内附件引用。
- 保留重复标题笔记，避免因为文件名冲突覆盖内容。

### 2. PDF / Word 改为真实 HTTP 下载

PDF 和 DOCX 仍由浏览器生成，以保持现有排版与转换行为；生成完成后：

1. 前端将 Blob 以流的方式暂存到后端；
2. 后端返回随机下载令牌；
3. 前端再通过 `/api/export/download/:token` 触发标准 HTTP 附件下载。

下载响应包含正确的 `Content-Type`、`Content-Disposition` 和 `Content-Length`，不再依赖 `about:blank` / Blob URL。

### 3. 资源与安全边界

- 所有创建任务与暂存接口均需要登录认证。
- Markdown 导出会校验笔记所有权/访问权限。
- 下载地址使用随机令牌，不暴露临时文件路径。
- 临时导出文件默认 30 分钟后过期并自动清理。
- PDF / DOCX 暂存文件限制为 512 MiB，每个用户最多保留 5 个。
- Markdown 内联附件累计限制为 128 MiB。
- 对文件名和附件路径进行规范化，拒绝目录穿越。
- 暂存接口仅接受 PDF 和 DOCX MIME 类型。
- CORS 明确允许导出文件名请求头。

## 测试

已执行并通过：

- 后端 TypeScript 检查：`npm run build:tsc`
- 后端导出与 CORS 测试：8/8 通过
  - ZIP 流式写入及重复标题
  - 单篇笔记扁平 ZIP 与附件
  - PDF 暂存及真实 HTTP 下载响应
  - 用户权限校验、异步任务状态和 CORS
- 前端导出测试：3/3 通过
  - 单篇 Markdown 服务端 ZIP 任务
  - Word 暂存及 HTTP 下载链路
- 前端生产构建：`npx vite build`

## 实机验证

已构建 AMD64 NAS 镜像并部署到极空间验证：

- 单篇 Markdown 导出成功完成；
- PDF 和 Word 导出成功完成；
- Chrono 下载任务不再停留在 `about:blank` 或 99%；
- 导出的文件名、内容及附件引用正常。

## 兼容性说明

- 不改变现有导出入口和用户操作方式。
- 不改变 PDF / DOCX 的浏览器端生成与排版逻辑，仅替换最终下载传输方式。
- PR 仅包含源码、依赖声明和测试文件，不包含任何 Docker 镜像或构建产物。
