### PR TITLE
feat(tasks): 完善任务与习惯统计视图

### DIFF
--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -1952,6 +1952,19 @@ export const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  // v44: 任务完成时间持久化，供记录/趋势/热力图统计使用。
+  {
+    version: 44,
+    name: "tasks-completed-at",
+    up: (db) => {
+      const cols = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+      if (!cols.some((c) => c.name === "completedAt")) {
+        db.prepare("ALTER TABLE tasks ADD COLUMN completedAt TEXT").run();
+      }
+      db.prepare("UPDATE tasks SET completedAt = COALESCE(completedAt, updatedAt) WHERE isCompleted = 1 AND completedAt IS NULL").run();
+      db.prepare("UPDATE tasks SET completedAt = NULL WHERE isCompleted = 0 AND completedAt IS NOT NULL").run();
+    },
+  },
 ];
 
 /** 当前代码已知的最高 schema 版本（== MIGRATIONS 里 max(version)）。 */

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -436,6 +436,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     title TEXT NOT NULL,
     "isCompleted" BOOLEAN DEFAULT false,
+    "completedAt" TIMESTAMPTZ,
     priority INTEGER DEFAULT 2,
     "dueDate" TEXT,
     "noteId" TEXT REFERENCES notes(id) ON DELETE SET NULL,
@@ -466,6 +467,7 @@ CREATE INDEX IF NOT EXISTS idx_tasks_due ON tasks("dueDate");
 CREATE INDEX IF NOT EXISTS idx_tasks_dueAt ON tasks("dueAt");
 CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks("workspaceId");
 CREATE INDEX IF NOT EXISTS idx_tasks_completed ON tasks("isCompleted");
+CREATE INDEX IF NOT EXISTS idx_tasks_completed_at ON tasks("completedAt");
 CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks("projectId");
 
 CREATE TABLE IF NOT EXISTS task_templates (

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -256,6 +256,7 @@ function initSchema(db: Database.Database) {
       userId TEXT NOT NULL,
       title TEXT NOT NULL,
       isCompleted INTEGER DEFAULT 0,
+      completedAt TEXT,
       priority INTEGER DEFAULT 2,
       dueDate TEXT,
       noteId TEXT,

--- a/backend/src/routes/habits.ts
+++ b/backend/src/routes/habits.ts
@@ -34,6 +34,23 @@ type HabitListRecord = HabitRecord & {
     todayCheckinDate?: string | null;
 };
 
+type HabitCheckinListRecord = {
+    id: string;
+    habitId: string;
+    userId: string;
+    workspaceId: string | null;
+    checkinDate: string;
+    status: HabitStatus;
+    note: string;
+    createdAt: string;
+    updatedAt: string;
+    habitTitle: string;
+    habitColor: string;
+    habitIcon: string;
+    habitArchivedAt: string | null;
+    creatorName?: string | null;
+};
+
 const STATUS_SET = new Set<HabitStatus>(["success", "partial", "failure"]);
 const ROLE_RANK: Record<string, number> = { viewer: 1, commenter: 2, editor: 3, admin: 4, owner: 5 };
 
@@ -219,6 +236,60 @@ habits.get("/stats", requireWorkspaceFeature("tasks"), (c) => {
     });
 });
 
