### PR TITLE
chore: 同步 main@b10c2cb 基线到 #248 分支

### DIFF
--- a/frontend/src/components/__tests__/OfflineIndicatorConflictPresentation.test.ts
+++ b/frontend/src/components/__tests__/OfflineIndicatorConflictPresentation.test.ts
@@ -57,8 +57,10 @@ describe("OfflineIndicator conflict presentation", () => {
     expect(getQueueItemNotePreview(conflictItem())).toBe("同步冲突处理方案");
   });
 
-  it("replaces persisted English conflict errors with a clear user-facing explanation", () => {
-    expect(getQueueItemStatusMessage(conflictItem())).toBe("两个版本均已保留，请确认最终使用的内容。");
+  it("explains the two explicit resolution choices", () => {
+    expect(getQueueItemStatusMessage(conflictItem())).toBe(
+      "两个版本均已保留。请选择保留此设备内容，或使用服务器内容。",
+    );
   });
 
   it("falls back safely when old queue data has no title or content", () => {
@@ -131,7 +133,7 @@ describe("OfflineIndicator status information architecture", () => {
     });
   });
 
-  it("uses an explicit conflict message instead of a generic queue state", () => {
+  it("opens the real conflict resolution flow instead of a dead-end queue state", () => {
     expect(getSyncIndicatorPresentation({
       ...basePresentationInput,
       pendingCount: 3,
@@ -141,9 +143,9 @@ describe("OfflineIndicator status information architecture", () => {
     })).toMatchObject({
       tone: "error",
       label: "3 篇笔记存在版本冲突",
-      description: "两个版本均已保留，请查看后确认最终内容。",
+      description: "本地和服务器内容都已保留，请选择最终版本。",
       action: "details",
-      actionLabel: "查看冲突",
+      actionLabel: "处理冲突",
     });
   });
 

--- a/frontend/src/components/common/OfflineIndicator.tsx
+++ b/frontend/src/components/common/OfflineIndicator.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
+  CloudDownload,
   CloudOff,
+  CloudUpload,
   Download,
   Loader2,
   RefreshCw,
@@ -22,9 +24,14 @@ import {
   SYNC_SNAPSHOT_APPLIED_EVENT,
   type SyncSummary,
 } from "@/lib/syncEngine";
+import {
+  resolveNoteConflict,
+  type ConflictResolutionChoice,
+} from "@/lib/conflictResolution";
 import { toast } from "@/lib/toast";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
-import { useAppActions } from "@/store/AppContext";
+import { useApp, useAppActions } from "@/store/AppContext";
+import { confirm as confirmDialog } from "@/components/ui/confirm";
 
 function itemTypeLabel(item: OfflineQueueItem): string {
   if (item.type === "createNote") return "新建笔记";
@@ -54,9 +61,9 @@ export function getQueueItemNotePreview(item: OfflineQueueItem): string {
 
 export function getQueueItemStatusMessage(item: OfflineQueueItem): string {
   if (item.conflict || item.errorCode === "VERSION_CONFLICT") {
-    return "两个版本均已保留，请确认最终使用的内容。";
+    return "两个版本均已保留。请选择保留此设备内容，或使用服务器内容。";
   }
-  return item.message || (item.blocked ? "自动同步已暂停，本地内容仍然保留。" : "正在等待服务器确认。 ");
+  return item.message || (item.blocked ? "自动同步已暂停，本地内容仍然保留。" : "正在等待服务器确认。");
 }
 
 export type SyncIndicatorAction = "none" | "details" | "retry";
@@ -123,9 +130,9 @@ export function getSyncIndicatorPresentation({
     return {
       tone: "error",
       label: `${conflictCount} 篇笔记存在版本冲突`,
-      description: "两个版本均已保留，请查看后确认最终内容。",
+      description: "本地和服务器内容都已保留，请选择最终版本。",
       action: queueCount > 0 ? "details" : "retry",
-      actionLabel: queueCount > 0 ? "查看冲突" : "重新同步",
+      actionLabel: queueCount > 0 ? "处理冲突" : "重新同步",
     };
   }
 
@@ -168,6 +175,7 @@ function downloadDiagnostics(): void {
 }
 
 export default function OfflineIndicator() {
+  const { state } = useApp();
   const actions = useAppActions();
   const { isOnline, wasOffline, pendingCount, flush } = useNetworkStatus();
   const [summary, setSummary] = useState<SyncSummary>(() => getSyncSummary());
@@ -175,6 +183,10 @@ export default function OfflineIndicator() {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [retryingId, setRetryingId] = useState<string | null>(null);
   const [retryingAll, setRetryingAll] = useState(false);
+  const [resolvingConflict, setResolvingConflict] = useState<{
+    itemId: string;
+    choice: ConflictResolutionChoice;
+  } | null>(null);
   const [showPending, setShowPending] = useState(false);
   const [showSyncing, setShowSyncing] = useState(false);
   const recoveryToastShownRef = useRef(false);
@@ -298,6 +310,46 @@ export default function OfflineIndicator() {
     }
   }, [flush, isOnline]);
 
+  const handleResolveConflict = useCallback(async (
+    item: OfflineQueueItem,
+    choice: ConflictResolutionChoice,
+  ) => {
+    if (!isOnline || resolvingConflict) return;
+
+    const keepLocal = choice === "keep-local";
+    const confirmed = await confirmDialog({
+      title: keepLocal ? "保留此设备版本？" : "使用服务器版本？",
+      description: keepLocal
+        ? "此设备中的内容将成为正式版本。服务器当前内容会保留在版本历史中，之后仍可恢复。"
+        : "服务器内容将继续作为正式版本；此设备中的修改会先另存为一篇冲突副本，不会直接丢弃。",
+      confirmText: keepLocal ? "保留此设备版本" : "使用服务器版本",
+      cancelText: "取消",
+      danger: false,
+    });
+    if (!confirmed) return;
+
+    setResolvingConflict({ itemId: item.id, choice });
+    try {
+      const result = await resolveNoteConflict(item, choice);
+      if (state.activeNote?.id === item.noteId) {
+        actions.setActiveNote(result.note);
+      }
+      actions.refreshNotes();
+      if (choice === "keep-local") {
+        toast.success("已保留此设备版本，冲突已解决");
+      } else if (result.conflictCopy) {
+        toast.success(`已使用服务器版本，本地修改已另存为“${result.conflictCopy.title}”`);
+      } else {
+        toast.success("本地和服务器内容一致，冲突已清理");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "处理失败");
+      toast.error(`冲突处理失败：${message}`);
+    } finally {
+      setResolvingConflict(null);
+    }
+  }, [actions, isOnline, resolvingConflict, state.activeNote?.id]);
+
   if (!status) return null;
 
   if (status.compact) {
@@ -324,18 +376,18 @@ export default function OfflineIndicator() {
   }[status.tone];
 
   const StatusIcon = status.tone === "offline" ? CloudOff : status.tone === "error" ? AlertTriangle : RefreshCw;
-  const detailsTitle = conflictCount > 0 ? "需要处理的同步问题" : "未同步内容";
+  const detailsTitle = conflictCount > 0 ? "处理版本冲突" : "未同步内容";
   const detailsDescription = conflictCount > 0
-    ? "本地内容和服务器内容都已保留。请确认每项状态后再决定最终版本。"
+    ? "每篇笔记都可以单独选择最终版本。任何一侧的内容都不会被静默删除。"
     : "这些修改尚未得到服务器确认，本地内容仍然保留。";
 
   return (
     <div
-      className="fixed right-3 z-[95] w-[min(420px,calc(100vw-24px))]"
+      className="fixed right-3 z-[95] w-[min(440px,calc(100vw-24px))]"
       style={{ bottom: "calc(12px + var(--safe-area-bottom, 0px))" }}
     >
       {detailsOpen && queue.length > 0 && status.action === "details" && (
-        <section className="mb-2 max-h-[min(60vh,520px)] overflow-hidden rounded-2xl border border-app-border bg-app-elevated shadow-2xl">
+        <section className="mb-2 max-h-[min(72vh,620px)] overflow-hidden rounded-2xl border border-app-border bg-app-elevated shadow-2xl">
           <header className="flex items-start justify-between gap-3 border-b border-app-border px-4 py-3">
             <div className="min-w-0">
               <h3 className="text-sm font-semibold text-tx-primary">{detailsTitle}</h3>
@@ -351,62 +403,90 @@ export default function OfflineIndicator() {
             </button>
           </header>
 
-          <div className="max-h-[360px] overflow-y-auto p-3">
+          <div className="max-h-[480px] overflow-y-auto p-3">
             <div className="space-y-2">
               {queue.map((item) => {
                 const isConflict = item.conflict || item.errorCode === "VERSION_CONFLICT";
                 const canRetry = isOnline && !isConflict && item.retryable !== false;
                 const noteTitle = getQueueItemNoteTitle(item);
                 const notePreview = getQueueItemNotePreview(item);
+                const resolving = resolvingConflict?.itemId === item.id;
                 return (
                   <article key={item.id} className="rounded-xl border border-app-border bg-app-bg/60 p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-tx-primary" title={noteTitle}>
-                          {noteTitle}
-                        </p>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-[11px] text-tx-tertiary">{itemTypeLabel(item)}</span>
-                          {isConflict && (
-                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
-                              版本冲突
-                            </span>
-                          )}
-                        </div>
-                        {notePreview && (
-                          <p className="mt-1.5 line-clamp-2 text-xs leading-5 text-tx-secondary">
-                            {notePreview}
+                    <div className="min-w-0">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-tx-primary" title={noteTitle}>
+                            {noteTitle}
                           </p>
-                        )}
-                        <p className="mt-1.5 text-xs leading-5 text-tx-secondary">
-                          {getQueueItemStatusMessage(item)}
-                        </p>
-                        <details className="mt-1.5 text-[10px] text-tx-tertiary">
-                          <summary className="cursor-pointer select-none hover:text-tx-secondary">技术详情</summary>
-                          <div className="mt-1 space-y-0.5 break-all font-mono">
-                            <p>笔记 ID：{item.noteId}</p>
-                            <p>已尝试：{item.retryCount} 次</p>
-                            {item.errorCode && <p>错误码：{item.errorCode}</p>}
-                            {typeof item.serverVersion === "number" && <p>服务器版本：{item.serverVersion}</p>}
+                          <div className="mt-0.5 flex flex-wrap items-center gap-2">
+                            <span className="text-[11px] text-tx-tertiary">{itemTypeLabel(item)}</span>
+                            {isConflict && (
+                              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
+                                版本冲突
+                              </span>
+                            )}
                           </div>
-                        </details>
+                        </div>
+                        {!isConflict && (
+                          <button
+                            type="button"
+                            disabled={!canRetry || retryingId === item.id}
+                            onClick={() => void retryOne(item)}
+                            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-app-border px-2.5 py-1.5 text-xs font-medium text-tx-secondary hover:bg-app-hover disabled:cursor-not-allowed disabled:opacity-40"
+                            title={item.retryable === false ? "该操作不能自动重试，请先导出本地副本" : "重新同步此项"}
+                          >
+                            {retryingId === item.id ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+                            重试
+                          </button>
+                        )}
                       </div>
-                      {isConflict ? (
-                        <span className="shrink-0 rounded-lg bg-amber-100 px-2.5 py-1.5 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
-                          需人工确认
-                        </span>
-                      ) : (
-                        <button
-                          type="button"
-                          disabled={!canRetry || retryingId === item.id}
-                          onClick={() => void retryOne(item)}
-                          className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-app-border px-2.5 py-1.5 text-xs font-medium text-tx-secondary hover:bg-app-hover disabled:cursor-not-allowed disabled:opacity-40"
-                          title={item.retryable === false ? "该操作不能自动重试，请先导出本地副本" : "重新同步此项"}
-                        >
-                          {retryingId === item.id ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-                          重试
-                        </button>
+
+                      {notePreview && (
+                        <p className="mt-2 line-clamp-3 rounded-lg bg-app-elevated px-2.5 py-2 text-xs leading-5 text-tx-secondary">
+                          {notePreview}
+                        </p>
                       )}
+                      <p className="mt-2 text-xs leading-5 text-tx-secondary">
+                        {getQueueItemStatusMessage(item)}
+                      </p>
+
+                      {isConflict && (
+                        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                          <button
+                            type="button"
+                            disabled={!isOnline || resolving}
+                            onClick={() => void handleResolveConflict(item, "use-server")}
+                            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-lg border border-app-border bg-app-elevated px-3 py-2 text-xs font-medium text-tx-primary hover:bg-app-hover disabled:cursor-not-allowed disabled:opacity-45"
+                          >
+                            {resolving && resolvingConflict?.choice === "use-server"
+                              ? <Loader2 size={13} className="animate-spin" />
+                              : <CloudDownload size={13} />}
+                            使用服务器版本
+                          </button>
+                          <button
+                            type="button"
+                            disabled={!isOnline || resolving}
+                            onClick={() => void handleResolveConflict(item, "keep-local")}
+                            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-lg bg-accent-primary px-3 py-2 text-xs font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+                          >
+                            {resolving && resolvingConflict?.choice === "keep-local"
+                              ? <Loader2 size={13} className="animate-spin" />
+                              : <CloudUpload size={13} />}
+                            保留此设备版本
+                          </button>
+                        </div>
+                      )}
+
+                      <details className="mt-2 text-[10px] text-tx-tertiary">
+                        <summary className="cursor-pointer select-none hover:text-tx-secondary">技术详情</summary>
+                        <div className="mt-1 space-y-0.5 break-all font-mono">
+                          <p>笔记 ID：{item.noteId}</p>
+                          <p>已尝试：{item.retryCount} 次</p>
+                          {item.errorCode && <p>错误码：{item.errorCode}</p>}
+                          {typeof item.serverVersion === "number" && <p>服务器版本：{item.serverVersion}</p>}
+                        </div>
+                      </details>
                     </div>
                   </article>
                 );

--- a/frontend/src/lib/__tests__/apiConfirmedNoteMutations.test.ts
+++ b/frontend/src/lib/__tests__/apiConfirmedNoteMutations.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import { clearQueue, getQueueLength } from "@/lib/offlineQueue";
+
+function serverNote() {
+  return {
+    id: "note-1",
+    userId: "user-1",
+    notebookId: "book-1",
+    workspaceId: null,
+    title: "confirmed",
+    content: "body",
+    contentText: "body",
+    contentFormat: "markdown",
+    version: 9,
+    isPinned: 0,
+    isFavorite: 0,
+    isLocked: 0,
+    isArchived: 0,
+    isTrashed: 0,
+    trashedAt: null,
+    sortOrder: 0,
+    createdAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T02:00:00.000Z",
+  };
+}
+
+describe("server-confirmed note mutations", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem("nowen-server-url", "https://sync.test");
+    localStorage.setItem("nowen-token", "token");
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: false });
+    clearQueue();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+  });
+
+  it("still performs a real request while offline instead of creating an optimistic queue item", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(serverNote()),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(api.updateNoteConfirmed("note-1", {
+      title: "confirmed",
+      content: "body",
+      contentText: "body",
+      contentFormat: "markdown",
+      version: 8,
+    })).resolves.toMatchObject({ id: "note-1", version: 9 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.test/api/notes/note-1",
+      expect.objectContaining({ method: "PUT", signal: expect.anything() }),
+    );
+    expect(getQueueLength()).toBe(0);
+  });
+});

--- a/frontend/src/lib/__tests__/conflictResolution.test.ts
+++ b/frontend/src/lib/__tests__/conflictResolution.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "@/types";
+import type { OfflineQueueItem } from "@/lib/offlineQueue";
+
+const apiMock = vi.hoisted(() => ({
+  getNote: vi.fn(),
+  updateNoteConfirmed: vi.fn(),
+  createNoteConfirmed: vi.fn(),
+}));
+const discardNoteQueueItems = vi.hoisted(() => vi.fn());
+const clearDraft = vi.hoisted(() => vi.fn());
+const loadDraft = vi.hoisted(() => vi.fn());
+const clearOfflineNoteSnapshot = vi.hoisted(() => vi.fn());
+const clearNoteSyncConflict = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("@/lib/offlineQueue", () => ({ discardNoteQueueItems }));
+vi.mock("@/lib/draftStorage", () => ({ clearDraft, loadDraft }));
+vi.mock("@/lib/offlineRead", () => ({ clearOfflineNoteSnapshot }));
+vi.mock("@/lib/noteSyncSafety", () => ({ clearNoteSyncConflict }));
+
+import {
+  getConflictCopyId,
+  resolveNoteConflict,
+} from "@/lib/conflictResolution";
+
+function remoteNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1",
+    userId: "user-1",
+    notebookId: "book-1",
+    workspaceId: null,
+    title: "服务器标题",
+    content: "服务器正文",
+    contentText: "服务器正文",
+    contentFormat: "markdown",
+    version: 8,
+    createdAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T01:00:00.000Z",
+    isPinned: 0,
+    isFavorite: 0,
+    isLocked: 0,
+    isArchived: 0,
+    isTrashed: 0,
+    trashedAt: null,
+    sortOrder: 0,
+    ...overrides,
+  } as Note;
+}
+
+function conflictItem(): OfflineQueueItem {
+  return {
+    id: "queue-1",
+    type: "updateNote",
+    noteId: "note-1",
+    url: "/notes/note-1",
+    method: "PUT",
+    body: {
+      title: "本地标题",
+      content: "本地正文",
+      contentText: "本地正文",
+      contentFormat: "markdown",
+      version: 3,
+    },
+    localPayload: {
+      title: "本地标题",
+      content: "本地正文",
+      contentText: "本地正文",
+      contentFormat: "markdown",
+      version: 3,
+    },
+    enqueuedAt: Date.now(),
+    retryCount: 0,
+    conflict: true,
+    blocked: true,
+    retryable: false,
+    errorCode: "VERSION_CONFLICT",
+    serverVersion: 8,
+  };
+}
+
+describe("resolveNoteConflict", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadDraft.mockReturnValue(null);
+    apiMock.getNote.mockResolvedValue(remoteNote());
+  });
+
+  it("keeps the local version using a non-queued confirmed write and clears only after ACK", async () => {
+    const updated = remoteNote({
+      title: "本地标题",
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 9,
+    });
+    apiMock.updateNoteConfirmed.mockResolvedValue(updated);
+
+    await expect(resolveNoteConflict(conflictItem(), "keep-local")).resolves.toEqual({ note: updated });
+
+    expect(apiMock.updateNoteConfirmed).toHaveBeenCalledWith("note-1", expect.objectContaining({
+      title: "本地标题",
+      content: "本地正文",
+      version: 8,
+    }));
+    expect(discardNoteQueueItems).toHaveBeenCalledWith(["note-1"]);
+    expect(clearDraft).toHaveBeenCalledWith("note-1");
+    expect(clearNoteSyncConflict).toHaveBeenCalledWith("note-1");
+  });
+
+  it("does not clear a keep-local conflict until the server increments the revision", async () => {
+    apiMock.updateNoteConfirmed.mockResolvedValue(remoteNote({ version: 8 }));
+
+    await expect(resolveNoteConflict(conflictItem(), "keep-local")).rejects.toThrow("服务器尚未确认");
+    expect(discardNoteQueueItems).not.toHaveBeenCalled();
+  });
+
+  it("creates a recoverable conflict copy with a stable id before accepting the server version", async () => {
+    const item = conflictItem();
+    const copyId = getConflictCopyId(item.id);
+    const copy = remoteNote({ id: copyId, title: "本地标题（冲突副本 2026-07-14 10:00）", version: 1 });
+    apiMock.createNoteConfirmed.mockResolvedValue(copy);
+
+    const result = await resolveNoteConflict(item, "use-server");
+
+    expect(copyId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    expect(getConflictCopyId(item.id)).toBe(copyId);
+    expect(apiMock.createNoteConfirmed).toHaveBeenCalledWith(expect.objectContaining({
+      id: copyId,
+      notebookId: "book-1",
+      title: expect.stringContaining("本地标题（冲突副本"),
+      content: "本地正文",
+    }));
+    expect(result.note.id).toBe("note-1");
+    expect(result.conflictCopy).toBe(copy);
+    expect(discardNoteQueueItems).toHaveBeenCalledWith(["note-1"]);
+  });
+
+  it("recovers an already committed deterministic conflict copy after a lost response", async () => {
+    const item = conflictItem();
+    const copyId = getConflictCopyId(item.id);
+    const conflictError = Object.assign(new Error("duplicate"), {
+      status: 409,
+      code: "NOTE_ID_CONFLICT",
+    });
+    const existingCopy = remoteNote({ id: copyId, title: "已存在的冲突副本", version: 1 });
+    apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
+    apiMock.getNote
+      .mockResolvedValueOnce(remoteNote())
+      .mockResolvedValueOnce(existingCopy);
+
+    const result = await resolveNoteConflict(item, "use-server");
+
+    expect(apiMock.getNote).toHaveBeenNthCalledWith(2, copyId);
+    expect(result.conflictCopy).toBe(existingCopy);
+    expect(discardNoteQueueItems).toHaveBeenCalledWith(["note-1"]);
+  });
+
+  it("keeps every local artifact when the confirmed copy write fails", async () => {
+    apiMock.createNoteConfirmed.mockRejectedValue(new Error("offline"));
+
+    await expect(resolveNoteConflict(conflictItem(), "use-server")).rejects.toThrow("offline");
+    expect(discardNoteQueueItems).not.toHaveBeenCalled();
+    expect(clearDraft).not.toHaveBeenCalled();
+    expect(clearNoteSyncConflict).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
+++ b/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
@@ -3,7 +3,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "@/lib/api";
 import { markOfflineNoteSnapshot, clearOfflineNoteSnapshot } from "@/lib/offlineRead";
-import { installNoteSyncSafety, NOTE_SYNC_PENDING_EVENT } from "@/lib/noteSyncSafety";
+import {
+  installNoteSyncSafety,
+  NOTE_SYNC_PENDING_EVENT,
+} from "@/lib/noteSyncSafety";
+import {
+  getQueue,
+  OFFLINE_QUEUE_CONFLICT_EVENT,
+} from "@/lib/offlineQueue";
 
 const INSTALL_KEY = "__NOWEN_NOTE_SYNC_SAFETY_V1__";
 const realGetNote = api.getNote;
@@ -98,6 +105,49 @@ describe("installed note sync safety", () => {
     expect(transportGet).toHaveBeenCalledTimes(1);
     expect(transportUpdate).not.toHaveBeenCalled();
     expect(localStorage.getItem("nowen-note-sync-conflicts:v1")).toContain("new server body");
+  });
+
+  it("pauses later writes after one conflict and only refreshes the preserved local payload", async () => {
+    const transportGet = vi.fn().mockResolvedValue(note(9, "new server body"));
+    const transportUpdate = vi.fn();
+    (api as any).getNote = transportGet;
+    (api as any).updateNote = transportUpdate;
+    markOfflineNoteSnapshot(note(4, "old cached body"));
+    installNoteSyncSafety();
+
+    const conflictEvents = vi.fn();
+    window.addEventListener(OFFLINE_QUEUE_CONFLICT_EVENT, conflictEvents);
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "first local body",
+      contentText: "first local body",
+      contentFormat: "markdown",
+    } as any)).rejects.toMatchObject({ code: "VERSION_CONFLICT" });
+
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "latest local body",
+      contentText: "latest local body",
+      contentFormat: "markdown",
+    } as any)).resolves.toMatchObject({
+      id: "note-1",
+      version: 9,
+      content: "latest local body",
+    });
+    window.removeEventListener(OFFLINE_QUEUE_CONFLICT_EVENT, conflictEvents);
+
+    expect(transportGet).toHaveBeenCalledTimes(1);
+    expect(transportUpdate).not.toHaveBeenCalled();
+    expect(conflictEvents).toHaveBeenCalledTimes(1);
+    expect(getQueue()).toEqual([
+      expect.objectContaining({
+        noteId: "note-1",
+        conflict: true,
+        localPayload: expect.objectContaining({ content: "latest local body" }),
+      }),
+    ]);
   });
 
   it("blocks same-version writes when the cached base body differs from the server", async () => {

--- a/frontend/src/lib/__tests__/noteSyncSafetyConflictRecords.test.ts
+++ b/frontend/src/lib/__tests__/noteSyncSafetyConflictRecords.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearNoteSyncConflict,
+  getNoteSyncConflict,
+  listNoteSyncConflicts,
+  recordNoteSyncConflict,
+  type NoteSyncConflictRecord,
+} from "@/lib/noteSyncSafety";
+
+function record(overrides: Partial<NoteSyncConflictRecord> = {}): NoteSyncConflictRecord {
+  return {
+    noteId: "note-1",
+    baseVersion: 3,
+    serverVersion: 8,
+    localTitle: "本地标题",
+    localContent: "本地正文",
+    localContentText: "本地正文",
+    createdAt: Date.now(),
+    reason: "VERSION_CONFLICT",
+    ...overrides,
+  };
+}
+
+describe("noteSyncSafety conflict records", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("stores only the latest record for one note and suppresses an identical conflict notification", () => {
+    expect(recordNoteSyncConflict(record({ createdAt: 1 }))).toBe(true);
+    expect(recordNoteSyncConflict(record({ createdAt: 2 }))).toBe(false);
+    expect(listNoteSyncConflicts()).toHaveLength(1);
+    expect(getNoteSyncConflict("note-1")?.createdAt).toBe(2);
+  });
+
+  it("treats changed local content as a new conflict while still replacing the old record", () => {
+    recordNoteSyncConflict(record({ createdAt: 1 }));
+    expect(recordNoteSyncConflict(record({ localContent: "更新后的本地正文", createdAt: 2 }))).toBe(true);
+    expect(listNoteSyncConflicts()).toHaveLength(1);
+    expect(getNoteSyncConflict("note-1")?.localContent).toBe("更新后的本地正文");
+  });
+
+  it("clears one resolved note without deleting other conflict records", () => {
+    recordNoteSyncConflict(record({ noteId: "note-1" }));
+    recordNoteSyncConflict(record({ noteId: "note-2" }));
+    clearNoteSyncConflict("note-1");
+    expect(getNoteSyncConflict("note-1")).toBeNull();
+    expect(getNoteSyncConflict("note-2")).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 export * from "./api.impl";
 
 import { api as baseApi, getBaseUrl, getCurrentWorkspace } from "./api.impl";
-import type { Task } from "@/types";
+import type { Note, Task } from "@/types";
 
 export type TaskActivityEvent = {
   id: string;
@@ -24,6 +24,13 @@ type TaskActivityQuery = {
 type EnhancedApi = typeof baseApi & {
   getTaskActivityEvents: (params?: TaskActivityQuery) => Promise<TaskActivityEvent[]>;
   restoreTaskCompletedAt: (taskId: string, completedAt: string) => Promise<Task>;
+  /**
+   * Conflict resolution writes must be confirmed by the server immediately. Unlike the normal
+   * note mutation methods, these calls never turn a network failure into an optimistic offline
+   * queue item, because doing so would make the UI claim that a conflict was resolved too early.
+   */
+  createNoteConfirmed: (data: Partial<Note>) => Promise<Note>;
+  updateNoteConfirmed: (id: string, data: Partial<Note>) => Promise<Note>;
 };
 
 async function authenticatedJson<T>(path: string, init?: RequestInit): Promise<T> {
@@ -48,12 +55,34 @@ async function authenticatedJson<T>(path: string, init?: RequestInit): Promise<T
   if (!response.ok) {
     const error = new Error(
       typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
-    ) as Error & { code?: string; status?: number };
+    ) as Error & { code?: string; status?: number; currentVersion?: number };
     error.code = payload?.code;
     error.status = response.status;
+    if (typeof payload?.currentVersion === "number") error.currentVersion = payload.currentVersion;
     throw error;
   }
   return payload as T;
+}
+
+function generateConfirmedNoteId(): string {
+  const randomUUID = typeof crypto !== "undefined" ? (crypto as any).randomUUID : undefined;
+  if (typeof randomUUID === "function") return randomUUID.call(crypto);
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}-4${Math.random().toString(16).slice(2, 5)}-${Math.random().toString(16).slice(2, 6)}-${Math.random().toString(16).slice(2, 14)}`;
+}
+
+async function confirmedNoteJson<T>(path: string, init: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), 30_000);
+  try {
+    return await authenticatedJson<T>(path, { ...init, signal: controller.signal });
+  } catch (error) {
+    if ((error as { name?: string })?.name === "AbortError") {
+      throw new Error("服务器确认超时，请检查网络后重试。");
+    }
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
 }
 
 const api = baseApi as EnhancedApi;
@@ -74,6 +103,28 @@ api.restoreTaskCompletedAt = (taskId: string, completedAt: string) =>
     method: "PATCH",
     body: JSON.stringify({ completedAt }),
   });
+
+api.createNoteConfirmed = async (data: Partial<Note>) => {
+  const payload: Partial<Note> & { id: string } = {
+    ...data,
+    id: data.id || generateConfirmedNoteId(),
+  };
+  const created = await confirmedNoteJson<Note>("/notes", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  void import("@/lib/syncEngine").then((module) => module.cacheNoteContent(created)).catch(() => {});
+  return created;
+};
+
+api.updateNoteConfirmed = async (id: string, data: Partial<Note>) => {
+  const updated = await confirmedNoteJson<Note>(`/notes/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+  void import("@/lib/syncEngine").then((module) => module.cacheNoteContent(updated)).catch(() => {});
+  return updated;
+};
 
 // Preserve real completion time when a caller (notably task backup import) supplies it.
 const nativeCreateTask = baseApi.createTask.bind(baseApi);

--- a/frontend/src/lib/conflictResolution.ts
+++ b/frontend/src/lib/conflictResolution.ts
@@ -1,0 +1,167 @@
+import type { Note } from "@/types";
+import { api } from "@/lib/api";
+import {
+  discardNoteQueueItems,
+  type OfflineQueueItem,
+} from "@/lib/offlineQueue";
+import { clearDraft, loadDraft } from "@/lib/draftStorage";
+import { clearOfflineNoteSnapshot } from "@/lib/offlineRead";
+import { clearNoteSyncConflict } from "@/lib/noteSyncSafety";
+
+export type ConflictResolutionChoice = "keep-local" | "use-server";
+
+export interface ConflictResolutionResult {
+  note: Note;
+  conflictCopy?: Note;
+}
+
+type ConflictPayload = {
+  title: string;
+  content: string;
+  contentText: string;
+  contentFormat?: Note["contentFormat"];
+};
+
+function payloadFromQueue(item: OfflineQueueItem): Partial<ConflictPayload> {
+  const payload = item.localPayload || item.body || {};
+  return {
+    title: typeof payload.title === "string" ? payload.title : undefined,
+    content: typeof payload.content === "string" ? payload.content : undefined,
+    contentText: typeof payload.contentText === "string" ? payload.contentText : undefined,
+    contentFormat: typeof payload.contentFormat === "string"
+      ? payload.contentFormat as Note["contentFormat"]
+      : undefined,
+  };
+}
+
+export function getConflictLocalPayload(
+  item: OfflineQueueItem,
+  remote: Note,
+): ConflictPayload {
+  const queued = payloadFromQueue(item);
+  const draft = loadDraft(item.noteId);
+  return {
+    title: draft?.title ?? queued.title ?? remote.title,
+    content: draft?.content ?? queued.content ?? remote.content,
+    contentText: draft?.contentText ?? queued.contentText ?? remote.contentText,
+    contentFormat: queued.contentFormat ?? remote.contentFormat,
+  };
+}
+
+function sameContent(local: ConflictPayload, remote: Note): boolean {
+  return local.title === remote.title
+    && local.content === remote.content
+    && local.contentText === remote.contentText
+    && (local.contentFormat || remote.contentFormat) === remote.contentFormat;
+}
+
+function formatConflictCopyTitle(title: string, now = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
+  return `${title || "未命名笔记"}（冲突副本 ${stamp}）`;
+}
+
+/**
+ * Generate a stable RFC4122-shaped UUID from the queue item id. If a request reaches the server
+ * but the response is lost, a retry addresses the same copy instead of creating duplicates.
+ */
+export function getConflictCopyId(itemId: string): string {
+  const bytes = new Uint8Array(16);
+  let h1 = 0x811c9dc5;
+  let h2 = 0x9e3779b9;
+  for (let index = 0; index < itemId.length; index += 1) {
+    const code = itemId.charCodeAt(index);
+    h1 = Math.imul(h1 ^ code, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ (code + index), 0x85ebca6b) >>> 0;
+  }
+  for (let index = 0; index < 16; index += 1) {
+    h1 = Math.imul(h1 ^ (h1 >>> 13), 0x5bd1e995) >>> 0;
+    h2 = Math.imul(h2 ^ (h2 >>> 15), 0x27d4eb2d) >>> 0;
+    bytes[index] = ((index % 2 === 0 ? h1 : h2) >>> ((index % 4) * 8)) & 0xff;
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function clearResolvedConflict(noteId: string): void {
+  discardNoteQueueItems([noteId]);
+  clearDraft(noteId);
+  clearNoteSyncConflict(noteId);
+  clearOfflineNoteSnapshot(noteId);
+}
+
+async function keepLocalVersion(
+  item: OfflineQueueItem,
+  remote: Note,
+  local: ConflictPayload,
+): Promise<ConflictResolutionResult> {
+  const updated = await api.updateNoteConfirmed(item.noteId, {
+    title: local.title,
+    content: local.content,
+    contentText: local.contentText,
+    contentFormat: local.contentFormat || remote.contentFormat,
+    version: remote.version,
+  });
+  if (typeof updated.version !== "number" || updated.version <= remote.version) {
+    throw new Error("服务器尚未确认此设备版本，请保持页面打开后重试。");
+  }
+  clearResolvedConflict(item.noteId);
+  return { note: updated };
+}
+
+async function createOrLoadConflictCopy(
+  item: OfflineQueueItem,
+  remote: Note,
+  local: ConflictPayload,
+): Promise<Note> {
+  const copyId = getConflictCopyId(item.id);
+  try {
+    return await api.createNoteConfirmed({
+      id: copyId,
+      notebookId: remote.notebookId,
+      workspaceId: remote.workspaceId,
+      title: formatConflictCopyTitle(local.title),
+      content: local.content,
+      contentText: local.contentText,
+      contentFormat: local.contentFormat || remote.contentFormat,
+    });
+  } catch (error) {
+    const details = error as { status?: number; code?: string };
+    if (details.status !== 409 || details.code !== "NOTE_ID_CONFLICT") throw error;
+    // The previous request may have committed successfully while its response was lost. Because
+    // the id is deterministic for this conflict, loading it is safe and makes retry idempotent.
+    return api.getNote(copyId);
+  }
+}
+
+async function useServerVersion(
+  item: OfflineQueueItem,
+  remote: Note,
+  local: ConflictPayload,
+): Promise<ConflictResolutionResult> {
+  let conflictCopy: Note | undefined;
+  if (!sameContent(local, remote)) {
+    conflictCopy = await createOrLoadConflictCopy(item, remote, local);
+  }
+  clearResolvedConflict(item.noteId);
+  return { note: remote, conflictCopy };
+}
+
+export async function resolveNoteConflict(
+  item: OfflineQueueItem,
+  choice: ConflictResolutionChoice,
+): Promise<ConflictResolutionResult> {
+  if (!(item.conflict || item.errorCode === "VERSION_CONFLICT")) {
+    throw new Error("该项目不是版本冲突，不能使用冲突处理流程。");
+  }
+
+  const remote = await api.getNote(item.noteId);
+  const local = getConflictLocalPayload(item, remote);
+
+  if (choice === "keep-local") {
+    return keepLocalVersion(item, remote, local);
+  }
+  return useServerVersion(item, remote, local);
+}

--- a/frontend/src/lib/noteSyncSafety.ts
+++ b/frontend/src/lib/noteSyncSafety.ts
@@ -8,13 +8,19 @@ import {
   isOfflineNoteSnapshot,
   markOfflineNoteSnapshot,
 } from "@/lib/offlineRead";
-import { OFFLINE_QUEUE_CONFLICT_EVENT } from "@/lib/offlineQueue";
+import {
+  OFFLINE_QUEUE_CONFLICT_EVENT,
+  enqueue,
+  getQueue,
+  updateItem,
+} from "@/lib/offlineQueue";
 import { saveDraft } from "@/lib/draftStorage";
 
 const INSTALL_KEY = "__NOWEN_NOTE_SYNC_SAFETY_V1__" as const;
 const CONFLICT_STORAGE_KEY = "nowen-note-sync-conflicts:v1";
 const MAX_CONFLICTS = 20;
 const MAX_SNAPSHOT_CHARS = 500_000;
+const resolvingNoteIds = new Set<string>();
 
 export const NOTE_SYNC_PENDING_EVENT = "nowen:note-sync-pending";
 
@@ -66,19 +72,51 @@ function readConflictRecords(): NoteSyncConflictRecord[] {
   }
 }
 
+function conflictSignature(record: NoteSyncConflictRecord): string {
+  return JSON.stringify([
+    record.noteId,
+    record.baseVersion,
+    record.serverVersion ?? null,
+    record.localTitle ?? "",
+    record.localContent ?? "",
+    record.localContentText ?? "",
+    record.reason,
+  ]);
+}
+
 export function listNoteSyncConflicts(): NoteSyncConflictRecord[] {
   return readConflictRecords();
 }
 
-export function recordNoteSyncConflict(record: NoteSyncConflictRecord): void {
+export function getNoteSyncConflict(noteId: string): NoteSyncConflictRecord | null {
+  return readConflictRecords().find((record) => record.noteId === noteId) || null;
+}
+
+export function clearNoteSyncConflict(noteId: string): void {
   try {
-    const records = readConflictRecords()
-      .filter((item) => item.noteId !== record.noteId || item.createdAt !== record.createdAt);
+    const next = readConflictRecords().filter((record) => record.noteId !== noteId);
+    if (next.length === 0) localStorage.removeItem(CONFLICT_STORAGE_KEY);
+    else localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    /* keep queue/draft as the durable fallback */
+  }
+}
+
+/**
+ * Persist one current record per note. Returning false means the exact same conflict was
+ * already known, allowing callers to suppress duplicate toasts without losing the payload.
+ */
+export function recordNoteSyncConflict(record: NoteSyncConflictRecord): boolean {
+  const previous = getNoteSyncConflict(record.noteId);
+  const changed = !previous || conflictSignature(previous) !== conflictSignature(record);
+  try {
+    const records = readConflictRecords().filter((item) => item.noteId !== record.noteId);
     records.unshift(record);
     localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(records.slice(0, MAX_CONFLICTS)));
   } catch {
-    // The complete local edit remains in draftStorage even if conflict metadata hits quota.
+    // The complete local edit remains in draftStorage and offlineQueue even if metadata hits quota.
   }
+  return changed;
 }
 
 function persistLocalDraft(
@@ -156,6 +194,66 @@ function buildConflictRecord(
   };
 }
 
+function isConflictQueueItem(item: { conflict?: boolean; errorCode?: string }): boolean {
+  return item.conflict === true || item.errorCode === "VERSION_CONFLICT";
+}
+
+function upsertConflictQueueItem(
+  noteId: string,
+  data: NoteMutation,
+  serverVersion?: number,
+): void {
+  const body = { ...data } as Record<string, unknown>;
+  const existing = getQueue().find(
+    (item) => item.noteId === noteId && item.type === "updateNote",
+  );
+  const patch = {
+    body,
+    localPayload: body,
+    conflict: true,
+    blocked: true,
+    retryable: false,
+    errorCode: "VERSION_CONFLICT",
+    serverVersion,
+    failedAt: Date.now(),
+    lastAttemptAt: Date.now(),
+    lastHttpStatus: 409,
+    message: "版本冲突：本地内容已保留，等待用户选择最终版本。",
+  } as const;
+
+  if (existing) {
+    updateItem(existing.id, patch);
+    return;
+  }
+
+  enqueue({
+    type: "updateNote",
+    noteId,
+    url: `/notes/${noteId}`,
+    method: "PUT",
+    ...patch,
+  });
+}
+
+export function hasPendingNoteSyncConflict(noteId: string): boolean {
+  if (getNoteSyncConflict(noteId)) return true;
+  return getQueue().some(
+    (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
+  );
+}
+
+export async function runWithNoteConflictResolution<T>(
+  noteId: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  resolvingNoteIds.add(noteId);
+  try {
+    return await task();
+  } finally {
+    resolvingNoteIds.delete(noteId);
+  }
+}
+
 function preserveConflict(
   noteId: string,
   data: NoteMutation,
@@ -165,9 +263,41 @@ function preserveConflict(
 ): NoteSyncConflictRecord {
   const record = buildConflictRecord(noteId, data, baseVersion, server, reason);
   persistLocalDraft(noteId, data, baseVersion, { serverVersion: record.serverVersion });
-  recordNoteSyncConflict(record);
-  dispatchConflict(record, data);
+  upsertConflictQueueItem(noteId, data, record.serverVersion);
+  const shouldNotify = recordNoteSyncConflict(record);
+  if (shouldNotify) dispatchConflict(record, data);
   return record;
+}
+
+function pausedConflictResponse(
+  noteId: string,
+  data: NoteMutation,
+  baseVersion: number,
+): Note {
+  const record = getNoteSyncConflict(noteId);
+  const queued = getQueue().find(
+    (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
+  );
+  const serverVersion = record?.serverVersion ?? queued?.serverVersion ?? baseVersion;
+  const updatedAt = record?.serverUpdatedAt || new Date().toISOString();
+
+  persistLocalDraft(noteId, data, baseVersion, { serverVersion });
+  upsertConflictQueueItem(noteId, data, serverVersion);
+  // EditorPane clears drafts after every resolved update. Restore the conflicted draft after that
+  // success bookkeeping finishes, while deliberately avoiding another network request.
+  window.setTimeout(() => {
+    persistLocalDraft(noteId, data, baseVersion, { serverVersion });
+  }, 0);
+
+  return {
+    id: noteId,
+    title: typeof data.title === "string" ? data.title : record?.localTitle || "",
+    content: typeof data.content === "string" ? data.content : record?.localContent || "",
+    contentText: typeof data.contentText === "string" ? data.contentText : record?.localContentText || "",
+    contentFormat: (data.contentFormat || "markdown") as Note["contentFormat"],
+    version: serverVersion,
+    updatedAt,
+  } as Note;
 }
 
 export function installNoteSyncSafety(): void {
@@ -194,6 +324,10 @@ export function installNoteSyncSafety(): void {
         "缺少服务端版本，已阻止不安全保存。请重新加载笔记后重试。",
         400,
       );
+    }
+
+    if (versioned && !resolvingNoteIds.has(noteId) && hasPendingNoteSyncConflict(noteId)) {
+      return pausedConflictResponse(noteId, data, baseVersion);
     }
 
     if (versioned) persistLocalDraft(noteId, data, baseVersion);
@@ -277,6 +411,7 @@ export function installNoteSyncSafety(): void {
   guardedWindow[INSTALL_KEY] = () => {
     (api as any).getNote = originalGetNote;
     (api as any).updateNote = originalUpdateNote;
+    resolvingNoteIds.clear();
     delete guardedWindow[INSTALL_KEY];
   };
 }


### PR DESCRIPTION
将已同步 `main@b10c2cb` 的 `issue-247-pg-runtime@2f3d082` 合入 `issue-248-direct-db-audit`。

- 仅更新堆叠分支基线
- 不合并 #255/#258 到 main
- 保留 #248 当前数据库边界清理改动