### PR TITLE
chore: 同步 main@c222bfd 基线到 #248 分支

### DIFF
--- a/frontend/src/components/__tests__/OfflineIndicatorConflictPresentation.test.ts
+++ b/frontend/src/components/__tests__/OfflineIndicatorConflictPresentation.test.ts
@@ -4,6 +4,7 @@ import {
   getQueueItemNotePreview,
   getQueueItemNoteTitle,
   getQueueItemStatusMessage,
+  getSyncIndicatorPresentation,
 } from "../common/OfflineIndicator";
 
 function conflictItem(overrides: Partial<OfflineQueueItem> = {}): OfflineQueueItem {
@@ -35,6 +36,18 @@ function conflictItem(overrides: Partial<OfflineQueueItem> = {}): OfflineQueueIt
   };
 }
 
+const basePresentationInput = {
+  isOnline: true,
+  isBootstrapping: false,
+  showSyncing: false,
+  pendingCount: 0,
+  showPending: false,
+  failedCount: 0,
+  conflictCount: 0,
+  queueCount: 0,
+  lastError: null,
+};
+
 describe("OfflineIndicator conflict presentation", () => {
   it("shows the note title from the preserved local payload", () => {
     expect(getQueueItemNoteTitle(conflictItem())).toBe("产品需求记录");
@@ -44,13 +57,105 @@ describe("OfflineIndicator conflict presentation", () => {
     expect(getQueueItemNotePreview(conflictItem())).toBe("同步冲突处理方案");
   });
 
-  it("replaces persisted English conflict errors with a clear Chinese explanation", () => {
-    expect(getQueueItemStatusMessage(conflictItem())).toBe("已停止自动覆盖，本地内容已保留，请处理版本冲突。");
+  it("replaces persisted English conflict errors with a clear user-facing explanation", () => {
+    expect(getQueueItemStatusMessage(conflictItem())).toBe("两个版本均已保留，请确认最终使用的内容。");
   });
 
   it("falls back safely when old queue data has no title or content", () => {
     const item = conflictItem({ body: null, localPayload: null });
     expect(getQueueItemNoteTitle(item)).toBe("未命名笔记");
     expect(getQueueItemNotePreview(item)).toBe("");
+  });
+});
+
+describe("OfflineIndicator status information architecture", () => {
+  it("keeps normal successful synchronization invisible", () => {
+    expect(getSyncIndicatorPresentation(basePresentationInput)).toBeNull();
+  });
+
+  it("does not show a short bootstrap operation before the delay", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      isBootstrapping: true,
+      showSyncing: false,
+    })).toBeNull();
+  });
+
+  it("shows long-running synchronization as a compact non-expandable status", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      isBootstrapping: true,
+      showSyncing: true,
+    })).toMatchObject({
+      tone: "syncing",
+      label: "正在同步…",
+      action: "none",
+      compact: true,
+    });
+  });
+
+  it("explains offline preservation without exposing the queue", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      isOnline: false,
+      pendingCount: 2,
+      queueCount: 2,
+    })).toMatchObject({
+      tone: "offline",
+      label: "当前离线",
+      description: "2 项修改已保存在本机，联网后将自动同步。",
+      action: "none",
+    });
+  });
+
+  it("does not flash transient pending writes before they become meaningful", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      pendingCount: 1,
+      queueCount: 1,
+      showPending: false,
+    })).toBeNull();
+  });
+
+  it("offers details only when actual unsynchronized content exists", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      pendingCount: 2,
+      queueCount: 2,
+      showPending: true,
+    })).toMatchObject({
+      tone: "pending",
+      label: "2 项修改尚未同步",
+      action: "details",
+      actionLabel: "查看并重试",
+    });
+  });
+
+  it("uses an explicit conflict message instead of a generic queue state", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      pendingCount: 3,
+      failedCount: 3,
+      conflictCount: 3,
+      queueCount: 3,
+    })).toMatchObject({
+      tone: "error",
+      label: "3 篇笔记存在版本冲突",
+      description: "两个版本均已保留，请查看后确认最终内容。",
+      action: "details",
+      actionLabel: "查看冲突",
+    });
+  });
+
+  it("offers a direct retry when synchronization failed without queue items", () => {
+    expect(getSyncIndicatorPresentation({
+      ...basePresentationInput,
+      lastError: "network timeout",
+    })).toMatchObject({
+      tone: "error",
+      label: "同步暂时失败",
+      action: "retry",
+      actionLabel: "重新同步",
+    });
   });
 });

