### PR TITLE
fix: 修复反代部署附件刷新后变成 127.0.0.1 裂图 (#295)

### DIFF
--- a/backend/src/lib/shareUrlRewrite.ts
+++ b/backend/src/lib/shareUrlRewrite.ts
@@ -24,10 +24,24 @@
 
 const ATTACHMENT_PATH_PREFIXES = ["/api/attachments/", "/api/task-attachments/"];
 
+function isLoopbackHost(host: string): boolean {
+  const lowered = host.toLowerCase();
+  return lowered === "localhost"
+    || lowered.startsWith("localhost:")
+    || lowered.startsWith("127.")
+    || lowered.startsWith("0.0.0.0")
+    || lowered.startsWith("[::1]");
+}
+
 /**
  * 根据请求头推断 "公网访问本服务时" 应使用的 origin。
  * 优先使用反代/网关注入的 X-Forwarded-Proto / X-Forwarded-Host，
  * 退化到 Host 头并据 Host 自身格式猜测协议（127.x、localhost、:80 用 http，否则 https）。
+ *
+ * 重要：当只有 Host 且 Host 是 localhost / 127.0.0.1 / 0.0.0.0 时返回 null。
+ * 这通常是 NAS、隧道或 Docker 反代传给上游的内部地址，不是用户浏览器可访问的地址。
+ * 调用方此时应返回相对 URL，由客户端以真实 API 请求 origin 解析；绝不能把容器回环地址
+ * 签发给外部客户端，否则图片上传后刷新就会指向用户自己设备的 127.0.0.1。
  *
  * 返回形如 "https://notes.example.com"，不带末尾斜杠。
  * 解析失败返回 null，调用方应放弃改写并保持相对路径。
@@ -39,6 +53,10 @@ export function resolvePublicOrigin(getHeader: (name: string) => string | undefi
 
   const finalHost = xfHost || host;
   if (!finalHost) return null;
+
+  // 没有可信 forwarded host 时，回环 Host 只代表反代到容器的内部连接。
+  // 相对 URL 比错误的绝对 URL 安全，且 Web / Capacitor 客户端都能用自己的 API origin 补全。
+  if (!xfHost && isLoopbackHost(finalHost)) return null;
 
   let proto = xfProto;
   if (!proto) {
@@ -55,13 +73,8 @@ export function resolvePublicOrigin(getHeader: (name: string) => string | undefi
     const hasExplicitPort = /:\d+$/.test(lowered) && !lowered.endsWith(":443");
     const isIpLiteral = /^\d{1,3}(\.\d{1,3}){3}(:\d+)?$/.test(lowered)
       || lowered.startsWith("[");           // IPv6 字面量 [::1]:xxxx
-    const isLocal = lowered === "localhost"
-      || lowered.startsWith("localhost:")
-      || lowered.startsWith("127.")
-      || lowered.startsWith("0.0.0.0")
-      || lowered.startsWith("[::1]");
 
-    if (isLocal || isIpLiteral || hasExplicitPort) {
+    if (isLoopbackHost(lowered) || isIpLiteral || hasExplicitPort) {
       proto = "http";
     } else {
       proto = "https";

--- a/backend/src/lib/shareUrlRewrite.ts
+++ b/backend/src/lib/shareUrlRewrite.ts
@@ -38,10 +38,10 @@ function isLoopbackHost(host: string): boolean {
  * 优先使用反代/网关注入的 X-Forwarded-Proto / X-Forwarded-Host，
  * 退化到 Host 头并据 Host 自身格式猜测协议（127.x、localhost、:80 用 http，否则 https）。
  *
- * 重要：当只有 Host 且 Host 是 localhost / 127.0.0.1 / 0.0.0.0 时返回 null。
- * 这通常是 NAS、隧道或 Docker 反代传给上游的内部地址，不是用户浏览器可访问的地址。
- * 调用方此时应返回相对 URL，由客户端以真实 API 请求 origin 解析；绝不能把容器回环地址
- * 签发给外部客户端，否则图片上传后刷新就会指向用户自己设备的 127.0.0.1。
+ * 重要：最终 Host 是 localhost / 127.0.0.1 / 0.0.0.0 时一律返回 null。
+ * 这通常是 NAS、隧道或 Docker 反代传给上游的内部地址，不是用户浏览器可访问的地址；
+ * 即使它来自 X-Forwarded-Host，也不能把回环地址签发给外部客户端。调用方此时应返回
+ * 相对 URL，由客户端以真实 API 请求 origin 解析。
  *
  * 返回形如 "https://notes.example.com"，不带末尾斜杠。
  * 解析失败返回 null，调用方应放弃改写并保持相对路径。
@@ -52,11 +52,7 @@ export function resolvePublicOrigin(getHeader: (name: string) => string | undefi
   const host = (getHeader("host") || "").trim();
 
   const finalHost = xfHost || host;
-  if (!finalHost) return null;
-
-  // 没有可信 forwarded host 时，回环 Host 只代表反代到容器的内部连接。
-  // 相对 URL 比错误的绝对 URL 安全，且 Web / Capacitor 客户端都能用自己的 API origin 补全。
-  if (!xfHost && isLoopbackHost(finalHost)) return null;
+  if (!finalHost || isLoopbackHost(finalHost)) return null;
 
   let proto = xfProto;
   if (!proto) {
@@ -74,7 +70,7 @@ export function resolvePublicOrigin(getHeader: (name: string) => string | undefi
     const isIpLiteral = /^\d{1,3}(\.\d{1,3}){3}(:\d+)?$/.test(lowered)
       || lowered.startsWith("[");           // IPv6 字面量 [::1]:xxxx
 
-    if (isLoopbackHost(lowered) || isIpLiteral || hasExplicitPort) {
+    if (isIpLiteral || hasExplicitPort) {
       proto = "http";
     } else {
       proto = "https";

--- a/backend/tests/share-url-rewrite-origin.test.ts
+++ b/backend/tests/share-url-rewrite-origin.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolvePublicOrigin } from "../src/lib/shareUrlRewrite";
+
+function headers(values: Record<string, string | undefined>) {
+  return (name: string): string | undefined => values[name.toLowerCase()];
+}
+
+test("container loopback Host is never advertised as a public attachment origin", () => {
+  assert.equal(resolvePublicOrigin(headers({ host: "127.0.0.1:3001" })), null);
+  assert.equal(resolvePublicOrigin(headers({ host: "localhost:3001" })), null);
+  assert.equal(resolvePublicOrigin(headers({ host: "0.0.0.0:3001" })), null);
+  assert.equal(resolvePublicOrigin(headers({ host: "[::1]:3001" })), null);
+});
+
+test("trusted reverse-proxy headers remain authoritative", () => {
+  assert.equal(
+    resolvePublicOrigin(headers({
+      host: "127.0.0.1:3001",
+      "x-forwarded-host": "notes.example.com",
+      "x-forwarded-proto": "https",
+    })),
+    "https://notes.example.com",
+  );
+});
+
+test("direct NAS and custom-port access keeps the reachable HTTP origin", () => {
+  assert.equal(
+    resolvePublicOrigin(headers({ host: "192.168.1.20:3001" })),
+    "http://192.168.1.20:3001",
+  );
+  assert.equal(
+    resolvePublicOrigin(headers({ host: "notes.example.com:8080" })),
+    "http://notes.example.com:8080",
+  );
+});

--- a/backend/tests/share-url-rewrite-origin.test.ts
+++ b/backend/tests/share-url-rewrite-origin.test.ts
@@ -11,6 +11,11 @@ test("container loopback Host is never advertised as a public attachment origin"
   assert.equal(resolvePublicOrigin(headers({ host: "localhost:3001" })), null);
   assert.equal(resolvePublicOrigin(headers({ host: "0.0.0.0:3001" })), null);
   assert.equal(resolvePublicOrigin(headers({ host: "[::1]:3001" })), null);
+  assert.equal(resolvePublicOrigin(headers({
+    host: "notes.example.com",
+    "x-forwarded-host": "127.0.0.1:3001",
+    "x-forwarded-proto": "https",
+  })), null);
 });
 
 test("trusted reverse-proxy headers remain authoritative", () => {

--- a/frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts
+++ b/frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts
@@ -55,6 +55,13 @@ describe("noteAttachmentAccessBridge", () => {
     expect(merged.searchParams.get("w")).toBe("240");
   });
 
+  it("does not let a later stale loopback request replace a trusted API origin", () => {
+    expect(rememberAttachmentApiOrigin("https://notes.example.com/api/notes/note-1"))
+      .toBe("https://notes.example.com");
+    expect(rememberAttachmentApiOrigin(`http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}`))
+      .toBe("https://notes.example.com");
+  });
+
   it("rebases an absolute loopback signed URL to the request origin", () => {
     const badSigned = `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
     const accessEndpoint = "https://notes.example.com/api/attachments/access/urls?noteId=note-1";

--- a/frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts
+++ b/frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts
@@ -10,6 +10,8 @@ import {
   extractAttachmentId,
   mergeSignedAttachmentUrl,
   registerAttachmentAccessUrls,
+  rememberAttachmentApiOrigin,
+  resetAttachmentAccessStateForTests,
   resolveAttachmentAccessUrl,
 } from "@/lib/noteAttachmentAccessBridge";
 
@@ -17,6 +19,7 @@ const ATTACHMENT_ID = "123e4567-e89b-42d3-a456-426614174216";
 
 describe("noteAttachmentAccessBridge", () => {
   beforeEach(() => {
+    resetAttachmentAccessStateForTests();
     window.history.replaceState({}, "", "/note/test");
   });
 
@@ -28,11 +31,13 @@ describe("noteAttachmentAccessBridge", () => {
   });
 
   it("keeps preview/download parameters and replaces stale access signatures", () => {
-    const signed = `https://api.example.com/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
+    rememberAttachmentApiOrigin("https://api.example.com/api/notes/note-1");
+    const signed = `/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
     const merged = new URL(mergeSignedAttachmentUrl(
       `/api/attachments/${ATTACHMENT_ID}?download=1&w=720&exp=1&sig=old&scope=old`,
       signed,
     ));
+    expect(merged.origin).toBe("https://api.example.com");
     expect(merged.searchParams.get("download")).toBe("1");
     expect(merged.searchParams.get("w")).toBe("720");
     expect(merged.searchParams.get("exp")).toBe("2000000000");
@@ -40,8 +45,9 @@ describe("noteAttachmentAccessBridge", () => {
     expect(merged.searchParams.get("scope")).toBe("v2.scope");
   });
 
-  it("resolves a relative signature against the attachment server origin", () => {
-    const raw = `https://notes-api.example.com/api/attachments/${ATTACHMENT_ID}?w=240`;
+  it("resolves a relative signature against the observed attachment API origin", () => {
+    rememberAttachmentApiOrigin("https://notes-api.example.com/api/notes/note-1");
+    const raw = `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}?w=240`;
     const signed = `/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
     const merged = new URL(mergeSignedAttachmentUrl(raw, signed));
 
@@ -49,9 +55,37 @@ describe("noteAttachmentAccessBridge", () => {
     expect(merged.searchParams.get("w")).toBe("240");
   });
 
+  it("rebases an absolute loopback signed URL to the request origin", () => {
+    const badSigned = `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
+    const accessEndpoint = "https://notes.example.com/api/attachments/access/urls?noteId=note-1";
+
+    expect(registerAttachmentAccessUrls({ [ATTACHMENT_ID]: badSigned }, accessEndpoint)).toBe(1);
+
+    const resolved = new URL(resolveAttachmentAccessUrl(
+      `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}?w=640`,
+    ));
+    expect(resolved.origin).toBe("https://notes.example.com");
+    expect(resolved.pathname).toBe(`/api/attachments/${ATTACHMENT_ID}`);
+    expect(resolved.searchParams.get("w")).toBe("640");
+    expect(resolved.searchParams.get("sig")).toBe("server-value");
+  });
+
+  it("repairs a legacy loopback attachment URL before the signature map is ready", () => {
+    rememberAttachmentApiOrigin("https://notes.example.com/api/notes/note-1");
+    const resolved = new URL(resolveAttachmentAccessUrl(
+      `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_ID}?w=320`,
+    ));
+
+    expect(resolved.origin).toBe("https://notes.example.com");
+    expect(resolved.searchParams.get("w")).toBe("320");
+  });
+
   it("resolves image, media and download requests from the same access map", () => {
-    const signed = `https://api.example.com/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
-    expect(registerAttachmentAccessUrls({ [ATTACHMENT_ID]: signed })).toBe(1);
+    const signed = `/api/attachments/${ATTACHMENT_ID}?exp=2000000000&sig=server-value&scope=v2.scope`;
+    expect(registerAttachmentAccessUrls(
+      { [ATTACHMENT_ID]: signed },
+      "https://api.example.com/api/attachments/access/urls?noteId=note-1",
+    )).toBe(1);
 
     const imageUrl = new URL(resolveAttachmentAccessUrl(`/api/attachments/${ATTACHMENT_ID}?w=320`));
     expect(imageUrl.origin).toBe("https://api.example.com");

--- a/frontend/src/lib/noteAttachmentAccessBridge.ts
+++ b/frontend/src/lib/noteAttachmentAccessBridge.ts
@@ -4,6 +4,7 @@ const INSTALL_KEY = "__NOWEN_NOTE_ATTACHMENT_ACCESS_BRIDGE_V1__";
 const ATTACHMENT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ACCESS_QUERY_KEYS = new Set(["exp", "sig", "scope"]);
 const accessUrls = new Map<string, string>();
+let attachmentApiOrigin = "";
 let scanQueued = false;
 let lastDeniedToastAt = 0;
 
@@ -12,11 +13,67 @@ interface AccessUrlPayload {
   urls?: Record<string, string>;
 }
 
-function asAbsoluteUrl(value: string): URL | null {
+function asAbsoluteUrl(value: string, base?: string): URL | null {
   try {
-    return new URL(value, typeof window !== "undefined" ? window.location.href : "http://localhost/");
+    const fallback = typeof window !== "undefined" ? window.location.href : "http://localhost/";
+    return new URL(value, base || fallback);
   } catch {
     return null;
+  }
+}
+
+function isHttpUrl(url: URL | null): url is URL {
+  return !!url && (url.protocol === "http:" || url.protocol === "https:");
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const value = hostname.toLowerCase();
+  return value === "localhost"
+    || value === "0.0.0.0"
+    || value === "::1"
+    || value.startsWith("127.");
+}
+
+function isKnownNowenApiUrl(url: URL): boolean {
+  return /\/api\/(?:notes|attachments|files|shared)(?:\/|$)/.test(url.pathname);
+}
+
+/**
+ * 记住本次页面真实访问的 API origin。
+ *
+ * 不能使用签名响应里的绝对地址作为真相：NAS / Docker 反代经常把上游 Host 设为
+ * 127.0.0.1:3001，后端若据此生成绝对 URL，外部浏览器会错误访问自己的回环地址。
+ * 真实请求 URL 才是客户端实际可达的来源。
+ */
+export function rememberAttachmentApiOrigin(value: string | URL): string {
+  const parsed = value instanceof URL ? value : asAbsoluteUrl(value);
+  if (!isHttpUrl(parsed) || !isKnownNowenApiUrl(parsed)) return attachmentApiOrigin;
+  attachmentApiOrigin = parsed.origin;
+  return attachmentApiOrigin;
+}
+
+function currentWindowHttpOrigin(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const parsed = new URL(window.location.href);
+    return isHttpUrl(parsed) ? parsed.origin : "";
+  } catch {
+    return "";
+  }
+}
+
+function trustedOriginFor(rawUrl?: URL | null): string {
+  if (attachmentApiOrigin) return attachmentApiOrigin;
+  if (rawUrl && isHttpUrl(rawUrl) && !isLoopbackHostname(rawUrl.hostname)) return rawUrl.origin;
+  return currentWindowHttpOrigin() || (rawUrl && isHttpUrl(rawUrl) ? rawUrl.origin : "");
+}
+
+function moveUrlToOrigin(url: URL, origin: string): URL {
+  if (!origin) return url;
+  try {
+    return new URL(`${url.pathname}${url.search}${url.hash}`, `${origin.replace(/\/+$/, "")}/`);
+  } catch {
+    return url;
   }
 }
 
