### PR TITLE
chore: 同步 main@1cc78c6 基线到 #248 分支

### DIFF
--- a/backend/src/routes/user-preferences-sync.ts
+++ b/backend/src/routes/user-preferences-sync.ts
@@ -1,0 +1,314 @@
+import { Hono } from "hono";
+import { getDb } from "../db/schema";
+
+type MarkdownViewMode = "source" | "preview" | "split";
+type ReadingDensity = "cozy" | "compact";
+type EditorMode = "md" | "tiptap";
+type CodeBlockTheme =
+  | "github-dark"
+  | "github-light"
+  | "dracula"
+  | "monokai"
+  | "solarized-light"
+  | "one-dark"
+  | "nord";
+
+export interface SyncedUserPreferences {
+  noteTitleAsAppTitle: boolean;
+  outlineDefaultOpen: boolean;
+  lockOnOpen: boolean;
+  showNotesInNotebookTree: boolean;
+  readingDensity: ReadingDensity;
+  showNoteListUpdatedTime: boolean;
+  enableNoteTabs: boolean;
+  markdownDefaultViewMode: MarkdownViewMode;
+  defaultEditorMode: EditorMode;
+  codeBlockTheme: CodeBlockTheme;
+  noteListTitleOnly: boolean;
+}
+
+type PreferenceKey = keyof SyncedUserPreferences;
+type PreferencePatch = Partial<SyncedUserPreferences>;
+type FieldUpdatedAt = Partial<Record<PreferenceKey, string>>;
+
+interface StoredPreferenceMeta {
+  version: 2;
+  revision: number;
+  fieldUpdatedAt: FieldUpdatedAt;
+}
+
+interface StoredPreferenceDocument extends SyncedUserPreferences {
+  __meta?: StoredPreferenceMeta;
+}
+
+interface PreferenceState {
+  prefs: SyncedUserPreferences;
+  hasPreferences: boolean;
+  revision: number;
+  fieldUpdatedAt: FieldUpdatedAt;
+  updatedAt: string | null;
+}
+
+export const DEFAULT_SYNCED_USER_PREFERENCES: SyncedUserPreferences = {
+  noteTitleAsAppTitle: false,
+  outlineDefaultOpen: false,
+  lockOnOpen: false,
+  showNotesInNotebookTree: false,
+  readingDensity: "cozy",
+  showNoteListUpdatedTime: true,
+  enableNoteTabs: false,
+  markdownDefaultViewMode: "source",
+  defaultEditorMode: "tiptap",
+  codeBlockTheme: "github-dark",
+  noteListTitleOnly: false,
+};
+
+const PREFERENCE_KEYS = Object.keys(DEFAULT_SYNCED_USER_PREFERENCES) as PreferenceKey[];
+const PREFERENCE_KEY_SET = new Set<string>(PREFERENCE_KEYS);
+const CODE_BLOCK_THEMES = new Set<CodeBlockTheme>([
+  "github-dark",
+  "github-light",
+  "dracula",
+  "monokai",
+  "solarized-light",
+  "one-dark",
+  "nord",
+]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizePreferenceValue<K extends PreferenceKey>(
+  key: K,
+  value: unknown,
+  fallback: SyncedUserPreferences[K],
+): SyncedUserPreferences[K] {
+  switch (key) {
+    case "noteTitleAsAppTitle":
+    case "outlineDefaultOpen":
+    case "lockOnOpen":
+    case "showNotesInNotebookTree":
+    case "showNoteListUpdatedTime":
+    case "enableNoteTabs":
+    case "noteListTitleOnly":
+      return (typeof value === "boolean" ? value : fallback) as SyncedUserPreferences[K];
+    case "readingDensity":
+      return (value === "cozy" || value === "compact" ? value : fallback) as SyncedUserPreferences[K];
+    case "markdownDefaultViewMode":
+      return (
+        value === "source" || value === "preview" || value === "split"
+          ? value
+          : fallback
+      ) as SyncedUserPreferences[K];
+    case "defaultEditorMode":
+      return (value === "md" || value === "tiptap" ? value : fallback) as SyncedUserPreferences[K];
+    case "codeBlockTheme":
+      return (
+        typeof value === "string" && CODE_BLOCK_THEMES.has(value as CodeBlockTheme)
+          ? value
+          : fallback
+      ) as SyncedUserPreferences[K];
+  }
+}
+
+export function normalizeSyncedUserPreferences(
+  input: unknown,
+  base: SyncedUserPreferences = DEFAULT_SYNCED_USER_PREFERENCES,
+): SyncedUserPreferences {
+  const raw = isObject(input) ? input : {};
+  const next = { ...base };
+  for (const key of PREFERENCE_KEYS) {
+    next[key] = normalizePreferenceValue(key, raw[key], base[key]) as never;
+  }
+  return next;
+}
+
+function parseFieldUpdatedAt(value: unknown): FieldUpdatedAt {
+  if (!isObject(value)) return {};
+  const result: FieldUpdatedAt = {};
+  for (const key of PREFERENCE_KEYS) {
+    const timestamp = value[key];
+    if (typeof timestamp === "string" && timestamp.length <= 64) {
+      result[key] = timestamp;
+    }
+  }
+  return result;
+}
+
+export function readPreferenceState(userId: string): PreferenceState {
+  const row = getDb()
+    .prepare("SELECT preferencesJson, updatedAt FROM user_preferences WHERE userId = ?")
+    .get(userId) as { preferencesJson: string; updatedAt: string } | undefined;
+
+  if (!row) {
+    return {
+      prefs: DEFAULT_SYNCED_USER_PREFERENCES,
+      hasPreferences: false,
+      revision: 0,
+      fieldUpdatedAt: {},
+      updatedAt: null,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(row.preferencesJson) as unknown;
+    const raw = isObject(parsed) ? parsed : {};
+    const meta = isObject(raw.__meta) ? raw.__meta : {};
+    const revision = typeof meta.revision === "number" &&
+      Number.isInteger(meta.revision) &&
+      meta.revision > 0
+      ? meta.revision
+      : 1;
+
+    return {
+      prefs: normalizeSyncedUserPreferences(raw),
+      hasPreferences: true,
+      revision,
+      fieldUpdatedAt: parseFieldUpdatedAt(meta.fieldUpdatedAt),
+      updatedAt: row.updatedAt || null,
+    };
+  } catch {
+    return {
+      prefs: DEFAULT_SYNCED_USER_PREFERENCES,
+      hasPreferences: true,
+      revision: 1,
+      fieldUpdatedAt: {},
+      updatedAt: row.updatedAt || null,
+    };
+  }
+}
+
+function validatePatch(input: unknown): { patch: PreferencePatch; errors: string[] } {
+  const raw = isObject(input) ? input : {};
+  const patch: PreferencePatch = {};
+  const errors: string[] = [];
+
+  for (const key of PREFERENCE_KEYS) {
+    if (!(key in raw)) continue;
+    const current = DEFAULT_SYNCED_USER_PREFERENCES[key];
+    const normalized = normalizePreferenceValue(key, raw[key], current);
+    if (normalized === current && raw[key] !== current) {
+      errors.push(`${key} 的值无效`);
+      continue;
+    }
+    patch[key] = normalized as never;
+  }
+
+  return { patch, errors };
+}
+
+function serializeStoredPreferences(
+  prefs: SyncedUserPreferences,
+  revision: number,
+  fieldUpdatedAt: FieldUpdatedAt,
+): string {
+  const document: StoredPreferenceDocument = {
+    ...prefs,
+    __meta: {
+      version: 2,
+      revision,
+      fieldUpdatedAt,
+    },
+  };
+  return JSON.stringify(document);
+}
+
+function responsePayload(userId: string, state: PreferenceState, conflict = false) {
+  return {
+    ...state.prefs,
+    hasPreferences: state.hasPreferences,
+    userId,
+    revision: state.revision,
+    fieldUpdatedAt: state.fieldUpdatedAt,
+    updatedAt: state.updatedAt,
+    conflict,
+  };
+}
+
+async function writePreferences(c: any) {
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const body = await c.req.json().catch(() => ({}));
+  const raw = isObject(body) ? body : {};
+  const { patch, errors } = validatePatch(raw);
+  if (errors.length > 0) {
+    return c.json({ error: errors[0], code: "INVALID_USER_PREFERENCE" }, 400);
+  }
+
+  const patchKeys = Object.keys(patch) as PreferenceKey[];
+  if (patchKeys.length === 0) {
+    const unknownKeys = Object.keys(raw).filter((key) => !PREFERENCE_KEY_SET.has(key) && !key.startsWith("_"));
+    return c.json({
+      error: unknownKeys.length > 0
+        ? "请求中没有可同步的账号级偏好字段"
+        : "至少需要提供一个偏好字段",
+      code: "EMPTY_USER_PREFERENCE_PATCH",
+    }, 400);
+  }
+
+  const current = readPreferenceState(userId);
+  const baseRevision = typeof raw._baseRevision === "number" && Number.isInteger(raw._baseRevision)
+    ? raw._baseRevision
+    : null;
+  const migration = raw._migration === true;
+  const conflict = baseRevision !== null && baseRevision !== current.revision;
+
+  // 两台设备同时做首次迁移时，后到的设备不能用本地旧值覆盖已经建立的账号偏好。
+  if (migration && current.hasPreferences) {
+    return c.json(responsePayload(userId, current, true));
+  }
+
+  const nextPrefs = { ...current.prefs };
+  const changedKeys: PreferenceKey[] = [];
+  for (const key of patchKeys) {
+    if (!current.hasPreferences || nextPrefs[key] !== patch[key]) {
+      nextPrefs[key] = patch[key] as never;
+      changedKeys.push(key);
+    }
+  }
+
+  if (changedKeys.length === 0 && current.hasPreferences) {
+    return c.json(responsePayload(userId, current, conflict));
+  }
+
+  const now = new Date().toISOString();
+  const nextRevision = current.revision + 1;
+  const fieldUpdatedAt = { ...current.fieldUpdatedAt };
+  for (const key of changedKeys) fieldUpdatedAt[key] = now;
+
+  getDb().prepare(`
+    INSERT INTO user_preferences (userId, preferencesJson, updatedAt)
+    VALUES (?, ?, ?)
+    ON CONFLICT(userId) DO UPDATE SET
+      preferencesJson = excluded.preferencesJson,
+      updatedAt = excluded.updatedAt
+  `).run(
+    userId,
+    serializeStoredPreferences(nextPrefs, nextRevision, fieldUpdatedAt),
+    now,
+  );
+
+  return c.json(responsePayload(userId, {
+    prefs: nextPrefs,
+    hasPreferences: true,
+    revision: nextRevision,
+    fieldUpdatedAt,
+    updatedAt: now,
+  }, conflict));
+}
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  return c.json(responsePayload(userId, readPreferenceState(userId)));
+});
+
+// PUT 保持旧客户端兼容；PATCH 为新客户端提供明确的增量语义。
+app.put("/", writePreferences);
+app.patch("/", writePreferences);
+
+export default app;

