### PR TITLE
chore: 再次同步最新 main 到 PG 运行时分支

### DIFF
--- a/frontend/src/components/MarkdownEditorImpl.tsx
+++ b/frontend/src/components/MarkdownEditorImpl.tsx
@@ -170,6 +170,19 @@ interface MarkdownEditorProps extends NoteEditorProps {
   onAIAssistant?: () => void;
 }
 
+export function normalizeMarkdownViewModeForMobile(
+  viewMode: MarkdownViewMode,
+  isMobile: boolean,
+): MarkdownViewMode {
+  return isMobile && viewMode === "split" ? "source" : viewMode;
+}
+
+function isMobileMarkdownViewport(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(max-width: 639px)").matches;
+}
+
 // ---------------------------------------------------------------------------
 // ��������С��ť + �ָ���
 // ---------------------------------------------------------------------------
@@ -399,7 +412,9 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
 
   // MARKDOWN-PREVIEW-MODE-01: 源码/预览/分屏模式
   const defaultViewMode = userPrefs.markdownDefaultViewMode;
-  const [viewMode, setViewMode] = useState<MarkdownViewMode>(defaultViewMode);
+  const [viewMode, setViewMode] = useState<MarkdownViewMode>(() =>
+    normalizeMarkdownViewModeForMobile(defaultViewMode, isMobileMarkdownViewport()),
+  );
   const [previewMarkdown, setPreviewMarkdown] = useState(() =>
     normalizeToMarkdown(note.content, note.contentText)
   );
@@ -410,6 +425,15 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
   useEffect(() => {
     viewModeRef.current = viewMode;
   }, [viewMode]);
+
+  const setMarkdownViewMode = useCallback((nextViewMode: MarkdownViewMode) => {
+    const nextMode = normalizeMarkdownViewModeForMobile(nextViewMode, isMobileMarkdownViewport());
+    if (nextMode !== "source") {
+      const view = viewRef.current;
+      if (view) setPreviewMarkdown(view.state.doc.toString());
+    }
+    setViewMode(nextMode);
+  }, []);
 
   /**
    * ���༭�����һ���ɷ��� onUpdate �� markdown �ַ�����
@@ -1485,6 +1509,40 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
             <Redo size={iconSize} />
           </ToolbarButton>
 
+          {/* MARKDOWN-MOBILE-PREVIEW-01: 预览入口前置，避免被横向工具栏遮挡。 */}
+          <div className="flex shrink-0 items-center gap-0.5 rounded-md border border-app-border sm:hidden">
+            <button
+              type="button"
+              onClick={() => setMarkdownViewMode("source")}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-[5px] transition-colors",
+                viewMode === "source"
+                  ? "bg-accent-primary/10 text-accent-primary"
+                  : "text-tx-tertiary active:bg-app-hover",
+              )}
+              title={tr("markdown.view.source") || "源码"}
+              aria-label={tr("markdown.view.source") || "源码"}
+              aria-pressed={viewMode === "source"}
+            >
+              <FileCode size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setMarkdownViewMode("preview")}
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-[5px] transition-colors",
+                viewMode === "preview"
+                  ? "bg-accent-primary/10 text-accent-primary"
+                  : "text-tx-tertiary active:bg-app-hover",
+              )}
+              title={tr("markdown.view.preview") || "预览"}
+              aria-label={tr("markdown.view.preview") || "预览"}
+              aria-pressed={viewMode === "preview"}
+            >
+              <Eye size={14} />
+            </button>
+          </div>
+
           <ToolbarDivider />
 
           <ToolbarButton
@@ -1622,10 +1680,10 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
           )}
 
           {/* MARKDOWN-PREVIEW-MODE-01: 视图模式切换 */}
-          <div className="ml-auto flex items-center gap-0.5 rounded-md border border-app-border overflow-hidden">
+          <div className="ml-auto hidden items-center gap-0.5 overflow-hidden rounded-md border border-app-border sm:flex">
             <button
               type="button"
