### PR TITLE
chore: 同步 main@f0ad5ce 基线到 #248 分支

### DIFF
--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -21,7 +21,7 @@ import { syncNow } from "@/lib/syncEngine"
 import { deleteNote as deleteLocalNote, getNote as getLocalNote, putNote as putLocalNote } from "@/lib/localStore"
 import { confirm } from "@/components/ui/confirm";
 import { highlightTextNode, sanitizeSearchHtml, stripSearchMarks } from "@/lib/searchHighlight";
-import { getNoteListDragHint, reorderNotesWithinNotebook } from "@/lib/noteManualSort";
+import { getNoteListDragHint, reorderNotesWithinNotebook, shouldUseHtmlNoteDragging } from "@/lib/noteManualSort";
 // "导入 Word 文档" 走 dynamic import（见 createNoteInNotebook），减少首屏 bundle 体积。
 
 /* ===== 排序模式 ===== */
@@ -47,6 +47,12 @@ function loadSortPref(): { by: SortBy; dir: SortDir } {
 
 function saveSortPref(pref: { by: SortBy; dir: SortDir }) {
   try { localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(pref)); } catch {}
+}
+
+function isCoarsePointer(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(pointer: coarse)").matches;
 }
 
 const TIME_VISIBILITY_STORAGE_KEY = "nowen.noteList.showTime";
@@ -1187,7 +1193,7 @@ function VirtualNoteList({
   selectedIds,
   onSelectNote,
   onContextMenu,
-  canDragSort,
+  useHtmlNoteDragging,
   dragOverNoteId,
   onDragStart,
   onDragOver,
@@ -1210,7 +1216,7 @@ function VirtualNoteList({
   selectedIds: Set<string>;
   onSelectNote: (noteId: string, e: React.MouseEvent) => void;
   onContextMenu: (e: React.MouseEvent, noteId: string) => void;
-  canDragSort?: boolean;
+  useHtmlNoteDragging?: boolean;
   dragOverNoteId?: string | null;
   onDragStart?: (e: React.DragEvent, noteId: string) => void;
   onDragOver?: (e: React.DragEvent, noteId: string) => void;
@@ -1290,7 +1296,7 @@ function VirtualNoteList({
               isSelected={selectedIds.has(note.id)}
               onClick={(e) => onSelectNote(note.id, e)}
               onContextMenu={(e) => onContextMenu(e, note.id)}
-              draggable={canDragSort}
+              draggable={useHtmlNoteDragging}
               onDragStart={(e) => onDragStart?.(e, note.id)}
               onDragOver={(e) => onDragOver?.(e, note.id)}
               onDragEnd={() => onDragEnd?.()}
@@ -2708,6 +2714,7 @@ export default function NoteList() {
   const canDragSort = sortPref.by === "manual" && (
     state.viewMode === "notebook" || state.viewMode === "all" || state.viewMode === "favorites" || state.viewMode === "tag"
   );
+  const useHtmlNoteDragging = shouldUseHtmlNoteDragging(canDragSort, isCoarsePointer());
   const noteDragHint = getNoteListDragHint(canDragSort);
 
   // 判别 DataTransfer 是否带"操作系统外部文件"——
@@ -3463,7 +3470,7 @@ export default function NoteList() {
             selectedIds={selectedIds}
             onSelectNote={handleSelectNote}
             onContextMenu={(e, noteId) => openMenu(e, noteId, "note")}
-            canDragSort={canDragSort}
+            useHtmlNoteDragging={useHtmlNoteDragging}
             dragOverNoteId={dragOverNoteId}
             onDragStart={handleDragStart}
             onDragOver={handleDragOver}
@@ -3497,7 +3504,7 @@ export default function NoteList() {
                 isSelected={selectedIds.has(note.id)}
                 onClick={(e) => handleSelectNote(note.id, e)}
                 onContextMenu={(e) => openMenu(e, note.id, "note")}
-                draggable={canDragSort}
+                draggable={useHtmlNoteDragging}
                 onDragStart={(e) => handleDragStart(e, note.id)}
                 onDragOver={(e) => handleDragOver(e, note.id)}
                 onDragEnd={handleDragEnd}

--- a/frontend/src/components/__tests__/NoteListMobileTouch.test.ts
+++ b/frontend/src/components/__tests__/NoteListMobileTouch.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const noteListSource = readFileSync(
+  path.resolve(__dirname, "../NoteList.tsx"),
+  "utf8",
+);
+
+describe("NoteList Android touch interaction", () => {
+  it("粗指针设备上的笔记卡片不启用 HTML draggable", () => {
+    expect(noteListSource).toContain(
+      "shouldUseHtmlNoteDragging(canDragSort, isCoarsePointer())",
+    );
+    expect(noteListSource.match(/draggable=\{useHtmlNoteDragging\}/g)).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/__tests__/noteManualSort.test.ts
+++ b/frontend/src/lib/__tests__/noteManualSort.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getNoteListDragHint,
   reorderNotesWithinNotebook,
+  shouldUseHtmlNoteDragging,
 } from "@/lib/noteManualSort";
 
 const note = (id: string, notebookId = "nb", isLocked = 0) => ({
@@ -67,5 +68,13 @@ describe("getNoteListDragHint", () => {
 
   it("手动排序时提示可拖动", () => {
     expect(getNoteListDragHint(true)).toBe("拖动调整笔记顺序");
+  });
+});
+
+describe("shouldUseHtmlNoteDragging", () => {
+  it("在粗指针触摸设备上禁用 HTML 拖拽", () => {
+    expect(shouldUseHtmlNoteDragging(true, true)).toBe(false);
+    expect(shouldUseHtmlNoteDragging(true, false)).toBe(true);
+    expect(shouldUseHtmlNoteDragging(false, false)).toBe(false);
   });
 });

--- a/frontend/src/lib/noteManualSort.ts
+++ b/frontend/src/lib/noteManualSort.ts
@@ -10,6 +10,10 @@ export function getNoteListDragHint(canDragSort: boolean): string {
   return canDragSort ? "拖动调整笔记顺序" : "切换到手动排序后可拖动调整顺序";
 }
 
+export function shouldUseHtmlNoteDragging(canDragSort: boolean, coarsePointer: boolean): boolean {
+  return canDragSort && !coarsePointer;
+}
+
 export function getDropZoneFromClientY(clientY: number, rect: Pick<DOMRect, "top" | "height">): NoteDropZone {
   return clientY < rect.top + rect.height / 2 ? "before" : "after";
 }


### PR DESCRIPTION
将已同步 `main@f0ad5ce` 的 `issue-247-pg-runtime@3b06541` 合入 `issue-248-direct-db-audit`。

- 仅更新堆叠分支基线
- 不合并 #255/#258 到 main
- 保留 #248 当前 SQLite 直连清理改动