### PR TITLE
chore: 同步 main@b6168da 基线到 #248 分支

### DIFF
--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -121,10 +121,22 @@ const activityMigration: Migration = {
   up: ensureTaskActivitySchema,
 };
 
+const repairNotesFtsMigration: Migration = {
+  version: 46,
+  name: "repair-notes-fts-index",
+  up: (db) => {
+    // External-content FTS tables can drift after interrupted historical imports
+    // or old trigger versions. Rebuild from notes once during upgrade; the live
+    // insert/update/delete triggers keep it synchronized afterwards.
+    db.prepare("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')").run();
+  },
+};
+
 export const MIGRATIONS: Migration[] = [
   ...BASE_MIGRATIONS.filter((migration) => migration.version !== 44),
   patchedV44,
   activityMigration,
+  repairNotesFtsMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/lib/searchQuery.ts
+++ b/backend/src/lib/searchQuery.ts
@@ -1,13 +1,60 @@
+const ZERO_WIDTH_RE = /[\u200B-\u200D\uFEFF]/g;
+
+/**
+ * Normalize user-visible text for reliable literal search.
+ *
+ * NFKC folds full-width latin letters/numbers and compatibility characters,
+ * lower-casing makes ASCII/Unicode case differences deterministic, and hidden
+ * zero-width characters no longer make an otherwise visible keyword miss.
+ */
+export function normalizeSearchText(value: string): string {
+  return (value || "")
+    .normalize("NFKC")
+    .replace(ZERO_WIDTH_RE, "")
+    .toLocaleLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Split a query into literal AND terms while keeping punctuation attached.
+ * Keeping `c++`, `foo-bar` and version strings intact prevents the tokenizer
+ * from broadening them into unrelated single-letter/token matches.
+ */
 export function splitSearchTerms(query: string): string[] {
-  return Array.from(new Set((query || "").match(/[\p{Script=Han}]+|[^\s\p{Script=Han}]+/gu) || []));
+  const normalized = normalizeSearchText(query);
+  return Array.from(new Set(normalized.match(/[\p{Script=Han}]+|[^\s\p{Script=Han}]+/gu) || []));
 }
 
 export function hasHanText(query: string): boolean {
-  return /\p{Script=Han}/u.test(query || "");
+  return /\p{Script=Han}/u.test(normalizeSearchText(query));
 }
 
+/** Build a conservative FTS5 query used only for candidate ranking. */
 export function buildFtsSearchTerm(query: string): string {
-  return splitSearchTerms(query)
+  const tokens = normalizeSearchText(query).match(/[\p{L}\p{N}_]+/gu) || [];
+  return Array.from(new Set(tokens))
     .map((term) => `"${term.replace(/"/g, '""')}"*`)
     .join(" AND ");
+}
+
+export function countSearchTermOccurrences(source: string, term: string): number {
+  const haystack = normalizeSearchText(source);
+  const needle = normalizeSearchText(term);
+  if (!haystack || !needle) return 0;
+
+  let count = 0;
+  let from = 0;
+  while (from < haystack.length) {
+    const index = haystack.indexOf(needle, from);
+    if (index < 0) break;
+    count += 1;
+    from = index + Math.max(needle.length, 1);
+  }
+  return count;
+}
+
+export function containsAllSearchTerms(source: string, terms: string[]): boolean {
+  const normalized = normalizeSearchText(source);
+  return terms.length > 0 && terms.every((term) => normalized.includes(normalizeSearchText(term)));
 }

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -1,9 +1,18 @@
 import { Hono } from "hono";
+import type Database from "better-sqlite3";
 import { getDb } from "../db/schema";
 import { getUserWorkspaceRole } from "../middleware/acl";
-import { buildFtsSearchTerm, hasHanText, splitSearchTerms } from "../lib/searchQuery";
+import {
+  buildFtsSearchTerm,
+  countSearchTermOccurrences,
+  normalizeSearchText,
+  splitSearchTerms,
+} from "../lib/searchQuery";
 
 const app = new Hono();
+const registeredSearchDatabases = new WeakSet<object>();
+
+type MatchField = "title" | "content" | "tag" | "attachment";
 
 type SearchRow = {
   id: string;
@@ -11,18 +20,38 @@ type SearchRow = {
   notebookId: string;
   workspaceId: string | null;
   title: string;
-  contentText?: string;
+  contentText: string;
   updatedAt: string;
   isFavorite: number;
   isPinned: number;
+  contentFormat?: string;
+  notebookName?: string | null;
+  tagText: string;
+  attachmentNames: string;
+  attachmentText: string;
+};
+
+type SearchScope = {
+  sql: string;
+  params: unknown[];
+};
+
+type MatchSource = {
+  field: MatchField;
+  label: string;
+  text: string;
+  priority: number;
+};
+
+type SearchResultWithScore = Omit<SearchRow, "contentText" | "tagText" | "attachmentNames" | "attachmentText"> & {
   snippet: string;
   titleHtml: string;
   snippetHtml: string;
+  matchedField: "title" | "content" | "title+content";
+  matchedFields: MatchField[];
+  matchReason: MatchField;
+  matchCount: number;
   score: number;
-  matchedField?: "title" | "content" | "title+content";
-  matchCount?: number;
-  contentFormat?: string;
-  notebookName?: string | null;
 };
 
 function escapeHtml(text: string): string {
@@ -34,221 +63,402 @@ function escapeHtml(text: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function getSearchTerms(query: string): string[] {
-  const terms = splitSearchTerms(query)
-    .map((term) => term.trim())
-    .filter(Boolean);
-  return Array.from(new Set(terms.length > 0 ? terms : [query.trim()]))
-    .sort((a, b) => b.length - a.length);
-}
-
-function countOccurrences(source: string, term: string): number {
-  if (!source || !term) return 0;
-  const haystack = source.toLocaleLowerCase();
-  const needle = term.toLocaleLowerCase();
-  let count = 0;
-  let from = 0;
-  while (from < haystack.length) {
-    const index = haystack.indexOf(needle, from);
-    if (index < 0) break;
-    count += 1;
-    from = index + Math.max(needle.length, 1);
-  }
-  return count;
-}
-
-function buildMatchMeta(title: string, contentText: string, query: string): {
-  matchedField: "title" | "content" | "title+content";
-  matchCount: number;
+function normalizeWithSourceMap(source: string): {
+  normalized: string;
+  starts: number[];
+  ends: number[];
 } {
-  const terms = getSearchTerms(query);
-  const titleCount = terms.reduce((sum, term) => sum + countOccurrences(title || "", term), 0);
-  const contentCount = terms.reduce((sum, term) => sum + countOccurrences(contentText || "", term), 0);
+  let normalized = "";
+  const starts: number[] = [];
+  const ends: number[] = [];
+  let sourceOffset = 0;
 
-  const matchedField = titleCount > 0 && contentCount > 0
-    ? "title+content"
-    : titleCount > 0
-      ? "title"
-      : "content";
+  for (const char of source || "") {
+    const normalizedChar = char
+      .normalize("NFKC")
+      .replace(/[\u200B-\u200D\uFEFF]/g, "")
+      .toLocaleLowerCase();
+    for (let i = 0; i < normalizedChar.length; i += 1) {
+      normalized += normalizedChar[i];
+      starts.push(sourceOffset);
+      ends.push(sourceOffset + char.length);
+    }
+    sourceOffset += char.length;
+  }
 
-  // FTS tokenization may match a normalized form that cannot be reproduced with a literal
-  // substring count (for example punctuation-separated terms). A returned search row still
-  // represents at least one match, so never expose a zero badge to the client.
-  return { matchedField, matchCount: Math.max(1, titleCount + contentCount) };
+  return { normalized, starts, ends };
 }
 
-function markPlainText(text: string, query: string): string {
-  if (!text || !query) return escapeHtml(text || "");
-  const terms = getSearchTerms(query).filter(Boolean);
-  if (terms.length === 0) return escapeHtml(text);
+function findMatchRanges(source: string, terms: string[]): Array<{ start: number; end: number }> {
+  if (!source || terms.length === 0) return [];
+  const mapped = normalizeWithSourceMap(source);
+  const ranges: Array<{ start: number; end: number }> = [];
 
-  const matcher = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
-  return text
-    .split(matcher)
-    .map((part, index) => index % 2 === 1 ? `<mark>${escapeHtml(part)}</mark>` : escapeHtml(part))
-    .join("");
+  for (const rawTerm of terms) {
+    const term = normalizeSearchText(rawTerm);
+    if (!term) continue;
+    let from = 0;
+    while (from < mapped.normalized.length) {
+      const index = mapped.normalized.indexOf(term, from);
+      if (index < 0) break;
+      const endIndex = index + term.length - 1;
+      const start = mapped.starts[index];
+      const end = mapped.ends[endIndex];
+      if (start !== undefined && end !== undefined) ranges.push({ start, end });
+      from = index + Math.max(term.length, 1);
+    }
+  }
+
+  ranges.sort((a, b) => a.start - b.start || b.end - a.end);
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const range of ranges) {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.start > previous.end) {
+      merged.push({ ...range });
+    } else {
+      previous.end = Math.max(previous.end, range.end);
+    }
+  }
+  return merged;
+}
+
+function markPlainText(text: string, terms: string[]): string {
+  if (!text) return "";
+  const ranges = findMatchRanges(text, terms);
+  if (ranges.length === 0) return escapeHtml(text);
+
+  let output = "";
+  let cursor = 0;
+  for (const range of ranges) {
+    output += escapeHtml(text.slice(cursor, range.start));
+    output += `<mark>${escapeHtml(text.slice(range.start, range.end))}</mark>`;
+    cursor = range.end;
+  }
+  output += escapeHtml(text.slice(cursor));
+  return output;
 }
 
 function findFirstMatch(source: string, terms: string[]): { index: number; length: number } | null {
-  if (!source) return null;
-  const lowerSource = source.toLocaleLowerCase();
-  let best: { index: number; length: number } | null = null;
-
-  for (const term of terms) {
-    const index = lowerSource.indexOf(term.toLocaleLowerCase());
-    if (index < 0) continue;
-    if (!best || index < best.index || (index === best.index && term.length > best.length)) {
-      best = { index, length: term.length };
-    }
-  }
-  return best;
+  const ranges = findMatchRanges(source, terms);
+  const first = ranges[0];
+  return first ? { index: first.start, length: first.end - first.start } : null;
 }
 
-function buildPlainSnippet(title: string, contentText: string, query: string): string {
-  const terms = getSearchTerms(query);
-  const contentMatch = findFirstMatch(contentText, terms);
-  if (contentMatch) {
-    const start = Math.max(0, contentMatch.index - 70);
-    const end = Math.min(contentText.length, contentMatch.index + contentMatch.length + 150);
-    const prefix = start > 0 ? "..." : "";
-    const suffix = end < contentText.length ? "..." : "";
-    return `${prefix}${markPlainText(contentText.slice(start, end), query)}${suffix}`;
+function buildPlainSnippet(source: string, terms: string[], label?: string): string {
+  const match = findFirstMatch(source, terms);
+  if (!match) return label ? `${escapeHtml(label)}：${escapeHtml(source.slice(0, 220))}` : escapeHtml(source.slice(0, 220));
+
+  const start = Math.max(0, match.index - 70);
+  const end = Math.min(source.length, match.index + match.length + 150);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < source.length ? "..." : "";
+  const marked = markPlainText(source.slice(start, end), terms);
+  return `${label ? `${escapeHtml(label)}：` : ""}${prefix}${marked}${suffix}`;
+}
+
+function ensureSearchSqlFunctions(db: Database.Database): void {
+  if (registeredSearchDatabases.has(db as object)) return;
+  db.function(
+    "nowen_search_normalize",
+    { deterministic: true },
+    (value: unknown) => normalizeSearchText(value === null || value === undefined ? "" : String(value)),
+  );
+  registeredSearchDatabases.add(db as object);
+}
+
+function buildSearchScope(workspaceId: string | undefined, userId: string): SearchScope | null {
+  if (workspaceId && workspaceId !== "personal") {
+    const role = getUserWorkspaceRole(workspaceId, userId);
+    if (!role) return null;
+    return { sql: "n.workspaceId = ?", params: [workspaceId] };
   }
 
-  const titleMatch = findFirstMatch(title, terms);
-  if (titleMatch) return markPlainText(title, query);
-
-  const source = contentText || title || "";
-  return markPlainText(source.slice(0, 220), query);
+  return {
+    sql: `((n.userId = ? AND n.workspaceId IS NULL)
+      OR EXISTS (
+        SELECT 1
+        FROM notebook_members nm
+        JOIN notebooks shared_nb ON shared_nb.id = nm.notebookId
+        WHERE nm.notebookId = n.notebookId
+          AND nm.userId = ?
+          AND nm.status = 'active'
+          AND shared_nb.userId <> ?
+          AND shared_nb.isDeleted = 0
+      ))`,
+    params: [userId, userId, userId],
+  };
 }
+
+function getUserRole(db: Database.Database, userId: string): string | null {
+  const row = db.prepare("SELECT role FROM users WHERE id = ?").get(userId) as { role?: string } | undefined;
+  return row?.role || null;
+}
+
+function checkFtsIntegrity(db: Database.Database): { healthy: boolean; detail: string } {
+  try {
+    // rank=1 asks FTS5 to compare the external-content index with the notes table.
+    db.prepare("INSERT INTO notes_fts(notes_fts, rank) VALUES('integrity-check', 1)").run();
+    return { healthy: true, detail: "ok" };
+  } catch (error) {
+    return {
+      healthy: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function fetchFtsScores(
+  db: Database.Database,
+  searchTerm: string,
+  scope: SearchScope,
+): { scores: Map<string, number>; degraded: boolean } {
+  const scores = new Map<string, number>();
+  if (!searchTerm) return { scores, degraded: false };
+
+  try {
+    const rows = db.prepare(`
+      SELECT n.id, bm25(notes_fts, 8.0, 1.0) AS score
+      FROM notes_fts
+      JOIN notes n ON notes_fts.rowid = n.rowid
+      JOIN notebooks nb ON nb.id = n.notebookId
+      WHERE notes_fts MATCH ?
+        AND ${scope.sql}
+        AND n.isTrashed = 0
+        AND nb.isDeleted = 0
+      ORDER BY score
+      LIMIT 500
+    `).all(searchTerm, ...scope.params) as Array<{ id: string; score: number }>;
+    for (const row of rows) scores.set(row.id, Number(row.score) || 0);
+    return { scores, degraded: false };
+  } catch (error) {
+    console.warn("[search] FTS ranking unavailable; using verified literal results:", error);
+    return { scores, degraded: true };
+  }
+}
+
+function buildSearchResult(
+  row: SearchRow,
+  terms: string[],
+  normalizedQuery: string,
+  ftsScore: number | undefined,
+): SearchResultWithScore | null {
+  const sources: MatchSource[] = [
+    { field: "title", label: "标题", text: row.title || "", priority: 0 },
+    { field: "content", label: "正文", text: row.contentText || "", priority: 1 },
+    { field: "tag", label: "标签", text: row.tagText || "", priority: 2 },
+    {
+      field: "attachment",
+      label: "附件",
+      text: [row.attachmentNames, row.attachmentText].filter(Boolean).join("\n"),
+      priority: 3,
+    },
+  ];
+
+  // Every literal query term must have a visible source. FTS is never allowed to
+  // admit a row by itself, which eliminates stale/tokenizer-only ghost results.
+  const allTermsExplained = terms.every((term) =>
+    sources.some((source) => countSearchTermOccurrences(source.text, term) > 0),
+  );
+  if (!allTermsExplained) return null;
+
+  const matchedSources = sources
+    .map((source) => ({
+      ...source,
+      matchCount: terms.reduce(
+        (sum, term) => sum + countSearchTermOccurrences(source.text, term),
+        0,
+      ),
+      coverage: terms.filter((term) => countSearchTermOccurrences(source.text, term) > 0).length,
+      exactQuery: normalizedQuery ? normalizeSearchText(source.text).includes(normalizedQuery) : false,
+    }))
+    .filter((source) => source.matchCount > 0)
+    .sort((a, b) =>
+      Number(b.exactQuery) - Number(a.exactQuery)
+      || b.coverage - a.coverage
+      || a.priority - b.priority,
+    );
+
+  const primary = matchedSources[0];
+  if (!primary) return null;
+
+  const matchedFields = matchedSources.map((source) => source.field);
+  const matchCount = matchedSources.reduce((sum, source) => sum + source.matchCount, 0);
+  const hasTitle = matchedFields.includes("title");
+  const hasContent = matchedFields.includes("content");
+  const matchedField = hasTitle && hasContent ? "title+content" : hasTitle ? "title" : "content";
+  const snippetHtml = buildPlainSnippet(
+    primary.text,
+    terms,
+    primary.field === "title" || primary.field === "content" ? undefined : primary.label,
+  );
+
+  const manualScore = primary.priority * 10
+    - (primary.exactQuery ? 5 : 0)
+    - Math.min(matchCount, 20) / 100;
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    notebookId: row.notebookId,
+    workspaceId: row.workspaceId,
+    title: row.title,
+    updatedAt: row.updatedAt,
+    isFavorite: row.isFavorite,
+    isPinned: row.isPinned,
+    contentFormat: row.contentFormat,
+    notebookName: row.notebookName,
+    snippet: snippetHtml,
+    titleHtml: markPlainText(row.title, terms),
+    snippetHtml,
+    matchedField,
+    matchedFields,
+    matchReason: primary.field,
+    matchCount,
+    score: ftsScore ?? manualScore,
+  };
+}
+
+app.get("/health", (c) => {
+  const db = getDb();
+  const userId = c.req.header("X-User-Id") || "demo";
+  const integrity = checkFtsIntegrity(db);
+  return c.json({
+    ...integrity,
+    canRebuild: getUserRole(db, userId) === "admin",
+    checkedAt: new Date().toISOString(),
+  });
+});
+
+app.post("/rebuild", (c) => {
+  const db = getDb();
+  const userId = c.req.header("X-User-Id") || "demo";
+  if (getUserRole(db, userId) !== "admin") {
+    return c.json({ error: "仅管理员可以重建全文搜索索引" }, 403);
+  }
+
+  try {
+    const rebuild = db.transaction(() => {
+      db.prepare("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')").run();
+    });
+    rebuild();
+    const integrity = checkFtsIntegrity(db);
+    console.info(`[search] notes_fts rebuilt by user ${userId}; healthy=${integrity.healthy}`);
+    return c.json({
+      success: integrity.healthy,
+      ...integrity,
+      rebuiltAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error("[search] notes_fts rebuild failed:", error);
+    return c.json({ success: false, healthy: false, detail }, 500);
+  }
+});
 
 app.get("/", (c) => {
   const db = getDb();
+  ensureSearchSqlFunctions(db);
+
   const userId = c.req.header("X-User-Id") || "demo";
-  const q = (c.req.query("q") || "").trim();
+  const q = (c.req.query("q") || "").trim().slice(0, 200);
   const workspaceId = c.req.query("workspaceId");
   if (!q) return c.json([]);
 
-  const scopeParams: any[] = [];
-  const scopeSql =
-    workspaceId && workspaceId !== "personal"
-      ? (() => {
-          const role = getUserWorkspaceRole(workspaceId, userId);
-          if (!role) return null;
-          scopeParams.push(workspaceId);
-          return "n.workspaceId = ?";
-        })()
-      : (() => {
-          scopeParams.push(userId, userId, userId);
-          return `((n.userId = ? AND n.workspaceId IS NULL)
-            OR EXISTS (
-              SELECT 1
-              FROM notebook_members nm
-              JOIN notebooks shared_nb ON shared_nb.id = nm.notebookId
-              WHERE nm.notebookId = n.notebookId
-                AND nm.userId = ?
-                AND nm.status = 'active'
-                AND shared_nb.userId <> ?
-                AND shared_nb.isDeleted = 0
-            ))`;
-        })();
+  const scope = buildSearchScope(workspaceId, userId);
+  if (!scope) return c.json({ error: "无权访问该工作区" }, 403);
 
-  if (!scopeSql) return c.json({ error: "无权访问该工作区" }, 403);
+  const terms = splitSearchTerms(q);
+  if (terms.length === 0) return c.json([]);
+  const normalizedQuery = normalizeSearchText(q);
 
-  const rows = new Map<string, SearchRow>();
-  const searchTerm = buildFtsSearchTerm(q);
+  const perTermCondition = `(
+    instr(nowen_search_normalize(COALESCE(n.title, '')), ?) > 0
+    OR instr(nowen_search_normalize(COALESCE(n.contentText, '')), ?) > 0
+    OR EXISTS (
+      SELECT 1
+      FROM note_tags nt
+      JOIN tags t ON t.id = nt.tagId
+      WHERE nt.noteId = n.id
+        AND instr(nowen_search_normalize(COALESCE(t.name, '')), ?) > 0
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM attachments a
+      LEFT JOIN attachment_chunks ac ON ac.attachmentId = a.id
+      WHERE a.noteId = n.id
+        AND (
+          instr(nowen_search_normalize(COALESCE(a.filename, '')), ?) > 0
+          OR instr(nowen_search_normalize(COALESCE(ac.chunkText, '')), ?) > 0
+        )
+    )
+  )`;
+  const termSql = terms.map(() => perTermCondition).join(" AND ");
+  const termParams = terms.flatMap((term) => [term, term, term, term, term]);
 
-  if (searchTerm) {
-    const ftsRows = db.prepare(`
-      SELECT n.id, n.userId, n.notebookId, n.workspaceId, n.title, n.contentText, n.updatedAt,
-        CASE WHEN EXISTS(SELECT 1 FROM favorites f WHERE f.noteId = n.id AND f.userId = ?) THEN 1 ELSE 0 END AS isFavorite,
-        n.isPinned,
-        snippet(notes_fts, 1, '<mark>', '</mark>', '...', 90) AS snippet,
-        highlight(notes_fts, 0, '<mark>', '</mark>') AS titleHtml,
-        snippet(notes_fts, 1, '<mark>', '</mark>', '...', 90) AS snippetHtml,
-        rank AS score,
-        n.contentFormat,
-        nb.name AS notebookName
-      FROM notes_fts
-      JOIN notes n ON notes_fts.rowid = n.rowid
-      LEFT JOIN notebooks nb ON nb.id = n.notebookId
-      WHERE notes_fts MATCH ? AND ${scopeSql} AND n.isTrashed = 0
-      ORDER BY rank
-      LIMIT 100
-    `).all(userId, searchTerm, ...scopeParams) as SearchRow[];
+  const rows = db.prepare(`
+    SELECT
+      n.id,
+      n.userId,
+      n.notebookId,
+      n.workspaceId,
+      n.title,
+      COALESCE(n.contentText, '') AS contentText,
+      n.updatedAt,
+      CASE WHEN EXISTS(
+        SELECT 1 FROM favorites f WHERE f.noteId = n.id AND f.userId = ?
+      ) THEN 1 ELSE 0 END AS isFavorite,
+      n.isPinned,
+      n.contentFormat,
+      nb.name AS notebookName,
+      COALESCE((
+        SELECT group_concat(t.name, char(10))
+        FROM note_tags nt
+        JOIN tags t ON t.id = nt.tagId
+        WHERE nt.noteId = n.id
+      ), '') AS tagText,
+      COALESCE((
+        SELECT group_concat(a.filename, char(10))
+        FROM attachments a
+        WHERE a.noteId = n.id
+      ), '') AS attachmentNames,
+      COALESCE((
+        SELECT group_concat(ac.chunkText, char(10))
+        FROM attachments a
+        JOIN attachment_chunks ac ON ac.attachmentId = a.id
+        WHERE a.noteId = n.id
+      ), '') AS attachmentText
+    FROM notes n
+    JOIN notebooks nb ON nb.id = n.notebookId
+    WHERE ${scope.sql}
+      AND n.isTrashed = 0
+      AND nb.isDeleted = 0
+      AND (${termSql})
+    ORDER BY
+      CASE
+        WHEN instr(nowen_search_normalize(COALESCE(n.title, '')), ?) > 0 THEN 0
+        WHEN instr(nowen_search_normalize(COALESCE(n.contentText, '')), ?) > 0 THEN 1
+        ELSE 2
+      END,
+      n.updatedAt DESC
+    LIMIT 300
+  `).all(
+    userId,
+    ...scope.params,
+    ...termParams,
+    normalizedQuery,
+    normalizedQuery,
+  ) as SearchRow[];
 
-    for (const row of ftsRows) {
-      rows.set(row.id, {
-        ...row,
-        ...buildMatchMeta(row.title, row.contentText || "", q),
-      });
-    }
-  }
-
-  if (hasHanText(q)) {
-    // FTS5's default tokenizer is not reliable for every CJK phrase. Keep the existing
-    // literal AND fallback, but return the same rich result contract as the FTS branch.
-    const terms = splitSearchTerms(q).map((term) => term.trim()).filter(Boolean);
-    if (terms.length > 0) {
-      const andConditions = terms
-        .map(() => `(n.title LIKE '%' || ? || '%' OR n.contentText LIKE '%' || ? || '%')`)
-        .join(" AND ");
-      const likeParams = terms.flatMap((term) => [term, term]);
-
-      const likeRows = db.prepare(`
-        SELECT n.id, n.userId, n.notebookId, n.workspaceId, n.title, n.contentText, n.updatedAt,
-          CASE WHEN EXISTS(SELECT 1 FROM favorites f WHERE f.noteId = n.id AND f.userId = ?) THEN 1 ELSE 0 END AS isFavorite,
-          n.isPinned,
-          n.contentFormat,
-          nb.name AS notebookName
-        FROM notes n
-        LEFT JOIN notebooks nb ON nb.id = n.notebookId
-        WHERE ${scopeSql} AND n.isTrashed = 0
-          AND (${andConditions})
-        ORDER BY n.updatedAt DESC
-        LIMIT 100
-      `).all(userId, ...scopeParams, ...likeParams) as Array<SearchRow & { contentText: string }>;
-
-      for (const row of likeRows) {
-        if (rows.has(row.id)) continue;
-        const snippetHtml = buildPlainSnippet(row.title, row.contentText || "", q);
-        const matchMeta = buildMatchMeta(row.title, row.contentText || "", q);
-
-        rows.set(row.id, {
-          id: row.id,
-          userId: row.userId,
-          notebookId: row.notebookId,
-          workspaceId: row.workspaceId,
-          title: row.title,
-          contentText: row.contentText,
-          updatedAt: row.updatedAt,
-          isFavorite: row.isFavorite,
-          isPinned: row.isPinned,
-          snippet: snippetHtml,
-          titleHtml: markPlainText(row.title, q),
-          snippetHtml,
-          score: 10,
-          contentFormat: row.contentFormat,
-          notebookName: row.notebookName,
-          ...matchMeta,
-        });
-      }
-    }
-  }
+  const fts = fetchFtsScores(db, buildFtsSearchTerm(q), scope);
+  c.header("X-Search-Index-Status", fts.degraded ? "degraded" : "ok");
 
   return c.json(
-    Array.from(rows.values())
+    rows
+      .map((row) => buildSearchResult(row, terms, normalizedQuery, fts.scores.get(row.id)))
+      .filter((row): row is SearchResultWithScore => Boolean(row))
       .sort((a, b) => a.score - b.score || b.updatedAt.localeCompare(a.updatedAt))
       .slice(0, 100)
-      .map(({ score, contentText: _contentText, ...row }) => ({
-        ...row,
-        matchedField: row.matchedField || "title+content",
-        matchCount: Math.max(1, row.matchCount || 1),
-      })),
+      .map(({ score: _score, ...row }) => row),
   );
 });
 

--- a/backend/tests/search-experience.test.ts
+++ b/backend/tests/search-experience.test.ts
@@ -14,6 +14,11 @@ const OTHER_ID = "search-other";
 const NOTEBOOK_ID = "search-notebook";
 const ENGLISH_NOTE_ID = "search-english";
 const CHINESE_NOTE_ID = "search-chinese";
+const FULLWIDTH_NOTE_ID = "search-fullwidth";
+const CPP_NOTE_ID = "search-cpp";
+const C_NOTE_ID = "search-c";
+const META_NOTE_ID = "search-meta";
+const MUTABLE_NOTE_ID = "search-mutable";
 
 let app: Hono;
 let getDb: () => Database.Database;
@@ -27,7 +32,14 @@ async function search(userId: string, query: string) {
   const response = await app.request(`/search?q=${encodeURIComponent(query)}`, {
     headers: { "X-User-Id": userId },
   });
-  return { status: response.status, json: await response.json() as any[] };
+  return { status: response.status, headers: response.headers, json: await response.json() as any[] };
+}
+
+function insertNote(id: string, title: string, contentText: string, contentFormat = "markdown") {
+  db().prepare(`
+    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, OWNER_ID, NOTEBOOK_ID, title, contentText, contentFormat);
 }
 
 test.before(async () => {
@@ -43,34 +55,50 @@ test.before(async () => {
 
   db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
     .run(OWNER_ID, OWNER_ID, "hash");
+  db().prepare("UPDATE users SET role = 'admin' WHERE id = ?").run(OWNER_ID);
   db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
     .run(OTHER_ID, OTHER_ID, "hash");
   db().prepare("INSERT INTO notebooks (id, userId, name, icon) VALUES (?, ?, ?, ?)")
     .run(NOTEBOOK_ID, OWNER_ID, "Search notes", "🔎");
 
-  db().prepare(`
-    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(
+  insertNote(
     ENGLISH_NOTE_ID,
-    OWNER_ID,
-    NOTEBOOK_ID,
     "Alpha alpha guide",
     "An alpha example with another ALPHA occurrence.",
-    "markdown",
   );
-
-  db().prepare(`
-    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(
+  insertNote(
     CHINESE_NOTE_ID,
-    OWNER_ID,
-    NOTEBOOK_ID,
     "中文全文检索",
     "搜索体验需要突出搜索关键词，并展示搜索结果。",
     "tiptap-json",
   );
+  insertNote(FULLWIDTH_NOTE_ID, "兼容字符", "发布编号是ＡＢＣ１２３。", "tiptap-json");
+  insertNote(CPP_NOTE_ID, "Modern C++ handbook", "RAII and templates");
+  insertNote(C_NOTE_ID, "C language handbook", "Pointers and memory");
+  insertNote(META_NOTE_ID, "Release planning", "This note deliberately has no metadata keywords.");
+  insertNote(MUTABLE_NOTE_ID, "Mutable note", "before unique-old-keyword");
+
+  db().prepare("INSERT INTO tags (id, userId, name, color) VALUES (?, ?, ?, ?)")
+    .run("search-tag", OWNER_ID, "项目代号X9", "#58a6ff");
+  db().prepare("INSERT INTO note_tags (noteId, tagId) VALUES (?, ?)")
+    .run(META_NOTE_ID, "search-tag");
+
+  db().prepare(`
+    INSERT INTO attachments (id, noteId, userId, filename, mimeType, size, path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "search-attachment",
+    META_NOTE_ID,
+    OWNER_ID,
+    "roadmap-2026.pdf",
+    "application/pdf",
+    128,
+    "search/roadmap-2026.pdf",
+  );
+  db().prepare(`
+    INSERT INTO attachment_chunks (attachmentId, chunkIndex, chunkText)
+    VALUES (?, ?, ?)
+  `).run("search-attachment", 1, "附件正文包含唯一召回词火星计划。 ");
 });
 
 test.after(() => {
@@ -87,6 +115,7 @@ test("search results include accurate match counts and notebook metadata", async
   assert.equal(result.id, ENGLISH_NOTE_ID);
   assert.equal(result.matchCount, 4);
   assert.equal(result.matchedField, "title+content");
+  assert.deepEqual(result.matchedFields, ["title", "content"]);
   assert.equal(result.notebookName, "Search notes");
   assert.equal(result.contentFormat, "markdown");
   assert.equal("contentText" in result, false, "full contentText must not leak into search payloads");
@@ -94,14 +123,93 @@ test("search results include accurate match counts and notebook metadata", async
   assert.match(result.snippetHtml, /<mark>/i);
 });
 
-test("Chinese fallback returns highlighted context and content-only metadata", async () => {
+test("Chinese search returns highlighted context and content-only metadata", async () => {
   const response = await search(OWNER_ID, "搜索");
   assert.equal(response.status, 200);
   const result = response.json.find((item) => item.id === CHINESE_NOTE_ID);
   assert.ok(result);
   assert.equal(result.matchCount, 3);
   assert.equal(result.matchedField, "content");
-  assert.match(result.snippetHtml, /<mark>[^<]*搜索[^<]*<\/mark>/i);
+  assert.equal(result.matchReason, "content");
+  assert.match(result.snippetHtml, /<mark>搜索<\/mark>/i);
+});
+
+test("full-width text is searchable with half-width input", async () => {
+  const response = await search(OWNER_ID, "abc123");
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.json.map((item) => item.id), [FULLWIDTH_NOTE_ID]);
+  assert.match(response.json[0].snippetHtml, /<mark>ＡＢＣ１２３<\/mark>/i);
+});
+
+test("punctuation stays literal and does not admit tokenizer-only false positives", async () => {
+  const response = await search(OWNER_ID, "C++");
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.json.map((item) => item.id), [CPP_NOTE_ID]);
+  assert.equal(response.json.some((item) => item.id === C_NOTE_ID), false);
+});
+
+test("tag, attachment filename and extracted attachment text expose their hit reason", async () => {
+  const tagResult = (await search(OWNER_ID, "项目代号X9")).json[0];
+  assert.equal(tagResult.id, META_NOTE_ID);
+  assert.deepEqual(tagResult.matchedFields, ["tag"]);
+  assert.equal(tagResult.matchReason, "tag");
+  assert.match(tagResult.snippetHtml, /标签：/);
+  assert.match(tagResult.snippetHtml, /<mark>项目代号X9<\/mark>/);
+
+  const filenameResult = (await search(OWNER_ID, "roadmap-2026.pdf")).json[0];
+  assert.equal(filenameResult.id, META_NOTE_ID);
+  assert.deepEqual(filenameResult.matchedFields, ["attachment"]);
+  assert.equal(filenameResult.matchReason, "attachment");
+  assert.match(filenameResult.snippetHtml, /附件：/);
+
+  const contentResult = (await search(OWNER_ID, "火星计划")).json[0];
+  assert.equal(contentResult.id, META_NOTE_ID);
+  assert.equal(contentResult.matchReason, "attachment");
+  assert.match(contentResult.snippetHtml, /<mark>火星计划<\/mark>/);
+});
+
+test("editing, trashing, restoring and deleting a note never leaves ghost results", async () => {
+  assert.equal((await search(OWNER_ID, "unique-old-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("UPDATE notes SET contentText = ?, updatedAt = datetime('now') WHERE id = ?")
+    .run("after unique-new-keyword", MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-old-keyword")).json, []);
+  assert.equal((await search(OWNER_ID, "unique-new-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("UPDATE notes SET isTrashed = 1 WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-new-keyword")).json, []);
+
+  db().prepare("UPDATE notes SET isTrashed = 0 WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.equal((await search(OWNER_ID, "unique-new-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("DELETE FROM notes WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-new-keyword")).json, []);
+});
+
+test("search index health is observable and admins can rebuild it safely", async () => {
+  const healthResponse = await app.request("/search/health", {
+    headers: { "X-User-Id": OWNER_ID },
+  });
+  const health = await healthResponse.json() as any;
+  assert.equal(healthResponse.status, 200);
+  assert.equal(health.healthy, true);
+  assert.equal(health.canRebuild, true);
+
+  const rebuildResponse = await app.request("/search/rebuild", {
+    method: "POST",
+    headers: { "X-User-Id": OWNER_ID },
+  });
+  const rebuilt = await rebuildResponse.json() as any;
+  assert.equal(rebuildResponse.status, 200);
+  assert.equal(rebuilt.success, true);
+  assert.equal(rebuilt.healthy, true);
+  assert.equal((await search(OWNER_ID, "alpha")).json[0]?.id, ENGLISH_NOTE_ID);
+
+  const forbiddenResponse = await app.request("/search/rebuild", {
+    method: "POST",
+    headers: { "X-User-Id": OTHER_ID },
+  });
+  assert.equal(forbiddenResponse.status, 403);
 });
 
 test("personal-space search does not expose another user's notes", async () => {

--- a/backend/tests/search-experience.test.ts
+++ b/backend/tests/search-experience.test.ts
@@ -14,6 +14,11 @@ const OTHER_ID = "search-other";
 const NOTEBOOK_ID = "search-notebook";
 const ENGLISH_NOTE_ID = "search-english";
 const CHINESE_NOTE_ID = "search-chinese";
+const FULLWIDTH_NOTE_ID = "search-fullwidth";
+const CPP_NOTE_ID = "search-cpp";
+const C_NOTE_ID = "search-c";
+const META_NOTE_ID = "search-meta";
+const MUTABLE_NOTE_ID = "search-mutable";
 
 let app: Hono;
 let getDb: () => Database.Database;
@@ -27,7 +32,14 @@ async function search(userId: string, query: string) {
   const response = await app.request(`/search?q=${encodeURIComponent(query)}`, {
     headers: { "X-User-Id": userId },
   });
-  return { status: response.status, json: await response.json() as any[] };
+  return { status: response.status, headers: response.headers, json: await response.json() as any[] };
+}
+
+function insertNote(id: string, title: string, contentText: string, contentFormat = "markdown") {
+  db().prepare(`
+    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, OWNER_ID, NOTEBOOK_ID, title, contentText, contentFormat);
 }
 
 test.before(async () => {
@@ -43,34 +55,50 @@ test.before(async () => {
 
   db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
     .run(OWNER_ID, OWNER_ID, "hash");
+  db().prepare("UPDATE users SET role = 'admin' WHERE id = ?").run(OWNER_ID);
   db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
     .run(OTHER_ID, OTHER_ID, "hash");
   db().prepare("INSERT INTO notebooks (id, userId, name, icon) VALUES (?, ?, ?, ?)")
     .run(NOTEBOOK_ID, OWNER_ID, "Search notes", "🔎");
 
-  db().prepare(`
-    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(
+  insertNote(
     ENGLISH_NOTE_ID,
-    OWNER_ID,
-    NOTEBOOK_ID,
     "Alpha alpha guide",
     "An alpha example with another ALPHA occurrence.",
-    "markdown",
   );
-
-  db().prepare(`
-    INSERT INTO notes (id, userId, notebookId, title, contentText, contentFormat)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(
+  insertNote(
     CHINESE_NOTE_ID,
-    OWNER_ID,
-    NOTEBOOK_ID,
     "中文全文检索",
     "搜索体验需要突出搜索关键词，并展示搜索结果。",
     "tiptap-json",
   );
+  insertNote(FULLWIDTH_NOTE_ID, "兼容字符", "发布编号是ＡＢＣ１２３。", "tiptap-json");
+  insertNote(CPP_NOTE_ID, "Modern C++ handbook", "RAII and templates");
+  insertNote(C_NOTE_ID, "C language handbook", "Pointers and memory");
+  insertNote(META_NOTE_ID, "Release planning", "This note deliberately has no metadata keywords.");
+  insertNote(MUTABLE_NOTE_ID, "Mutable note", "before unique-old-keyword");
+
+  db().prepare("INSERT INTO tags (id, userId, name, color) VALUES (?, ?, ?, ?)")
+    .run("search-tag", OWNER_ID, "项目代号X9", "#58a6ff");
+  db().prepare("INSERT INTO note_tags (noteId, tagId) VALUES (?, ?)")
+    .run(META_NOTE_ID, "search-tag");
+
+  db().prepare(`
+    INSERT INTO attachments (id, noteId, userId, filename, mimeType, size, path)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "search-attachment",
+    META_NOTE_ID,
+    OWNER_ID,
+    "roadmap-2026.pdf",
+    "application/pdf",
+    128,
+    "search/roadmap-2026.pdf",
+  );
+  db().prepare(`
+    INSERT INTO attachment_chunks (attachmentId, chunkIndex, chunkText)
+    VALUES (?, ?, ?)
+  `).run("search-attachment", 1, "附件正文包含唯一召回词火星计划。 ");
 });
 
 test.after(() => {
@@ -87,6 +115,7 @@ test("search results include accurate match counts and notebook metadata", async
   assert.equal(result.id, ENGLISH_NOTE_ID);
   assert.equal(result.matchCount, 4);
   assert.equal(result.matchedField, "title+content");
+  assert.deepEqual(result.matchedFields, ["title", "content"]);
   assert.equal(result.notebookName, "Search notes");
   assert.equal(result.contentFormat, "markdown");
   assert.equal("contentText" in result, false, "full contentText must not leak into search payloads");
@@ -94,14 +123,93 @@ test("search results include accurate match counts and notebook metadata", async
   assert.match(result.snippetHtml, /<mark>/i);
 });
 
-test("Chinese fallback returns highlighted context and content-only metadata", async () => {
+test("Chinese search returns highlighted context and content-only metadata", async () => {
   const response = await search(OWNER_ID, "搜索");
   assert.equal(response.status, 200);
   const result = response.json.find((item) => item.id === CHINESE_NOTE_ID);
   assert.ok(result);
   assert.equal(result.matchCount, 3);
   assert.equal(result.matchedField, "content");
+  assert.equal(result.matchReason, "content");
   assert.match(result.snippetHtml, /<mark>搜索<\/mark>/i);
+});
+
+test("full-width text is searchable with half-width input", async () => {
+  const response = await search(OWNER_ID, "abc123");
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.json.map((item) => item.id), [FULLWIDTH_NOTE_ID]);
+  assert.match(response.json[0].snippetHtml, /<mark>ＡＢＣ１２３<\/mark>/i);
+});
+
+test("punctuation stays literal and does not admit tokenizer-only false positives", async () => {
+  const response = await search(OWNER_ID, "C++");
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.json.map((item) => item.id), [CPP_NOTE_ID]);
+  assert.equal(response.json.some((item) => item.id === C_NOTE_ID), false);
+});
+
+test("tag, attachment filename and extracted attachment text expose their hit reason", async () => {
+  const tagResult = (await search(OWNER_ID, "项目代号X9")).json[0];
+  assert.equal(tagResult.id, META_NOTE_ID);
+  assert.deepEqual(tagResult.matchedFields, ["tag"]);
+  assert.equal(tagResult.matchReason, "tag");
+  assert.match(tagResult.snippetHtml, /标签：/);
+  assert.match(tagResult.snippetHtml, /<mark>项目代号X9<\/mark>/);
+
+  const filenameResult = (await search(OWNER_ID, "roadmap-2026.pdf")).json[0];
+  assert.equal(filenameResult.id, META_NOTE_ID);
+  assert.deepEqual(filenameResult.matchedFields, ["attachment"]);
+  assert.equal(filenameResult.matchReason, "attachment");
+  assert.match(filenameResult.snippetHtml, /附件：/);
+
+  const contentResult = (await search(OWNER_ID, "火星计划")).json[0];
+  assert.equal(contentResult.id, META_NOTE_ID);
+  assert.equal(contentResult.matchReason, "attachment");
+  assert.match(contentResult.snippetHtml, /<mark>火星计划<\/mark>/);
+});
+
+test("editing, trashing, restoring and deleting a note never leaves ghost results", async () => {
+  assert.equal((await search(OWNER_ID, "unique-old-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("UPDATE notes SET contentText = ?, updatedAt = datetime('now') WHERE id = ?")
+    .run("after unique-new-keyword", MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-old-keyword")).json, []);
+  assert.equal((await search(OWNER_ID, "unique-new-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("UPDATE notes SET isTrashed = 1 WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-new-keyword")).json, []);
+
+  db().prepare("UPDATE notes SET isTrashed = 0 WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.equal((await search(OWNER_ID, "unique-new-keyword")).json[0]?.id, MUTABLE_NOTE_ID);
+
+  db().prepare("DELETE FROM notes WHERE id = ?").run(MUTABLE_NOTE_ID);
+  assert.deepEqual((await search(OWNER_ID, "unique-new-keyword")).json, []);
+});
+
+test("search index health is observable and admins can rebuild it safely", async () => {
+  const healthResponse = await app.request("/search/health", {
+    headers: { "X-User-Id": OWNER_ID },
+  });
+  const health = await healthResponse.json() as any;
+  assert.equal(healthResponse.status, 200);
+  assert.equal(health.healthy, true);
+  assert.equal(health.canRebuild, true);
+
+  const rebuildResponse = await app.request("/search/rebuild", {
+    method: "POST",
+    headers: { "X-User-Id": OWNER_ID },
+  });
+  const rebuilt = await rebuildResponse.json() as any;
+  assert.equal(rebuildResponse.status, 200);
+  assert.equal(rebuilt.success, true);
+  assert.equal(rebuilt.healthy, true);
+  assert.equal((await search(OWNER_ID, "alpha")).json[0]?.id, ENGLISH_NOTE_ID);
+
+  const forbiddenResponse = await app.request("/search/rebuild", {
+    method: "POST",
+    headers: { "X-User-Id": OTHER_ID },
+  });
+  assert.equal(forbiddenResponse.status, 403);
 });
 
 test("personal-space search does not expose another user's notes", async () => {

--- a/backend/tests/search-query.test.ts
+++ b/backend/tests/search-query.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildFtsSearchTerm,
+  containsAllSearchTerms,
+  countSearchTermOccurrences,
+  normalizeSearchText,
+  splitSearchTerms,
+} from "../src/lib/searchQuery";
+
+test("search normalization folds width, case, whitespace and zero-width characters", () => {
+  assert.equal(normalizeSearchText("  ＡＢＣ\u200B１２３  "), "abc123");
+  assert.equal(normalizeSearchText("Alpha\n\tBETA"), "alpha beta");
+});
+
+test("literal terms keep punctuation that changes meaning", () => {
+  assert.deepEqual(splitSearchTerms("C++ foo-bar 中文检索"), ["c++", "foo-bar", "中文检索"]);
+  assert.equal(containsAllSearchTerms("Modern C++ and foo-bar", ["c++", "foo-bar"]), true);
+  assert.equal(containsAllSearchTerms("C language and foo bar", ["c++", "foo-bar"]), false);
+});
+
+test("FTS candidates are conservative tokens and never define final truth", () => {
+  assert.equal(buildFtsSearchTerm("C++ foo-bar"), '"c"* AND "foo"* AND "bar"*');
+  assert.equal(buildFtsSearchTerm("全文搜索"), '"全文搜索"*');
+});
+
+test("occurrence counting uses the same normalization as filtering", () => {
+  assert.equal(countSearchTermOccurrences("ＡＢＣ１２３ abc123", "abc123"), 2);
+  assert.equal(countSearchTermOccurrences("Alpha alpha ALPHA", "alpha"), 3);
+});


### PR DESCRIPTION
将已同步 `main@b6168da` 的 `issue-247-pg-runtime@e5d9254` 合入 `issue-248-direct-db-audit`。

- 仅更新堆叠分支基线
- 不合并 #255/#258 到 main
- 保留 #248 当前 SQLite 直连清理改动