### PR TITLE
fix: 修复安卓主题切换抖动与图片旋转缩放 (#270)

### DIFF
--- a/frontend/src/components/EditorImageTransformBridge.tsx
+++ b/frontend/src/components/EditorImageTransformBridge.tsx
@@ -7,6 +7,7 @@ import {
   normalizeImageRotation,
   type ImageRotation,
 } from "@/lib/imageNodeTransformBootstrap";
+import { computeEditorImageTransformLayout } from "@/lib/editorImageTransformLayout";
 
 interface TiptapEditorLike {
   state: any;
@@ -26,8 +27,19 @@ interface ImageTarget {
   mobileSheet: HTMLElement | null;
 }
 
+const MOBILE_BACKDROP_SELECTOR = [
+  'button[aria-label="关闭图片操作"]',
+  'button[aria-label="Close image actions"]',
+].join(",");
+const originalBackdropPointerEvents = new WeakMap<HTMLButtonElement, string>();
+const imageLoadListeners = new WeakSet<HTMLImageElement>();
+
 function isEnglishUi(): boolean {
   return document.documentElement.lang?.toLowerCase().startsWith("en") ?? false;
+}
+
+function isCoarsePointer(): boolean {
+  return typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)")?.matches === true;
 }
 
 function findDesktopImageToolbar(): HTMLElement | null {
@@ -78,38 +90,152 @@ function selectedImageTarget(): Omit<ImageTarget, "desktopToolbar" | "mobileShee
   };
 }
 
