### PR TITLE
feat(editor): 支持无序列表三级循环嵌套样式，优化 PNG/PDF 导出并修复高亮与转换冲突

### DIFF
--- a/frontend/src/components/TiptapEditor.tsx
+++ b/frontend/src/components/TiptapEditor.tsx
@@ -918,16 +918,15 @@ function createKeyboardExtension(flushSaveRef: React.MutableRefObject<() => void
           const ok = delta === 1
             ? editor.chain().focus().sinkListItem("taskItem").run()
             : editor.chain().focus().liftListItem("taskItem").run();
-          if (ok) return true;
-          // 若无法 sink/lift（例如已是最外层），退化为块级 indent
+          return true; // 列表内禁止退化为块级 indent
         } else if (isInBulletOrOrdered()) {
           const ok = delta === 1
             ? editor.chain().focus().sinkListItem("listItem").run()
             : editor.chain().focus().liftListItem("listItem").run();
           if (ok) {
             normalizeAdjacentLists(editor);
-            return true;
           }
+          return true; // 列表内禁止退化为块级 indent
         }
 
         // 其余：调整块级 indent 属性

--- a/frontend/src/components/TiptapEditor.tsx
+++ b/frontend/src/components/TiptapEditor.tsx
@@ -1035,6 +1035,34 @@ function ToolbarDivider() {
   return <div className="h-5 w-px shrink-0 bg-app-border mx-1" />;
 }
 
