### PR TITLE
chore: trigger Issue #322 direct-main implementation

### DIFF
--- a/.github/issue322-pr-trigger.md
+++ b/.github/issue322-pr-trigger.md
@@ -1,1 +1,3 @@
 This pull request only triggers the one-shot Issue #322 implementation workflow. Production changes are committed directly to main by the workflow after validation.
+
+Diagnostics run: 2

--- a/.github/issue322-pr-trigger.md
+++ b/.github/issue322-pr-trigger.md
@@ -1,0 +1,1 @@
+This pull request only triggers the one-shot Issue #322 implementation workflow. Production changes are committed directly to main by the workflow after validation.


### PR DESCRIPTION
仅用于触发 `.github/workflows/issue-322-main-implementation.yml`。

生产代码由工作流在 lint、build、test 全部通过后直接提交到 `main`，本 PR 不承载生产改动。关联 #322。