--- a/backend/src/routes/user-preferences.ts
+++ b/backend/src/routes/user-preferences.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import syncRoutes from "./user-preferences-sync";
 import legacyRoutes from "./user-preferences-legacy";
 import reliableAIRoutes from "./ai-reliable";
 import mobileBootstrapRoutes from "./mobile-bootstrap";
@@ -10,7 +11,10 @@ import mobileBootstrapRoutes from "./mobile-bootstrap";
  */
 const app = new Hono();
 
-// Must be mounted before `/`: the legacy router also owns the root preference route.
+// Root preference GET/PUT/PATCH must be mounted before the legacy router. The new
+// implementation keeps the old flat response fields while adding account-scoped
+// revision metadata and field-level merge semantics.
+app.route("/", syncRoutes);
 app.route("/mobile-bootstrap", mobileBootstrapRoutes);
 app.route("/ai-reliable", reliableAIRoutes);
 app.route("/", legacyRoutes);

--- a/backend/tests/user-preferences-sync.test.ts
+++ b/backend/tests/user-preferences-sync.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-user-prefs-sync-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+const USER_ID = "prefs-sync-user";
+const OTHER_ID = "prefs-sync-other";
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+function db() {
+  return getDb();
+}
+
+async function requestJson(method: string, body?: unknown, userId = USER_ID) {
+  const response = await app.request("/user-preferences", {
+    method,
+    headers: {
+      "X-User-Id": userId,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: response.status, json: await response.json() as any };
+}
+
+test.before(async () => {
+  const [routeModule, schemaModule] = await Promise.all([
+    import("../src/routes/user-preferences"),
+    import("../src/db/schema"),
+  ]);
+  app = new Hono();
+  app.route("/user-preferences", routeModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+
+  db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+  db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(OTHER_ID, OTHER_ID, "hash");
+});
+
+test.beforeEach(() => {
+  db().prepare("DELETE FROM user_preferences").run();
+});
+
+test.after(() => {
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("reads legacy flat preference rows and upgrades them on the next partial write", async () => {
+  db().prepare(`
+    INSERT INTO user_preferences (userId, preferencesJson, updatedAt)
+    VALUES (?, ?, ?)
+  `).run(USER_ID, JSON.stringify({
+    noteTitleAsAppTitle: true,
+    readingDensity: "compact",
+  }), "2026-07-01T00:00:00.000Z");
+
+  const before = await requestJson("GET");
+  assert.equal(before.status, 200);
+  assert.equal(before.json.noteTitleAsAppTitle, true);
+  assert.equal(before.json.readingDensity, "compact");
+  assert.equal(before.json.revision, 1);
+  assert.equal(before.json.userId, USER_ID);
+
+  const updated = await requestJson("PUT", {
+    showNotesInNotebookTree: true,
+    _baseRevision: 1,
+  });
+  assert.equal(updated.status, 200);
+  assert.equal(updated.json.noteTitleAsAppTitle, true);
+  assert.equal(updated.json.showNotesInNotebookTree, true);
+  assert.equal(updated.json.revision, 2);
+  assert.equal(updated.json.conflict, false);
+
+  const stored = db().prepare("SELECT preferencesJson FROM user_preferences WHERE userId = ?")
+    .get(USER_ID) as { preferencesJson: string };
+  const parsed = JSON.parse(stored.preferencesJson);
+  assert.equal(parsed.noteTitleAsAppTitle, true);
+  assert.equal(parsed.showNotesInNotebookTree, true);
+  assert.equal(parsed.__meta.version, 2);
+  assert.equal(parsed.__meta.revision, 2);
+});
+
+test("merges stale field-level updates instead of replacing the whole document", async () => {
+  const first = await requestJson("PUT", {
+    noteTitleAsAppTitle: true,
+    _baseRevision: 0,
+  });
+  assert.equal(first.json.revision, 1);
+
+  const second = await requestJson("PUT", {
+    readingDensity: "compact",
+    _baseRevision: 0,
+  });
+  assert.equal(second.status, 200);
+  assert.equal(second.json.conflict, true);
+  assert.equal(second.json.revision, 2);
+  assert.equal(second.json.noteTitleAsAppTitle, true);
+  assert.equal(second.json.readingDensity, "compact");
+  assert.ok(second.json.fieldUpdatedAt.noteTitleAsAppTitle);
+  assert.ok(second.json.fieldUpdatedAt.readingDensity);
+});
+
+test("prevents a second first-run migration from overwriting established remote preferences", async () => {
+  const first = await requestJson("PUT", {
+    noteTitleAsAppTitle: true,
+    markdownDefaultViewMode: "preview",
+    _baseRevision: 0,
+    _migration: true,
+  });
+  assert.equal(first.json.revision, 1);
+
+  const second = await requestJson("PUT", {
+    noteTitleAsAppTitle: false,
+    markdownDefaultViewMode: "split",
+    _baseRevision: 0,
+    _migration: true,
+  });
+  assert.equal(second.status, 200);
+  assert.equal(second.json.conflict, true);
+  assert.equal(second.json.noteTitleAsAppTitle, true);
+  assert.equal(second.json.markdownDefaultViewMode, "preview");
+  assert.equal(second.json.revision, 1);
+});
+
+test("keeps caches isolated per user and never persists sensitive unknown fields", async () => {
+  const saved = await requestJson("PUT", {
+    enableNoteTabs: true,
+    apiKey: "should-never-be-stored",
+    token: "also-secret",
+  });
+  assert.equal(saved.status, 200);
+  assert.equal(saved.json.enableNoteTabs, true);
+  assert.equal("apiKey" in saved.json, false);
+  assert.equal("token" in saved.json, false);
+
+  const raw = db().prepare("SELECT preferencesJson FROM user_preferences WHERE userId = ?")
+    .get(USER_ID) as { preferencesJson: string };
+  assert.doesNotMatch(raw.preferencesJson, /should-never-be-stored|also-secret|apiKey|token/);
+
+  const other = await requestJson("GET", undefined, OTHER_ID);
+  assert.equal(other.status, 200);
+  assert.equal(other.json.enableNoteTabs, false);
+  assert.equal(other.json.hasPreferences, false);
+  assert.equal(other.json.userId, OTHER_ID);
+});
+
+test("rejects invalid values for known preference fields", async () => {
+  const result = await requestJson("PUT", { readingDensity: "ultra-compact" });
+  assert.equal(result.status, 400);
+  assert.equal(result.json.code, "INVALID_USER_PREFERENCE");
+});

--- a/frontend/src/hooks/useUserPreferences.tsx
+++ b/frontend/src/hooks/useUserPreferences.tsx
@@ -8,120 +8,50 @@ import React, {
   useState,
 } from "react";
 import { api } from "@/lib/api";
+import {
+  DEFAULT_USER_PREFERENCES,
+  LEGACY_CODE_BLOCK_THEME_KEY,
+  LEGACY_EDITOR_MODE_KEY,
+  LEGACY_NOTE_LIST_TITLE_ONLY_KEY,
+  accountPreferenceStorageKey,
+  claimLegacyUserPreferences,
+  decodeUserIdFromToken,
+  mergePendingPreferences,
+  normalizeUserPreferences,
+  readAccountPreferenceCache,
+  sanitizeUserPreferencePatch,
+  writeAccountPreferenceCache,
+  type CodeBlockThemeId,
+  type EditorMode,
+  type UserPreferenceCache,
+  type UserPreferencePatch,
+  type UserPreferences,
+} from "@/lib/userPreferenceAccountCache";
+
+export type {
+  CodeBlockThemeId,
+  EditorMode,
+  MarkdownViewMode,
+  ReadingDensity,
+  UserPreferences,
+} from "@/lib/userPreferenceAccountCache";
 
 /**
  * 用户级 UI 偏好（per-user, synced）
  *
- * 与 useSiteSettings 的区别：
- *   - useSiteSettings  → 站点级配置（site_title / favicon / 字体），走后端 API，
- *     全站共享，**只有管理员能改**；
- *   - useUserPreferences（本 hook）→ 当前用户的私人偏好，优先同步到后端，
- *     localStorage 仅作为启动缓存和离线兜底。
- *
- * 这里收纳的是"看起来该跟用户走，但又不该污染笔记数据本身"的开关，例如：
- *   - 标签页/窗口标题是显示笔记标题还是软件名；
- *   - 进入笔记后大纲面板默认开/关；
- *   - 进入笔记后是否进入"视图层只读"（不改库 isLocked，仅本会话只读）。
- *
- * 设计选择：
- *   - 单例 Provider + Context，避免每个组件各自 useState 导致跨组件不同步。
- *   - 持久化失败（隐身模式 / 配额满）静默回退到内存态，UI 仍可用。
- *   - 字段类型显式 boolean，不用 unknown JSON——以后加新字段就在这里加 key。
+ * 账号级偏好以服务端为准，并在浏览器中使用 userId 隔离的缓存作为启动/离线兜底。
+ * 窗口位置、下载目录、缓存大小等设备级配置不进入这里；API Key、Token 等敏感信息
+ * 也不属于普通偏好白名单。
  */
 
-const STORAGE_KEY = "nowen.user-prefs.v1";
-
-/** 阅读密度：影响编辑器正文段落与列表项的纵向间距/行高。
- *   - "cozy"   ：默认宽松（保持历史观感）
- *   - "compact"：紧凑——减少 ~30% 纵向空间，长笔记翻屏更省力
- * 仅影响 .ProseMirror 下的 p / li，不动标题/代码块/表格，避免破坏视觉锚点。 */
-export type ReadingDensity = "cozy" | "compact";
-export type MarkdownViewMode = "source" | "preview" | "split";
-
-export interface UserPreferences {
-  /** 标签页/Electron 窗口标题是否跟随当前笔记标题（关闭则用站点名）。默认 false。 */
-  noteTitleAsAppTitle: boolean;
-  /** 进入任意笔记时大纲面板是否默认展开。默认 false。 */
-  outlineDefaultOpen: boolean;
-  /** 进入任意笔记时是否默认进入"视图层只读"。默认 false。
-   *  注意：这不会修改笔记自身的 isLocked 字段，只影响本会话该笔记的编辑权限。 */
-  lockOnOpen: boolean;
-  /** 笔记本目录是否在展开节点下显示直属笔记。默认 false。 */
-  showNotesInNotebookTree: boolean;
-  /** 阅读密度（cozy/compact）。默认 cozy，即与历史一致的宽松排版。 */
-  readingDensity: ReadingDensity;
-  /** 笔记列表是否显示更新时间。默认 true。 */
-  showNoteListUpdatedTime: boolean;
-  /** 是否启用编辑区顶部多笔记标签页。默认 false。 */
-  enableNoteTabs: boolean;
-  /** Markdown 笔记默认打开视图。默认 source，保持历史行为。 */
-  markdownDefaultViewMode: MarkdownViewMode;
-}
-
-const DEFAULT_PREFS: UserPreferences = {
-  noteTitleAsAppTitle: false,
-  outlineDefaultOpen: false,
-  lockOnOpen: false,
-  showNotesInNotebookTree: false,
-  readingDensity: "cozy",
-  showNoteListUpdatedTime: true,
-  enableNoteTabs: false,
-  markdownDefaultViewMode: "source",
+type RemotePreferences = UserPreferences & {
+  hasPreferences?: boolean;
+  userId?: string;
+  revision?: number;
+  fieldUpdatedAt?: Partial<Record<keyof UserPreferences, string>>;
+  updatedAt?: string | null;
+  conflict?: boolean;
 };
-
-function normalizeUserPreferences(parsed: Partial<UserPreferences>): UserPreferences {
-  return {
-    noteTitleAsAppTitle: typeof parsed.noteTitleAsAppTitle === "boolean"
-      ? parsed.noteTitleAsAppTitle
-      : DEFAULT_PREFS.noteTitleAsAppTitle,
-    outlineDefaultOpen: typeof parsed.outlineDefaultOpen === "boolean"
-      ? parsed.outlineDefaultOpen
-      : DEFAULT_PREFS.outlineDefaultOpen,
-    lockOnOpen: typeof parsed.lockOnOpen === "boolean"
-      ? parsed.lockOnOpen
-      : DEFAULT_PREFS.lockOnOpen,
-    showNotesInNotebookTree: typeof parsed.showNotesInNotebookTree === "boolean"
-      ? parsed.showNotesInNotebookTree
-      : DEFAULT_PREFS.showNotesInNotebookTree,
-    readingDensity: parsed.readingDensity === "compact" || parsed.readingDensity === "cozy"
-      ? parsed.readingDensity
-      : DEFAULT_PREFS.readingDensity,
-    showNoteListUpdatedTime: typeof parsed.showNoteListUpdatedTime === "boolean"
-      ? parsed.showNoteListUpdatedTime
-      : (localStorage.getItem("nowen.noteList.showTime") !== null
-        ? localStorage.getItem("nowen.noteList.showTime") === "true"
-        : DEFAULT_PREFS.showNoteListUpdatedTime),
-    enableNoteTabs: typeof parsed.enableNoteTabs === "boolean"
-      ? parsed.enableNoteTabs
-      : DEFAULT_PREFS.enableNoteTabs,
-    markdownDefaultViewMode:
-      parsed.markdownDefaultViewMode === "source" ||
-      parsed.markdownDefaultViewMode === "preview" ||
-      parsed.markdownDefaultViewMode === "split"
-        ? parsed.markdownDefaultViewMode
-        : DEFAULT_PREFS.markdownDefaultViewMode,
-  };
-}
-
-function readFromStorage(): UserPreferences {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return DEFAULT_PREFS;
-    const parsed = JSON.parse(raw) as Partial<UserPreferences>;
-    // 字段做白名单 + 类型校验，防止旧版本 / 手改 localStorage 把布尔变成字符串
-    return normalizeUserPreferences(parsed);
-  } catch {
-    return DEFAULT_PREFS;
-  }
-}
-
-function writeToStorage(prefs: UserPreferences): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
-  } catch {
-    // 隐身模式 / quota exceeded 时静默丢弃；UI 仍能正常运行（只是下次启动复位）
-  }
-}
 
 interface UserPreferencesContextValue {
   prefs: UserPreferences;
@@ -129,57 +59,234 @@ interface UserPreferencesContextValue {
 }
 
 const UserPreferencesContext = createContext<UserPreferencesContextValue>({
-  prefs: DEFAULT_PREFS,
+  prefs: DEFAULT_USER_PREFERENCES,
   setPref: () => {},
 });
 
+function currentIdentity(): { token: string; userId: string } | null {
+  try {
+    const token = localStorage.getItem("nowen-token") || "";
+    const userId = decodeUserIdFromToken(token);
+    return token && userId ? { token, userId } : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyLegacyPreferenceBridges(prefs: UserPreferences, notify = true): void {
+  try {
+    localStorage.setItem(LEGACY_EDITOR_MODE_KEY, prefs.defaultEditorMode);
+    localStorage.setItem(LEGACY_CODE_BLOCK_THEME_KEY, prefs.codeBlockTheme);
+    localStorage.setItem(LEGACY_NOTE_LIST_TITLE_ONLY_KEY, String(prefs.noteListTitleOnly));
+    document.documentElement.setAttribute("data-code-theme", prefs.codeBlockTheme);
+    if (!notify) return;
+    window.dispatchEvent(new CustomEvent<EditorMode>("nowen:editor-mode-change", {
+      detail: prefs.defaultEditorMode,
+    }));
+    window.dispatchEvent(new CustomEvent<CodeBlockThemeId>("nowen:codeblock-theme-change", {
+      detail: prefs.codeBlockTheme,
+    }));
+    window.dispatchEvent(new CustomEvent<boolean>("nowen:note-list-title-only-change", {
+      detail: prefs.noteListTitleOnly,
+    }));
+  } catch {
+    // localStorage / document 在隐私模式或测试环境不可用时，账号偏好内存态仍然有效。
+  }
+}
+
+function initialPreferences(): UserPreferences {
+  const identity = currentIdentity();
+  if (!identity) return DEFAULT_USER_PREFERENCES;
+  const prefs = readAccountPreferenceCache(localStorage, identity.userId)?.prefs || DEFAULT_USER_PREFERENCES;
+  applyLegacyPreferenceBridges(prefs, false);
+  return prefs;
+}
+
+function samePreferenceValue<K extends keyof UserPreferences>(
+  left: UserPreferences[K] | undefined,
+  right: UserPreferences[K] | undefined,
+): boolean {
+  return left === right;
+}
+
 export function UserPreferencesProvider({ children }: { children: React.ReactNode }) {
-  const [prefs, setPrefs] = useState<UserPreferences>(() => readFromStorage());
+  const [prefs, setPrefs] = useState<UserPreferences>(initialPreferences);
   const prefsRef = useRef(prefs);
+  const activeUserIdRef = useRef<string | null>(currentIdentity()?.userId || null);
+  const revisionRef = useRef(0);
+  const pendingRef = useRef<UserPreferencePatch>({});
+  const syncSequenceRef = useRef(0);
 
   useEffect(() => {
     prefsRef.current = prefs;
   }, [prefs]);
 
-  // 阅读密度作用到全局：通过 body class 触发 CSS 变量切换，从而影响 .ProseMirror p/li 的间距。
-  // 放在 Provider 而非具体组件里，是因为编辑器并不一定挂载（设置弹窗也要能预览到效果）。
+  // 阅读密度作用到全局：通过 body class 触发 CSS 变量切换。
   useEffect(() => {
     const cls = "density-compact";
-    if (prefs.readingDensity === "compact") {
-      document.body.classList.add(cls);
-    } else {
-      document.body.classList.remove(cls);
-    }
+    document.body.classList.toggle(cls, prefs.readingDensity === "compact");
   }, [prefs.readingDensity]);
 
-  // 多标签页 / 多窗口同步：监听 storage 事件，让另一个 tab 改了开关后这个 tab 也跟上。
+  // 兼容已经存在的编辑器模式、代码块主题和标题列表模块。它们继续使用原来的
+  // localStorage key，但值由账号偏好回填；用户在旧入口修改时由下方事件监听反向同步。
   useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key !== STORAGE_KEY) return;
-      setPrefs(readFromStorage());
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
+    applyLegacyPreferenceBridges(prefs);
+  }, [prefs.defaultEditorMode, prefs.codeBlockTheme, prefs.noteListTitleOnly]);
+
+  const applyCache = useCallback((cache: UserPreferenceCache) => {
+    activeUserIdRef.current = cache.userId;
+    revisionRef.current = cache.revision;
+    pendingRef.current = cache.pending;
+    prefsRef.current = cache.prefs;
+    setPrefs(cache.prefs);
+    writeAccountPreferenceCache(localStorage, cache);
   }, []);
 
-  const syncFromServer = useCallback(async () => {
+  const resetForIdentity = useCallback((userId: string | null) => {
+    activeUserIdRef.current = userId;
+    revisionRef.current = 0;
+    pendingRef.current = {};
+
+    if (!userId) {
+      prefsRef.current = DEFAULT_USER_PREFERENCES;
+      setPrefs(DEFAULT_USER_PREFERENCES);
+      applyLegacyPreferenceBridges(DEFAULT_USER_PREFERENCES);
+      return null;
+    }
+
+    const cached = readAccountPreferenceCache(localStorage, userId);
+    const next: UserPreferenceCache = cached || {
+      version: 2,
+      userId,
+      prefs: DEFAULT_USER_PREFERENCES,
+      revision: 0,
+      pending: {},
+    };
+    applyCache(next);
+    return cached;
+  }, [applyCache]);
+
+  const persistPatch = useCallback(async (
+    userId: string,
+    changes: UserPreferencePatch,
+    migration = false,
+  ) => {
+    const sanitized = sanitizeUserPreferencePatch(changes);
+    const keys = Object.keys(sanitized) as Array<keyof UserPreferences>;
+    if (keys.length === 0) return;
+
+    const sentRevision = revisionRef.current;
     try {
-      if (!localStorage.getItem("nowen-token")) return;
-      const remote = await api.getUserPreferences();
-      const remotePrefs = normalizeUserPreferences(remote);
+      const remote = await api.updateUserPreferences({
+        ...sanitized,
+        _baseRevision: sentRevision,
+        _migration: migration,
+      } as any) as RemotePreferences;
+
+      const identity = currentIdentity();
+      if (!identity || identity.userId !== userId || activeUserIdRef.current !== userId) return;
+
+      const latestCache = readAccountPreferenceCache(localStorage, userId) || {
+        version: 2 as const,
+        userId,
+        prefs: prefsRef.current,
+        revision: revisionRef.current,
+        pending: pendingRef.current,
+      };
+      const pending = { ...latestCache.pending };
+      for (const key of keys) {
+        if (samePreferenceValue(pending[key], sanitized[key])) delete pending[key];
+      }
+
+      const remoteRevision = Number(remote.revision) || 0;
+      // 并发保存可能乱序返回。旧 revision 只能确认对应 pending 已送达，不能再用
+      // 旧响应的整包值覆盖较新的本地缓存。
+      const responseIsStale = remoteRevision < latestCache.revision;
+      const basePrefs = responseIsStale
+        ? latestCache.prefs
+        : normalizeUserPreferences(remote);
+      const merged = mergePendingPreferences(basePrefs, pending);
+      applyCache({
+        version: 2,
+        userId,
+        prefs: merged,
+        revision: Math.max(latestCache.revision, remoteRevision),
+        pending,
+      });
+    } catch {
+      // 网络失败不回滚 UI；pending 会保存在账号隔离缓存中，下次聚焦/登录时重试。
+    }
+  }, [applyCache]);
+
+  const syncFromServer = useCallback(async () => {
+    const sequence = ++syncSequenceRef.current;
+    const identity = currentIdentity();
+    if (!identity) {
+      resetForIdentity(null);
+      return;
+    }
+
+    const { userId } = identity;
+    const cachedAtStart = resetForIdentity(userId);
+
+    try {
+      const remote = await api.getUserPreferences() as RemotePreferences;
+      const latestIdentity = currentIdentity();
+      if (
+        sequence !== syncSequenceRef.current ||
+        !latestIdentity ||
+        latestIdentity.userId !== userId ||
+        (remote.userId && remote.userId !== userId)
+      ) return;
+
+      const latestCache = readAccountPreferenceCache(localStorage, userId) || cachedAtStart;
+      const latestPending = latestCache?.pending || pendingRef.current;
 
       if (remote.hasPreferences) {
-        setPrefs(remotePrefs);
-        writeToStorage(remotePrefs);
+        const remotePrefs = normalizeUserPreferences(remote);
+        const merged = mergePendingPreferences(remotePrefs, latestPending);
+        applyCache({
+          version: 2,
+          userId,
+          prefs: merged,
+          revision: Math.max(latestCache?.revision || 0, Number(remote.revision) || 0),
+          pending: latestPending,
+        });
+        if (Object.keys(latestPending).length > 0) {
+          void persistPatch(userId, latestPending);
+        }
         return;
       }
 
-      // 旧版本的开关只存在当前浏览器。服务器还没有记录时，先把本地值迁移上去。
-      await api.updateUserPreferences(prefsRef.current);
+      // 首次升级：优先使用启动时已经存在的当前账号 v2 缓存；没有时才认领一次
+      // 旧版全局缓存。resetForIdentity 创建的默认空缓存不能抢占旧缓存迁移来源。
+      const legacy = cachedAtStart ? null : claimLegacyUserPreferences(localStorage, userId);
+      const seed = cachedAtStart?.prefs || legacy || latestCache?.prefs || DEFAULT_USER_PREFERENCES;
+      const pending = sanitizeUserPreferencePatch({ ...seed, ...latestPending });
+      applyCache({
+        version: 2,
+        userId,
+        prefs: normalizeUserPreferences({ ...seed, ...latestPending }),
+        revision: 0,
+        pending,
+      });
+      void persistPatch(userId, pending, true);
     } catch {
-      // 未登录、离线或旧后端时保留 localStorage 行为，避免设置页不可用。
+      // 未登录、离线或旧后端时继续使用当前账号自己的缓存，绝不回退到其它账号缓存。
     }
-  }, []);
+  }, [applyCache, persistPatch, resetForIdentity]);
+
+  // 多标签页/多窗口同步：只监听当前账号自己的缓存 key。
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      const identity = currentIdentity();
+      if (!identity || event.key !== accountPreferenceStorageKey(identity.userId)) return;
+      const cache = readAccountPreferenceCache(localStorage, identity.userId);
+      if (cache && cache.revision >= revisionRef.current) applyCache(cache);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [applyCache]);
 
   useEffect(() => {
     void syncFromServer();
@@ -192,18 +299,58 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
   }, [syncFromServer]);
 
   const setPref = useCallback(<K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => {
-    setPrefs((prev) => {
-      if (prev[key] === value) return prev;
-      const next = { ...prev, [key]: value };
-      writeToStorage(next);
-      if (localStorage.getItem("nowen-token")) {
-        api.updateUserPreferences(next).catch(() => {
-          // 网络失败不回滚 UI；localStorage 仍作为离线兜底。
-        });
-      }
+    setPrefs((previous) => {
+      if (previous[key] === value) return previous;
+      const next = { ...previous, [key]: value };
+      prefsRef.current = next;
+
+      const identity = currentIdentity();
+      if (!identity) return next;
+
+      const existing = readAccountPreferenceCache(localStorage, identity.userId);
+      const pending: UserPreferencePatch = {
+        ...(existing?.pending || pendingRef.current),
+        [key]: value,
+      };
+      const cache: UserPreferenceCache = {
+        version: 2,
+        userId: identity.userId,
+        prefs: next,
+        revision: existing?.revision ?? revisionRef.current,
+        pending,
+      };
+      writeAccountPreferenceCache(localStorage, cache);
+      activeUserIdRef.current = identity.userId;
+      revisionRef.current = cache.revision;
+      pendingRef.current = pending;
+      void persistPatch(identity.userId, { [key]: value } as UserPreferencePatch);
       return next;
     });
-  }, []);
+  }, [persistPatch]);
+
+  // 旧入口反向桥接：不改它们的 UI 结构，只把用户操作转换成账号级偏好字段。
+  useEffect(() => {
+    const onEditorMode = (event: Event) => {
+      const mode = (event as CustomEvent<EditorMode>).detail;
+      if (mode === "md" || mode === "tiptap") setPref("defaultEditorMode", mode);
+    };
+    const onCodeTheme = (event: Event) => {
+      const theme = (event as CustomEvent<CodeBlockThemeId>).detail;
+      if (theme) setPref("codeBlockTheme", theme);
+    };
+    const onTitleOnly = (event: Event) => {
+      const enabled = (event as CustomEvent<boolean>).detail;
+      if (typeof enabled === "boolean") setPref("noteListTitleOnly", enabled);
+    };
+    window.addEventListener("nowen:editor-mode-change", onEditorMode);
+    window.addEventListener("nowen:codeblock-theme-change", onCodeTheme);
+    window.addEventListener("nowen:note-list-title-only-change", onTitleOnly);
+    return () => {
+      window.removeEventListener("nowen:editor-mode-change", onEditorMode);
+      window.removeEventListener("nowen:codeblock-theme-change", onCodeTheme);
+      window.removeEventListener("nowen:note-list-title-only-change", onTitleOnly);
+    };
+  }, [setPref]);
 
   const value = useMemo(() => ({ prefs, setPref }), [prefs, setPref]);
 

--- a/frontend/src/lib/__tests__/userPreferenceAccountCache.test.ts
+++ b/frontend/src/lib/__tests__/userPreferenceAccountCache.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_USER_PREFERENCES,
+  LEGACY_CODE_BLOCK_THEME_KEY,
+  LEGACY_EDITOR_MODE_KEY,
+  LEGACY_NOTE_LIST_TITLE_ONLY_KEY,
+  LEGACY_USER_PREFERENCES_KEY,
+  accountPreferenceStorageKey,
+  claimLegacyUserPreferences,
+  decodeUserIdFromToken,
+  mergePendingPreferences,
+  readAccountPreferenceCache,
+  sanitizeUserPreferencePatch,
+  writeAccountPreferenceCache,
+  type StorageLike,
+} from "../userPreferenceAccountCache";
+
+class MemoryStorage implements StorageLike {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+function tokenFor(userId: string): string {
+  const base64url = (value: object) => Buffer.from(JSON.stringify(value))
+    .toString("base64url");
+  return `${base64url({ alg: "HS256", typ: "JWT" })}.${base64url({ userId })}.signature`;
+}
+
+describe("user preference account cache", () => {
+  it("derives the cache identity from the authenticated JWT", () => {
+    expect(decodeUserIdFromToken(tokenFor("user-a"))).toBe("user-a");
+    expect(decodeUserIdFromToken("invalid-token")).toBeNull();
+  });
+
+  it("strictly separates preference caches for different accounts", () => {
+    const storage = new MemoryStorage();
+    writeAccountPreferenceCache(storage, {
+      version: 2,
+      userId: "user-a",
+      prefs: {
+        ...DEFAULT_USER_PREFERENCES,
+        readingDensity: "compact",
+        codeBlockTheme: "nord",
+      },
+      revision: 3,
+      pending: { readingDensity: "compact", codeBlockTheme: "nord" },
+    });
+    writeAccountPreferenceCache(storage, {
+      version: 2,
+      userId: "user-b",
+      prefs: {
+        ...DEFAULT_USER_PREFERENCES,
+        enableNoteTabs: true,
+        defaultEditorMode: "md",
+      },
+      revision: 7,
+      pending: {},
+    });
+
+    expect(accountPreferenceStorageKey("user-a")).not.toBe(accountPreferenceStorageKey("user-b"));
+    expect(readAccountPreferenceCache(storage, "user-a")?.prefs.readingDensity).toBe("compact");
+    expect(readAccountPreferenceCache(storage, "user-a")?.prefs.codeBlockTheme).toBe("nord");
+    expect(readAccountPreferenceCache(storage, "user-a")?.prefs.enableNoteTabs).toBe(false);
+    expect(readAccountPreferenceCache(storage, "user-b")?.prefs.enableNoteTabs).toBe(true);
+    expect(readAccountPreferenceCache(storage, "user-b")?.prefs.defaultEditorMode).toBe("md");
+    expect(readAccountPreferenceCache(storage, "user-b")?.revision).toBe(7);
+  });
+
+  it("allows the legacy browser-wide cache to be claimed by only one account", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(LEGACY_USER_PREFERENCES_KEY, JSON.stringify({
+      noteTitleAsAppTitle: true,
+      markdownDefaultViewMode: "preview",
+    }));
+    storage.setItem(LEGACY_EDITOR_MODE_KEY, "md");
+    storage.setItem(LEGACY_CODE_BLOCK_THEME_KEY, "dracula");
+    storage.setItem(LEGACY_NOTE_LIST_TITLE_ONLY_KEY, "true");
+
+    const first = claimLegacyUserPreferences(storage, "user-a");
+    const second = claimLegacyUserPreferences(storage, "user-b");
+
+    expect(first?.noteTitleAsAppTitle).toBe(true);
+    expect(first?.markdownDefaultViewMode).toBe("preview");
+    expect(first?.defaultEditorMode).toBe("md");
+    expect(first?.codeBlockTheme).toBe("dracula");
+    expect(first?.noteListTitleOnly).toBe(true);
+    expect(second).toBeNull();
+  });
+
+  it("keeps offline pending fields on top of a newer remote document", () => {
+    const merged = mergePendingPreferences(
+      { ...DEFAULT_USER_PREFERENCES, noteTitleAsAppTitle: true },
+      {
+        readingDensity: "compact",
+        enableNoteTabs: true,
+        noteListTitleOnly: true,
+      },
+    );
+
+    expect(merged.noteTitleAsAppTitle).toBe(true);
+    expect(merged.readingDensity).toBe("compact");
+    expect(merged.enableNoteTabs).toBe(true);
+    expect(merged.noteListTitleOnly).toBe(true);
+  });
+
+  it("drops unknown and sensitive fields from local pending payloads", () => {
+    const patch = sanitizeUserPreferencePatch({
+      enableNoteTabs: true,
+      codeBlockTheme: "nord",
+      apiKey: "secret",
+      token: "secret-token",
+    });
+
+    expect(patch).toEqual({ enableNoteTabs: true, codeBlockTheme: "nord" });
+    expect(JSON.stringify(patch)).not.toContain("secret");
+  });
+});

--- a/frontend/src/lib/editorMode.ts
+++ b/frontend/src/lib/editorMode.ts
@@ -18,6 +18,7 @@
 export type EditorMode = "md" | "tiptap";
 
 export const EDITOR_MODE_KEY = "nowen.editor_mode";
+export const EDITOR_MODE_CHANGE_EVENT = "nowen:editor-mode-change";
 
 /** URL 查询参数 key；`?md=1` 强制启用 MD，`?md=0` 强制启用 Tiptap */
 const URL_FORCE_KEY = "md";
@@ -49,12 +50,17 @@ export function resolveEditorMode(defaultMode: EditorMode = "tiptap"): EditorMod
 }
 
 /**
- * 把当前选择持久化到 localStorage。失败时静默（隐私模式 / quota）。
- * 调用方应在成功切换后调用。
+ * 把当前选择持久化到 localStorage，并广播给账号偏好同步层。失败时静默
+ * （隐私模式 / quota）。调用方应在成功切换后调用。
  */
 export function persistEditorMode(mode: EditorMode): void {
   try {
     localStorage.setItem(EDITOR_MODE_KEY, mode);
+  } catch {
+    /* ignore */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent<EditorMode>(EDITOR_MODE_CHANGE_EVENT, { detail: mode }));
   } catch {
     /* ignore */
   }

--- a/frontend/src/lib/noteListTitleOnlyMode.ts
+++ b/frontend/src/lib/noteListTitleOnlyMode.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY = "nowen.noteList.titleOnly";
+const CHANGE_EVENT = "nowen:note-list-title-only-change";
 const BODY_CLASS = "note-list-title-only";
 const STYLE_ID = "nowen-note-list-title-only-style";
 const BUTTON_ATTR = "data-note-list-title-only-toggle";
@@ -14,6 +15,9 @@ function readEnabled(): boolean {
 
 function writeEnabled(value: boolean) {
   try { localStorage.setItem(STORAGE_KEY, String(value)); } catch {}
+  try {
+    window.dispatchEvent(new CustomEvent<boolean>(CHANGE_EVENT, { detail: value }));
+  } catch {}
 }
 
 function ensureStyle() {
@@ -80,12 +84,16 @@ function patchVirtualLists() {
   });
 }
 
+function refreshMode() {
+  applyBodyClass();
+  updateToggleLabels();
+  patchVirtualLists();
+}
+
 function toggleMode() {
   const next = !readEnabled();
   writeEnabled(next);
-  applyBodyClass(next);
-  updateToggleLabels();
-  patchVirtualLists();
+  refreshMode();
 }
 
 function shouldUseSortButton(button: HTMLButtonElement): boolean {
@@ -134,10 +142,9 @@ export function initNoteListTitleOnlyMode() {
   });
   window.addEventListener("storage", (event) => {
     if (event.key !== STORAGE_KEY) return;
-    applyBodyClass();
-    updateToggleLabels();
-    patchVirtualLists();
+    refreshMode();
   });
+  window.addEventListener(CHANGE_EVENT, refreshMode);
   window.addEventListener("resize", scheduleSync);
   document.addEventListener("scroll", scheduleSync, true);
 }