--- a/frontend/src/components/common/OfflineIndicator.tsx
+++ b/frontend/src/components/common/OfflineIndicator.tsx
@@ -1,8 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
-  CheckCircle2,
-  ChevronDown,
   CloudOff,
   Download,
   Loader2,
@@ -12,7 +10,6 @@ import {
 import { api } from "@/lib/api";
 import {
   exportQueueDiagnostics,
-  getFailedQueueItems,
   getQueue,
   retryFailedQueueItems,
   retryQueueItem,
@@ -25,6 +22,7 @@ import {
   SYNC_SNAPSHOT_APPLIED_EVENT,
   type SyncSummary,
 } from "@/lib/syncEngine";
+import { toast } from "@/lib/toast";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useAppActions } from "@/store/AppContext";
 
@@ -56,9 +54,105 @@ export function getQueueItemNotePreview(item: OfflineQueueItem): string {
 
 export function getQueueItemStatusMessage(item: OfflineQueueItem): string {
   if (item.conflict || item.errorCode === "VERSION_CONFLICT") {
-    return "已停止自动覆盖，本地内容已保留，请处理版本冲突。";
+    return "两个版本均已保留，请确认最终使用的内容。";
   }
-  return item.message || (item.blocked ? "已暂停自动重试" : "等待服务器确认");
+  return item.message || (item.blocked ? "自动同步已暂停，本地内容仍然保留。" : "正在等待服务器确认。 ");
+}
+
+export type SyncIndicatorAction = "none" | "details" | "retry";
+export type SyncIndicatorTone = "offline" | "syncing" | "error" | "pending";
+
+export interface SyncIndicatorPresentation {
+  tone: SyncIndicatorTone;
+  label: string;
+  description?: string;
+  action: SyncIndicatorAction;
+  actionLabel?: string;
+  compact?: boolean;
+}
+
+export interface SyncIndicatorPresentationInput {
+  isOnline: boolean;
+  isBootstrapping: boolean;
+  showSyncing: boolean;
+  pendingCount: number;
+  showPending: boolean;
+  failedCount: number;
+  conflictCount: number;
+  queueCount: number;
+  lastError?: string | null;
+}
+
+/**
+ * Translate internal sync state into the small set of states a user needs to understand.
+ * Normal successful synchronization deliberately returns null and stays invisible.
+ */
+export function getSyncIndicatorPresentation({
+  isOnline,
+  isBootstrapping,
+  showSyncing,
+  pendingCount,
+  showPending,
+  failedCount,
+  conflictCount,
+  queueCount,
+  lastError,
+}: SyncIndicatorPresentationInput): SyncIndicatorPresentation | null {
+  if (!isOnline) {
+    return {
+      tone: "offline",
+      label: "当前离线",
+      description: pendingCount > 0
+        ? `${pendingCount} 项修改已保存在本机，联网后将自动同步。`
+        : "联网后将自动恢复同步。",
+      action: "none",
+    };
+  }
+
+  if (isBootstrapping) {
+    if (!showSyncing) return null;
+    return {
+      tone: "syncing",
+      label: "正在同步…",
+      action: "none",
+      compact: true,
+    };
+  }
+
+  if (conflictCount > 0) {
+    return {
+      tone: "error",
+      label: `${conflictCount} 篇笔记存在版本冲突`,
+      description: "两个版本均已保留，请查看后确认最终内容。",
+      action: queueCount > 0 ? "details" : "retry",
+      actionLabel: queueCount > 0 ? "查看冲突" : "重新同步",
+    };
+  }
+
+  if (failedCount > 0 || lastError) {
+    const count = Math.max(failedCount, pendingCount);
+    return {
+      tone: "error",
+      label: count > 0 ? `${count} 项修改尚未同步` : "同步暂时失败",
+      description: count > 0
+        ? "本地内容已保留，可查看后重新同步。"
+        : "本地内容未丢失，可以重新同步。",
+      action: queueCount > 0 ? "details" : "retry",
+      actionLabel: queueCount > 0 ? "查看并重试" : "重新同步",
+    };
+  }
+
+  if (pendingCount > 0 && showPending) {
+    return {
+      tone: "pending",
+      label: `${pendingCount} 项修改尚未同步`,
+      description: "本地内容已保存，正在等待服务器确认。",
+      action: queueCount > 0 ? "details" : "retry",
+      actionLabel: queueCount > 0 ? "查看并重试" : "重新同步",
+    };
+  }
+
+  return null;
 }
 
 function downloadDiagnostics(): void {
@@ -81,13 +175,12 @@ export default function OfflineIndicator() {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [retryingId, setRetryingId] = useState<string | null>(null);
   const [retryingAll, setRetryingAll] = useState(false);
-  const [dismissedRecovery, setDismissedRecovery] = useState(false);
+  const [showPending, setShowPending] = useState(false);
+  const [showSyncing, setShowSyncing] = useState(false);
+  const recoveryToastShownRef = useRef(false);
 
   useEffect(() => subscribeSyncSummary(setSummary), []);
   useEffect(() => subscribeOfflineQueue(() => setQueue(getQueue())), []);
-  useEffect(() => {
-    if (!wasOffline) setDismissedRecovery(false);
-  }, [wasOffline]);
 
   useEffect(() => {
     const handleSnapshot = () => {
@@ -101,56 +194,91 @@ export default function OfflineIndicator() {
     return () => window.removeEventListener(SYNC_SNAPSHOT_APPLIED_EVENT, handleSnapshot);
   }, [actions]);
 
-  const failedItems = useMemo(() => getFailedQueueItems(), [queue]);
+  const failedItems = useMemo(() => queue.filter(
+    (item) => item.conflict || item.blocked || !!item.errorCode || item.retryCount > 0,
+  ), [queue]);
   const conflictCount = failedItems.filter(
     (item) => item.conflict || item.errorCode === "VERSION_CONFLICT",
   ).length;
+  const retryableCount = queue.filter(
+    (item) => !(item.conflict || item.errorCode === "VERSION_CONFLICT") && item.retryable !== false,
+  ).length;
 
-  const status = useMemo(() => {
-    if (!isOnline) {
-      return {
-        tone: "offline" as const,
-        label: pendingCount > 0 ? `离线 · ${pendingCount} 条待同步` : "当前离线",
-        description: "恢复网络后会自动补拉服务端变更并重试队列。",
-      };
+  // A normal save often enters and leaves the queue within one network round trip. Do not flash
+  // a global warning unless it remains pending long enough to be meaningful to the user.
+  useEffect(() => {
+    if (
+      !isOnline ||
+      pendingCount === 0 ||
+      failedItems.length > 0 ||
+      summary.state === "bootstrapping"
+    ) {
+      setShowPending(false);
+      return;
     }
-    if (summary.state === "bootstrapping") {
-      return {
-        tone: "syncing" as const,
-        label: "正在同步",
-        description: "正在等待服务器确认并刷新本地派生数据。",
-      };
+    const timer = window.setTimeout(() => setShowPending(true), 2200);
+    return () => window.clearTimeout(timer);
+  }, [failedItems.length, isOnline, pendingCount, summary.state]);
+
+  // Likewise, hide very short bootstrap work and show only a small, non-expandable progress pill
+  // when synchronization actually takes noticeable time.
+  useEffect(() => {
+    if (summary.state !== "bootstrapping") {
+      setShowSyncing(false);
+      return;
     }
-    if (failedItems.length > 0 || summary.lastError) {
-      return {
-        tone: "error" as const,
-        label: conflictCount > 0
-          ? `${conflictCount} 条同步冲突待处理`
-          : `${Math.max(failedItems.length, pendingCount)} 条同步失败`,
-        description: conflictCount > 0
-          ? "已停止自动覆盖，本地内容已保留。"
-          : summary.lastError || failedItems[0]?.message || "操作已保留在本地，未被静默丢弃。",
-      };
+    const timer = window.setTimeout(() => setShowSyncing(true), 450);
+    return () => window.clearTimeout(timer);
+  }, [summary.state]);
+
+  // Recovery is a completed result, not a management surface. Announce it once through the
+  // existing transient toast system instead of leaving an expandable success card on screen.
+  useEffect(() => {
+    if (!wasOffline) {
+      recoveryToastShownRef.current = false;
+      return;
     }
-    if (pendingCount > 0) {
-      return {
-        tone: "pending" as const,
-        label: `${pendingCount} 条待同步`,
-        description: "服务器尚未确认完成，可点击立即重试。",
-      };
+    const recovered = isOnline
+      && summary.state !== "bootstrapping"
+      && pendingCount === 0
+      && failedItems.length === 0
+      && !summary.lastError;
+    if (recovered && !recoveryToastShownRef.current) {
+      recoveryToastShownRef.current = true;
+      toast.success("已恢复连接，内容已同步");
     }
-    if (wasOffline && !dismissedRecovery) {
-      return {
-        tone: "success" as const,
-        label: "已恢复连接并完成校验",
-        description: "列表、笔记本和标签状态已重新拉取。",
-      };
+  }, [failedItems.length, isOnline, pendingCount, summary.lastError, summary.state, wasOffline]);
+
+  const status = useMemo(() => getSyncIndicatorPresentation({
+    isOnline,
+    isBootstrapping: summary.state === "bootstrapping",
+    showSyncing,
+    pendingCount,
+    showPending,
+    failedCount: failedItems.length,
+    conflictCount,
+    queueCount: queue.length,
+    lastError: summary.lastError,
+  }), [
+    conflictCount,
+    failedItems.length,
+    isOnline,
+    pendingCount,
+    queue.length,
+    showPending,
+    showSyncing,
+    summary.lastError,
+    summary.state,
+  ]);
+
+  useEffect(() => {
+    if (!status || status.action !== "details" || queue.length === 0) {
+      setDetailsOpen(false);
     }
-    return null;
-  }, [conflictCount, dismissedRecovery, failedItems, isOnline, pendingCount, summary.lastError, summary.state, wasOffline]);
+  }, [queue.length, status]);
 
   const retryOne = useCallback(async (item: OfflineQueueItem) => {
-    if (!isOnline || item.conflict || item.errorCode === "VERSION_CONFLICT") return;
+    if (!isOnline || item.conflict || item.errorCode === "VERSION_CONFLICT" || item.retryable === false) return;
     setRetryingId(item.id);
     try {
       if (retryQueueItem(item.id)) await flush(true);
@@ -172,111 +300,118 @@ export default function OfflineIndicator() {
 
   if (!status) return null;
 
+  if (status.compact) {
+    return (
+      <div
+        className="fixed right-3 z-[95]"
+        style={{ bottom: "calc(12px + var(--safe-area-bottom, 0px))" }}
+        role="status"
+        aria-live="polite"
+      >
+        <div className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-app-elevated px-3 py-2 text-xs font-medium text-tx-secondary shadow-lg dark:border-blue-900">
+          <Loader2 size={14} className="animate-spin text-blue-600 dark:text-blue-400" />
+          {status.label}
+        </div>
+      </div>
+    );
+  }
+
   const toneClasses = {
     offline: "border-zinc-300 bg-zinc-900 text-white dark:border-zinc-700",
-    syncing: "border-blue-300 bg-blue-600 text-white dark:border-blue-800",
+    syncing: "border-blue-200 bg-app-elevated text-tx-primary dark:border-blue-900",
     error: "border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100",
     pending: "border-blue-200 bg-white text-zinc-900 dark:border-blue-900 dark:bg-zinc-900 dark:text-zinc-100",
-    success: "border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-100",
   }[status.tone];
 
-  const StatusIcon = status.tone === "offline"
-    ? CloudOff
-    : status.tone === "syncing"
-      ? Loader2
-      : status.tone === "error"
-        ? AlertTriangle
-        : status.tone === "success"
-          ? CheckCircle2
-          : RefreshCw;
+  const StatusIcon = status.tone === "offline" ? CloudOff : status.tone === "error" ? AlertTriangle : RefreshCw;
+  const detailsTitle = conflictCount > 0 ? "需要处理的同步问题" : "未同步内容";
+  const detailsDescription = conflictCount > 0
+    ? "本地内容和服务器内容都已保留。请确认每项状态后再决定最终版本。"
+    : "这些修改尚未得到服务器确认，本地内容仍然保留。";
 
   return (
     <div
       className="fixed right-3 z-[95] w-[min(420px,calc(100vw-24px))]"
       style={{ bottom: "calc(12px + var(--safe-area-bottom, 0px))" }}
     >
-      {detailsOpen && (
+      {detailsOpen && queue.length > 0 && status.action === "details" && (
         <section className="mb-2 max-h-[min(60vh,520px)] overflow-hidden rounded-2xl border border-app-border bg-app-elevated shadow-2xl">
           <header className="flex items-start justify-between gap-3 border-b border-app-border px-4 py-3">
             <div className="min-w-0">
-              <h3 className="text-sm font-semibold text-tx-primary">同步队列</h3>
-              <p className="mt-0.5 text-xs leading-5 text-tx-tertiary">
-                成功项会在服务器 ACK 后移除；失败项保留本地内容，不会自动清空。
-              </p>
+              <h3 className="text-sm font-semibold text-tx-primary">{detailsTitle}</h3>
+              <p className="mt-0.5 text-xs leading-5 text-tx-tertiary">{detailsDescription}</p>
             </div>
             <button
               type="button"
               onClick={() => setDetailsOpen(false)}
               className="rounded-lg p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
-              aria-label="关闭同步详情"
+              aria-label="关闭未同步内容"
             >
               <X size={15} />
             </button>
           </header>
 
           <div className="max-h-[360px] overflow-y-auto p-3">
-            {queue.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-app-border px-4 py-8 text-center text-sm text-tx-tertiary">
-                当前没有待同步操作
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {queue.map((item) => {
-                  const isConflict = item.conflict || item.errorCode === "VERSION_CONFLICT";
-                  const canRetry = isOnline && !isConflict;
-                  const noteTitle = getQueueItemNoteTitle(item);
-                  const notePreview = getQueueItemNotePreview(item);
-                  return (
-                    <article key={item.id} className="rounded-xl border border-app-border bg-app-bg/60 p-3">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold text-tx-primary" title={noteTitle}>
-                            {noteTitle}
-                          </p>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className="text-[11px] text-tx-tertiary">{itemTypeLabel(item)}</span>
-                            <span className="rounded-full bg-app-hover px-2 py-0.5 text-[10px] text-tx-tertiary">
-                              重试 {item.retryCount} 次
+            <div className="space-y-2">
+              {queue.map((item) => {
+                const isConflict = item.conflict || item.errorCode === "VERSION_CONFLICT";
+                const canRetry = isOnline && !isConflict && item.retryable !== false;
+                const noteTitle = getQueueItemNoteTitle(item);
+                const notePreview = getQueueItemNotePreview(item);
+                return (
+                  <article key={item.id} className="rounded-xl border border-app-border bg-app-bg/60 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-tx-primary" title={noteTitle}>
+                          {noteTitle}
+                        </p>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-[11px] text-tx-tertiary">{itemTypeLabel(item)}</span>
+                          {isConflict && (
+                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
+                              版本冲突
                             </span>
-                            {isConflict && (
-                              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
-                                版本冲突
-                              </span>
-                            )}
-                          </div>
-                          {notePreview && (
-                            <p className="mt-1.5 line-clamp-2 text-xs leading-5 text-tx-secondary">
-                              {notePreview}
-                            </p>
                           )}
-                          <p className="mt-1.5 text-xs leading-5 text-tx-secondary">
-                            {getQueueItemStatusMessage(item)}
-                          </p>
-                          <details className="mt-1.5 text-[10px] text-tx-tertiary">
-                            <summary className="cursor-pointer select-none hover:text-tx-secondary">技术详情</summary>
-                            <div className="mt-1 space-y-0.5 break-all font-mono">
-                              <p>笔记 ID：{item.noteId}</p>
-                              {item.errorCode && <p>错误码：{item.errorCode}</p>}
-                              {typeof item.serverVersion === "number" && <p>服务器版本：{item.serverVersion}</p>}
-                            </div>
-                          </details>
                         </div>
+                        {notePreview && (
+                          <p className="mt-1.5 line-clamp-2 text-xs leading-5 text-tx-secondary">
+                            {notePreview}
+                          </p>
+                        )}
+                        <p className="mt-1.5 text-xs leading-5 text-tx-secondary">
+                          {getQueueItemStatusMessage(item)}
+                        </p>
+                        <details className="mt-1.5 text-[10px] text-tx-tertiary">
+                          <summary className="cursor-pointer select-none hover:text-tx-secondary">技术详情</summary>
+                          <div className="mt-1 space-y-0.5 break-all font-mono">
+                            <p>笔记 ID：{item.noteId}</p>
+                            <p>已尝试：{item.retryCount} 次</p>
+                            {item.errorCode && <p>错误码：{item.errorCode}</p>}
+                            {typeof item.serverVersion === "number" && <p>服务器版本：{item.serverVersion}</p>}
+                          </div>
+                        </details>
+                      </div>
+                      {isConflict ? (
+                        <span className="shrink-0 rounded-lg bg-amber-100 px-2.5 py-1.5 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
+                          需人工确认
+                        </span>
+                      ) : (
                         <button
                           type="button"
                           disabled={!canRetry || retryingId === item.id}
                           onClick={() => void retryOne(item)}
                           className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-app-border px-2.5 py-1.5 text-xs font-medium text-tx-secondary hover:bg-app-hover disabled:cursor-not-allowed disabled:opacity-40"
-                          title={isConflict ? "版本冲突不能盲目重放，请先导出诊断或从版本历史处理" : "重试此项"}
+                          title={item.retryable === false ? "该操作不能自动重试，请先导出本地副本" : "重新同步此项"}
                         >
                           {retryingId === item.id ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
                           重试
                         </button>
-                      </div>
-                    </article>
-                  );
-                })}
-              </div>
-            )}
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
           </div>
 
           <footer className="flex flex-wrap items-center justify-between gap-2 border-t border-app-border px-3 py-2.5">
@@ -286,49 +421,43 @@ export default function OfflineIndicator() {
               className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-tx-secondary hover:bg-app-hover"
             >
               <Download size={13} />
-              导出诊断与本地副本
+              导出本地副本
             </button>
-            <button
-              type="button"
-              disabled={!isOnline || retryingAll || queue.every((item) => item.conflict || item.errorCode === "VERSION_CONFLICT")}
-              onClick={() => void retryAll()}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {retryingAll ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
-              重试全部可重试项
-            </button>
+            {retryableCount > 0 && (
+              <button
+                type="button"
+                disabled={!isOnline || retryingAll}
+                onClick={() => void retryAll()}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-accent-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {retryingAll ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
+                重新同步
+              </button>
+            )}
           </footer>
         </section>
       )}
 
-      <div className={`flex items-center gap-2 rounded-xl border px-3 py-2.5 shadow-lg ${toneClasses}`}>
-        <StatusIcon size={16} className={status.tone === "syncing" ? "shrink-0 animate-spin" : "shrink-0"} />
-        <button
-          type="button"
-          onClick={() => setDetailsOpen((open) => !open)}
-          className="min-w-0 flex-1 text-left"
-        >
+      <div className={`flex items-center gap-3 rounded-xl border px-3 py-2.5 shadow-lg ${toneClasses}`} role="status" aria-live="polite">
+        <StatusIcon size={16} className="shrink-0" />
+        <div className="min-w-0 flex-1">
           <span className="block truncate text-xs font-semibold">{status.label}</span>
-          <span className="block truncate text-[11px] opacity-75">{status.description}</span>
-        </button>
-        {status.tone === "success" && (
+          {status.description && <span className="block truncate text-[11px] opacity-75">{status.description}</span>}
+        </div>
+        {status.action !== "none" && status.actionLabel && (
           <button
             type="button"
-            onClick={() => setDismissedRecovery(true)}
-            className="rounded-md p-1 opacity-70 hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
-            aria-label="关闭提示"
+            disabled={status.action === "retry" && retryingAll}
+            onClick={() => {
+              if (status.action === "details") setDetailsOpen((open) => !open);
+              else void retryAll();
+            }}
+            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-current/20 bg-white/20 px-2.5 py-1.5 text-xs font-medium hover:bg-white/30 disabled:opacity-50 dark:bg-black/10 dark:hover:bg-black/20"
           >
-            <X size={13} />
+            {status.action === "retry" && retryingAll && <Loader2 size={12} className="animate-spin" />}
+            {status.actionLabel}
           </button>
         )}
-        <button
-          type="button"
-          onClick={() => setDetailsOpen((open) => !open)}
-          className="rounded-md p-1 opacity-70 hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
-          aria-label="查看同步详情"
-        >
-          <ChevronDown size={14} className={detailsOpen ? "rotate-180 transition-transform" : "transition-transform"} />
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
将已同步 `main@c222bfd` 的 `issue-247-pg-runtime@726c427` 合入 `issue-248-direct-db-audit`。

- 仅更新堆叠分支基线
- 不合并 #255/#258 到 main
- 保留 #248 当前数据库边界清理改动