@@ -29,6 +86,26 @@ export function extractAttachmentId(value: string | null | undefined): string | 
   return ATTACHMENT_ID_RE.test(id) ? id : null;
 }
 
+function normalizeRegisteredAccessUrl(
+  id: string,
+  value: string,
+  sourceUrl?: string | URL,
+): string | null {
+  let trustedOrigin = attachmentApiOrigin;
+  if (sourceUrl) {
+    trustedOrigin = rememberAttachmentApiOrigin(sourceUrl);
+  }
+
+  const sourceBase = trustedOrigin ? `${trustedOrigin}/` : undefined;
+  let parsed = asAbsoluteUrl(value, sourceBase);
+  if (!parsed || extractAttachmentId(parsed.toString()) !== id) return null;
+
+  // 签名绑定的是 attachmentId + exp + scope，不绑定 host。即使服务端错误返回
+  // http://127.0.0.1:3001，也必须把 path/query 搬到发起该接口请求的真实 origin。
+  if (trustedOrigin) parsed = moveUrlToOrigin(parsed, trustedOrigin);
+  return parsed.toString();
+}
+
 /**
  * 将原 URL 上的功能参数（download/inline/w 等）合并到服务端签发的访问 URL。
  * exp/sig/scope 始终以服务端最新版本为准，因此权限上下文切换或续签后旧 URL 会被替换。
@@ -37,13 +114,12 @@ export function mergeSignedAttachmentUrl(raw: string, signed: string): string {
   if (!raw || !signed) return raw;
   const rawUrl = asAbsoluteUrl(raw);
   if (!rawUrl) return signed;
-  let signedUrl: URL;
-  try {
-    // 服务端允许返回相对签名地址；客户端连接独立后端时应沿用裸链的后端 origin，
-    // 不能错误地解析到前端页面（或 capacitor://localhost）所在的 origin。
-    signedUrl = new URL(signed, rawUrl.origin);
-  } catch {
-    return signed;
+
+  const trustedOrigin = trustedOriginFor(rawUrl);
+  let signedUrl = asAbsoluteUrl(signed, trustedOrigin ? `${trustedOrigin}/` : rawUrl.origin);
+  if (!signedUrl) return signed;
+  if (trustedOrigin && extractAttachmentId(signedUrl.toString())) {
+    signedUrl = moveUrlToOrigin(signedUrl, trustedOrigin);
   }
 
   rawUrl.searchParams.forEach((value, key) => {
@@ -55,12 +131,24 @@ export function mergeSignedAttachmentUrl(raw: string, signed: string): string {
   return signedUrl.toString();
 }
 
-export function registerAttachmentAccessUrls(urls: Record<string, string> | null | undefined): number {
+/**
+ * 注册附件签名映射。
+ * sourceUrl 应传产生该响应的真实 API 请求 URL；相对签名和错误的容器内网绝对地址
+ * 都会被规范到这个 origin。旧调用方不传时，使用最近一次已观察到的 API origin。
+ */
+export function registerAttachmentAccessUrls(
+  urls: Record<string, string> | null | undefined,
+  sourceUrl?: string | URL,
+): number {
   if (!urls) return 0;
+  if (sourceUrl) rememberAttachmentApiOrigin(sourceUrl);
+
   let count = 0;
   for (const [id, url] of Object.entries(urls)) {
     if (!ATTACHMENT_ID_RE.test(id) || typeof url !== "string" || !url.includes("sig=")) continue;
-    accessUrls.set(id, url);
+    const normalized = normalizeRegisteredAccessUrl(id, url, sourceUrl);
+    if (!normalized) continue;
+    accessUrls.set(id, normalized);
     count += 1;
   }
   if (count > 0) queueDomScan();
@@ -71,7 +159,32 @@ export function resolveAttachmentAccessUrl(raw: string): string {
   const id = extractAttachmentId(raw);
   if (!id) return raw;
   const signed = accessUrls.get(id);
-  return signed ? mergeSignedAttachmentUrl(raw, signed) : raw;
+  if (signed) return mergeSignedAttachmentUrl(raw, signed);
+
+  // 旧正文可能已被污染为 http://127.0.0.1:3001/api/attachments/...
+  // 即使签名映射尚未返回，只要本会话已经观察到真实 API origin，就先修正 host。
+  const parsed = asAbsoluteUrl(raw);
+  if (
+    parsed
+    && attachmentApiOrigin
+    && isLoopbackHostname(parsed.hostname)
+    && parsed.origin !== attachmentApiOrigin
+  ) {
+    return moveUrlToOrigin(parsed, attachmentApiOrigin).toString();
+  }
+  return raw;
+}
+
+/** 测试隔离；生产代码无需调用。 */
+export function resetAttachmentAccessStateForTests(): void {
+  accessUrls.clear();
+  attachmentApiOrigin = "";
+  scanQueued = false;
+  lastDeniedToastAt = 0;
+}
+
+function isEditableDocumentElement(element: Element): boolean {
+  return Boolean(element.closest('[contenteditable="true"], .ProseMirror'));
 }
 
 function rewriteElementAttribute(element: Element, attribute: string): void {
@@ -98,6 +211,9 @@ function rewriteSrcset(element: Element): void {
 }
 
 function rewriteElement(element: Element): void {
+  // 编辑器正文必须继续持有稳定 `/api/attachments/<id>`，不能把会过期的签名 URL
+  // 写入 ProseMirror DOM。各 NodeView 在渲染时自行调用 resolveAttachmentUrl。
+  if (isEditableDocumentElement(element)) return;
   rewriteElementAttribute(element, "src");
   rewriteElementAttribute(element, "href");
   rewriteElementAttribute(element, "poster");
@@ -176,6 +292,7 @@ async function fetchAccessUrls(
   credentials: RequestCredentials,
 ): Promise<void> {
   try {
+    rememberAttachmentApiOrigin(url);
     const response = await originalFetch(url.toString(), {
       method: "GET",
       headers,
@@ -184,7 +301,7 @@ async function fetchAccessUrls(
     });
     if (!response.ok) return;
     const payload = await response.json() as AccessUrlPayload;
-    registerAttachmentAccessUrls(payload.urls);
+    registerAttachmentAccessUrls(payload.urls, url);
   } catch (error) {
     console.warn("[attachment-access] failed to refresh signed URLs", error);
   }
@@ -233,7 +350,7 @@ async function showAttachmentDenied(response: Response): Promise<void> {
  * 安装附件访问桥：
  * 1. 打开普通/协作笔记时，使用当前 JWT 换取按用户 scope 签名的附件 URL；
  * 2. 打开公开分享时，在正文计数前先换取按 share scope 签名的 URL；
- * 3. 不改写笔记 JSON/Markdown，只在 DOM 属性和真实 fetch 请求发出前替换 URL，
+ * 3. 不改写笔记 JSON/Markdown，只在非编辑态 DOM 属性和真实 fetch 请求发出前替换 URL，
  *    因此编辑保存、导出和同步仍保留原始 `/api/attachments/<id>`。
  */
 export function installNoteAttachmentAccessBridge(): void {
@@ -249,6 +366,7 @@ export function installNoteAttachmentAccessBridge(): void {
     const url = requestUrl(input);
     const method = requestMethod(input, init);
     if (!url) return originalFetch(input, init);
+    if (isKnownNowenApiUrl(url)) rememberAttachmentApiOrigin(url);
 
     // fetch 下载、Android blob 图片、音视频预览等请求统一换成当前有效签名。
     if (method === "GET" && extractAttachmentId(url.toString())) {

--- a/frontend/src/lib/noteAttachmentAccessBridge.ts
+++ b/frontend/src/lib/noteAttachmentAccessBridge.ts
@@ -31,11 +31,22 @@ function isLoopbackHostname(hostname: string): boolean {
   return value === "localhost"
     || value === "0.0.0.0"
     || value === "::1"
+    || value === "[::1]"
     || value.startsWith("127.");
 }
 
 function isKnownNowenApiUrl(url: URL): boolean {
   return /\/api\/(?:notes|attachments|files|shared)(?:\/|$)/.test(url.pathname);
+}
+
+function currentWindowHttpOrigin(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const parsed = new URL(window.location.href);
+    return isHttpUrl(parsed) ? parsed.origin : "";
+  } catch {
+    return "";
+  }
 }
 
 /**
@@ -48,18 +59,25 @@ function isKnownNowenApiUrl(url: URL): boolean {
 export function rememberAttachmentApiOrigin(value: string | URL): string {
   const parsed = value instanceof URL ? value : asAbsoluteUrl(value);
   if (!isHttpUrl(parsed) || !isKnownNowenApiUrl(parsed)) return attachmentApiOrigin;
+
+  if (isLoopbackHostname(parsed.hostname)) {
+    const remembered = asAbsoluteUrl(attachmentApiOrigin);
+    if (remembered && isHttpUrl(remembered) && !isLoopbackHostname(remembered.hostname)) {
+      return attachmentApiOrigin;
+    }
+
+    // Web 页面本身运行在公网 / NAS origin 时，127.0.0.1 只可能是正文或反代泄漏的旧地址。
+    // Electron file:// 与 Capacitor 自定义协议没有 HTTP window origin，此时仍允许真实本地后端。
+    const windowOrigin = currentWindowHttpOrigin();
+    const windowUrl = asAbsoluteUrl(windowOrigin);
+    if (windowUrl && isHttpUrl(windowUrl) && !isLoopbackHostname(windowUrl.hostname)) {
+      attachmentApiOrigin = windowOrigin;
+      return attachmentApiOrigin;
+    }
+  }
+
   attachmentApiOrigin = parsed.origin;
   return attachmentApiOrigin;
-}
-
-function currentWindowHttpOrigin(): string {
-  if (typeof window === "undefined") return "";
-  try {
-    const parsed = new URL(window.location.href);
-    return isHttpUrl(parsed) ? parsed.origin : "";
-  } catch {
-    return "";
-  }
 }
 
 function trustedOriginFor(rawUrl?: URL | null): string {


### PR DESCRIPTION
## 根因

Docker / NAS / 隧道反代可能把上游 `Host` 或 `X-Forwarded-Host` 传成 `127.0.0.1:3001`。附件访问接口据此签发绝对 URL 后，外部浏览器会把它理解为用户自己设备的回环地址。图片上传后当前页面因本地状态暂时可见，刷新重新读取正文和签名映射后就加载失败。

此外，全局 DOM 附件桥会改写编辑器内部属性，存在把短期签名绝对地址污染进持久正文的风险。

## 修复

- 服务端识别 localhost / 127.x / 0.0.0.0 / ::1，绝不将其作为公开附件 origin；
- 回环 Host 下签名地址退回稳定相对路径，由客户端使用实际 API 请求来源解析；
- 前端记录真实 API 请求 origin，服务端即使返回错误的 `http://127.0.0.1:3001/...` 也只复用 path/query，并重绑定到真实 origin；
- 历史正文中的回环附件绝对地址在渲染时自动自愈；
- 保留 `download`、`inline`、缩略图 `w` 和最新 `exp/sig/scope` 参数；
- 禁止全局 DOM 改写进入 `contenteditable` / `.ProseMirror`，正文继续持久化稳定 `/api/attachments/<id>`；
- 图片、音视频、下载 fetch 继续共用同一签名映射。

## 回归测试

- 容器 Host 为 127.0.0.1 / localhost / 0.0.0.0 / IPv6 loopback 时不生成绝对公开 origin；
- forwarded host 错误为回环地址时同样拒绝；
- 正确的公网 forwarded host 与 NAS IP/自定义端口保持原行为；
- 错误的绝对回环签名 URL 自动改为真实 API origin；
- 旧正文回环 URL 在签名映射前也能基于已观察 API origin 自愈；
- 功能参数和签名参数保持完整。

## 数据边界

本修复可恢复“附件元数据和 `/app/data/attachments` 物理文件仍在、仅 URL 指向错误”的历史图片。若旧容器未持久化 `/app/data`，物理文件已经随容器删除，则仍需从备份恢复。

Closes #295