+function getActiveListType(editor: Editor | null): "bulletList" | "orderedList" | "taskList" | null {
+  if (!editor) return null;
+
+  const isBullet = editor.isActive("bulletList");
+  const isOrdered = editor.isActive("orderedList");
+  const isTask = editor.isActive("taskList");
+
+  const activeCount = (isBullet ? 1 : 0) + (isOrdered ? 1 : 0) + (isTask ? 1 : 0);
+  if (activeCount === 0) return null;
+  if (activeCount === 1) {
+    if (isBullet) return "bulletList";
+    if (isOrdered) return "orderedList";
+    if (isTask) return "taskList";
+  }
+
+  const { state } = editor;
+  const { selection } = state;
+  const { $from } = selection;
+  for (let depth = $from.depth; depth > 0; depth--) {
+    const node = $from.node(depth);
+    const name = node.type.name;
+    if (name === "bulletList" && isBullet) return "bulletList";
+    if (name === "orderedList" && isOrdered) return "orderedList";
+    if (name === "taskList" && isTask) return "taskList";
+  }
+  return null;
+}
+
 /**
  * 字号选择器（轻量 Popover）
  * - 4 个预设档位 + 自定义 px 输入（8-96）
@@ -1536,6 +1564,7 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
   const isTitleComposingRef = useRef(false);
   const lastEmittedTitleRef = useRef(note.title);
   const [wordStats, setWordStats] = useState({ chars: 0, charsNoSpace: 0, words: 0 });
+  const [, setSelectionTick] = useState(0);
   const [showAI, setShowAI] = useState(false);
   const [aiSelectedText, setAiSelectedText] = useState("");
   const [aiPosition, setAiPosition] = useState<{ top: number; left: number } | undefined>();
@@ -2630,6 +2659,9 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
     },
     onTransaction: ({ transaction }) => {
       mapAsyncInsertAnchors(asyncInsertAnchorsRef.current, transaction);
+    },
+    onSelectionUpdate: () => {
+      setSelectionTick((t) => t + 1);
     },
     onUpdate: ({ editor }) => {
       // setContent 触发的 onUpdate 不应该保存（防止死循环）
@@ -4620,21 +4652,21 @@ export default forwardRef<NoteEditorHandle, TiptapEditorProps>(function TiptapEd
 
         <ToolbarButton
           onClick={() => toggleBulletListSmart(editor)}
-          isActive={editor.isActive("bulletList")}
+          isActive={getActiveListType(editor) === "bulletList"}
           title={t('tiptap.bulletList')}
         >
           <List size={iconSize} />
         </ToolbarButton>
         <ToolbarButton
           onClick={() => toggleOrderedListSmart(editor)}
-          isActive={editor.isActive("orderedList")}
+          isActive={getActiveListType(editor) === "orderedList"}
           title={t('tiptap.orderedList')}
         >
           <ListOrdered size={iconSize} />
         </ToolbarButton>
         <ToolbarButton
           onClick={() => editor.chain().focus().toggleTaskList().run()}
-          isActive={editor.isActive("taskList")}
+          isActive={getActiveListType(editor) === "taskList"}
           title={t('tiptap.taskList')}
         >
           <CheckSquare size={iconSize} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -323,17 +323,17 @@ body {
   -webkit-padding-start: 1.5rem;
 }
 
-.ProseMirror ol li {
+.ProseMirror ol > li {
   display: list-item !important;
   list-style-type: decimal !important;
 }
 
-/* 纭繚宓屽鏈夊簭鍒楄〃涔熸纭樉绀虹紪鍙?*/
-.ProseMirror ol ol li {
+/* 确保嵌套有序列表也正确显示编号 */
+.ProseMirror ol > li > ol > li {
   list-style-type: lower-alpha !important;
 }
 
-.ProseMirror ol ol ol li {
+.ProseMirror ol > li > ol > li > ol > li {
   list-style-type: lower-roman !important;
 }
 
@@ -1307,7 +1307,7 @@ body.density-compact {
     padding-inline-start: 1.5rem;
   }
 
-  .ProseMirror ol li {
+  .ProseMirror ol > li {
     display: list-item !important;
     list-style-type: decimal !important;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -251,7 +251,69 @@ body {
 .ProseMirror ul {
   padding-left: 1.5rem;
   margin: 0.75rem 0;
-  list-style-type: disc;
+  list-style: none !important;
+}
+
+.ProseMirror ul > li:not([data-type="taskItem"]) {
+  position: relative;
+}
+
+.ProseMirror ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  position: absolute;
+  left: -1.2rem;
+  top: 0;
+  display: inline-block;
+  color: var(--pm-text);
+  font-size: 1.1em;
+}
+
+.ProseMirror ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.ProseMirror ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.ProseMirror ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
 }
 
 .ProseMirror ol {
@@ -1509,10 +1571,70 @@ body.density-compact {
   margin: 0.85em 0;
   padding-left: 1.6em;
 }
-.shared-note-content ul { list-style: disc; }
+.shared-note-content ul {
+  list-style: none !important;
+}
 .shared-note-content ol { list-style: decimal; }
-.shared-note-content ul ul { list-style: circle; }
-.shared-note-content ul ul ul { list-style: square; }
+
+.shared-note-content ul > li:not([data-type="taskItem"]) {
+  position: relative;
+}
+
+.shared-note-content ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  position: absolute;
+  left: -1.2em;
+  top: 0;
+  display: inline-block;
+}
+
+.shared-note-content ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.shared-note-content ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  font-size: 1em;
+  top: 0;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "•";
+  font-size: 1em;
+  top: 0;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "◦";
+  font-size: 1.1em;
+  top: 0;
+}
+
+.shared-note-content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before {
+  content: "▪";
+  font-size: 1.2em;
+  top: -0.05em;
+}
 .shared-note-content li {
   margin: 0.25em 0;
 }

--- a/frontend/src/lib/exportService.ts
+++ b/frontend/src/lib/exportService.ts
@@ -1469,6 +1469,17 @@ async function buildPrintableHtml(note: {
     .content th, .content td { border: 1px solid #d0d7de; padding: 6px 10px; text-align: left; }
     .content th { background: #f6f8fa; font-weight: 600; }
     .content ul, .content ol { padding-left: 1.4em; margin: 8px 0; }
+    .content ul { list-style: none !important; }
+    .content ul > li:not([data-type="taskItem"]) { position: relative; }
+    .content ul > li:not([data-type="taskItem"])::before { content: "•"; position: absolute; left: -1.2em; top: 0; display: inline-block; }
+    .content ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .content ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
+    .content ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "•"; font-size: 1em; top: 0; }
+    .content ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
+    .content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "•"; font-size: 1em; top: 0; }
+    .content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .content ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
     .content ul[data-type="taskList"] { list-style: none; padding-left: 0; }
     .content ul[data-type="taskList"] li { display: flex; align-items: flex-start; gap: 8px; margin: 4px 0; }
     .content ul[data-type="taskList"] li > label { user-select: none; }

--- a/frontend/src/lib/noteImageExportCore.ts
+++ b/frontend/src/lib/noteImageExportCore.ts
@@ -273,6 +273,17 @@ function buildStyle(theme: "light" | "dark", fontFamily: string, lineHeight: str
     .nowen-note-image-export-body a { color: ${dark ? "#79b8ff" : "#0969da"}; text-decoration: none; }
     .nowen-note-image-export-body strong { font-weight: 700; }
     .nowen-note-image-export-body ul, .nowen-note-image-export-body ol { margin: 10px 0; padding-left: 1.65em; }
+    .nowen-note-image-export-body ul { list-style: none !important; }
+    .nowen-note-image-export-body ul > li:not([data-type="taskItem"]) { position: relative; }
+    .nowen-note-image-export-body ul > li:not([data-type="taskItem"])::before { content: "•"; position: absolute; left: -1.2em; top: 0; display: inline-block; }
+    .nowen-note-image-export-body ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "•"; font-size: 1em; top: 0; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "•"; font-size: 1em; top: 0; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "◦"; font-size: 1.1em; top: 0; }
+    .nowen-note-image-export-body ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li:not([data-type="taskItem"])::before { content: "▪"; font-size: 1.2em; top: -0.05em; }
     .nowen-note-image-export-body li { margin: 4px 0; }
     .nowen-note-image-export-body li > p { margin: 2px 0; }
     .nowen-note-image-export-body ul[data-type="taskList"] { padding-left: 0; list-style: none; }


### PR DESCRIPTION
## 1. 变更描述 (Description)
本 PR 实现了无序列表（`ul`）在编辑器、分享页、图片导出及文件导出中的**三级循环嵌套样式**（实心圆 ➜ 空心圆 ➜ 方形 ➜ 实心圆...），修复了嵌套列表在导出图片和 PDF 时符号比例失调的渲染 Bug，修复了列表类型转换时产生的样式冲突，并优化了菜单栏对当前光标所在列表类型的高亮状态显示。
<img width="992" height="785" alt="Q1 目标与 OKR" src="https://github.com/user-attachments/assets/b6123f2a-0ff3-4c9a-bbce-3f1d5154f969" />
[Q1 目标与 OKR.pdf](https://github.com/user-attachments/files/30075635/Q1.OKR.pdf)
### 核心功能与修复点：
* **三级循环列表样式**：
  * **1, 4, 7... 级**：实心圆 `•` (Bullet)
  * **2, 5, 8... 级**：空心圆 `◦` (White Bullet)
  * **3, 6, 9... 级**：小方形 `▪` (Small Square)
* **导出一致性优化（PNG & PDF）**：
  * 绕过 `html2canvas` 渲染原生 `list-style-type` 时“方形过大、圆形过小”的绘制缺陷。
  * 改用 **自定义伪元素 `::before` + 字符实体** 渲染列表符号，并进行了精准的 `font-size` 和 `top` 偏移量微调，确保浏览器预览、PNG 图片导出以及 PDF 打印导出效果在视觉上完全对称与一致。
* **新增菜单栏单击高亮响应**：
  * 通过配置 `onSelectionUpdate` 监听器与 `selectionTick` 强制渲染状态，使得工具栏上的列表高亮状态能够完美响应鼠标单击等光标变更事件，高亮结果会准确指向当前光标所处的具体列表类型。
<img width="916" height="875" alt="ScreenShot_2026-07-16_141105_522" src="https://github.com/user-attachments/assets/f587c46d-7108-49cf-b950-8810f8ccfa16" />

* **修复列表切换重叠冲突**：
  * **问题**：当外层无序列表切换成有序（数字）列表时，内部嵌套的无序列表项会同时显示“数字编号”与“无序列表圆点”的重叠 Bug。
  * **解决**：将原有的后代选择器 `.ProseMirror ol li` 重构为子选择器 `ol > li`。限制了数字样式仅渲染在有序层级，防止污染泄露到嵌套无序列表层。
* **Tab 键缩进逻辑优化**：
  * 限制列表内的 `Tab`/`Shift-Tab` 键仅用于列表项嵌套，无法继续嵌套时不再退化执行全局视觉缩进（`changeIndent`）。
---
## 2. 关联文件变更 (Files Changed)
* frontend/src/index.css: 
  * 重构了 `ProseMirror` 编辑器和 `.shared-note-content` 分享页下的无序列表样式，移除原生 `list-style-type`，改用 `::before` 字符列表项实现 1~9 级嵌套循环。
  * 将 `.ProseMirror ol li` 及嵌套样式重构为 `ol > li` 强限制子选择器，隔离样式泄露。
* frontend/src/components/TiptapEditor.tsx:
  * 新增 `getActiveListType` 工具函数，并重构了“无序列表”、“有序列表”、“任务列表”三个菜单栏按钮的 `isActive` 判定。
  * 引入了 `selectionTick` 响应机制和 `onSelectionUpdate` 回调，使工具栏能够完美响应单次点击等光标变更事件。
  * 调整快捷键 `handleTab` 逻辑，列表在 `sinkListItem` / `liftListItem` 返回失败时直接消费事件，不再执行 `changeIndent`。
* frontend/src/lib/noteImageExportCore.ts:
  * 在图片导出模版的内联样式中同步应用 `::before` 字符列表项的 CSS 规则，确保导出的 PNG 列表中符号大小、比例完美一致。
* frontend/src/lib/exportService.ts:
  * 同步更新 HTML/PDF 导出的 CSS 模版，使各端渲染排版高度统一。
---
## 3. 测试与验证 (How to Test)
1. **单次点击高亮响应测试**：
   * 将光标在无序列表与普通段落文本之间进行**单次点击切换**，确认菜单栏“无序列表”按钮的高亮阴影状态能立刻且实时地出现/消失，无需再双击选中。
2. **菜单高亮精确度测试**：
   * 插入一个混合嵌套列表（例如：外层有序，内层无序）。
   * 将光标点击在第一层（有序），检查菜单栏是否**仅高亮“有序列表”**按钮。
   * 将光标点击在第二层（无序），检查菜单栏是否**仅高亮“无序列表”**按钮。
3. **列表切换验证（重叠冲突修复）**：
   * 新建列表：一级无序，二级无序。
   * 点击菜单栏切换一级为“数字列表”，观察二级及以下依然为无序列表，且**圆点/数字不再发生任何重叠与样式泄露**。
4. **常规循环嵌套测试**：
   * 依次按 `Tab` 增加嵌套级数，确认列表项的符号呈现 `•` ➜ `◦` ➜ `▪` ➜ `•` 顺畅循环。
5. **导出 PNG & PDF 测试**：
   * 将包含多级列表的笔记分别导出为图片和 PDF，验证所有的项目符号渲染位置正确，大小和外观与网页端预览保持一致。