-function applyWrapperTransform(wrapper: HTMLElement, rotation: ImageRotation, flipX: boolean): void {
-  const transform = getPersistentImageTransform(rotation, flipX);
-  if (wrapper.style.transform !== transform) wrapper.style.transform = transform;
-  if (wrapper.style.transformOrigin !== "center center") wrapper.style.transformOrigin = "center center";
+function positive(value: unknown): number | null {
+  const numeric = Number.parseFloat(String(value ?? ""));
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function setStyle(element: HTMLElement, property: keyof CSSStyleDeclaration, value: string): void {
+  if (element.style[property] !== value) {
+    (element.style[property] as string) = value;
+  }
+}
+
+function availableImageWidth(wrapper: HTMLElement, fallback: number): number {
+  const parent = wrapper.parentElement;
+  const parentWidth = parent?.clientWidth
+    || wrapper.closest<HTMLElement>(".ProseMirror")?.clientWidth
+    || fallback;
+  const style = getComputedStyle(wrapper);
+  const margins = (positive(style.marginLeft) || 0) + (positive(style.marginRight) || 0);
+  return Math.max(1, parentWidth - margins);
+}
+
+/**
+ * Keep the editor's selection frame in normal document flow and rotate only the visual image.
+ * This prevents 90°/270° images from painting over the following paragraph, and keeps handles
+ * plus the live `px` badge readable instead of rotating them with the bitmap.
+ */
+export function applyImageTransformLayout(
+  wrapper: HTMLElement,
+  rotation: ImageRotation,
+  flipX: boolean,
+): boolean {
+  const image = wrapper.querySelector<HTMLImageElement>("img");
+  if (!image) return false;
+
+  const measuredWidth = image.offsetWidth;
+  const measuredHeight = image.offsetHeight;
+  const naturalWidth = image.naturalWidth
+    || positive(image.getAttribute("width"))
+    || measuredWidth;
+  const naturalHeight = image.naturalHeight
+    || (measuredWidth > 0 && measuredHeight > 0 && naturalWidth > 0
+      ? naturalWidth * measuredHeight / measuredWidth
+      : measuredHeight);
+
+  if (!naturalWidth || !naturalHeight) {
+    if (!imageLoadListeners.has(image)) {
+      imageLoadListeners.add(image);
+      image.addEventListener("load", () => {
+        imageLoadListeners.delete(image);
+        requestAnimationFrame(syncAllImageWrappers);
+      }, { once: true });
+    }
+    return false;
+  }
+
+  const attributeWidth = positive(image.getAttribute("width"));
+  let requestedWidth = attributeWidth
+    || positive(image.dataset.nowenRequestedImageWidth)
+    || measuredWidth
+    || naturalWidth;
+  if (!attributeWidth && !image.dataset.nowenRequestedImageWidth) {
+    image.dataset.nowenRequestedImageWidth = String(requestedWidth);
+  }
+
+  const layout = computeEditorImageTransformLayout({
+    requestedWidth,
+    naturalWidth,
+    naturalHeight,
+    availableWidth: availableImageWidth(wrapper, requestedWidth),
+    rotation,
+  });
+  if (!layout) return false;
+
   wrapper.dataset.imageRotation = String(rotation);
   wrapper.dataset.imageFlipX = flipX ? "true" : "false";
-  if (wrapper.style.transition !== "transform 160ms ease") {
-    wrapper.style.transition = "transform 160ms ease";
-  }
-  const sideways = rotation === 90 || rotation === 270;
+  wrapper.dataset.nowenRotationLayout = "frame";
+
+  // React's NodeView historically wrote the transform on this wrapper. Explicitly neutralize
+  // it because wrapper children include the selection outline, four handles and size tooltip.
+  setStyle(wrapper, "transform", "none");
+  setStyle(wrapper, "transformOrigin", "center center");
+  setStyle(wrapper, "transition", "none");
+  setStyle(wrapper, "width", `${layout.frameWidth}px`);
+  setStyle(wrapper, "height", `${layout.frameHeight}px`);
+  setStyle(wrapper, "maxWidth", "100%");
+  setStyle(wrapper, "overflow", "visible");
+  setStyle(wrapper, "verticalAlign", "middle");
+
+  const persistentTransform = getPersistentImageTransform(rotation, flipX);
+  const visualTransform = `translate(-50%, -50%)${persistentTransform ? ` ${persistentTransform}` : ""}`;
+  image.dataset.nowenImageVisual = "true";
+  setStyle(image, "position", "absolute");
+  setStyle(image, "left", "50%");
+  setStyle(image, "top", "50%");
+  setStyle(image, "width", `${layout.imageWidth}px`);
+  setStyle(image, "height", `${layout.imageHeight}px`);
+  setStyle(image, "maxWidth", "none");
+  setStyle(image, "transform", visualTransform);
+  setStyle(image, "transformOrigin", "center center");
+  setStyle(image, "transition", isCoarsePointer() ? "none" : "transform 160ms ease");
+
+  // Old bridge versions swapped cursors because the entire wrapper rotated. Handles are now
+  // axis-aligned, so restore their original cursor direction.
   wrapper.querySelectorAll<HTMLElement>('span[style*="resize"]').forEach((handle) => {
-    const current = handle.dataset.originalResizeCursor || handle.style.cursor;
-    if (!current) return;
-    if (!handle.dataset.originalResizeCursor) handle.dataset.originalResizeCursor = current;
-    const next = sideways
-      ? current === "nwse-resize" ? "nesw-resize" : current === "nesw-resize" ? "nwse-resize" : current
-      : current;
-    if (handle.style.cursor !== next) handle.style.cursor = next;
+    const original = handle.dataset.originalResizeCursor || handle.style.cursor;
+    if (!original) return;
+    handle.dataset.originalResizeCursor = original;
+    if (handle.style.cursor !== original) handle.style.cursor = original;
   });
+  return true;
 }
 
 function syncAllImageWrappers(): void {
   document.querySelectorAll<HTMLElement>(".resizable-image-wrapper").forEach((wrapper) => {
-    const desc = (wrapper as HTMLElement & {
-      pmViewDesc?: { node?: { type?: { name?: string }; attrs?: Record<string, unknown> } };
-    }).pmViewDesc;
-    if (desc?.node?.type?.name !== "image") return;
-    applyWrapperTransform(
+    applyImageTransformLayout(
       wrapper,
-      normalizeImageRotation(desc.node.attrs?.rotation),
-      normalizeImageFlipX(desc.node.attrs?.flipX),
+      normalizeImageRotation(wrapper.dataset.imageRotation),
+      normalizeImageFlipX(wrapper.dataset.imageFlipX),
     );
+  });
+}
+
+/**
+ * The compact Android image menu renders a transparent fixed backdrop above the editor.
+ * Let pointer/touch events pass through that backdrop so a visible resize handle works on the
+ * first drag. The action sheet itself remains interactive because it is a separate z-70 node.
+ */
+export function allowImageResizeThroughMobileBackdrop(root: ParentNode = document): number {
+  const backdrops = Array.from(root.querySelectorAll<HTMLButtonElement>(MOBILE_BACKDROP_SELECTOR));
+  backdrops.forEach((button) => {
+    if (!originalBackdropPointerEvents.has(button)) {
+      originalBackdropPointerEvents.set(button, button.style.pointerEvents || "");
+    }
+    button.dataset.nowenImageBackdropPassthrough = "true";
+    if (button.style.pointerEvents !== "none") button.style.pointerEvents = "none";
+  });
+  return backdrops.length;
+}
+
+function restoreMobileBackdropPointerCapture(root: ParentNode = document): void {
+  root.querySelectorAll<HTMLButtonElement>('[data-nowen-image-backdrop-passthrough="true"]').forEach((button) => {
+    const original = originalBackdropPointerEvents.get(button) ?? "";
+    if (original) button.style.pointerEvents = original;
+    else button.style.removeProperty("pointer-events");
+    delete button.dataset.nowenImageBackdropPassthrough;
+    originalBackdropPointerEvents.delete(button);
   });
 }
 
@@ -186,26 +312,29 @@ export default function EditorImageTransformBridge() {
     syncAllImageWrappers();
     const selected = selectedImageTarget();
     if (!selected) {
+      restoreMobileBackdropPointerCapture();
       targetRef.current = null;
       setTarget(null);
       return;
     }
+
+    allowImageResizeThroughMobileBackdrop();
     const next: ImageTarget = {
       ...selected,
       desktopToolbar: findDesktopImageToolbar(),
       mobileSheet: findCompactMobileSheet(),
     };
-    applyWrapperTransform(next.wrapper, next.rotation, next.flipX);
+    applyImageTransformLayout(next.wrapper, next.rotation, next.flipX);
     if (next.desktopToolbar) positionDesktopToolbar(next.desktopToolbar, next.wrapper);
     const previous = targetRef.current;
-    const changed = !previous ||
-      previous.editor !== next.editor ||
-      previous.pos !== next.pos ||
-      previous.wrapper !== next.wrapper ||
-      previous.rotation !== next.rotation ||
-      previous.flipX !== next.flipX ||
-      previous.desktopToolbar !== next.desktopToolbar ||
-      previous.mobileSheet !== next.mobileSheet;
+    const changed = !previous
+      || previous.editor !== next.editor
+      || previous.pos !== next.pos
+      || previous.wrapper !== next.wrapper
+      || previous.rotation !== next.rotation
+      || previous.flipX !== next.flipX
+      || previous.desktopToolbar !== next.desktopToolbar
+      || previous.mobileSheet !== next.mobileSheet;
     targetRef.current = next;
     if (changed) setTarget(next);
   }, []);
@@ -213,26 +342,36 @@ export default function EditorImageTransformBridge() {
   useEffect(() => {
     let frame = 0;
     let attachedEditor: TiptapEditorLike | null = null;
+    let observedEditorDom: HTMLElement | null = null;
     const schedule = () => {
       if (frame) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(reconcile);
     };
+    const resizeObserver = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(schedule)
+      : null;
     const attachEditor = () => {
       const editorDom = document.querySelector<HTMLElement>('.ProseMirror[contenteditable="true"]');
       const editor = (editorDom as (HTMLElement & { editor?: TiptapEditorLike }) | null)?.editor || null;
-      if (editor === attachedEditor) return;
-      if (attachedEditor) {
-        attachedEditor.off("selectionUpdate", schedule);
-        attachedEditor.off("transaction", schedule);
-        attachedEditor.off("focus", schedule);
-        attachedEditor.off("blur", schedule);
+      if (editor !== attachedEditor) {
+        if (attachedEditor) {
+          attachedEditor.off("selectionUpdate", schedule);
+          attachedEditor.off("transaction", schedule);
+          attachedEditor.off("focus", schedule);
+          attachedEditor.off("blur", schedule);
+        }
+        attachedEditor = editor;
+        if (attachedEditor) {
+          attachedEditor.on("selectionUpdate", schedule);
+          attachedEditor.on("transaction", schedule);
+          attachedEditor.on("focus", schedule);
+          attachedEditor.on("blur", schedule);
+        }
       }
-      attachedEditor = editor;
-      if (attachedEditor) {
-        attachedEditor.on("selectionUpdate", schedule);
-        attachedEditor.on("transaction", schedule);
-        attachedEditor.on("focus", schedule);
-        attachedEditor.on("blur", schedule);
+      if (editorDom !== observedEditorDom) {
+        if (observedEditorDom) resizeObserver?.unobserve(observedEditorDom);
+        observedEditorDom = editorDom;
+        if (observedEditorDom) resizeObserver?.observe(observedEditorDom);
       }
     };
     const observe = () => {
@@ -243,22 +382,36 @@ export default function EditorImageTransformBridge() {
       const handle = event.target instanceof HTMLElement ? event.target : null;
       if (!handle?.style.cursor.includes("resize")) return;
       const wrapper = handle.closest<HTMLElement>(".resizable-image-wrapper");
-      const transform = wrapper?.style.transform || "";
-      if (!wrapper || !transform) return;
-      // Existing NodeView drag code measures getBoundingClientRect().width. Temporarily remove
-      // rotation during the same pointer event so 90° images still resize from their real width.
-      wrapper.style.transform = "";
+      const image = wrapper?.querySelector<HTMLImageElement>('img[data-nowen-image-visual="true"]');
+      const transform = image?.style.transform || "";
+      if (!image || !transform) return;
+      const transition = image.style.transition;
+      // ResizableImageView reads getBoundingClientRect().width on pointer down. Remove only the
+      // bitmap transform during that synchronous event so it receives the unrotated image width.
+      image.style.transition = "none";
+      image.style.transform = "none";
       queueMicrotask(() => {
-        if (wrapper.isConnected) wrapper.style.transform = transform;
+        if (!image.isConnected) return;
+        image.style.transform = transform;
+        image.style.transition = transition;
       });
     };
+
     observe();
     const observer = new MutationObserver(observe);
     observer.observe(document.body, {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["class", "style", "aria-label"],
+      attributeFilter: [
+        "class",
+        "style",
+        "aria-label",
+        "width",
+        "src",
+        "data-image-rotation",
+        "data-image-flip-x",
+      ],
     });
     window.addEventListener("resize", schedule);
     window.addEventListener("scroll", schedule, true);
@@ -267,10 +420,12 @@ export default function EditorImageTransformBridge() {
     return () => {
       if (frame) cancelAnimationFrame(frame);
       observer.disconnect();
+      resizeObserver?.disconnect();
       window.removeEventListener("resize", schedule);
       window.removeEventListener("scroll", schedule, true);
       document.removeEventListener("mousedown", prepareResizeMeasurement, true);
       document.removeEventListener("touchstart", prepareResizeMeasurement, true);
+      restoreMobileBackdropPointerCapture();
       if (attachedEditor) {
         attachedEditor.off("selectionUpdate", schedule);
         attachedEditor.off("transaction", schedule);

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -10,7 +10,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       // next-themes 会把选择写入 localStorage(storageKey)，后续沿用用户偏好。
       defaultTheme="light"
       enableSystem
-      disableTransitionOnChange={false}
+      // Android WebView 在根节点 class 改变时若同时执行全站 transition-colors，
+      // 会连续重绘大面积背景并出现明显闪白/抖动。主题切换期间临时禁用 CSS
+      // transition，切换完成后 next-themes 会自动恢复，不影响普通交互动效。
+      disableTransitionOnChange
       storageKey="nowen-note-theme"
     >
       {children}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTheme } from "next-themes";
-import { motion, AnimatePresence } from "framer-motion";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -11,49 +10,40 @@ export default function ThemeToggle() {
   const [mounted, setMounted] = React.useState(false);
 
   const themes = [
-    { key: "light", icon: Sun, label: t('theme.light') },
-    { key: "dark", icon: Moon, label: t('theme.dark') },
-    { key: "system", icon: Monitor, label: t('theme.system') },
+    { key: "light", icon: Sun, label: t("theme.light") },
+    { key: "dark", icon: Moon, label: t("theme.dark") },
+    { key: "system", icon: Monitor, label: t("theme.system") },
   ] as const;
 
   React.useEffect(() => setMounted(true), []);
   if (!mounted) return null;
 
   return (
-    <div className="flex items-center gap-1 p-1 rounded-lg bg-app-hover">
-      {themes.map(({ key, icon: Icon, label }) => (
-        <button
-          key={key}
-          onClick={() => setTheme(key)}
-          title={label}
-          className={cn(
-            "relative p-1.5 rounded-md transition-colors",
-            theme === key
-              ? "text-accent-primary"
-              : "text-tx-tertiary hover:text-tx-secondary"
-          )}
-        >
-          {theme === key && (
-            <motion.div
-              layoutId="theme-indicator"
-              className="absolute inset-0 rounded-md bg-app-active"
-              transition={{ type: "spring", duration: 0.4, bounce: 0.15 }}
-            />
-          )}
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={key + (theme === key ? "-active" : "")}
-              initial={{ rotate: -90, opacity: 0, scale: 0.8 }}
-              animate={{ rotate: 0, opacity: 1, scale: 1 }}
-              exit={{ rotate: 90, opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.2 }}
-              className="relative z-10"
-            >
-              <Icon size={14} />
-            </motion.div>
-          </AnimatePresence>
-        </button>
-      ))}
+    <div className="flex items-center gap-1 rounded-lg bg-app-hover p-1">
+      {themes.map(({ key, icon: Icon, label }) => {
+        const active = theme === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => {
+              if (!active) setTheme(key);
+            }}
+            title={label}
+            aria-label={label}
+            aria-pressed={active}
+            className={cn(
+              "relative flex h-7 w-7 touch-manipulation items-center justify-center rounded-md transition-colors duration-100",
+              active
+                ? "bg-app-active text-accent-primary"
+                : "text-tx-tertiary hover:text-tx-secondary active:bg-app-active/70",
+            )}
+            style={{ WebkitTapHighlightColor: "transparent" }}
+          >
+            <Icon size={14} aria-hidden="true" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/EditorImageTransformBridge.test.tsx
+++ b/frontend/src/components/__tests__/EditorImageTransformBridge.test.tsx
@@ -4,6 +4,8 @@ import Image from "@tiptap/extension-image";
 import { afterEach, describe, expect, it } from "vitest";
 import "@/lib/imageNodeTransformBootstrap";
 import {
+  allowImageResizeThroughMobileBackdrop,
+  applyImageTransformLayout,
   findImageTransformWrapper,
   updateImageAttributesAt,
 } from "@/components/EditorImageTransformBridge";
@@ -13,7 +15,7 @@ describe("EditorImageTransformBridge", () => {
     document.body.innerHTML = "";
   });
 
-  it("applies transforms to the inline-block image wrapper inside a React NodeView", () => {
+  it("finds the inline-block image wrapper inside a React NodeView", () => {
     document.body.innerHTML = `
       <span class="react-renderer node-image">
         <span class="resizable-image-wrapper" style="display: inline-block">
@@ -37,6 +39,56 @@ describe("EditorImageTransformBridge", () => {
     expect(findImageTransformWrapper(image)).toBe(
       document.querySelector(".resizable-image-wrapper"),
     );
+  });
+
+  it("reserves the rotated visual bounds while keeping handles and the px badge upright", () => {
+    document.body.innerHTML = `
+      <p id="parent">
+        <span class="resizable-image-wrapper" style="transform: rotate(90deg); margin: 0">
+          <img src="/image.png" width="600" style="width: 600px; height: auto; max-width: 100%">
+          <span data-controls style="position:absolute;inset:0">
+            <span data-handle style="cursor:nwse-resize"></span>
+            <span data-size>600px</span>
+          </span>
+        </span>
+      </p>
+    `;
+    const parent = document.querySelector<HTMLElement>("#parent")!;
+    const wrapper = document.querySelector<HTMLElement>(".resizable-image-wrapper")!;
+    const image = wrapper.querySelector<HTMLImageElement>("img")!;
+    const handle = wrapper.querySelector<HTMLElement>("[data-handle]")!;
+    const badge = wrapper.querySelector<HTMLElement>("[data-size]")!;
+    Object.defineProperty(parent, "clientWidth", { value: 800, configurable: true });
+    Object.defineProperties(image, {
+      naturalWidth: { value: 1200, configurable: true },
+      naturalHeight: { value: 600, configurable: true },
+      offsetWidth: { value: 600, configurable: true },
+      offsetHeight: { value: 300, configurable: true },
+    });
+
+    expect(applyImageTransformLayout(wrapper, 90, true)).toBe(true);
+    expect(wrapper.style.transform).toBe("none");
+    expect(wrapper.style.width).toBe("300px");
+    expect(wrapper.style.height).toBe("600px");
+    expect(image.style.position).toBe("absolute");
+    expect(image.style.transform).toContain("translate(-50%, -50%)");
+    expect(image.style.transform).toContain("rotate(90deg)");
+    expect(image.style.transform).toContain("scaleX(-1)");
+    expect(handle.style.cursor).toBe("nwse-resize");
+    expect(badge.style.transform).toBe("");
+  });
+
+  it("lets the first resize gesture pass through the compact mobile sheet backdrop", () => {
+    document.body.innerHTML = `
+      <button aria-label="关闭图片操作" style="pointer-events:auto"></button>
+      <button aria-label="Close image actions"></button>
+    `;
+
+    expect(allowImageResizeThroughMobileBackdrop()).toBe(2);
+    document.querySelectorAll<HTMLButtonElement>("button").forEach((button) => {
+      expect(button.style.pointerEvents).toBe("none");
+      expect(button.dataset.nowenImageBackdropPassthrough).toBe("true");
+    });
   });
 
   it("updates a selected inline image without dispatching a focus transaction", () => {

--- a/frontend/src/lib/__tests__/editorImageTransformLayout.test.ts
+++ b/frontend/src/lib/__tests__/editorImageTransformLayout.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { computeEditorImageTransformLayout } from "@/lib/editorImageTransformLayout";
+
+describe("computeEditorImageTransformLayout", () => {
+  it("swaps the visual frame for a landscape quarter turn", () => {
+    const layout = computeEditorImageTransformLayout({
+      requestedWidth: 800,
+      naturalWidth: 1200,
+      naturalHeight: 600,
+      availableWidth: 700,
+      rotation: 90,
+    });
+
+    expect(layout).toEqual({
+      imageWidth: 700,
+      imageHeight: 350,
+      frameWidth: 350,
+      frameHeight: 700,
+      sideways: true,
+    });
+  });
+
+  it("shrinks a portrait source before rotation so it cannot overflow horizontally", () => {
+    const layout = computeEditorImageTransformLayout({
+      requestedWidth: 600,
+      naturalWidth: 600,
+      naturalHeight: 1200,
+      availableWidth: 400,
+      rotation: 270,
+    });
+
+    expect(layout).toEqual({
+      imageWidth: 200,
+      imageHeight: 400,
+      frameWidth: 400,
+      frameHeight: 200,
+      sideways: true,
+    });
+  });
+
+  it("keeps normal and 180 degree images in their original layout orientation", () => {
+    const normal = computeEditorImageTransformLayout({
+      requestedWidth: 500,
+      naturalWidth: 1000,
+      naturalHeight: 500,
+      availableWidth: 420,
+      rotation: 0,
+    });
+    const upsideDown = computeEditorImageTransformLayout({
+      requestedWidth: 500,
+      naturalWidth: 1000,
+      naturalHeight: 500,
+      availableWidth: 420,
+      rotation: 180,
+    });
+
+    expect(normal).toMatchObject({
+      imageWidth: 420,
+      imageHeight: 210,
+      frameWidth: 420,
+      frameHeight: 210,
+      sideways: false,
+    });
+    expect(upsideDown).toEqual(normal);
+  });
+
+  it("returns null until the image has usable intrinsic dimensions", () => {
+    expect(computeEditorImageTransformLayout({
+      naturalWidth: 0,
+      naturalHeight: 0,
+      availableWidth: 400,
+      rotation: 90,
+    })).toBeNull();
+  });
+});

--- a/frontend/src/lib/editorImageTransformLayout.ts
+++ b/frontend/src/lib/editorImageTransformLayout.ts
@@ -1,0 +1,59 @@
+import type { ImageRotation } from "@/lib/imageNodeTransformBootstrap";
+
+export interface EditorImageTransformLayoutInput {
+  requestedWidth?: number | null;
+  naturalWidth: number;
+  naturalHeight: number;
+  availableWidth: number;
+  rotation: ImageRotation;
+}
+
+export interface EditorImageTransformLayout {
+  imageWidth: number;
+  imageHeight: number;
+  frameWidth: number;
+  frameHeight: number;
+  sideways: boolean;
+}
+
+function positive(value: unknown): number | null {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+/**
+ * CSS transforms do not participate in normal document flow. A 90°/270° image therefore
+ * needs an axis-aligned frame whose width/height are swapped, otherwise the visual pixels
+ * overlap the following paragraph while the editor still reserves the unrotated rectangle.
+ *
+ * The returned image dimensions always fit the editor column. Portrait images are reduced
+ * before a quarter turn so their rotated width cannot exceed the available content width.
+ */
+export function computeEditorImageTransformLayout(
+  input: EditorImageTransformLayoutInput,
+): EditorImageTransformLayout | null {
+  const naturalWidth = positive(input.naturalWidth);
+  const naturalHeight = positive(input.naturalHeight);
+  if (!naturalWidth || !naturalHeight) return null;
+
+  const ratio = naturalWidth / naturalHeight;
+  const availableWidth = positive(input.availableWidth) || naturalWidth;
+  const requestedWidth = positive(input.requestedWidth) || naturalWidth;
+  const sideways = input.rotation === 90 || input.rotation === 270;
+
+  // For a portrait source, the rotated visual width is imageWidth / ratio. Limit the
+  // unrotated width first so the final visual frame remains inside the editor column.
+  const maxImageWidth = sideways && ratio < 1
+    ? availableWidth * ratio
+    : availableWidth;
+  const imageWidth = Math.max(1, Math.min(requestedWidth, maxImageWidth));
+  const imageHeight = imageWidth / ratio;
+
+  return {
+    imageWidth,
+    imageHeight,
+    frameWidth: sideways ? imageHeight : imageWidth,
+    frameHeight: sideways ? imageWidth : imageHeight,
+    sideways,
+  };
+}


### PR DESCRIPTION
## 修复内容

### Android 主题切换
- `next-themes` 切换根主题 class 时临时禁用全局 CSS transition，避免 WebView 大面积重绘闪烁
- 移除主题按钮的 Framer Motion 布局弹簧和图标进出场旋转，改为轻量静态状态切换
- 增加 `touch-manipulation` 和关闭点击高亮，减少安卓点击反馈抖动

### 编辑器图片旋转与缩放
- 不再旋转 `.resizable-image-wrapper`，只旋转图片本体
- 为 90°/270° 图片计算旋转后的轴对齐占位框，交换视觉宽高，避免覆盖相邻图片和后续文字
- 竖图旋转前按编辑器可用宽度缩放，避免旋转后横向溢出
- 缩放框、四角手柄、选中描边和拖拽中的 `px` 尺寸提示保持正向
- 使用 `ResizeObserver` 在屏幕旋转、编辑区宽度变化后重新计算布局
- Android 粗指针环境取消图片旋转过渡，避免旋转过程中短暂越界
- 透明移动端图片菜单遮罩改为触摸穿透，菜单打开时第一次拖动手柄即可缩放
- 缩放开始前仅临时移除图片本体 transform，保证旧 NodeView 仍取得未旋转宽度

## 回归测试
- 横图 90° 占位宽高交换
- 竖图 270° 旋转后不超出编辑区
- 0°/180° 保持原布局方向
- 旋转后手柄、尺寸标签保持正向
- 中英文移动端图片遮罩均允许首次缩放手势穿透

Closes #270