+habits.get("/checkins", requireWorkspaceFeature("tasks"), (c) => {
+    const db = getDb();
+    const userId = c.req.header("X-User-Id")!;
+    const scope = resolveHabitScope(c, userId);
+    if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+    const from = c.req.query("from");
+    const to = c.req.query("to");
+    const includeArchived = c.req.query("includeArchived") !== "0";
+    if ((from && !isValidDateKey(from)) || (to && !isValidDateKey(to))) return invalidDate(c);
+    if (from && to && from > to) {
+        return c.json({ error: "from must not be later than to", code: "INVALID_DATE_RANGE" }, 400);
+    }
+
+    const params: unknown[] = [];
+    const whereParts: string[] = [];
+    if (scope.scope === "workspace") {
+        whereParts.push("h.workspaceId = ?");
+        params.push(scope.workspaceId);
+    } else {
+        whereParts.push("h.userId = ?", "h.workspaceId IS NULL");
+        params.push(userId);
+    }
+    if (!includeArchived) whereParts.push("h.archivedAt IS NULL");
+    if (from) {
+        whereParts.push("hc.checkinDate >= ?");
+        params.push(from);
+    }
+    if (to) {
+        whereParts.push("hc.checkinDate <= ?");
+        params.push(to);
+    }
+
+    const rows = db.prepare(`
+      SELECT
+        hc.*,
+        h.title AS habitTitle,
+        h.color AS habitColor,
+        h.icon AS habitIcon,
+        h.archivedAt AS habitArchivedAt,
+        users.username AS creatorName
+      FROM habit_checkins hc
+      INNER JOIN habits h ON h.id = hc.habitId
+      LEFT JOIN users ON users.id = h.userId
+      WHERE ${whereParts.join(" AND ")}
+      ORDER BY hc.checkinDate DESC, h.sortOrder ASC, hc.createdAt DESC
+    `).all(...params) as HabitCheckinListRecord[];
+
+    return c.json(rows.map((row) => ({
+        ...row,
+        canManage: canManageResource(row.userId, row.workspaceId, userId),
+    })));
+});
+
 habits.post("/", requireWorkspaceFeature("tasks"), async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
@@ -373,6 +444,22 @@ habits.patch("/:id/archive", async (c) => {
     db.prepare("UPDATE habits SET archivedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(archivedAt, id);
     const updated = db.prepare("SELECT * FROM habits WHERE id = ?").get(id);
     return c.json(updated);
+});
+
+habits.delete("/:id", async (c) => {
+    const db = getDb();
+    const userId = c.req.header("X-User-Id")!;
+    const id = c.req.param("id");
+    const habit = getHabitOr404(id);
+    if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
+    const disabled = rejectDisabledHabitFeature(c, habit.workspaceId);
+    if (disabled) return disabled;
+    if (!canManageResource(habit.userId, habit.workspaceId, userId)) {
+        return c.json({ error: "无权删除该习惯", code: "FORBIDDEN" }, 403);
+    }
+
+    db.prepare("DELETE FROM habits WHERE id = ?").run(id);
+    return c.json({ success: true });
 });
 
 export default habits;

--- a/backend/src/routes/task-templates.ts
+++ b/backend/src/routes/task-templates.ts
@@ -169,7 +169,7 @@ taskTemplates.post('/:id/apply', async (c) => {
   const createdTasks: any[] = [];
 
   const insertStmt = db.prepare(
-    'INSERT INTO tasks (id, userId, workspaceId, title, description, priority, isCompleted, status, sortOrder, projectId, parentId, dueDate, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, 0, \'todo\', ?, ?, ?, ?, datetime(\'now\'), datetime(\'now\'))'
+    'INSERT INTO tasks (id, userId, workspaceId, title, description, priority, isCompleted, completedAt, status, sortOrder, projectId, parentId, dueDate, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, 0, NULL, \'todo\', ?, ?, ?, ?, datetime(\'now\'), datetime(\'now\'))'
   );
 
   const createAll = db.transaction(() => {

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -363,14 +363,15 @@ tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
   }
 
   const effectiveIsCompleted = status === "done" ? 1 : 0;
+  const effectiveCompletedAt = effectiveIsCompleted ? new Date().toISOString() : null;
 
   const effectiveRepeatEndDate = repeatRule === "none" ? null : repeatEndDate;
   const repeatSequenceIndex = repeatRule === "none" ? null : 1;
 
   db.prepare(`
-    INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, userId, effectiveWorkspaceId, title.trim(), description, effectiveIsCompleted, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson);
+    INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, completedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, userId, effectiveWorkspaceId, title.trim(), description, effectiveIsCompleted, effectiveCompletedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson);
 
   const task = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id);
   return c.json(task, 201);
@@ -472,6 +473,10 @@ tasks.put("/:id", (c) => {
       status = isCompleted ? "done" : (existing.status === "done" ? "todo" : existing.status);
     }
 
+    const completedAt = isCompleted
+      ? (existing.isCompleted ? (existing.completedAt ?? new Date().toISOString()) : new Date().toISOString())
+      : null;
+
     // Fix 2: validate projectId scope
     if (body.projectId !== undefined && projectId !== null && projectId !== existing.projectId) {
       const project = db.prepare("SELECT userId, workspaceId FROM task_projects WHERE id = ?").get(projectId) as any;
@@ -530,9 +535,9 @@ tasks.put("/:id", (c) => {
 
     db.prepare(`
       UPDATE tasks SET title = ?, isCompleted = ?, priority = ?, dueDate = ?, dueAt = ?, startDate = ?,
-        description = ?, noteId = ?, parentId = ?, sortOrder = ?, projectId = ?, status = ?, repeatRule = ?, repeatInterval = ?, repeatEndDate = ?, repeatEndCount = ?, repeatSequenceIndex = ?, repeatRuleJson = ?, updatedAt = datetime('now')
+        description = ?, noteId = ?, parentId = ?, sortOrder = ?, projectId = ?, status = ?, completedAt = ?, repeatRule = ?, repeatInterval = ?, repeatEndDate = ?, repeatEndCount = ?, repeatSequenceIndex = ?, repeatRuleJson = ?, updatedAt = datetime('now')
       WHERE id = ?
-    `).run(title, isCompleted, priority, dueDate, dueAt, startDate, description, noteId, parentId, sortOrder, projectId, status, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatEndCount, repeatSequenceIndex, repeatRuleJson, id);
+    `).run(title, isCompleted, priority, dueDate, dueAt, startDate, description, noteId, parentId, sortOrder, projectId, status, completedAt, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatEndCount, repeatSequenceIndex, repeatRuleJson, id);
 
     let generatedTask = null;
     // Generate next repeated task when marking as done via PUT
@@ -721,8 +726,8 @@ function generateNextRepeatedTask(db: any, task: any): any {
 
   const newId = crypto.randomUUID();
   db.prepare(`
-    INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
-    VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, completedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
+    VALUES (?, ?, ?, ?, ?, 0, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(newId, task.userId, task.workspaceId, task.title, task.description || "", task.priority, nextDueDate, nextDueAt, null, task.noteId, task.parentId, task.projectId, 'todo', task.repeatRule, task.repeatInterval, task.repeatEndDate, groupId, task.id, task.repeatEndCount ?? null, nextSequenceIndex, task.repeatRuleJson);
 
   db.prepare("UPDATE tasks SET repeatNextGeneratedId = ? WHERE id = ?").run(newId, task.id);
@@ -750,7 +755,8 @@ tasks.patch("/:id/toggle", (c) => {
 
   const newStatus = task.isCompleted ? 0 : 1;
   const newTaskStatus = newStatus === 1 ? "done" : "todo";
-  db.prepare("UPDATE tasks SET isCompleted = ?, status = ?, updatedAt = datetime('now') WHERE id = ?").run(newStatus, newTaskStatus, id);
+  const completedAt = newStatus === 1 ? new Date().toISOString() : null;
+  db.prepare("UPDATE tasks SET isCompleted = ?, status = ?, completedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(newStatus, newTaskStatus, completedAt, id);
 
   const generatedTask = newStatus === 1 ? generateNextRepeatedTask(db, task) : null;
 
@@ -847,8 +853,9 @@ tasks.post("/batch", async (c) => {
 
       const completeIds = toComplete.map((t) => t.id);
       const cph = completeIds.map(() => "?").join(",");
-      db.prepare("UPDATE tasks SET isCompleted = 1, status = 'done', updatedAt = datetime('now') WHERE id IN (" + cph + ")")
-        .run(...completeIds);
+      const completedAt = new Date().toISOString();
+      db.prepare("UPDATE tasks SET isCompleted = 1, status = 'done', completedAt = ?, updatedAt = datetime('now') WHERE id IN (" + cph + ")")
+        .run(completedAt, ...completeIds);
 
       let generatedCount = 0;
       for (const task of toComplete) {

--- a/backend/tests/habits.test.ts
+++ b/backend/tests/habits.test.ts
@@ -238,6 +238,129 @@ test("archive hides habit from active list but keeps history", async () => {
     assert.equal(history.json[0].status, "failure");
 });
 
+test("unarchive restores habit to active list", async () => {
+    const created = await requestJson("POST", "/habits", { title: "Stretch" });
+    await requestJson("PATCH", `/habits/${created.json.id}/archive`, { archived: true });
+
+    const restored = await requestJson("PATCH", `/habits/${created.json.id}/archive`, { archived: false });
+    assert.equal(restored.status, 200);
+    assert.equal(restored.json.archivedAt, null);
+
+    const activeList = await requestJson("GET", "/habits");
+    assert.equal(activeList.status, 200);
+    assert.equal(activeList.json.length, 1);
+    assert.equal(activeList.json[0].title, "Stretch");
+});
+
+test("delete habit removes habit and its checkins", async () => {
+    const created = await requestJson("POST", "/habits", { title: "Delete me" });
+    await requestJson("POST", `/habits/${created.json.id}/checkins`, {
+        checkinDate: "2026-07-09",
+        status: "success",
+        note: "done",
+    });
+
+    const deleted = await requestJson("DELETE", `/habits/${created.json.id}`);
+    assert.equal(deleted.status, 200);
+    assert.equal(deleted.json.success, true);
+
+    const habitsCount = db()
+        .prepare("SELECT COUNT(*) AS count FROM habits WHERE id = ?")
+        .get(created.json.id) as { count: number };
+    const checkinsCount = db()
+        .prepare("SELECT COUNT(*) AS count FROM habit_checkins WHERE habitId = ?")
+        .get(created.json.id) as { count: number };
+    assert.equal(habitsCount.count, 0);
+    assert.equal(checkinsCount.count, 0);
+});
+
+test("collection checkin log includes archived habits for statistics view", async () => {
+    const first = await requestJson("POST", "/habits", { title: "Read" });
+    const second = await requestJson("POST", "/habits", { title: "Run" });
+
+    await requestJson("POST", `/habits/${first.json.id}/checkins`, {
+        checkinDate: "2026-07-08",
+        status: "success",
+        note: "chapter 1",
+    });
+    await requestJson("POST", `/habits/${second.json.id}/checkins`, {
+        checkinDate: "2026-07-09",
+        status: "partial",
+        note: "20 min",
+    });
+    await requestJson("PATCH", `/habits/${second.json.id}/archive`, { archived: true });
+
+    const log = await requestJson("GET", "/habits/checkins?includeArchived=1&from=2026-07-08&to=2026-07-09");
+    assert.equal(log.status, 200);
+    assert.equal(log.json.length, 2);
+    assert.equal(log.json[0].habitTitle, "Run");
+    assert.equal(log.json[0].status, "partial");
+    assert.ok(log.json[0].habitArchivedAt);
+    assert.equal(log.json[1].habitTitle, "Read");
+    assert.equal(log.json[1].note, "chapter 1");
+
+    const activeOnly = await requestJson("GET", "/habits/checkins?includeArchived=0");
+    assert.equal(activeOnly.status, 200);
+    assert.equal(activeOnly.json.length, 1);
+    assert.equal(activeOnly.json[0].habitTitle, "Read");
+});
+
+test("workspace feature flag tasks=false blocks collection checkin log endpoint", async () => {
+    const workspaceId = seedWorkspace({ id: "ws-disabled-checkins" });
+    const created = await requestJson("POST", `/habits?workspaceId=${workspaceId}`, { title: "Blocked log" });
+    assert.equal(created.status, 201);
+
+    db().prepare("UPDATE workspaces SET enabledFeatures = ? WHERE id = ?")
+        .run(JSON.stringify({ tasks: false }), workspaceId);
+
+    const log = await requestJson("GET", `/habits/checkins?workspaceId=${workspaceId}`);
+    assert.equal(log.status, 403);
+    assert.equal(log.json.code, "FEATURE_DISABLED");
+});
+
+test("workspace checkin log rejects non-members", async () => {
+    const workspaceId = seedWorkspace({ id: "ws-checkins-private" });
+    const created = await requestJson("POST", `/habits?workspaceId=${workspaceId}`, { title: "Team habit" });
+    assert.equal(created.status, 201);
+    await requestJson("POST", `/habits/${created.json.id}/checkins`, {
+        checkinDate: "2026-07-09",
+        status: "success",
+    });
+
+    const forbidden = await requestJsonAsUser(OTHER_USER_ID, "GET", `/habits/checkins?workspaceId=${workspaceId}`);
+    assert.equal(forbidden.status, 403);
+    assert.equal(forbidden.json.code, "FORBIDDEN");
+});
+
+test("collection checkin log isolates personal and workspace scopes", async () => {
+    const personal = await requestJson("POST", "/habits", { title: "Personal habit" });
+    await requestJson("POST", `/habits/${personal.json.id}/checkins`, {
+        checkinDate: "2026-07-08",
+        status: "success",
+        note: "personal",
+    });
+
+    const workspaceId = seedWorkspace({ id: "ws-checkins-scope" });
+    const shared = await requestJson("POST", `/habits?workspaceId=${workspaceId}`, { title: "Workspace habit" });
+    await requestJson("POST", `/habits/${shared.json.id}/checkins`, {
+        checkinDate: "2026-07-08",
+        status: "partial",
+        note: "workspace",
+    });
+
+    const personalLog = await requestJson("GET", "/habits/checkins");
+    assert.equal(personalLog.status, 200);
+    assert.equal(personalLog.json.length, 1);
+    assert.equal(personalLog.json[0].habitTitle, "Personal habit");
+    assert.equal(personalLog.json[0].workspaceId, null);
+
+    const workspaceLog = await requestJson("GET", `/habits/checkins?workspaceId=${workspaceId}`);
+    assert.equal(workspaceLog.status, 200);
+    assert.equal(workspaceLog.json.length, 1);
+    assert.equal(workspaceLog.json[0].habitTitle, "Workspace habit");
+    assert.equal(workspaceLog.json[0].workspaceId, workspaceId);
+});
+
 test("stats summary counts totals and current streak from success partial only", async () => {
     const first = await requestJson("POST", "/habits", { title: "Read" });
     const second = await requestJson("POST", "/habits", { title: "Run" });

--- a/backend/tests/task-completed-at.test.ts
+++ b/backend/tests/task-completed-at.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-task-completed-at-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+const USER_ID = "user-completed-at";
+
+function db() {
+  return getDb();
+}
+
+function seedUser() {
+  db()
+    .prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+}
+
+function resetTasks() {
+  db().prepare("DELETE FROM task_reminders").run();
+  db().prepare("DELETE FROM tasks").run();
+}
+
+async function requestJson(method: string, url: string, body?: unknown) {
+  const res = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": USER_ID,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: res.status, json: await res.json() };
+}
+
+test.before(async () => {
+  const [tasksModule, schemaModule] = await Promise.all([
+    import("../src/routes/tasks"),
+    import("../src/db/schema"),
+  ]);
+  app = new Hono();
+  app.route("/tasks", tasksModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+  seedUser();
+});
+
+test.beforeEach(() => {
+  resetTasks();
+});
+
+test.after(async () => {
+  closeDb();
+  for (let i = 0; i < 5; i++) {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    } catch (err: any) {
+      if (err?.code !== "EBUSY") throw err;
+      if (i === 4) return;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+});
+
+test("creating a done task persists completedAt", async () => {
+  const created = await requestJson("POST", "/tasks", {
+    title: "Already done",
+    status: "done",
+  });
+
+  assert.equal(created.status, 201);
+  assert.equal(created.json.isCompleted, 1);
+  assert.equal(created.json.status, "done");
+  assert.ok(created.json.completedAt);
+
+  const row = db().prepare("SELECT isCompleted, status, completedAt FROM tasks WHERE id = ?").get(created.json.id) as {
+    isCompleted: number;
+    status: string;
+    completedAt: string | null;
+  };
+  assert.equal(row.isCompleted, 1);
+  assert.equal(row.status, "done");
+  assert.ok(row.completedAt);
+});
+
+test("put sets completedAt when marking task done and preserves it on later edits", async () => {
+  const created = await requestJson("POST", "/tasks", { title: "Write changelog" });
+  assert.equal(created.status, 201);
+  assert.equal(created.json.completedAt, null);
+
+  const completed = await requestJson("PUT", `/tasks/${created.json.id}`, {
+    status: "done",
+  });
+  assert.equal(completed.status, 200);
+  assert.equal(completed.json.task.isCompleted, 1);
+  assert.ok(completed.json.task.completedAt);
+
+  const firstCompletedAt = completed.json.task.completedAt;
+
+  const edited = await requestJson("PUT", `/tasks/${created.json.id}`, {
+    title: "Write release changelog",
+  });
+  assert.equal(edited.status, 200);
+  assert.equal(edited.json.task.completedAt, firstCompletedAt);
+
+  const row = db().prepare("SELECT title, completedAt FROM tasks WHERE id = ?").get(created.json.id) as {
+    title: string;
+    completedAt: string | null;
+  };
+  assert.equal(row.title, "Write release changelog");
+  assert.equal(row.completedAt, firstCompletedAt);
+});
+
+test("put clears completedAt when reopening a completed task", async () => {
+  const created = await requestJson("POST", "/tasks", {
+    title: "Reopen me",
+    status: "done",
+  });
+
+  const reopened = await requestJson("PUT", `/tasks/${created.json.id}`, {
+    isCompleted: 0,
+  });
+  assert.equal(reopened.status, 200);
+  assert.equal(reopened.json.task.isCompleted, 0);
+  assert.equal(reopened.json.task.status, "todo");
+  assert.equal(reopened.json.task.completedAt, null);
+
+  const row = db().prepare("SELECT isCompleted, status, completedAt FROM tasks WHERE id = ?").get(created.json.id) as {
+    isCompleted: number;
+    status: string;
+    completedAt: string | null;
+  };
+  assert.equal(row.isCompleted, 0);
+  assert.equal(row.status, "todo");
+  assert.equal(row.completedAt, null);
+});
+
+test("toggle writes and clears completedAt", async () => {
+  const created = await requestJson("POST", "/tasks", { title: "Toggle me" });
+
+  const done = await requestJson("PATCH", `/tasks/${created.json.id}/toggle`);
+  assert.equal(done.status, 200);
+  assert.equal(done.json.task.isCompleted, 1);
+  assert.ok(done.json.task.completedAt);
+
+  const undone = await requestJson("PATCH", `/tasks/${created.json.id}/toggle`);
+  assert.equal(undone.status, 200);
+  assert.equal(undone.json.task.isCompleted, 0);
+  assert.equal(undone.json.task.completedAt, null);
+
+  const row = db().prepare("SELECT isCompleted, completedAt FROM tasks WHERE id = ?").get(created.json.id) as {
+    isCompleted: number;
+    completedAt: string | null;
+  };
+  assert.equal(row.isCompleted, 0);
+  assert.equal(row.completedAt, null);
+});
+
+test("batch complete stamps only incomplete tasks with completedAt", async () => {
+  const first = await requestJson("POST", "/tasks", { title: "Batch A" });
+  const second = await requestJson("POST", "/tasks", { title: "Batch B" });
+  const alreadyDone = await requestJson("POST", "/tasks", { title: "Batch C", status: "done" });
+
+  const existingCompletedAt = alreadyDone.json.completedAt;
+  assert.ok(existingCompletedAt);
+
+  const batch = await requestJson("POST", "/tasks/batch", {
+    ids: [first.json.id, second.json.id, alreadyDone.json.id],
+    action: "complete",
+  });
+
+  assert.equal(batch.status, 200);
+  assert.equal(batch.json.success, true);
+  assert.equal(batch.json.affected, 2);
+
+  const rows = db().prepare(
+    "SELECT id, isCompleted, status, completedAt FROM tasks WHERE id IN (?, ?, ?) ORDER BY id"
+  ).all(first.json.id, second.json.id, alreadyDone.json.id) as Array<{
+    id: string;
+    isCompleted: number;
+    status: string;
+    completedAt: string | null;
+  }>;
+
+  const stamped = rows.filter((row) => row.id !== alreadyDone.json.id);
+  assert.equal(stamped.length, 2);
+  assert.ok(stamped[0].completedAt);
+  assert.ok(stamped[1].completedAt);
+  assert.equal(stamped[0].completedAt, stamped[1].completedAt);
+
+  const preserved = rows.find((row) => row.id === alreadyDone.json.id);
+  assert.ok(preserved);
+  assert.equal(preserved?.isCompleted, 1);
+  assert.equal(preserved?.status, "done");
+  assert.equal(preserved?.completedAt, existingCompletedAt);
+});

--- a/backend/tests/tasks-completed-at-migration.test.ts
+++ b/backend/tests/tasks-completed-at-migration.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+import { MIGRATIONS } from "../src/db/migrations";
+
+function createLegacyDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      title TEXT NOT NULL,
+      description TEXT DEFAULT '',
+      isCompleted INTEGER NOT NULL DEFAULT 0,
+      priority INTEGER NOT NULL DEFAULT 2,
+      dueDate TEXT,
+      dueAt TEXT,
+      startDate TEXT,
+      noteId TEXT,
+      parentId TEXT,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      projectId TEXT,
+      status TEXT NOT NULL DEFAULT 'todo',
+      repeatRule TEXT DEFAULT 'none',
+      repeatInterval INTEGER DEFAULT 1,
+      repeatEndDate TEXT,
+      repeatGroupId TEXT,
+      repeatGeneratedFromId TEXT,
+      repeatNextGeneratedId TEXT,
+      repeatEndCount INTEGER,
+      repeatSequenceIndex INTEGER,
+      repeatRuleJson TEXT,
+      createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+      updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    INSERT INTO tasks (id, userId, title, isCompleted, status, updatedAt)
+    VALUES
+      ('task-done', 'user-1', 'Done task', 1, 'done', '2026-07-08T09:30:00'),
+      ('task-open', 'user-1', 'Open task', 0, 'todo', '2026-07-08T10:00:00');
+  `);
+  return db;
+}
+
+test("tasks-completed-at migration adds column and backfills completed rows", () => {
+  const migration = MIGRATIONS.find((m) => m.name === "tasks-completed-at");
+  assert.ok(migration, "tasks-completed-at migration should be registered");
+
+  const db = createLegacyDb();
+  migration.up(db);
+
+  const cols = db.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+  assert.ok(cols.some((col) => col.name === "completedAt"));
+
+  const rows = db.prepare("SELECT id, isCompleted, completedAt FROM tasks ORDER BY id").all() as Array<{
+    id: string;
+    isCompleted: number;
+    completedAt: string | null;
+  }>;
+
+  assert.deepEqual(rows, [
+    { id: "task-done", isCompleted: 1, completedAt: "2026-07-08T09:30:00" },
+    { id: "task-open", isCompleted: 0, completedAt: null },
+  ]);
+
+  db.close();
+});
+
+test("tasks-completed-at migration clears stale completedAt on incomplete rows", () => {
+  const migration = MIGRATIONS.find((m) => m.name === "tasks-completed-at");
+  assert.ok(migration, "tasks-completed-at migration should be registered");
+
+  const db = createLegacyDb();
+  db.prepare("ALTER TABLE tasks ADD COLUMN completedAt TEXT").run();
+  db.prepare("UPDATE tasks SET completedAt = ? WHERE id = 'task-open'").run("2026-07-01T08:00:00");
+
+  migration.up(db);
+
+  const row = db.prepare("SELECT isCompleted, completedAt FROM tasks WHERE id = 'task-open'").get() as {
+    isCompleted: number;
+    completedAt: string | null;
+  };
+  assert.equal(row.isCompleted, 0);
+  assert.equal(row.completedAt, null);
+
+  db.close();
+});

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { api } from "@/lib/api";
 import { toast } from "@/lib/toast";
-import { Task, TaskFilter, TaskStats, TaskStatus, TaskProject, TaskDependency, Habit, HabitStats, HabitCheckinStatus } from "@/types";
+import { Task, TaskFilter, TaskStats, TaskStatus, TaskProject, TaskDependency, Habit, HabitStats, HabitCheckinStatus, HabitCheckinListItem } from "@/types";
 import { cn } from "@/lib/utils";
 import { isTaskBlockedByDependency } from "./tasks/taskDependencyUtils";
 import {
@@ -45,6 +45,7 @@ import { taskMatchesSearch } from "./tasks/taskSearch";
 import { parseTaskQuickAdd, type TaskQuickAddParseResult } from "./tasks/taskSmartRecognition";
 import { HabitStatsOverview } from "./tasks/HabitStatsOverview";
 import { HabitRow } from "./tasks/HabitRow";
+import { StatsCenter } from "./tasks/StatsCenter";
 
 export function formatLocalDateKey(date = new Date()): string {
   const y = date.getFullYear();
@@ -76,7 +77,8 @@ function getQuickAddCreatePatch(parsed: TaskQuickAddParseResult): Partial<Task> 
 export default function TaskCenter() {
   const { t } = useTranslation();
 
-  type CenterMode = "tasks" | "habits";
+  type CenterMode = "tasks" | "habits" | "stats";
+  type HabitListMode = "active" | "archived" | "all";
 
   const FILTERS: { key: TaskFilter; label: string; icon: React.ReactNode }[] = [
     { key: "all", label: t("tasks.allTasks"), icon: <Inbox size={16} /> },
@@ -99,6 +101,7 @@ export default function TaskCenter() {
   const [centerMode, setCenterMode] = useState<CenterMode>("tasks");
   const [habits, setHabits] = useState<Habit[]>([]);
   const [habitStats, setHabitStats] = useState<HabitStats | null>(null);
+  const [habitListMode, setHabitListMode] = useState<HabitListMode>("active");
   const [newHabitTitle, setNewHabitTitle] = useState("");
   const [filter, setFilter] = useState<TaskFilter>("all");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -112,9 +115,30 @@ export default function TaskCenter() {
   const [searchQuery, setSearchQuery] = useState("");
   const [workspaceVersion, setWorkspaceVersion] = useState(0);
 
-  const pendingHabitCount = useMemo(
-    () => habits.filter((habit) => !habit.todayStatus).length,
+  const [statsTasks, setStatsTasks] = useState<Task[]>([]);
+  const [statsHabits, setStatsHabits] = useState<Habit[]>([]);
+  const [statsHabitCheckins, setStatsHabitCheckins] = useState<HabitCheckinListItem[]>([]);
+  const [statsLoading, setStatsLoading] = useState(false);
+
+  const activeHabits = useMemo(
+    () => habits.filter((habit) => !habit.archivedAt),
     [habits],
+  );
+
+  const archivedHabits = useMemo(
+    () => habits.filter((habit) => !!habit.archivedAt),
+    [habits],
+  );
+
+  const visibleHabits = useMemo(() => {
+    if (habitListMode === "archived") return archivedHabits;
+    if (habitListMode === "all") return habits;
+    return activeHabits;
+  }, [activeHabits, archivedHabits, habitListMode, habits]);
+
+  const pendingHabitCount = useMemo(
+    () => activeHabits.filter((habit) => !habit.todayStatus).length,
+    [activeHabits],
   );
 
   // Phase 5.2: dependencies
@@ -239,8 +263,8 @@ export default function TaskCenter() {
     try {
       const checkinDate = formatLocalDateKey();
       const [list, statsData] = await Promise.all([
-        api.getHabits(false, checkinDate),
-        api.getHabitStats(false, checkinDate),
+        api.getHabits(true, checkinDate),
+        api.getHabitStats(true, checkinDate),
       ]);
       setHabits(list);
       setHabitStats(statsData);
@@ -248,6 +272,30 @@ export default function TaskCenter() {
       console.error("Failed to load habits:", err);
     }
   }, []);
+
+  const loadStatsCenter = useCallback(async () => {
+    try {
+      setStatsLoading(true);
+      const checkinDate = formatLocalDateKey();
+      const [taskList, taskStatsData, habitList, habitStatsData, habitCheckins] = await Promise.all([
+        api.getTasks("all"),
+        api.getTaskStats(),
+        api.getHabits(true, checkinDate),
+        api.getHabitStats(true, checkinDate),
+        api.getHabitCheckinLog({ includeArchived: true }),
+      ]);
+      setStatsTasks(taskList);
+      setStats(taskStatsData);
+      setStatsHabits(habitList);
+      setHabitStats(habitStatsData);
+      setStatsHabitCheckins(habitCheckins);
+    } catch (err) {
+      console.error("Failed to load stats center:", err);
+      toast.error(t("stats.loadFailed"));
+    } finally {
+      setStatsLoading(false);
+    }
+  }, [t, workspaceVersion]);
 
   const loadDependencies = useCallback(async () => {
     try {
@@ -278,6 +326,12 @@ export default function TaskCenter() {
     return () => window.removeEventListener("nowen:workspace-changed", onWs);
   }, [loadTasks, loadHabits]);
 
+  useEffect(() => {
+    if (centerMode === "stats") {
+      loadStatsCenter();
+    }
+  }, [centerMode, loadStatsCenter]);
+
   const handleCreateHabit = async (): Promise<boolean> => {
     const title = newHabitTitle.trim();
     if (!title) return false;
@@ -286,7 +340,7 @@ export default function TaskCenter() {
       const habit = await api.createHabit({ title });
       setHabits((prev) => [habit, ...prev]);
       setNewHabitTitle("");
-      const statsData = await api.getHabitStats(false, checkinDate);
+      const statsData = await api.getHabitStats(true, checkinDate);
       setHabitStats(statsData);
       return true;
     } catch (err) {
@@ -304,18 +358,26 @@ export default function TaskCenter() {
         ? { ...item, todayStatus: updated.status, todayNote: updated.note, todayCheckinDate: updated.checkinDate }
         : item
     )));
-    const statsData = await api.getHabitStats(false, checkinDate);
+    const statsData = await api.getHabitStats(true, checkinDate);
     setHabitStats(statsData);
     toast.success(t("habits.toast.checkinUpdated"));
   };
 
-  const handleArchiveHabit = async (habit: Habit) => {
+  const handleArchiveHabitToggle = async (habit: Habit, archived: boolean) => {
     const checkinDate = formatLocalDateKey();
-    await api.archiveHabit(habit.id, true);
-    setHabits((prev) => prev.filter((item) => item.id !== habit.id));
-    const statsData = await api.getHabitStats(false, checkinDate);
+    const updated = await api.archiveHabit(habit.id, archived);
+    setHabits((prev) => prev.map((item) => (item.id === habit.id ? { ...item, ...updated } : item)));
+    const statsData = await api.getHabitStats(true, checkinDate);
     setHabitStats(statsData);
-    toast.success(t("habits.toast.archived"));
+    toast.success(archived ? t("habits.toast.archived") : t("habits.toast.unarchived"));
+  };
+
+  const handleDeleteHabit = async (habit: Habit) => {
+    await api.deleteHabit(habit.id);
+    setHabits((prev) => prev.filter((item) => item.id !== habit.id));
+    const statsData = await api.getHabitStats(true, formatLocalDateKey());
+    setHabitStats(statsData);
+    toast.success(t("habits.toast.deleted"));
   };
 
   // === Keyboard shortcuts ===
@@ -736,6 +798,17 @@ export default function TaskCenter() {
             </span>
           </button>
 
+          <button
+            onClick={() => { setCenterMode("stats"); setSelectedTaskId(null); setSearchQuery(""); setSelectedProjectId(null); }}
+            className={cn(
+              "flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors",
+              centerMode === "stats" ? "bg-accent-primary/10 text-accent-primary font-medium" : "text-tx-secondary hover:bg-app-hover"
+            )}
+          >
+            <BarChart3 size={16} />
+            <span className="flex-1 text-left">{t("stats.title")}</span>
+          </button>
+
           {/* Projects section */}
           <div className="mt-3 mb-0.5 px-3">
             <div className="flex items-center justify-between">
@@ -843,6 +916,16 @@ export default function TaskCenter() {
             )}>
               {pendingHabitCount}
             </span>
+          </button>
+          <button
+            onClick={() => { setCenterMode("stats"); setSelectedTaskId(null); setSearchQuery(""); setSelectedProjectId(null); }}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors shrink-0",
+              centerMode === "stats" ? "bg-accent-primary/15 text-accent-primary" : "text-tx-secondary bg-app-hover/50 active:bg-app-active"
+            )}
+          >
+            <BarChart3 size={14} />
+            {t("stats.title")}
           </button>
           {centerMode === "tasks" && (
             <>
@@ -976,12 +1059,19 @@ export default function TaskCenter() {
               )}
             </div>
           </div>
-        ) : (
+        ) : centerMode === "habits" ? (
           <div className="hidden md:flex items-center justify-between px-5 py-3 border-b border-app-border">
             <div className="flex items-center gap-2">
               <h1 className="text-lg font-bold text-tx-primary">{t("habits.title")}</h1>
             </div>
             <div className="text-xs text-tx-tertiary">{t("habits.summary")}</div>
+          </div>
+        ) : (
+          <div className="hidden md:flex items-center justify-between px-5 py-3 border-b border-app-border">
+            <div className="flex items-center gap-2">
+              <h1 className="text-lg font-bold text-tx-primary">{t("stats.title")}</h1>
+            </div>
+            <div className="text-xs text-tx-tertiary">{t("stats.subtitle")}</div>
           </div>
         )}
 
@@ -1003,22 +1093,42 @@ export default function TaskCenter() {
               </button>
             )}
           </div>
-        ) : (
+        ) : centerMode === "habits" ? (
           <div className="flex items-center gap-2 px-4 md:px-5 py-2 border-b border-app-border">
-            <input
-              type="text"
-              value={newHabitTitle}
-              onChange={(e) => setNewHabitTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleCreateHabit(); }}
-              placeholder={t("habits.createPlaceholder")}
-              className="flex-1 rounded-md border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-primary placeholder:text-tx-tertiary focus:outline-none focus:border-accent-primary"
-            />
-            <button
-              onClick={handleCreateHabit}
-              className="rounded-md bg-accent-primary px-3 py-2 text-sm text-white transition-opacity hover:opacity-90"
-            >
-              {t("habits.add")}
-            </button>
+            <div className="flex flex-1 items-center gap-2">
+              <input
+                type="text"
+                value={newHabitTitle}
+                onChange={(e) => setNewHabitTitle(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleCreateHabit(); }}
+                placeholder={t("habits.createPlaceholder")}
+                className="flex-1 rounded-md border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-primary placeholder:text-tx-tertiary focus:outline-none focus:border-accent-primary"
+              />
+              <button
+                onClick={handleCreateHabit}
+                className="rounded-md bg-accent-primary px-3 py-2 text-sm text-white transition-opacity hover:opacity-90"
+              >
+                {t("habits.add")}
+              </button>
+            </div>
+            <div className="flex items-center gap-1 rounded-lg bg-app-bg p-1">
+              {(["active", "archived", "all"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => setHabitListMode(mode)}
+                  className={cn(
+                    "rounded-md px-2.5 py-1.5 text-xs transition-colors",
+                    habitListMode === mode ? "bg-accent-primary text-white" : "text-tx-secondary hover:bg-app-hover"
+                  )}
+                >
+                  {mode === "active" ? t("habits.filters.active") : mode === "archived" ? t("habits.filters.archived") : t("habits.filters.all")}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="border-b border-app-border px-4 md:px-5 py-2 text-xs text-tx-tertiary">
+            {t("stats.summaryHint")}
           </div>
         )}
 
@@ -1060,20 +1170,32 @@ export default function TaskCenter() {
         )}
 
         {/* Task List / Board / Calendar View */}
-        {centerMode === "habits" ? (
+        {centerMode === "stats" ? (
+          <StatsCenter
+            tasks={statsTasks}
+            projects={projects}
+            taskStats={stats}
+            habits={statsHabits}
+            habitStats={habitStats}
+            checkins={statsHabitCheckins}
+            loading={statsLoading}
+            onRefresh={loadStatsCenter}
+          />
+        ) : centerMode === "habits" ? (
           <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 md:px-5 py-3">
-            {habits.length === 0 ? (
+            {visibleHabits.length === 0 ? (
               <div className="flex h-40 items-center justify-center text-sm text-tx-tertiary">
                 {t("habits.empty")}
               </div>
             ) : (
               <div className="space-y-2.5">
-                {habits.map((habit) => (
+                {visibleHabits.map((habit) => (
                   <HabitRow
                     key={habit.id}
                     habit={habit}
                     onCheckin={handleHabitCheckin}
-                    onArchive={handleArchiveHabit}
+                    onArchiveToggle={handleArchiveHabitToggle}
+                    onDelete={handleDeleteHabit}
                   />
                 ))}
               </div>

--- a/frontend/src/components/__tests__/StatsCenter.test.tsx
+++ b/frontend/src/components/__tests__/StatsCenter.test.tsx
@@ -1,0 +1,224 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Habit, HabitCheckinListItem, Task } from "@/types";
+import { StatsCenter } from "../tasks/StatsCenter";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (typeof params?.defaultValue === "string") return params.defaultValue;
+      if (!params || Object.keys(params).length === 0) return key;
+      return `${key}:${JSON.stringify(params)}`;
+    },
+    i18n: { language: "en-US" },
+  }),
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    userId: "u1",
+    workspaceId: null,
+    title: "Task One",
+    description: "",
+    isCompleted: 0,
+    priority: 2,
+    dueDate: null,
+    dueAt: null,
+    noteId: null,
+    parentId: null,
+    sortOrder: 0,
+    projectId: null,
+    status: "todo",
+    createdAt: "2026-07-08T08:00:00",
+    updatedAt: "2026-07-08T08:00:00",
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function makeHabit(overrides: Partial<Habit> = {}): Habit {
+  return {
+    id: "habit-1",
+    userId: "u1",
+    workspaceId: null,
+    title: "Habit One",
+    icon: "check-circle",
+    color: "#10b981",
+    sortOrder: 0,
+    archivedAt: null,
+    createdAt: "2026-01-01T00:00:00",
+    updatedAt: "2026-01-01T00:00:00",
+    todayStatus: null,
+    todayNote: null,
+    todayCheckinDate: null,
+    canManage: true,
+    ...overrides,
+  };
+}
+
+function makeCheckin(overrides: Partial<HabitCheckinListItem> = {}): HabitCheckinListItem {
+  return {
+    id: "checkin-1",
+    habitId: "habit-1",
+    userId: "u1",
+    workspaceId: null,
+    checkinDate: "2026-07-08",
+    status: "success",
+    note: "done",
+    createdAt: "2026-07-08T08:00:00",
+    updatedAt: "2026-07-08T08:00:00",
+    habitTitle: "Habit One",
+    habitColor: "#10b981",
+    habitIcon: "check-circle",
+    habitArchivedAt: null,
+    canManage: true,
+    ...overrides,
+  };
+}
+
+function renderStats(root: Root, props: Partial<React.ComponentProps<typeof StatsCenter>> = {}) {
+  const defaultProps: React.ComponentProps<typeof StatsCenter> = {
+    tasks: [],
+    projects: [],
+    taskStats: { total: 0, completed: 0, pending: 0, today: 0, overdue: 0, week: 0 },
+    habits: [],
+    habitStats: { totalCheckins: 0, checkinDays: 0, currentStreak: 0, successCount: 0, partialCount: 0, failureCount: 0 },
+    checkins: [],
+    loading: false,
+    onRefresh: vi.fn(),
+  };
+
+  return act(async () => {
+    root.render(<StatsCenter {...defaultProps} {...props} />);
+    await Promise.resolve();
+  });
+}
+
+function clickButton(host: HTMLDivElement, text: string) {
+  const button = Array.from(host.querySelectorAll("button")).find((item) => item.textContent?.includes(text));
+  expect(button).toBeDefined();
+  return act(async () => {
+    button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+describe("StatsCenter", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-08T10:00:00"));
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("renders task records, weekly trends, and heatmap from completedAt", async () => {
+    await renderStats(root, {
+      tasks: [
+        makeTask({ id: "task-a", title: "Task Alpha", createdAt: "2026-07-08T08:00:00", completedAt: "2026-07-08T09:00:00", isCompleted: 1, status: "done" }),
+        makeTask({ id: "task-b", title: "Task Beta", createdAt: "2026-06-23T11:00:00", completedAt: "2026-06-25T12:30:00", isCompleted: 1, status: "done" }),
+        makeTask({ id: "task-c", title: "Task Gamma", createdAt: "2026-01-03T07:00:00", completedAt: "2026-01-03T07:30:00", isCompleted: 1, status: "done" }),
+      ],
+      taskStats: { total: 3, completed: 3, pending: 0, today: 0, overdue: 0, week: 1 },
+    });
+
+    await clickButton(host, "stats.tabs.tasks");
+    await clickButton(host, "stats.task.tabs.records");
+
+    expect(host.textContent).toContain("Task Alpha");
+    expect(host.textContent).toContain("Task Beta");
+    expect(host.textContent).toContain("stats.task.recordCompleted");
+    expect(host.textContent).toContain("stats.task.recordCreated");
+
+    await clickButton(host, "stats.task.tabs.trends");
+
+    expect(host.textContent).toContain("stats.task.trendTitle");
+    expect(host.textContent).toContain('stats.task.trendLegend:{"created":1,"completed":1}');
+
+    await clickButton(host, "stats.task.tabs.heatmap");
+
+    expect(host.querySelector('[title="2026-07-08 · 1"]')).not.toBeNull();
+    expect(host.querySelector('[title="2026-06-25 · 1"]')).not.toBeNull();
+    expect(host.querySelector('[title="2026-01-03 · 1"]')).not.toBeNull();
+  });
+
+  it("renders project breakdown with real project names and stable grouping", async () => {
+    await renderStats(root, {
+      tasks: [
+        makeTask({ id: "task-p1a", title: "Task P1 A", projectId: "project-1", isCompleted: 1, status: "done" }),
+        makeTask({ id: "task-p1b", title: "Task P1 B", projectId: "project-1" }),
+        makeTask({ id: "task-p2", title: "Task P2", projectId: "project-2", isCompleted: 1, status: "done" }),
+        makeTask({ id: "task-none", title: "Task None", projectId: null }),
+      ],
+      projects: [
+        { id: "project-1", userId: "u1", workspaceId: null, name: "Alpha", icon: "briefcase", color: "#111827", sortOrder: 0, createdAt: "2026-01-01T00:00:00", updatedAt: "2026-01-01T00:00:00" },
+        { id: "project-2", userId: "u1", workspaceId: null, name: "Beta", icon: "briefcase", color: "#1d4ed8", sortOrder: 1, createdAt: "2026-01-01T00:00:00", updatedAt: "2026-01-01T00:00:00" },
+      ],
+      taskStats: { total: 4, completed: 2, pending: 2, today: 0, overdue: 0, week: 0 },
+    });
+
+    await clickButton(host, "stats.tabs.tasks");
+
+    expect(host.textContent).toContain("Alpha");
+    expect(host.textContent).toContain("Beta");
+    expect(host.textContent).toContain("tasks.noProject");
+    expect(host.textContent).toContain("1/2");
+    expect(host.textContent).toContain("1/1");
+    expect(host.textContent).not.toContain("已归类项目");
+  });
+
+  it("renders archived habit logs, active-only week view, and month/year summaries", async () => {
+    await renderStats(root, {
+      habits: [
+        makeHabit({ id: "habit-active", title: "Morning Run", todayStatus: "partial" }),
+        makeHabit({ id: "habit-archived", title: "Archived Reading", archivedAt: "2026-07-01T00:00:00" }),
+      ],
+      habitStats: { totalCheckins: 4, checkinDays: 4, currentStreak: 2, successCount: 2, partialCount: 1, failureCount: 1 },
+      checkins: [
+        makeCheckin({ id: "check-1", habitId: "habit-active", habitTitle: "Morning Run", checkinDate: "2026-07-06", status: "success", note: "5km" }),
+        makeCheckin({ id: "check-2", habitId: "habit-archived", habitTitle: "Archived Reading", checkinDate: "2026-07-07", status: "failure", note: "missed" , habitArchivedAt: "2026-07-01T00:00:00"}),
+        makeCheckin({ id: "check-3", habitId: "habit-active", habitTitle: "Morning Run", checkinDate: "2026-07-08", status: "partial", note: "2km" }),
+        makeCheckin({ id: "check-4", habitId: "habit-archived", habitTitle: "Archived Reading", checkinDate: "2026-02-03", status: "success", note: "book" , habitArchivedAt: "2026-07-01T00:00:00"}),
+      ],
+    });
+
+    await clickButton(host, "stats.tabs.habits");
+    await clickButton(host, "stats.habit.tabs.log");
+
+    expect(host.textContent).toContain("Archived Reading");
+    expect(host.textContent).toContain("missed");
+
+    await clickButton(host, "stats.habit.tabs.week");
+
+    expect(host.textContent).toContain("Morning Run");
+    expect(host.textContent).not.toContain("Archived Reading");
+    expect(host.textContent).toContain("habits.status.success");
+    expect(host.textContent).toContain("habits.status.partial");
+
+    await clickButton(host, "stats.habit.tabs.month");
+
+    expect(host.textContent).toContain("stats.habit.monthTitle");
+    expect(host.textContent).toContain("2026 July");
+    expect(host.querySelector('[title="2026-07-07 · 1"]')).not.toBeNull();
+    expect(host.querySelector('[title="2026-07-08 · 1"]')).not.toBeNull();
+
+    await clickButton(host, "stats.habit.tabs.year");
+
+    expect(host.textContent).toContain("Feb");
+    expect(host.textContent).toContain("Jul");
+  });
+});

--- a/frontend/src/components/__tests__/TaskCenterQuickAddIntegration.test.tsx
+++ b/frontend/src/components/__tests__/TaskCenterQuickAddIntegration.test.tsx
@@ -10,6 +10,9 @@ const apiMocks = vi.hoisted(() => ({
     getTaskStats: vi.fn(),
     getTaskDependencies: vi.fn(),
     getReminderOverview: vi.fn(),
+    getHabits: vi.fn(),
+    getHabitStats: vi.fn(),
+    getHabitCheckinLog: vi.fn(),
     createTask: vi.fn(),
     createTaskReminder: vi.fn(),
     toggleTask: vi.fn(),
@@ -23,12 +26,21 @@ const apiMocks = vi.hoisted(() => ({
     createTaskProject: vi.fn(),
     updateTaskProject: vi.fn(),
     deleteTaskProject: vi.fn(),
+    archiveHabit: vi.fn(),
+    deleteHabit: vi.fn(),
+    checkInHabit: vi.fn(),
+    createHabit: vi.fn(),
     taskAttachmentsBind: vi.fn(),
     childQuickAddTitle: "今天下午3点 子任务 提前3小时",
+    statsCenterProps: [] as any[],
+}));
+
+const i18nMocks = vi.hoisted(() => ({
+    t: (key: string) => key,
 }));
 
 vi.mock("react-i18next", () => ({
-    useTranslation: () => ({ t: (key: string) => key }),
+    useTranslation: () => ({ t: i18nMocks.t, i18n: { language: "zh-CN" } }),
 }));
 
 vi.mock("@/lib/toast", () => ({
@@ -44,6 +56,9 @@ vi.mock("@/lib/api", () => ({
         getTaskStats: apiMocks.getTaskStats,
         getTaskDependencies: apiMocks.getTaskDependencies,
         getReminderOverview: apiMocks.getReminderOverview,
+        getHabits: apiMocks.getHabits,
+        getHabitStats: apiMocks.getHabitStats,
+        getHabitCheckinLog: apiMocks.getHabitCheckinLog,
         createTask: apiMocks.createTask,
         createTaskReminder: apiMocks.createTaskReminder,
         toggleTask: apiMocks.toggleTask,
@@ -57,6 +72,10 @@ vi.mock("@/lib/api", () => ({
         createTaskProject: apiMocks.createTaskProject,
         updateTaskProject: apiMocks.updateTaskProject,
         deleteTaskProject: apiMocks.deleteTaskProject,
+        archiveHabit: apiMocks.archiveHabit,
+        deleteHabit: apiMocks.deleteHabit,
+        checkInHabit: apiMocks.checkInHabit,
+        createHabit: apiMocks.createHabit,
         taskAttachments: {
             bind: apiMocks.taskAttachmentsBind,
         },
@@ -118,6 +137,26 @@ vi.mock("../tasks/MobileProjectPicker", () => ({
     MobileProjectTrigger: () => null,
     MobileProjectPicker: () => null,
 }));
+vi.mock("../tasks/HabitStatsOverview", () => ({ HabitStatsOverview: () => null }));
+vi.mock("../tasks/HabitRow", () => ({
+    HabitRow: ({ habit, onArchiveToggle, onDelete }: any) => (
+        <div>
+            <span>{habit.title}</span>
+            <button data-testid={`archive-toggle-${habit.id}`} onClick={() => void onArchiveToggle(habit, !habit.archivedAt)}>
+                archive toggle
+            </button>
+            <button data-testid={`delete-habit-${habit.id}`} onClick={() => void onDelete(habit)}>
+                delete habit
+            </button>
+        </div>
+    ),
+}));
+vi.mock("../tasks/StatsCenter", () => ({
+    StatsCenter: (props: any) => {
+        apiMocks.statsCenterProps.push(props);
+        return <div data-testid="stats-center">stats center</div>;
+    },
+}));
 
 vi.mock("../tasks/TaskQuickAdd", () => ({
     TaskQuickAdd: ({ value, onChange, onSubmit, inputRef }: any) => (
@@ -157,6 +196,57 @@ function makeTask(overrides: Record<string, any> = {}) {
     };
 }
 
+function makeHabit(overrides: Record<string, any> = {}) {
+    return {
+        id: "habit-1",
+        userId: "u1",
+        workspaceId: null,
+        title: "habit",
+        icon: "check-circle",
+        color: "#10b981",
+        sortOrder: 0,
+        archivedAt: null,
+        createdAt: "2026-01-01T00:00:00",
+        updatedAt: "2026-01-01T00:00:00",
+        todayStatus: null,
+        todayNote: null,
+        todayCheckinDate: null,
+        canManage: true,
+        ...overrides,
+    };
+}
+
+function makeHabitStats() {
+    return {
+        totalCheckins: 0,
+        checkinDays: 0,
+        currentStreak: 0,
+        successCount: 0,
+        partialCount: 0,
+        failureCount: 0,
+    };
+}
+
+function makeHabitCheckinLogItem(overrides: Record<string, any> = {}) {
+    return {
+        id: "checkin-1",
+        habitId: "habit-1",
+        userId: "u1",
+        workspaceId: null,
+        checkinDate: "2026-07-08",
+        status: "success",
+        note: "done",
+        createdAt: "2026-07-08T08:00:00",
+        updatedAt: "2026-07-08T08:00:00",
+        habitTitle: "habit",
+        habitColor: "#10b981",
+        habitIcon: "check-circle",
+        habitArchivedAt: null,
+        canManage: true,
+        ...overrides,
+    };
+}
+
 function makeStats() {
     return { total: 0, completed: 0, pending: 0, today: 0, overdue: 0, week: 0 };
 }
@@ -185,9 +275,17 @@ describe("TaskCenter quick-add integration", () => {
         apiMocks.getTaskStats.mockResolvedValue(makeStats());
         apiMocks.getTaskDependencies.mockResolvedValue([]);
         apiMocks.getReminderOverview.mockResolvedValue({ missed: [], today: [], upcoming: [], disabled: [] });
+        apiMocks.getHabits.mockResolvedValue([]);
+        apiMocks.getHabitStats.mockResolvedValue(makeHabitStats());
+        apiMocks.getHabitCheckinLog.mockResolvedValue([]);
         apiMocks.createTask.mockResolvedValue(makeTask({ id: "new-task" }));
         apiMocks.createTaskReminder.mockResolvedValue({ id: "r1" });
+        apiMocks.archiveHabit.mockImplementation(async (id: string, archived: boolean) => makeHabit({ id, archivedAt: archived ? "2026-07-08T00:00:00" : null }));
+        apiMocks.deleteHabit.mockResolvedValue({ success: true });
+        apiMocks.checkInHabit.mockResolvedValue({ id: "check-1", habitId: "habit-1", status: "success", note: "", checkinDate: "2026-07-08" });
+        apiMocks.createHabit.mockResolvedValue(makeHabit({ id: "habit-new" }));
         apiMocks.childQuickAddTitle = "今天下午3点 子任务 提前3小时";
+        apiMocks.statsCenterProps.length = 0;
 
         host = document.createElement("div");
         document.body.appendChild(host);
@@ -347,5 +445,181 @@ describe("TaskCenter quick-add integration", () => {
         expect(payload).not.toHaveProperty("repeatInterval");
         expect(payload).not.toHaveProperty("repeatRuleJson");
         expect(apiMocks.createTaskReminder).not.toHaveBeenCalled();
+    });
+
+    it("unarchives habit and keeps it visible in active list", async () => {
+        apiMocks.getHabits.mockResolvedValueOnce([
+            makeHabit({ id: "habit-archived", title: "已归档习惯", archivedAt: "2026-07-07T00:00:00" }),
+        ]);
+        apiMocks.archiveHabit.mockResolvedValueOnce(
+            makeHabit({ id: "habit-archived", title: "已归档习惯", archivedAt: null }),
+        );
+
+        await renderTaskCenter(root);
+
+        const habitsTab = Array.from(host.querySelectorAll("button")).find((button) => button.textContent?.includes("habits.title"));
+        expect(habitsTab).not.toBeUndefined();
+
+        await act(async () => {
+            habitsTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        const archivedFilter = Array.from(host.querySelectorAll("button")).find((button) => button.textContent === "habits.filters.archived");
+        expect(archivedFilter).not.toBeUndefined();
+
+        await act(async () => {
+            archivedFilter!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        const toggle = host.querySelector<HTMLButtonElement>("[data-testid='archive-toggle-habit-archived']");
+        expect(toggle).not.toBeNull();
+
+        await act(async () => {
+            toggle!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        const activeFilter = Array.from(host.querySelectorAll("button")).find((button) => button.textContent === "habits.filters.active");
+        expect(activeFilter).not.toBeUndefined();
+
+        await act(async () => {
+            activeFilter!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        expect(apiMocks.archiveHabit).toHaveBeenCalledWith("habit-archived", false);
+        expect(host.textContent).toContain("已归档习惯");
+    });
+
+    it("deletes habit from archived list", async () => {
+        apiMocks.getHabits.mockResolvedValueOnce([
+            makeHabit({ id: "habit-delete", title: "待删除习惯", archivedAt: "2026-07-07T00:00:00" }),
+        ]);
+
+        await renderTaskCenter(root);
+
+        const habitsTab = Array.from(host.querySelectorAll("button")).find((button) => button.textContent?.includes("habits.title"));
+        await act(async () => {
+            habitsTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        const archivedFilter = Array.from(host.querySelectorAll("button")).find((button) => button.textContent === "habits.filters.archived");
+        await act(async () => {
+            archivedFilter!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        const del = host.querySelector<HTMLButtonElement>("[data-testid='delete-habit-habit-delete']");
+        expect(del).not.toBeNull();
+
+        await act(async () => {
+            del!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        expect(apiMocks.deleteHabit).toHaveBeenCalledWith("habit-delete");
+        expect(host.textContent).not.toContain("待删除习惯");
+    });
+
+    it("loads statistics data and passes it to stats center", async () => {
+        vi.useRealTimers();
+        apiMocks.getTasks.mockResolvedValue([makeTask({ id: "task-stats", title: "统计任务", completedAt: "2026-07-08T09:00:00" })]);
+        apiMocks.getTaskStats.mockResolvedValue({ total: 1, completed: 1, pending: 0, today: 0, overdue: 0, week: 1 });
+        apiMocks.getHabits.mockResolvedValue([makeHabit({ id: "habit-stats", title: "统计习惯" })]);
+        apiMocks.getHabitStats.mockResolvedValue({ totalCheckins: 2, checkinDays: 2, currentStreak: 2, successCount: 2, partialCount: 0, failureCount: 0 });
+        apiMocks.getHabitCheckinLog.mockResolvedValue([makeHabitCheckinLogItem({ habitId: "habit-stats", habitTitle: "统计习惯" })]);
+
+        await renderTaskCenter(root);
+
+        const statsTab = Array.from(host.querySelectorAll("button")).find((button) => button.textContent?.includes("stats.title"));
+        expect(statsTab).not.toBeUndefined();
+
+        await act(async () => {
+            statsTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        await vi.waitFor(() => {
+            expect(apiMocks.getHabitCheckinLog).toHaveBeenCalledTimes(1);
+            expect(apiMocks.statsCenterProps.at(-1)).toMatchObject({
+                tasks: [expect.objectContaining({ id: "task-stats" })],
+                habits: [expect.objectContaining({ id: "habit-stats" })],
+                checkins: [expect.objectContaining({ habitId: "habit-stats" })],
+                loading: false,
+            });
+        });
+
+        expect(host.querySelector("[data-testid='stats-center']")).not.toBeNull();
+    });
+
+    it("reloads statistics data after workspace change while staying on stats tab", async () => {
+        vi.useRealTimers();
+        let workspacePhase = 0;
+
+        apiMocks.getTasks.mockImplementation(async (filter?: string) => {
+            if (filter === "all") {
+                return workspacePhase === 0
+                    ? [makeTask({ id: "task-old", title: "旧工作区任务", completedAt: "2026-07-08T09:00:00" })]
+                    : [makeTask({ id: "task-new", title: "新工作区任务", completedAt: "2026-07-09T09:00:00" })];
+            }
+            return [];
+        });
+        apiMocks.getTaskStats.mockImplementation(async () => (
+            workspacePhase === 0
+                ? { total: 1, completed: 1, pending: 0, today: 0, overdue: 0, week: 1 }
+                : { total: 1, completed: 0, pending: 1, today: 0, overdue: 0, week: 0 }
+        ));
+        apiMocks.getHabits.mockImplementation(async () => (
+            workspacePhase === 0
+                ? [makeHabit({ id: "habit-old", title: "旧工作区习惯" })]
+                : [makeHabit({ id: "habit-new", title: "新工作区习惯" })]
+        ));
+        apiMocks.getHabitStats.mockImplementation(async () => (
+            workspacePhase === 0
+                ? { totalCheckins: 1, checkinDays: 1, currentStreak: 1, successCount: 1, partialCount: 0, failureCount: 0 }
+                : { totalCheckins: 2, checkinDays: 2, currentStreak: 2, successCount: 2, partialCount: 0, failureCount: 0 }
+        ));
+        apiMocks.getHabitCheckinLog.mockImplementation(async () => (
+            workspacePhase === 0
+                ? [makeHabitCheckinLogItem({ id: "check-old", habitId: "habit-old", habitTitle: "旧工作区习惯" })]
+                : [makeHabitCheckinLogItem({ id: "check-new", habitId: "habit-new", habitTitle: "新工作区习惯", checkinDate: "2026-07-09" })]
+        ));
+
+        await renderTaskCenter(root);
+
+        const statsTab = Array.from(host.querySelectorAll("button")).find((button) => button.textContent?.includes("stats.title"));
+        expect(statsTab).not.toBeUndefined();
+
+        await act(async () => {
+            statsTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        await vi.waitFor(() => {
+            expect(apiMocks.statsCenterProps.at(-1)).toMatchObject({
+                tasks: [expect.objectContaining({ id: "task-old" })],
+                habits: [expect.objectContaining({ id: "habit-old" })],
+                checkins: [expect.objectContaining({ id: "check-old" })],
+            });
+        });
+
+        workspacePhase = 1;
+
+        await act(async () => {
+            window.dispatchEvent(new Event("nowen:workspace-changed"));
+            await flush();
+        });
+
+        await vi.waitFor(() => {
+            expect(apiMocks.getHabitCheckinLog).toHaveBeenCalledTimes(2);
+            expect(apiMocks.statsCenterProps.at(-1)).toMatchObject({
+                tasks: [expect.objectContaining({ id: "task-new" })],
+                habits: [expect.objectContaining({ id: "habit-new" })],
+                checkins: [expect.objectContaining({ id: "check-new" })],
+            });
+        });
     });
 });

--- a/frontend/src/components/tasks/HabitRow.tsx
+++ b/frontend/src/components/tasks/HabitRow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Archive, Check, CircleSlash, Minus } from "lucide-react";
+import { Archive, Check, CircleSlash, Minus, RotateCcw, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { Habit, HabitCheckinStatus } from "@/types";
 import { cn } from "@/lib/utils";
@@ -8,17 +8,21 @@ import { toast } from "@/lib/toast";
 export function HabitRow({
   habit,
   onCheckin,
-  onArchive,
+  onArchiveToggle,
+  onDelete,
 }: {
   habit: Habit;
   onCheckin: (habit: Habit, status: HabitCheckinStatus, note: string) => Promise<void> | void;
-  onArchive: (habit: Habit) => Promise<void> | void;
+  onArchiveToggle: (habit: Habit, archived: boolean) => Promise<void> | void;
+  onDelete: (habit: Habit) => Promise<void> | void;
 }) {
   const { t } = useTranslation();
   const [note, setNote] = useState(habit.todayNote || "");
   const [submitting, setSubmitting] = useState(false);
   const [archiving, setArchiving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const canManage = (habit as Habit & { canManage?: boolean }).canManage !== false;
+  const isArchived = !!habit.archivedAt;
 
   useEffect(() => {
     setNote(habit.todayNote || "");
@@ -36,7 +40,7 @@ export function HabitRow({
   };
 
   const runCheckin = async (status: HabitCheckinStatus) => {
-    if (!canManage || submitting) return;
+    if (!canManage || submitting || isArchived) return;
     setSubmitting(true);
     try {
       await onCheckin(habit, status, note);
@@ -47,14 +51,25 @@ export function HabitRow({
     }
   };
 
-  const runArchive = async () => {
+  const runArchiveToggle = async (archived: boolean) => {
     if (!canManage || archiving) return;
     setArchiving(true);
     try {
-      await onArchive(habit);
+      await onArchiveToggle(habit, archived);
     } catch (error) {
       showActionError(error);
       setArchiving(false);
+    }
+  };
+
+  const runDelete = async () => {
+    if (!canManage || deleting || archiving || submitting) return;
+    setDeleting(true);
+    try {
+      await onDelete(habit);
+    } catch (error) {
+      showActionError(error);
+      setDeleting(false);
     }
   };
 
@@ -75,6 +90,11 @@ export function HabitRow({
                 {statusLabel[habit.todayStatus]}
               </span>
             )}
+            {isArchived && (
+              <span className="rounded-full bg-app-hover px-2 py-0.5 text-[10px] text-tx-tertiary">
+                {t("habits.status.archived")}
+              </span>
+            )}
             {habit.creatorName && (
               <span className="text-[10px] text-tx-tertiary">{habit.creatorName}</span>
             )}
@@ -83,39 +103,60 @@ export function HabitRow({
             type="text"
             value={note}
             onChange={(e) => setNote(e.target.value)}
-            disabled={!canManage || submitting || archiving}
+            disabled={!canManage || submitting || archiving || deleting || isArchived}
             placeholder={t("habits.notePlaceholder")}
             className="mt-2 w-full rounded-md border border-app-border bg-app-bg px-2.5 py-2 text-xs text-tx-primary placeholder:text-tx-tertiary focus:outline-none focus:border-accent-primary disabled:cursor-not-allowed disabled:opacity-60"
           />
           {canManage && (
             <div className="mt-2 flex flex-wrap items-center gap-2">
+              {!isArchived ? (
+                <>
+                  <button
+                    onClick={() => runCheckin("success")}
+                    disabled={submitting || archiving || deleting}
+                    className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-2.5 py-1.5 text-xs text-emerald-600 transition-colors hover:bg-emerald-500/20 disabled:opacity-50"
+                  >
+                    <Check size={13} /> {t("habits.actions.success")}
+                  </button>
+                  <button
+                    onClick={() => runCheckin("partial")}
+                    disabled={submitting || archiving || deleting}
+                    className="inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-600 transition-colors hover:bg-amber-500/20 disabled:opacity-50"
+                  >
+                    <Minus size={13} /> {t("habits.actions.partial")}
+                  </button>
+                  <button
+                    onClick={() => runCheckin("failure")}
+                    disabled={submitting || archiving || deleting}
+                    className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-2.5 py-1.5 text-xs text-red-600 transition-colors hover:bg-red-500/20 disabled:opacity-50"
+                  >
+                    <CircleSlash size={13} /> {t("habits.actions.failure")}
+                  </button>
+                  <button
+                    onClick={() => runArchiveToggle(true)}
+                    disabled={submitting || archiving || deleting}
+                    className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-tx-tertiary transition-colors hover:bg-app-hover hover:text-tx-secondary disabled:opacity-50"
+                  >
+                    <Archive size={13} /> {t("habits.actions.archive")}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={() => runArchiveToggle(false)}
+                    disabled={submitting || archiving || deleting}
+                    className="inline-flex items-center gap-1 rounded-md bg-sky-500/10 px-2.5 py-1.5 text-xs text-sky-700 transition-colors hover:bg-sky-500/20 disabled:opacity-50"
+                  >
+                    <RotateCcw size={13} /> {t("habits.actions.unarchive")}
+                  </button>
+                </>
+              )}
               <button
-                onClick={() => runCheckin("success")}
-                disabled={submitting || archiving}
-                className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-2.5 py-1.5 text-xs text-emerald-600 transition-colors hover:bg-emerald-500/20 disabled:opacity-50"
+                onClick={runDelete}
+                disabled={submitting || archiving || deleting}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-rose-600 transition-colors hover:bg-rose-500/10 disabled:opacity-50"
               >
-                <Check size={13} /> {t("habits.actions.success")}
-              </button>
-              <button
-                onClick={() => runCheckin("partial")}
-                disabled={submitting || archiving}
-                className="inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-600 transition-colors hover:bg-amber-500/20 disabled:opacity-50"
-              >
-                <Minus size={13} /> {t("habits.actions.partial")}
-              </button>
-              <button
-                onClick={() => runCheckin("failure")}
-                disabled={submitting || archiving}
-                className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-2.5 py-1.5 text-xs text-red-600 transition-colors hover:bg-red-500/20 disabled:opacity-50"
-              >
-                <CircleSlash size={13} /> {t("habits.actions.failure")}
-              </button>
-              <button
-                onClick={runArchive}
-                disabled={submitting || archiving}
-                className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-tx-tertiary transition-colors hover:bg-app-hover hover:text-tx-secondary disabled:opacity-50"
-              >
-                <Archive size={13} /> {t("habits.actions.archive")}
+                <Trash2 size={13} /> {t("habits.actions.delete")}
               </button>
             </div>
           )}

--- a/frontend/src/components/tasks/StatsCenter.tsx
+++ b/frontend/src/components/tasks/StatsCenter.tsx
@@ -1,0 +1,808 @@
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  format,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subWeeks,
+} from "date-fns";
+import { enUS, zhCN } from "date-fns/locale";
+import {
+  Activity,
+  CalendarDays,
+  CheckCircle2,
+  Clock3,
+  Flame,
+  FolderOpen,
+  ListChecks,
+  RefreshCw,
+  SquareCheckBig,
+  TrendingUp,
+} from "lucide-react";
+import type { Habit, HabitCheckinListItem, HabitStats, Task, TaskProject, TaskStats } from "@/types";
+import { cn } from "@/lib/utils";
+
+type StatsPrimaryTab = "overview" | "tasks" | "habits";
+type TaskStatsTab = "overview" | "details" | "records" | "trends" | "heatmap";
+type HabitStatsTab = "overview" | "log" | "week" | "month" | "year";
+
+type Props = {
+  tasks: Task[];
+  projects: TaskProject[];
+  taskStats: TaskStats | null;
+  habits: Habit[];
+  habitStats: HabitStats | null;
+  checkins: HabitCheckinListItem[];
+  loading: boolean;
+  onRefresh: () => void;
+};
+
+type TaskRecord = {
+  id: string;
+  kind: "created" | "completed";
+  at: Date;
+  task: Task;
+};
+
+function parseDateValue(value?: string | null): Date | null {
+  if (!value) return null;
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value.replace(" ", "T");
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toDateKey(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+function percentage(part: number, total: number): number {
+  if (!total) return 0;
+  return Math.round((part / total) * 100);
+}
+
+function getHeatColor(count: number): string {
+  if (count <= 0) return "bg-app-border/60";
+  if (count === 1) return "bg-emerald-200 text-emerald-900";
+  if (count === 2) return "bg-emerald-300 text-emerald-950";
+  if (count === 3) return "bg-emerald-400 text-white";
+  return "bg-emerald-600 text-white";
+}
+
+function getHabitStatusClass(status?: string | null): string {
+  if (status === "success") return "bg-emerald-500/15 text-emerald-700";
+  if (status === "partial") return "bg-amber-500/15 text-amber-700";
+  if (status === "failure") return "bg-rose-500/15 text-rose-700";
+  return "bg-app-hover text-tx-tertiary";
+}
+
+function MetricCard({
+  icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[11px] text-tx-tertiary">{label}</div>
+          <div className="mt-1 text-2xl font-semibold text-tx-primary">{value}</div>
+          {hint ? <div className="mt-1 text-xs text-tx-tertiary">{hint}</div> : null}
+        </div>
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/10 text-accent-primary">
+          {icon}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionTabs<T extends string>({
+  value,
+  items,
+  onChange,
+}: {
+  value: T;
+  items: Array<{ value: T; label: string }>;
+  onChange: (next: T) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <button
+          key={item.value}
+          onClick={() => onChange(item.value)}
+          className={cn(
+            "rounded-full px-3 py-1.5 text-xs transition-colors",
+            value === item.value
+              ? "bg-accent-primary text-white"
+              : "bg-app-hover text-tx-secondary hover:bg-app-active",
+          )}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function EmptyPanel({ text }: { text: string }) {
+  return (
+    <div className="flex min-h-52 items-center justify-center rounded-xl border border-dashed border-app-border bg-app-surface text-sm text-tx-tertiary">
+      {text}
+    </div>
+  );
+}
+
+export function StatsCenter({ tasks, projects, taskStats, habits, habitStats, checkins, loading, onRefresh }: Props) {
+  const { t, i18n } = useTranslation();
+  const dateLocale = i18n.language === "zh-CN" ? zhCN : enUS;
+  const [primaryTab, setPrimaryTab] = useState<StatsPrimaryTab>("overview");
+  const [taskTab, setTaskTab] = useState<TaskStatsTab>("overview");
+  const [habitTab, setHabitTab] = useState<HabitStatsTab>("overview");
+
+  const today = new Date();
+
+  const taskRecords = useMemo<TaskRecord[]>(() => {
+    return tasks
+      .flatMap((task) => {
+        const records: TaskRecord[] = [];
+        const createdAt = parseDateValue(task.createdAt);
+        const completedAt = parseDateValue(task.completedAt);
+        if (createdAt) records.push({ id: `${task.id}-created`, kind: "created", at: createdAt, task });
+        if (completedAt) records.push({ id: `${task.id}-completed`, kind: "completed", at: completedAt, task });
+        return records;
+      })
+      .sort((a, b) => b.at.getTime() - a.at.getTime());
+  }, [tasks]);
+
+  const taskOverview = useMemo(() => {
+    const overdue = tasks.filter((task) => !task.isCompleted && !!task.dueDate && parseDateValue(task.dueAt || task.dueDate) && parseDateValue(task.dueAt || `${task.dueDate}T23:59:59`)!.getTime() < Date.now()).length;
+    const withProject = tasks.filter((task) => !!task.projectId).length;
+    const statusCounts = tasks.reduce<Record<string, number>>((acc, task) => {
+      acc[task.status] = (acc[task.status] || 0) + 1;
+      return acc;
+    }, {});
+    const priorityCounts = tasks.reduce<Record<number, number>>((acc, task) => {
+      acc[task.priority] = (acc[task.priority] || 0) + 1;
+      return acc;
+    }, {});
+    return {
+      overdue,
+      withProject,
+      statusCounts,
+      priorityCounts,
+      completionRate: percentage(taskStats?.completed || 0, taskStats?.total || 0),
+    };
+  }, [taskStats, tasks]);
+
+  const trendRows = useMemo(() => {
+    const weekStarts = Array.from({ length: 12 }, (_, index) => startOfWeek(subWeeks(today, 11 - index), { weekStartsOn: 1 }));
+    return weekStarts.map((weekStart) => {
+      const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 });
+      const created = tasks.filter((task) => {
+        const at = parseDateValue(task.createdAt);
+        return at && at >= weekStart && at <= weekEnd;
+      }).length;
+      const completed = tasks.filter((task) => {
+        const at = parseDateValue(task.completedAt);
+        return at && at >= weekStart && at <= weekEnd;
+      }).length;
+      return {
+        key: format(weekStart, "yyyy-MM-dd"),
+        label: format(weekStart, "MM/dd", { locale: dateLocale }),
+        created,
+        completed,
+      };
+    });
+  }, [dateLocale, tasks, today]);
+
+  const yearHeatmap = useMemo(() => {
+    const start = startOfWeek(startOfYear(today), { weekStartsOn: 1 });
+    const end = endOfWeek(endOfYear(today), { weekStartsOn: 1 });
+    const days = eachDayOfInterval({ start, end });
+    const byDate = new Map<string, number>();
+    tasks.forEach((task) => {
+      const completedAt = parseDateValue(task.completedAt);
+      if (!completedAt) return;
+      const key = toDateKey(completedAt);
+      byDate.set(key, (byDate.get(key) || 0) + 1);
+    });
+    const weeks: Array<Array<{ date: Date; count: number; inYear: boolean }>> = [];
+    days.forEach((date, index) => {
+      const weekIndex = Math.floor(index / 7);
+      if (!weeks[weekIndex]) weeks[weekIndex] = [];
+      weeks[weekIndex].push({
+        date,
+        count: byDate.get(toDateKey(date)) || 0,
+        inYear: date.getFullYear() === today.getFullYear(),
+      });
+    });
+    return weeks;
+  }, [tasks, today]);
+
+  const activeHabits = useMemo(() => habits.filter((habit) => !habit.archivedAt), [habits]);
+  const archivedHabits = useMemo(() => habits.filter((habit) => !!habit.archivedAt), [habits]);
+
+  const habitLogByDay = useMemo(() => {
+    const map = new Map<string, HabitCheckinListItem[]>();
+    checkins.forEach((checkin) => {
+      const current = map.get(checkin.checkinDate) || [];
+      current.push(checkin);
+      map.set(checkin.checkinDate, current);
+    });
+    return map;
+  }, [checkins]);
+
+  const habitMonthCalendar = useMemo(() => {
+    const start = startOfWeek(startOfMonth(today), { weekStartsOn: 1 });
+    const end = endOfWeek(endOfMonth(today), { weekStartsOn: 1 });
+    return eachDayOfInterval({ start, end }).map((date) => {
+      const key = toDateKey(date);
+      const rows = habitLogByDay.get(key) || [];
+      const success = rows.filter((row) => row.status === "success").length;
+      const partial = rows.filter((row) => row.status === "partial").length;
+      const failure = rows.filter((row) => row.status === "failure").length;
+      return { date, rows, success, partial, failure };
+    });
+  }, [habitLogByDay, today]);
+
+  const habitWeekDates = useMemo(() => {
+    const start = startOfWeek(today, { weekStartsOn: 1 });
+    return Array.from({ length: 7 }, (_, index) => addDays(start, index));
+  }, [today]);
+
+  const habitYearSummary = useMemo(() => {
+    const rows = new Map<string, { label: string; total: number; success: number; partial: number; failure: number }>();
+    checkins.forEach((checkin) => {
+      const date = parseDateValue(checkin.checkinDate);
+      if (!date) return;
+      const key = format(date, "yyyy-MM");
+      const current = rows.get(key) || {
+        label: format(date, "MMM", { locale: dateLocale }),
+        total: 0,
+        success: 0,
+        partial: 0,
+        failure: 0,
+      };
+      current.total += 1;
+      if (checkin.status === "success") current.success += 1;
+      if (checkin.status === "partial") current.partial += 1;
+      if (checkin.status === "failure") current.failure += 1;
+      rows.set(key, current);
+    });
+    const months = [] as Array<{ key: string; label: string; total: number; success: number; partial: number; failure: number }>;
+    for (let month = 0; month < 12; month += 1) {
+      const date = new Date(today.getFullYear(), month, 1);
+      const key = format(date, "yyyy-MM");
+      const current = rows.get(key) || {
+        label: format(date, "MMM", { locale: dateLocale }),
+        total: 0,
+        success: 0,
+        partial: 0,
+        failure: 0,
+      };
+      months.push({ key, ...current });
+    }
+    return months;
+  }, [checkins, dateLocale, today]);
+
+  const topProjectRows = useMemo(() => {
+    const projectNameById = new Map(projects.map((project) => [project.id, project.name]));
+    const groups = new Map<string, { key: string; label: string; total: number; completed: number }>();
+    tasks.forEach((task) => {
+      const key = task.projectId || "__none__";
+      const label = task.projectId
+        ? projectNameById.get(task.projectId) || t("stats.task.projectAssigned", { defaultValue: "已归类项目" })
+        : t("tasks.noProject");
+      const current = groups.get(key) || { key, label, total: 0, completed: 0 };
+      current.total += 1;
+      if (task.isCompleted) current.completed += 1;
+      groups.set(key, current);
+    });
+    return [...groups.values()].sort((a, b) => b.total - a.total);
+  }, [projects, t, tasks]);
+
+  const recentHabitLogs = checkins.slice(0, 80);
+  const recentTaskRecords = taskRecords.slice(0, 80);
+
+  const renderOverview = () => (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          icon={<SquareCheckBig size={18} />}
+          label={t("stats.overview.totalTasks")}
+          value={taskStats?.total ?? tasks.length}
+          hint={t("stats.overview.taskCompletion", { percent: taskOverview.completionRate })}
+        />
+        <MetricCard
+          icon={<Clock3 size={18} />}
+          label={t("stats.overview.pendingTasks")}
+          value={taskStats?.pending ?? tasks.filter((task) => !task.isCompleted).length}
+          hint={t("stats.overview.overdueTasks", { count: taskOverview.overdue })}
+        />
+        <MetricCard
+          icon={<ListChecks size={18} />}
+          label={t("stats.overview.activeHabits")}
+          value={activeHabits.length}
+          hint={t("stats.overview.archivedHabits", { count: archivedHabits.length })}
+        />
+        <MetricCard
+          icon={<Flame size={18} />}
+          label={t("stats.overview.currentHabitStreak")}
+          value={habitStats?.currentStreak ?? 0}
+          hint={t("stats.overview.totalCheckins", { count: habitStats?.totalCheckins ?? 0 })}
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1.3fr_1fr]">
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-tx-primary">{t("stats.overview.recentTaskActivity")}</h3>
+              <p className="text-xs text-tx-tertiary">{t("stats.overview.recentTaskActivityDesc")}</p>
+            </div>
+            <Activity size={16} className="text-tx-tertiary" />
+          </div>
+          <div className="mt-4 space-y-2">
+            {recentTaskRecords.slice(0, 6).map((record) => (
+              <div key={record.id} className="flex items-center justify-between gap-3 rounded-lg bg-app-bg px-3 py-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-tx-primary">{record.task.title}</div>
+                  <div className="text-xs text-tx-tertiary">
+                    {record.kind === "completed" ? t("stats.task.recordCompleted") : t("stats.task.recordCreated")}
+                  </div>
+                </div>
+                <div className="shrink-0 text-xs text-tx-tertiary">
+                  {format(record.at, "MM/dd HH:mm", { locale: dateLocale })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-tx-primary">{t("stats.overview.recentHabitActivity")}</h3>
+              <p className="text-xs text-tx-tertiary">{t("stats.overview.recentHabitActivityDesc")}</p>
+            </div>
+            <CalendarDays size={16} className="text-tx-tertiary" />
+          </div>
+          <div className="mt-4 space-y-2">
+            {recentHabitLogs.slice(0, 6).map((item) => (
+              <div key={item.id} className="flex items-center justify-between gap-3 rounded-lg bg-app-bg px-3 py-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-tx-primary">{item.habitTitle}</div>
+                  <div className="truncate text-xs text-tx-tertiary">{item.note || t("stats.habit.emptyNote")}</div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className={cn("rounded-full px-2 py-0.5 text-[10px]", getHabitStatusClass(item.status))}>
+                    {t(`habits.status.${item.status}`)}
+                  </div>
+                  <div className="mt-1 text-[11px] text-tx-tertiary">{item.checkinDate}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderTaskOverview = () => (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard icon={<SquareCheckBig size={18} />} label={t("stats.task.total")} value={taskStats?.total ?? tasks.length} hint={t("stats.task.completed", { count: taskStats?.completed ?? 0 })} />
+        <MetricCard icon={<TrendingUp size={18} />} label={t("stats.task.completionRate")} value={`${taskOverview.completionRate}%`} hint={t("stats.task.pending", { count: taskStats?.pending ?? 0 })} />
+        <MetricCard icon={<Clock3 size={18} />} label={t("stats.task.overdue")} value={taskOverview.overdue} hint={t("stats.task.today", { count: taskStats?.today ?? 0 })} />
+        <MetricCard icon={<FolderOpen size={18} />} label={t("stats.task.projectCoverage")} value={`${percentage(taskOverview.withProject, tasks.length)}%`} hint={t("stats.task.projectCoverageHint", { count: taskOverview.withProject })} />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-tx-primary">{t("stats.task.statusBreakdown")}</h3>
+          <div className="mt-4 space-y-3">
+            {(["todo", "doing", "blocked", "done"] as const).map((status) => {
+              const count = taskOverview.statusCounts[status] || 0;
+              return (
+                <div key={status}>
+                  <div className="mb-1 flex items-center justify-between text-xs text-tx-secondary">
+                    <span>{t(`tasks.status${status.charAt(0).toUpperCase()}${status.slice(1)}`)}</span>
+                    <span>{count}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-app-bg">
+                    <div className="h-full rounded-full bg-accent-primary" style={{ width: `${percentage(count, tasks.length)}%` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-tx-primary">{t("stats.task.projectBreakdown")}</h3>
+          <div className="mt-4 space-y-3">
+            {topProjectRows.slice(0, 6).map((row) => (
+              <div key={row.key} className="rounded-lg bg-app-bg px-3 py-2">
+                <div className="flex items-center justify-between text-sm text-tx-primary">
+                  <span>{row.label}</span>
+                  <span>{row.completed}/{row.total}</span>
+                </div>
+                <div className="mt-2 h-2 rounded-full bg-app-border">
+                  <div className="h-full rounded-full bg-emerald-500" style={{ width: `${percentage(row.completed, row.total)}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderTaskDetails = () => {
+    if (!tasks.length) return <EmptyPanel text={t("stats.task.empty")} />;
+    return (
+      <div className="overflow-hidden rounded-xl border border-app-border bg-app-surface shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-app-bg text-xs text-tx-tertiary">
+              <tr>
+                <th className="px-4 py-3">{t("tasks.taskTitle")}</th>
+                <th className="px-4 py-3">{t("tasks.status")}</th>
+                <th className="px-4 py-3">{t("tasks.priority")}</th>
+                <th className="px-4 py-3">{t("tasks.createdAt")}</th>
+                <th className="px-4 py-3">{t("tasks.dueDate")}</th>
+                <th className="px-4 py-3">{t("stats.task.completedAt")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...tasks]
+                .sort((a, b) => (parseDateValue(b.completedAt)?.getTime() || parseDateValue(b.createdAt)?.getTime() || 0) - (parseDateValue(a.completedAt)?.getTime() || parseDateValue(a.createdAt)?.getTime() || 0))
+                .slice(0, 120)
+                .map((task) => (
+                  <tr key={task.id} className="border-t border-app-border/70">
+                    <td className="px-4 py-3 text-tx-primary">{task.title}</td>
+                    <td className="px-4 py-3 text-tx-secondary">{t(`tasks.status${task.status.charAt(0).toUpperCase()}${task.status.slice(1)}`)}</td>
+                    <td className="px-4 py-3 text-tx-secondary">{task.priority === 3 ? t("tasks.high") : task.priority === 1 ? t("tasks.low") : t("tasks.medium")}</td>
+                    <td className="px-4 py-3 text-tx-secondary">{parseDateValue(task.createdAt) ? format(parseDateValue(task.createdAt)!, "yyyy-MM-dd HH:mm", { locale: dateLocale }) : "-"}</td>
+                    <td className="px-4 py-3 text-tx-secondary">{task.dueAt || task.dueDate || "-"}</td>
+                    <td className="px-4 py-3 text-tx-secondary">{parseDateValue(task.completedAt) ? format(parseDateValue(task.completedAt)!, "yyyy-MM-dd HH:mm", { locale: dateLocale }) : "-"}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
+
+  const renderTaskRecords = () => {
+    if (!recentTaskRecords.length) return <EmptyPanel text={t("stats.task.noRecords")} />;
+    return (
+      <div className="space-y-2">
+        {recentTaskRecords.map((record) => (
+          <div key={record.id} className="rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-tx-primary">{record.task.title}</div>
+                <div className="mt-1 text-xs text-tx-tertiary">{record.kind === "completed" ? t("stats.task.recordCompleted") : t("stats.task.recordCreated")}</div>
+              </div>
+              <div className="shrink-0 text-xs text-tx-tertiary">{format(record.at, "yyyy-MM-dd HH:mm", { locale: dateLocale })}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderTaskTrends = () => {
+    const maxValue = Math.max(1, ...trendRows.map((row) => Math.max(row.created, row.completed)));
+    return (
+      <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-semibold text-tx-primary">{t("stats.task.trendTitle")}</h3>
+            <p className="text-xs text-tx-tertiary">{t("stats.task.trendDesc")}</p>
+          </div>
+        </div>
+        <div className="space-y-3">
+          {trendRows.map((row) => (
+            <div key={row.key}>
+              <div className="mb-1 flex items-center justify-between text-xs text-tx-secondary">
+                <span>{row.label}</span>
+                <span>{t("stats.task.trendLegend", { created: row.created, completed: row.completed })}</span>
+              </div>
+              <div className="grid grid-cols-[1fr_1fr] gap-2">
+                <div className="h-2 rounded-full bg-app-bg">
+                  <div className="h-full rounded-full bg-sky-500" style={{ width: `${(row.created / maxValue) * 100}%` }} />
+                </div>
+                <div className="h-2 rounded-full bg-app-bg">
+                  <div className="h-full rounded-full bg-emerald-500" style={{ width: `${(row.completed / maxValue) * 100}%` }} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  const renderTaskHeatmap = () => (
+    <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-tx-primary">{t("stats.task.heatmapTitle")}</h3>
+          <p className="text-xs text-tx-tertiary">{t("stats.task.heatmapDesc")}</p>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="flex gap-1 pb-2">
+          {yearHeatmap.map((week, index) => (
+            <div key={`week-${index}`} className="grid grid-rows-7 gap-1">
+              {week.map((cell) => (
+                <div
+                  key={cell.date.toISOString()}
+                  title={`${toDateKey(cell.date)} · ${cell.count}`}
+                  className={cn(
+                    "h-3 w-3 rounded-[4px]",
+                    cell.inYear ? getHeatColor(cell.count) : "bg-transparent",
+                  )}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderHabitOverview = () => (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard icon={<ListChecks size={18} />} label={t("stats.habit.habitCount")} value={habits.length} hint={t("stats.habit.activeArchived", { active: activeHabits.length, archived: archivedHabits.length })} />
+        <MetricCard icon={<Flame size={18} />} label={t("stats.habit.currentStreak")} value={habitStats?.currentStreak ?? 0} hint={t("stats.habit.checkinDays", { count: habitStats?.checkinDays ?? 0 })} />
+        <MetricCard icon={<CheckCircle2 size={18} />} label={t("stats.habit.successRate")} value={`${percentage((habitStats?.successCount ?? 0) + (habitStats?.partialCount ?? 0), habitStats?.totalCheckins ?? 0)}%`} hint={t("stats.habit.totalCheckins", { count: habitStats?.totalCheckins ?? 0 })} />
+        <MetricCard icon={<CalendarDays size={18} />} label={t("stats.habit.todayCheckins")} value={habitLogByDay.get(toDateKey(today))?.length ?? 0} hint={t("stats.habit.todayCheckinsHint", { count: activeHabits.filter((habit) => !!habit.todayStatus).length })} />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-tx-primary">{t("stats.habit.statusBreakdown")}</h3>
+          <div className="mt-4 grid grid-cols-3 gap-3">
+            <div className="rounded-lg bg-emerald-500/10 px-3 py-3">
+              <div className="text-[11px] text-emerald-700">{t("habits.status.success")}</div>
+              <div className="mt-1 text-xl font-semibold text-emerald-700">{habitStats?.successCount ?? 0}</div>
+            </div>
+            <div className="rounded-lg bg-amber-500/10 px-3 py-3">
+              <div className="text-[11px] text-amber-700">{t("habits.status.partial")}</div>
+              <div className="mt-1 text-xl font-semibold text-amber-700">{habitStats?.partialCount ?? 0}</div>
+            </div>
+            <div className="rounded-lg bg-rose-500/10 px-3 py-3">
+              <div className="text-[11px] text-rose-700">{t("habits.status.failure")}</div>
+              <div className="mt-1 text-xl font-semibold text-rose-700">{habitStats?.failureCount ?? 0}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-tx-primary">{t("stats.habit.archivedVisibility")}</h3>
+          <div className="mt-4 space-y-3 text-sm text-tx-secondary">
+            <div className="rounded-lg bg-app-bg px-3 py-2">{t("stats.habit.archivedHint1")}</div>
+            <div className="rounded-lg bg-app-bg px-3 py-2">{t("stats.habit.archivedHint2")}</div>
+            <div className="rounded-lg bg-app-bg px-3 py-2">{t("stats.habit.archivedHint3")}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderHabitLog = () => {
+    if (!recentHabitLogs.length) return <EmptyPanel text={t("stats.habit.noLogs")} />;
+    return (
+      <div className="space-y-2">
+        {recentHabitLogs.map((item) => (
+          <div key={item.id} className="rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: item.habitColor || "#10b981" }} />
+                  <div className="truncate text-sm font-medium text-tx-primary">{item.habitTitle}</div>
+                </div>
+                <div className="mt-1 truncate text-xs text-tx-tertiary">{item.note || t("stats.habit.emptyNote")}</div>
+              </div>
+              <div className="shrink-0 text-right">
+                <div className={cn("rounded-full px-2 py-0.5 text-[10px]", getHabitStatusClass(item.status))}>{t(`habits.status.${item.status}`)}</div>
+                <div className="mt-1 text-[11px] text-tx-tertiary">{item.checkinDate}</div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderHabitWeek = () => {
+    if (!activeHabits.length) return <EmptyPanel text={t("stats.habit.noActiveHabits")} />;
+    return (
+      <div className="overflow-hidden rounded-xl border border-app-border bg-app-surface shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-app-bg text-xs text-tx-tertiary">
+              <tr>
+                <th className="px-4 py-3">{t("habits.title")}</th>
+                {habitWeekDates.map((date) => (
+                  <th key={date.toISOString()} className="px-3 py-3 text-center">{format(date, "EE dd", { locale: dateLocale })}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {activeHabits.map((habit) => (
+                <tr key={habit.id} className="border-t border-app-border/70">
+                  <td className="px-4 py-3 text-tx-primary">{habit.title}</td>
+                  {habitWeekDates.map((date) => {
+                    const item = (habitLogByDay.get(toDateKey(date)) || []).find((row) => row.habitId === habit.id);
+                    return (
+                      <td key={`${habit.id}-${date.toISOString()}`} className="px-3 py-3 text-center">
+                        <span className={cn("inline-flex min-w-14 items-center justify-center rounded-full px-2 py-1 text-[10px]", getHabitStatusClass(item?.status))}>
+                          {item ? t(`habits.status.${item.status}`) : t("stats.habit.noCheckin")}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
+
+  const renderHabitMonth = () => (
+    <div className="rounded-xl border border-app-border bg-app-surface p-4 shadow-sm">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-tx-primary">{t("stats.habit.monthTitle")}</h3>
+        <p className="text-xs text-tx-tertiary">{format(today, "yyyy MMMM", { locale: dateLocale })}</p>
+      </div>
+      <div className="grid grid-cols-7 gap-2 text-center text-xs text-tx-tertiary">
+        {Array.from({ length: 7 }, (_, index) => (
+          <div key={`weekday-${index}`}>{format(addDays(startOfWeek(today, { weekStartsOn: 1 }), index), "EE", { locale: dateLocale })}</div>
+        ))}
+      </div>
+      <div className="mt-2 grid grid-cols-7 gap-2">
+        {habitMonthCalendar.map((cell) => (
+          <div
+            key={cell.date.toISOString()}
+            title={`${toDateKey(cell.date)} · ${cell.rows.length}`}
+            className={cn(
+              "min-h-24 rounded-xl border px-2 py-2 text-xs",
+              isSameMonth(cell.date, today) ? "border-app-border bg-app-bg" : "border-transparent bg-app-hover/40 text-tx-tertiary",
+              isToday(cell.date) && "ring-1 ring-accent-primary/50",
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-tx-primary">{format(cell.date, "d")}</span>
+              <span className="text-[10px] text-tx-tertiary">{cell.rows.length}</span>
+            </div>
+            <div className="mt-2 space-y-1">
+              <div className="h-1.5 rounded-full bg-app-border">
+                <div className="h-full rounded-full bg-emerald-500" style={{ width: `${percentage(cell.success, Math.max(cell.rows.length, 1))}%` }} />
+              </div>
+              <div className="h-1.5 rounded-full bg-app-border">
+                <div className="h-full rounded-full bg-amber-500" style={{ width: `${percentage(cell.partial, Math.max(cell.rows.length, 1))}%` }} />
+              </div>
+              <div className="h-1.5 rounded-full bg-app-border">
+                <div className="h-full rounded-full bg-rose-500" style={{ width: `${percentage(cell.failure, Math.max(cell.rows.length, 1))}%` }} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderHabitYear = () => (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      {habitYearSummary.map((month) => (
+        <div key={month.key} className="rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-sm">
+          <div className="text-sm font-semibold text-tx-primary">{month.label}</div>
+          <div className="mt-1 text-2xl font-semibold text-tx-primary">{month.total}</div>
+          <div className="mt-2 grid grid-cols-3 gap-2 text-[11px]">
+            <div className="rounded-md bg-emerald-500/10 px-2 py-1 text-emerald-700">{month.success}</div>
+            <div className="rounded-md bg-amber-500/10 px-2 py-1 text-amber-700">{month.partial}</div>
+            <div className="rounded-md bg-rose-500/10 px-2 py-1 text-rose-700">{month.failure}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 md:px-5 py-3">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-sm">
+        <div>
+          <h2 className="text-lg font-bold text-tx-primary">{t("stats.title")}</h2>
+          <p className="text-xs text-tx-tertiary">{t("stats.subtitle")}</p>
+        </div>
+        <button
+          onClick={onRefresh}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-lg border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-secondary transition-colors hover:bg-app-hover disabled:opacity-60"
+        >
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          {t("stats.refresh")}
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <SectionTabs
+          value={primaryTab}
+          onChange={setPrimaryTab}
+          items={[
+            { value: "overview", label: t("stats.tabs.overview") },
+            { value: "tasks", label: t("stats.tabs.tasks") },
+            { value: "habits", label: t("stats.tabs.habits") },
+          ]}
+        />
+
+        {loading ? (
+          <EmptyPanel text={t("stats.loading")} />
+        ) : primaryTab === "overview" ? (
+          renderOverview()
+        ) : primaryTab === "tasks" ? (
+          <div className="space-y-4">
+            <SectionTabs
+              value={taskTab}
+              onChange={setTaskTab}
+              items={[
+                { value: "overview", label: t("stats.task.tabs.overview") },
+                { value: "details", label: t("stats.task.tabs.details") },
+                { value: "records", label: t("stats.task.tabs.records") },
+                { value: "trends", label: t("stats.task.tabs.trends") },
+                { value: "heatmap", label: t("stats.task.tabs.heatmap") },
+              ]}
+            />
+            {taskTab === "overview" && renderTaskOverview()}
+            {taskTab === "details" && renderTaskDetails()}
+            {taskTab === "records" && renderTaskRecords()}
+            {taskTab === "trends" && renderTaskTrends()}
+            {taskTab === "heatmap" && renderTaskHeatmap()}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <SectionTabs
+              value={habitTab}
+              onChange={setHabitTab}
+              items={[
+                { value: "overview", label: t("stats.habit.tabs.overview") },
+                { value: "log", label: t("stats.habit.tabs.log") },
+                { value: "week", label: t("stats.habit.tabs.week") },
+                { value: "month", label: t("stats.habit.tabs.month") },
+                { value: "year", label: t("stats.habit.tabs.year") },
+              ]}
+            />
+            {habitTab === "overview" && renderHabitOverview()}
+            {habitTab === "log" && renderHabitLog()}
+            {habitTab === "week" && renderHabitWeek()}
+            {habitTab === "month" && renderHabitMonth()}
+            {habitTab === "year" && renderHabitYear()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1485,18 +1485,112 @@
     "status": {
       "success": "Success",
       "partial": "Partial",
-      "failure": "Failure"
+      "failure": "Failure",
+      "archived": "Archived"
     },
     "actions": {
       "success": "Success",
       "partial": "Partial",
       "failure": "Failure",
-      "archive": "Archive"
+      "archive": "Archive",
+      "unarchive": "Restore",
+      "delete": "Delete"
+    },
+    "filters": {
+      "active": "Active",
+      "archived": "Archived",
+      "all": "All"
     },
     "toast": {
       "createFailed": "Failed to create habit",
       "checkinUpdated": "Check-in updated",
-      "archived": "Habit archived"
+      "archived": "Habit archived",
+      "unarchived": "Habit restored",
+      "deleted": "Habit deleted"
+    }
+  },
+  "stats": {
+    "title": "Statistics",
+    "subtitle": "Review task execution and habit check-in performance",
+    "summaryHint": "The stats view contains overview, task analytics, and habit analytics.",
+    "refresh": "Refresh",
+    "loading": "Loading statistics...",
+    "loadFailed": "Failed to load statistics",
+    "tabs": {
+      "overview": "Overview",
+      "tasks": "Task Stats",
+      "habits": "Habit Stats"
+    },
+    "overview": {
+      "totalTasks": "Total Tasks",
+      "taskCompletion": "Completion {{percent}}%",
+      "pendingTasks": "Pending Tasks",
+      "overdueTasks": "{{count}} overdue",
+      "activeHabits": "Active Habits",
+      "archivedHabits": "{{count}} archived",
+      "currentHabitStreak": "Current Streak",
+      "totalCheckins": "{{count}} total check-ins",
+      "recentTaskActivity": "Recent Task Activity",
+      "recentTaskActivityDesc": "Track task creation and completion over time",
+      "recentHabitActivity": "Recent Habit Activity",
+      "recentHabitActivityDesc": "See recent check-ins with dates and notes"
+    },
+    "task": {
+      "total": "All Tasks",
+      "completed": "{{count}} completed",
+      "completionRate": "Completion Rate",
+      "pending": "{{count}} pending",
+      "overdue": "Overdue Tasks",
+      "today": "{{count}} due today",
+      "projectCoverage": "Project Coverage",
+      "projectCoverageHint": "{{count}} task(s) assigned to projects",
+      "statusBreakdown": "Status Breakdown",
+      "projectBreakdown": "Project Breakdown",
+      "projectAssigned": "Assigned Projects",
+      "completedAt": "Completed At",
+      "recordCreated": "Task Created",
+      "recordCompleted": "Task Completed",
+      "trendTitle": "12-Week Task Trend",
+      "trendDesc": "Left bar is created, right bar is completed",
+      "trendLegend": "Created {{created}} · Completed {{completed}}",
+      "heatmapTitle": "Yearly Completion Heatmap",
+      "heatmapDesc": "Review completion density by day",
+      "empty": "No tasks available for analytics",
+      "noRecords": "No task records yet",
+      "tabs": {
+        "overview": "Overview",
+        "details": "Task Details",
+        "records": "Task Records",
+        "trends": "Task Trend",
+        "heatmap": "Year Heatmap"
+      }
+    },
+    "habit": {
+      "habitCount": "Habit Count",
+      "activeArchived": "{{active}} active · {{archived}} archived",
+      "currentStreak": "Current Streak",
+      "checkinDays": "{{count}} check-in days",
+      "successRate": "Effective Check-in Rate",
+      "totalCheckins": "{{count}} total check-ins",
+      "todayCheckins": "Today's Check-ins",
+      "todayCheckinsHint": "{{count}} active habit(s) checked in today",
+      "statusBreakdown": "Status Breakdown",
+      "archivedVisibility": "Archive and History",
+      "archivedHint1": "Switch between active, archived, and all habits at any time.",
+      "archivedHint2": "Archived habits keep their historical check-ins and remain visible in stats.",
+      "archivedHint3": "Delete a habit only when you no longer need it.",
+      "emptyNote": "No note",
+      "noLogs": "No check-in logs yet",
+      "noActiveHabits": "No active habits",
+      "noCheckin": "No check-in",
+      "monthTitle": "Current Month Distribution",
+      "tabs": {
+        "overview": "Overview",
+        "log": "Check-in Log",
+        "week": "Week View",
+        "month": "Month View",
+        "year": "Year View"
+      }
     }
   },
   "tags": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1644,18 +1644,112 @@
     "status": {
       "success": "成功",
       "partial": "部分",
-      "failure": "失败"
+      "failure": "失败",
+      "archived": "已归档"
     },
     "actions": {
       "success": "成功",
       "partial": "部分",
       "failure": "失败",
-      "archive": "归档"
+      "archive": "归档",
+      "unarchive": "取消归档",
+      "delete": "删除"
+    },
+    "filters": {
+      "active": "活跃",
+      "archived": "已归档",
+      "all": "全部"
     },
     "toast": {
       "createFailed": "创建习惯失败",
       "checkinUpdated": "打卡已更新",
-      "archived": "习惯已归档"
+      "archived": "习惯已归档",
+      "unarchived": "习惯已恢复",
+      "deleted": "习惯已删除"
+    }
+  },
+  "stats": {
+    "title": "统计",
+    "subtitle": "概览任务执行与习惯打卡表现",
+    "summaryHint": "统计页包含总览、任务统计和习惯统计。",
+    "refresh": "刷新",
+    "loading": "正在加载统计...",
+    "loadFailed": "加载统计失败",
+    "tabs": {
+      "overview": "概览",
+      "tasks": "任务统计",
+      "habits": "习惯统计"
+    },
+    "overview": {
+      "totalTasks": "任务总数",
+      "taskCompletion": "完成率 {{percent}}%",
+      "pendingTasks": "待完成任务",
+      "overdueTasks": "逾期 {{count}} 项",
+      "activeHabits": "活跃习惯",
+      "archivedHabits": "归档 {{count}} 个",
+      "currentHabitStreak": "当前连续打卡",
+      "totalCheckins": "累计打卡 {{count}} 次",
+      "recentTaskActivity": "最近任务动态",
+      "recentTaskActivityDesc": "按创建 / 完成时间追踪任务活动",
+      "recentHabitActivity": "最近打卡动态",
+      "recentHabitActivityDesc": "查看最近一次次打卡的日期与备注"
+    },
+    "task": {
+      "total": "全部任务",
+      "completed": "已完成 {{count}} 项",
+      "completionRate": "完成率",
+      "pending": "待完成 {{count}} 项",
+      "overdue": "逾期任务",
+      "today": "今天到期 {{count}} 项",
+      "projectCoverage": "项目归类率",
+      "projectCoverageHint": "{{count}} 项已归类到项目",
+      "statusBreakdown": "状态分布",
+      "projectBreakdown": "项目分布",
+      "projectAssigned": "已归类项目",
+      "completedAt": "完成时间",
+      "recordCreated": "任务创建",
+      "recordCompleted": "任务完成",
+      "trendTitle": "近 12 周任务趋势",
+      "trendDesc": "左侧为创建数，右侧为完成数",
+      "trendLegend": "创建 {{created}} · 完成 {{completed}}",
+      "heatmapTitle": "年度完成热力图",
+      "heatmapDesc": "按天查看任务完成密度",
+      "empty": "暂无可统计的任务",
+      "noRecords": "暂无任务记录",
+      "tabs": {
+        "overview": "概览",
+        "details": "任务详情",
+        "records": "任务记录",
+        "trends": "任务趋势",
+        "heatmap": "年度热力图"
+      }
+    },
+    "habit": {
+      "habitCount": "习惯总数",
+      "activeArchived": "活跃 {{active}} · 归档 {{archived}}",
+      "currentStreak": "连续打卡",
+      "checkinDays": "累计打卡 {{count}} 天",
+      "successRate": "有效打卡率",
+      "totalCheckins": "累计打卡 {{count}} 次",
+      "todayCheckins": "今日打卡",
+      "todayCheckinsHint": "已有 {{count}} 个活跃习惯打卡",
+      "statusBreakdown": "打卡状态分布",
+      "archivedVisibility": "归档与历史",
+      "archivedHint1": "活跃、已归档、全部三种列表可随时切换。",
+      "archivedHint2": "归档后的习惯仍保留打卡记录，可在统计页继续查看。",
+      "archivedHint3": "确认不再需要的习惯可直接删除。",
+      "emptyNote": "无备注",
+      "noLogs": "暂无打卡日志",
+      "noActiveHabits": "暂无活跃习惯",
+      "noCheckin": "未打卡",
+      "monthTitle": "本月打卡分布",
+      "tabs": {
+        "overview": "概览",
+        "log": "打卡日志",
+        "week": "周视图",
+        "month": "月视图",
+        "year": "年视图"
+      }
     }
   },
   "tags": {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1593,12 +1593,24 @@ export const api = {
     request<import("@/types").Habit>(`/habits/${id}`, { method: "PUT", body: JSON.stringify(data) }),
   archiveHabit: (id: string, archived = true) =>
     request<import("@/types").Habit>(`/habits/${id}/archive`, { method: "PATCH", body: JSON.stringify({ archived }) }),
+  deleteHabit: (id: string) =>
+    request<{ success: boolean }>(`/habits/${id}`, { method: "DELETE" }),
   getHabitCheckins: (id: string, params?: { from?: string; to?: string }) => {
     const search = new URLSearchParams();
     if (params?.from) search.set("from", params.from);
     if (params?.to) search.set("to", params.to);
     const qs = search.toString() ? `?${search.toString()}` : "";
     return request<import("@/types").HabitCheckin[]>(`/habits/${id}/checkins${qs}`);
+  },
+  getHabitCheckinLog: (params?: { from?: string; to?: string; includeArchived?: boolean }) => {
+    const search = new URLSearchParams();
+    const ws = getCurrentWorkspace();
+    if (ws && ws !== "personal") search.set("workspaceId", ws);
+    if (params?.from) search.set("from", params.from);
+    if (params?.to) search.set("to", params.to);
+    if (params?.includeArchived === false) search.set("includeArchived", "0");
+    const qs = search.toString() ? `?${search.toString()}` : "";
+    return request<import("@/types").HabitCheckinListItem[]>(`/habits/checkins${qs}`);
   },
   checkInHabit: (id: string, data: { status: import("@/types").HabitCheckinStatus; note?: string; checkinDate?: string }) =>
     request<import("@/types").HabitCheckin>(`/habits/${id}/checkins`, { method: "POST", body: JSON.stringify(data) }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -396,6 +396,7 @@ export interface Task {
   title: string;
   description: string;
   isCompleted: number;
+  completedAt?: string | null;
   priority: TaskPriority;
   dueDate: string | null;
   /** Phase 2: 精确到分钟的截止时间，ISO 8601 格式（如 2026-06-12T18:00）。兼容旧 dueDate */
@@ -451,6 +452,7 @@ export interface Habit {
   todayStatus?: HabitCheckinStatus | null;
   todayNote?: string | null;
   todayCheckinDate?: string | null;
+  canManage?: boolean;
 }
 
 export interface HabitCheckin {
@@ -463,6 +465,15 @@ export interface HabitCheckin {
   note: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface HabitCheckinListItem extends HabitCheckin {
+  habitTitle: string;
+  habitColor: string;
+  habitIcon: string;
+  habitArchivedAt: string | null;
+  creatorName?: string | null;
+  canManage?: boolean;
 }
 
 export interface HabitStats {


### PR DESCRIPTION
## 背景
客户反馈当前习惯功能与待办耦合较重，统计信息不直观，存在以下主要问题：
https://github.com/cropflre/nowen-note/issues/241
- 习惯打卡只能看到次数，缺少按日期的日志、周/月/年视图
- 待办统计缺少任务记录、趋势和年度热力图
- 习惯归档后仅可归档不可恢复或删除，归档内容也不易查看
- 统计页在工作区切换后可能继续展示旧工作区数据
- 相关后端数据链路和测试覆盖不足，尤其是任务完成时间 `completedAt`、习惯集合日志权限边界等关键路径

## 变更说明
- 新增任务与习惯统计中心，提供总览、任务统计、习惯统计三类视图
- 任务统计补齐概览、任务详情、任务记录、趋势、年度热力图
- 习惯统计补齐概览、打卡日志、周视图、月视图、年视图
- 为任务新增并持久化 `completedAt` 字段，确保统计基于真实完成时间而非 `updatedAt`
- 新增习惯集合级打卡日志接口，支持统计视图读取历史打卡数据
- 支持习惯取消归档和删除，优化习惯管理体验
- 修复统计页在工作区切换后未刷新、继续展示旧工作区数据的问题
- 修复项目统计中多个项目显示为同一“已归类项目”标签的问题
- 补充前后端聚焦测试，覆盖：
  - 习惯删除、取消归档、统计数据加载
  - `StatsCenter` 真实组件逻辑
  - `/habits/checkins` 的 feature flag、成员权限、作用域隔离
  - `completedAt` 的创建、更新、toggle、batch complete、迁移回填与清空

## 范围
本次改动涉及：
- 前端任务中心与统计中心视图
- 前端习惯列表归档/删除交互
- 前端统计相关类型、接口和国际化文案
- 后端 tasks 路由中 `completedAt` 的写入与维护
- 后端 habits 路由中集合级打卡日志与删除能力
- SQLite / PostgreSQL schema 与迁移脚本
- 前后端对应测试用例

不包含：
- 根目录 `npm run dev:backend` 的 Electron 启动异常修复
- 后端现存的无关类型问题或其他历史构建问题

## 验证说明
已完成以下验证：
- `frontend: npm run build`
- `frontend: npm run test:run -- src/components/__tests__/TaskCenterQuickAddIntegration.test.tsx src/components/__tests__/StatsCenter.test.tsx`
- `backend: node --import tsx --test tests/habits.test.ts`
- `backend: node --import tsx --test tests/task-completed-at.test.ts tests/tasks-completed-at-migration.test.ts`

验证结果：
- 前端生产构建通过
- 统计中心组件测试通过
- 习惯路由权限与统计接口测试通过
- `completedAt` 路由与迁移测试通过