--- a/frontend/src/lib/userPreferenceAccountCache.ts
+++ b/frontend/src/lib/userPreferenceAccountCache.ts
@@ -1,0 +1,246 @@
+export type ReadingDensity = "cozy" | "compact";
+export type MarkdownViewMode = "source" | "preview" | "split";
+export type EditorMode = "md" | "tiptap";
+export type CodeBlockThemeId =
+  | "github-dark"
+  | "github-light"
+  | "dracula"
+  | "monokai"
+  | "solarized-light"
+  | "one-dark"
+  | "nord";
+
+export interface UserPreferences {
+  noteTitleAsAppTitle: boolean;
+  outlineDefaultOpen: boolean;
+  lockOnOpen: boolean;
+  showNotesInNotebookTree: boolean;
+  readingDensity: ReadingDensity;
+  showNoteListUpdatedTime: boolean;
+  enableNoteTabs: boolean;
+  markdownDefaultViewMode: MarkdownViewMode;
+  defaultEditorMode: EditorMode;
+  codeBlockTheme: CodeBlockThemeId;
+  noteListTitleOnly: boolean;
+}
+
+export type UserPreferencePatch = Partial<UserPreferences>;
+
+export interface UserPreferenceCache {
+  version: 2;
+  userId: string;
+  prefs: UserPreferences;
+  revision: number;
+  pending: UserPreferencePatch;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  noteTitleAsAppTitle: false,
+  outlineDefaultOpen: false,
+  lockOnOpen: false,
+  showNotesInNotebookTree: false,
+  readingDensity: "cozy",
+  showNoteListUpdatedTime: true,
+  enableNoteTabs: false,
+  markdownDefaultViewMode: "source",
+  defaultEditorMode: "tiptap",
+  codeBlockTheme: "github-dark",
+  noteListTitleOnly: false,
+};
+
+export const LEGACY_USER_PREFERENCES_KEY = "nowen.user-prefs.v1";
+export const LEGACY_USER_PREFERENCES_OWNER_KEY = "nowen.user-prefs.v1.migrated-user";
+export const LEGACY_EDITOR_MODE_KEY = "nowen.editor_mode";
+export const LEGACY_CODE_BLOCK_THEME_KEY = "nowen.codeBlockTheme";
+export const LEGACY_NOTE_LIST_TITLE_ONLY_KEY = "nowen.noteList.titleOnly";
+const ACCOUNT_CACHE_PREFIX = "nowen.user-prefs.v2:";
+const LEGACY_SHOW_TIME_KEY = "nowen.noteList.showTime";
+
+const PREFERENCE_KEYS = Object.keys(DEFAULT_USER_PREFERENCES) as Array<keyof UserPreferences>;
+const CODE_BLOCK_THEMES = new Set<CodeBlockThemeId>([
+  "github-dark",
+  "github-light",
+  "dracula",
+  "monokai",
+  "solarized-light",
+  "one-dark",
+  "nord",
+]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeUserPreferences(
+  input: unknown,
+  fallback: UserPreferences = DEFAULT_USER_PREFERENCES,
+  legacyShowTime?: boolean,
+): UserPreferences {
+  const raw = isObject(input) ? input as Partial<UserPreferences> : {};
+  return {
+    noteTitleAsAppTitle: typeof raw.noteTitleAsAppTitle === "boolean"
+      ? raw.noteTitleAsAppTitle
+      : fallback.noteTitleAsAppTitle,
+    outlineDefaultOpen: typeof raw.outlineDefaultOpen === "boolean"
+      ? raw.outlineDefaultOpen
+      : fallback.outlineDefaultOpen,
+    lockOnOpen: typeof raw.lockOnOpen === "boolean"
+      ? raw.lockOnOpen
+      : fallback.lockOnOpen,
+    showNotesInNotebookTree: typeof raw.showNotesInNotebookTree === "boolean"
+      ? raw.showNotesInNotebookTree
+      : fallback.showNotesInNotebookTree,
+    readingDensity: raw.readingDensity === "compact" || raw.readingDensity === "cozy"
+      ? raw.readingDensity
+      : fallback.readingDensity,
+    showNoteListUpdatedTime: typeof raw.showNoteListUpdatedTime === "boolean"
+      ? raw.showNoteListUpdatedTime
+      : legacyShowTime ?? fallback.showNoteListUpdatedTime,
+    enableNoteTabs: typeof raw.enableNoteTabs === "boolean"
+      ? raw.enableNoteTabs
+      : fallback.enableNoteTabs,
+    markdownDefaultViewMode:
+      raw.markdownDefaultViewMode === "source" ||
+      raw.markdownDefaultViewMode === "preview" ||
+      raw.markdownDefaultViewMode === "split"
+        ? raw.markdownDefaultViewMode
+        : fallback.markdownDefaultViewMode,
+    defaultEditorMode: raw.defaultEditorMode === "md" || raw.defaultEditorMode === "tiptap"
+      ? raw.defaultEditorMode
+      : fallback.defaultEditorMode,
+    codeBlockTheme:
+      typeof raw.codeBlockTheme === "string" && CODE_BLOCK_THEMES.has(raw.codeBlockTheme as CodeBlockThemeId)
+        ? raw.codeBlockTheme as CodeBlockThemeId
+        : fallback.codeBlockTheme,
+    noteListTitleOnly: typeof raw.noteListTitleOnly === "boolean"
+      ? raw.noteListTitleOnly
+      : fallback.noteListTitleOnly,
+  };
+}
+
+export function sanitizeUserPreferencePatch(input: unknown): UserPreferencePatch {
+  if (!isObject(input)) return {};
+  const normalized = normalizeUserPreferences(input);
+  const patch: UserPreferencePatch = {};
+  for (const key of PREFERENCE_KEYS) {
+    if (key in input) patch[key] = normalized[key] as never;
+  }
+  return patch;
+}
+
+export function accountPreferenceStorageKey(userId: string): string {
+  return `${ACCOUNT_CACHE_PREFIX}${encodeURIComponent(userId)}`;
+}
+
+export function decodeUserIdFromToken(token: string | null | undefined): string | null {
+  if (!token) return null;
+  try {
+    const payloadPart = token.split(".")[1];
+    if (!payloadPart) return null;
+    const base64 = payloadPart.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const decoded = globalThis.atob(padded);
+    const bytes = Uint8Array.from(decoded, (char) => char.charCodeAt(0));
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as { userId?: unknown };
+    return typeof payload.userId === "string" && payload.userId.trim()
+      ? payload.userId.trim()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readAccountPreferenceCache(
+  storage: StorageLike,
+  userId: string,
+): UserPreferenceCache | null {
+  try {
+    const raw = storage.getItem(accountPreferenceStorageKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isObject(parsed) || parsed.version !== 2 || parsed.userId !== userId) return null;
+    const revision = typeof parsed.revision === "number" &&
+      Number.isInteger(parsed.revision) &&
+      parsed.revision >= 0
+      ? parsed.revision
+      : 0;
+    return {
+      version: 2,
+      userId,
+      prefs: normalizeUserPreferences(parsed.prefs),
+      revision,
+      pending: sanitizeUserPreferencePatch(parsed.pending),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeAccountPreferenceCache(
+  storage: StorageLike,
+  cache: UserPreferenceCache,
+): void {
+  try {
+    storage.setItem(accountPreferenceStorageKey(cache.userId), JSON.stringify({
+      version: 2,
+      userId: cache.userId,
+      prefs: normalizeUserPreferences(cache.prefs),
+      revision: Math.max(0, Math.trunc(cache.revision || 0)),
+      pending: sanitizeUserPreferencePatch(cache.pending),
+    }));
+  } catch {
+    // 隐私模式、配额不足或只读存储时保留内存态。
+  }
+}
+
+export function claimLegacyUserPreferences(
+  storage: StorageLike,
+  userId: string,
+): UserPreferences | null {
+  try {
+    const owner = storage.getItem(LEGACY_USER_PREFERENCES_OWNER_KEY);
+    if (owner && owner !== userId) return null;
+
+    const raw = storage.getItem(LEGACY_USER_PREFERENCES_KEY);
+    const legacyShowTimeRaw = storage.getItem(LEGACY_SHOW_TIME_KEY);
+    const editorMode = storage.getItem(LEGACY_EDITOR_MODE_KEY);
+    const codeBlockTheme = storage.getItem(LEGACY_CODE_BLOCK_THEME_KEY);
+    const titleOnly = storage.getItem(LEGACY_NOTE_LIST_TITLE_ONLY_KEY);
+    if (!raw && legacyShowTimeRaw === null && editorMode === null && codeBlockTheme === null && titleOnly === null) {
+      return null;
+    }
+
+    let parsed: unknown = {};
+    if (raw) {
+      try { parsed = JSON.parse(raw); } catch { parsed = {}; }
+    }
+    const legacyShowTime = legacyShowTimeRaw === null
+      ? undefined
+      : legacyShowTimeRaw === "true";
+    const legacy = isObject(parsed) ? { ...parsed } : {};
+    if (editorMode === "md" || editorMode === "tiptap") legacy.defaultEditorMode = editorMode;
+    if (codeBlockTheme && CODE_BLOCK_THEMES.has(codeBlockTheme as CodeBlockThemeId)) {
+      legacy.codeBlockTheme = codeBlockTheme;
+    }
+    if (titleOnly !== null) legacy.noteListTitleOnly = titleOnly === "true";
+
+    // 第一个登录并发现旧缓存的账号获得迁移所有权，避免之后切换账号时重复上传。
+    storage.setItem(LEGACY_USER_PREFERENCES_OWNER_KEY, userId);
+    return normalizeUserPreferences(legacy, DEFAULT_USER_PREFERENCES, legacyShowTime);
+  } catch {
+    return null;
+  }
+}
+
+export function mergePendingPreferences(
+  remote: UserPreferences,
+  pending: UserPreferencePatch,
+): UserPreferences {
+  return normalizeUserPreferences({ ...remote, ...pending }, remote);
+}


### PR DESCRIPTION
将已同步 `main@1cc78c6` 的 `issue-247-pg-runtime@7386b81` 合入 `issue-248-direct-db-audit`。

- 仅更新堆叠分支基线
- 不合并 #255/#258 到 main
- 保留 #248 当前 SQLite 直连清理改动