-              onClick={() => setViewMode("source")}
+              onClick={() => setMarkdownViewMode("source")}
               className={cn(
                 "flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors",
                 viewMode === "source"
@@ -1639,12 +1697,7 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
             </button>
             <button
               type="button"
-              onClick={() => {
-                // 切换到预览时同步当前内容
-                const view = viewRef.current;
-                if (view) setPreviewMarkdown(view.state.doc.toString());
-                setViewMode("preview");
-              }}
+              onClick={() => setMarkdownViewMode("preview")}
               className={cn(
                 "flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors",
                 viewMode === "preview"
@@ -1658,12 +1711,7 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
             </button>
             <button
               type="button"
-              onClick={() => {
-                // 切换到分屏时同步当前内容到预览
-                const view = viewRef.current;
-                if (view) setPreviewMarkdown(view.state.doc.toString());
-                setViewMode("split");
-              }}
+              onClick={() => setMarkdownViewMode("split")}
               className={cn(
                 "flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors",
                 viewMode === "split"

--- a/frontend/src/components/MarkdownPreview.tsx
+++ b/frontend/src/components/MarkdownPreview.tsx
@@ -11,6 +11,7 @@ import { headingDataAttrs } from "@/lib/markdownPreviewOutline";
 import { preprocessMarkdownVideos } from "@/lib/markdownVideoSyntax";
 import { MarkdownVideoPreview } from "@/components/MarkdownVideoPreview";
 import { MarkdownCodeBlock, isMarkdownBlockCode } from "@/components/MarkdownCodeBlock";
+import { MathView } from "@/components/MathView";
 
 interface MarkdownPreviewProps {
   markdown: string;
@@ -21,6 +22,41 @@ interface MarkdownPreviewProps {
 }
 
 const RAW_HTML_RE = /<\/?[a-z][^>]*>/i;
+
+function preprocessMarkdownMath(markdown: string): string {
+  const fencedCode: string[] = [];
+  let text = markdown.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, (match) => {
+    const index = fencedCode.push(match) - 1;
+    return `\u0000NOWEN_MATH_CODE_${index}\u0000`;
+  });
+
+  text = text.replace(/\$\$([\s\S]+?)\$\$/g, (_match, source) => {
+    const encoded = encodeURIComponent(String(source).trim());
+    return `\n\n<div data-nowen-math-source="${encoded}" data-nowen-math-display="1"></div>\n\n`;
+  });
+
+  text = text.replace(
+    /(^|[^\\$\w])\$([^\s$][^$\n]*?[^\s$]|[^\s$])\$(?=$|[^\w$])/g,
+    (_match, prefix, source) => {
+      const encoded = encodeURIComponent(String(source));
+      return `${prefix}<span data-nowen-math-source="${encoded}" data-nowen-math-display="0"></span>`;
+    },
+  );
+
+  return text.replace(/\u0000NOWEN_MATH_CODE_(\d+)\u0000/g, (_match, index) => {
+    return fencedCode[Number(index)] || "";
+  });
+}
+
+function getMathSource(props: Record<string, unknown>): string | null {
+  const encoded = props["data-nowen-math-source"] ?? props.dataNowenMathSource;
+  if (typeof encoded !== "string") return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
+}
 
 const safeHtmlSchema = {
   ...defaultSchema,
@@ -40,6 +76,11 @@ const safeHtmlSchema = {
   ])),
   attributes: {
     ...(defaultSchema.attributes || {}),
+    "*": [
+      ...((defaultSchema.attributes || {})["*"] || []),
+      "dataNowenMathSource",
+      "dataNowenMathDisplay",
+    ],
     iframe: ["src", "title", "width", "height", "loading", "allow", "allowFullScreen", "referrerPolicy"],
     video: ["src", "controls", "poster", "preload", "width", "height"],
     audio: ["src", "controls", "preload"],
@@ -216,6 +257,16 @@ function createComponents(onTaskCheckboxChange?: (taskIndex: number, checked: bo
     mark: ({ children }) => <mark className="rounded bg-yellow-200/80 px-0.5 text-inherit dark:bg-yellow-500/30">{children}</mark>,
     kbd: ({ children }) => <kbd className="rounded border border-app-border bg-app-hover px-1.5 py-0.5 font-mono text-xs shadow-sm">{children}</kbd>,
     u: ({ children }) => <u className="underline underline-offset-2">{children}</u>,
+    span: ({ children, ...props }) => {
+      const source = getMathSource(props);
+      return source === null ? <span {...props}>{children}</span> : <MathView source={source} />;
+    },
+    div: ({ children, ...props }) => {
+      const source = getMathSource(props);
+      return source === null
+        ? <div {...props}>{children}</div>
+        : <MathView source={source} display />;
+    },
     code: ({ className, children }: any) => {
       const raw = String(children ?? "");
       const isBlock = isMarkdownBlockCode(className) || raw.endsWith("\n");
@@ -253,10 +304,10 @@ function createComponents(onTaskCheckboxChange?: (taskIndex: number, checked: bo
 
 export function MarkdownPreview({ markdown, className, compact, containerRef, onTaskCheckboxChange }: MarkdownPreviewProps) {
   const { t } = useTranslation();
-  const containsRawHtml = RAW_HTML_RE.test(markdown || "");
-  const renderedMarkdown = useMemo(() => preprocessMarkdownVideos((markdown || "")
+  const renderedMarkdown = useMemo(() => preprocessMarkdownMath(preprocessMarkdownVideos((markdown || "")
     .replace(/[\u200B-\u200D\uFEFF]/g, "")
-    .replace(/[\u00A0\u3000]/g, " ")), [markdown]);
+    .replace(/[\u00A0\u3000]/g, " "))), [markdown]);
+  const containsRawHtml = RAW_HTML_RE.test(renderedMarkdown);
   const components = useMemo(() => createComponents(onTaskCheckboxChange), [onTaskCheckboxChange]);
   const rehypePlugins: any[] = containsRawHtml ? [rehypeRaw, [rehypeSanitize, safeHtmlSchema]] : [];
 

--- a/frontend/src/components/__tests__/MarkdownEditor.mobilePreview.test.ts
+++ b/frontend/src/components/__tests__/MarkdownEditor.mobilePreview.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { normalizeMarkdownViewModeForMobile } from "../MarkdownEditorImpl";
+
+const editorSource = readFileSync(
+  path.resolve(__dirname, "../MarkdownEditorImpl.tsx"),
+  "utf8",
+);
+
+describe("MarkdownEditor mobile preview", () => {
+  it("falls back to source mode when a desktop split preference is opened on mobile", () => {
+    expect(normalizeMarkdownViewModeForMobile("split", true)).toBe("source");
+    expect(normalizeMarkdownViewModeForMobile("preview", true)).toBe("preview");
+    expect(normalizeMarkdownViewModeForMobile("split", false)).toBe("split");
+  });
+
+  it("places the mobile edit and preview controls before formatting tools", () => {
+    const mobileControls = editorSource.slice(
+      editorSource.indexOf("MARKDOWN-MOBILE-PREVIEW-01"),
+      editorSource.indexOf("<ToolbarDivider />", editorSource.indexOf("MARKDOWN-MOBILE-PREVIEW-01")),
+    );
+
+    expect(mobileControls).toContain("sm:hidden");
+    expect(mobileControls).toContain('setMarkdownViewMode("source")');
+    expect(mobileControls).toContain('setMarkdownViewMode("preview")');
+  });
+});

--- a/frontend/src/components/__tests__/MarkdownPreview.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownPreview.test.tsx
@@ -9,6 +9,12 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+vi.mock("@/components/MathView", () => ({
+  MathView: ({ source, display }: { source: string; display?: boolean }) => (
+    <span data-math-preview={display ? "block" : "inline"}>{source}</span>
+  ),
+}));
+
 describe("MarkdownPreview task checkboxes", () => {
   let host: HTMLDivElement;
   let root: Root;
@@ -48,5 +54,28 @@ describe("MarkdownPreview task checkboxes", () => {
     });
 
     expect(onTaskCheckboxChange).toHaveBeenCalledWith(1, true);
+  });
+
+  it("renders inline and block LaTeX while preserving fenced code", async () => {
+    const markdown = [
+      "行内公式 $E = mc^2$",
+      "",
+      "$$",
+      String.raw`\frac{-b \pm \sqrt{b^2-4ac}}{2a}`,
+      "$$",
+      "",
+      "```tex",
+      "$not_math$",
+      "```",
+    ].join("\n");
+
+    await act(async () => {
+      root.render(<MarkdownPreview markdown={markdown} />);
+    });
+
+    expect(host.querySelector('[data-math-preview="inline"]')?.textContent).toBe("E = mc^2");
+    expect(host.querySelector('[data-math-preview="block"]')?.textContent).toBe("\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}");
+    expect(host.querySelectorAll("[data-math-preview]")).toHaveLength(2);
+    expect(host.textContent).toContain("not_math");
   });
 });


### PR DESCRIPTION
仅将最新 `main@b1da1f0` 的 Markdown/移动端修复同步到 `issue-247-pg-runtime`。

- 不合并 #255 到 main
- 不修改 main
- 用作 #248 堆叠开发的最新基线