### PR TITLE
perf(sidebar): make notebook creation optimistic

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/index.js",
     "test": "node --import tsx --import ./tests/setup-db-isolation.ts --test tests/*.test.ts",
     "test:serial": "node scripts/run-tests-serial.mjs",
+    "fixture:phase-b": "node scripts/phase-b-notebook-fixture.mjs",
     "rebuild:node": "npm rebuild better-sqlite3",
     "rebuild:electron": "node ../scripts/rebuild-native.mjs --prebuild=true",
     "migrate:inline-images": "node ../scripts/migrate-inline-images-to-attachments.mjs",

--- a/backend/scripts/phase-b-notebook-fixture.mjs
+++ b/backend/scripts/phase-b-notebook-fixture.mjs
@@ -1,0 +1,78 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const args = Object.fromEntries(process.argv.slice(2).map((entry) => {
+  const [key, value = "true"] = entry.replace(/^--/, "").split("=");
+  return [key, value];
+}));
+
+const dbPath = fs.realpathSync(path.resolve(process.env.DB_PATH || ""));
+const tempRoots = [os.tmpdir(), "/tmp"].map((root) => fs.realpathSync(root) + path.sep);
+if (!tempRoots.some((root) => dbPath.startsWith(root)) || !dbPath.includes("phase-b")) {
+  throw new Error("Phase B fixture refuses to use a database outside a phase-b temporary path");
+}
+
+const count = Number(args.count || 10);
+const shape = args.shape === "four-level" ? "four-level" : "roots";
+const expansion = args.expansion === "current-path" ? "current-path" : "all";
+const scope = args.scope === "team" ? "team" : "personal";
+const withNotes = args.notes === "on";
+if (![10, 100, 500, 1000].includes(count)) throw new Error(`Unsupported count: ${count}`);
+
+const db = new Database(dbPath);
+const user = db.prepare("SELECT id FROM users WHERE username = ?").get("phaseb");
+if (!user) throw new Error("Run seed-demo for the phaseb user first");
+
+const workspaceId = "phase-b-workspace";
+const reset = db.transaction(() => {
+  db.prepare("DELETE FROM notes WHERE userId = ?").run(user.id);
+  db.prepare("DELETE FROM notebooks WHERE userId = ? OR workspaceId = ?").run(user.id, workspaceId);
+  db.prepare(`INSERT INTO workspaces (id, name, icon, ownerId)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET ownerId = excluded.ownerId`).run(workspaceId, "Phase B Team", "🏢", user.id);
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role)
+    VALUES (?, ?, 'owner')
+    ON CONFLICT(workspaceId, userId) DO UPDATE SET role = 'owner'`).run(workspaceId, user.id);
+
+  const insertNotebook = db.prepare(`INSERT INTO notebooks
+    (id, userId, workspaceId, parentId, name, icon, sortOrder, isExpanded)
+    VALUES (?, ?, ?, ?, ?, '📒', ?, ?)`);
+  const insertNote = db.prepare(`INSERT INTO notes
+    (id, userId, workspaceId, notebookId, title, content, contentText, sortOrder)
+    VALUES (?, ?, ?, ?, ?, '{}', ?, 0)`);
+
+  for (let index = 0; index < count; index += 1) {
+    const depth = shape === "four-level" ? index % 4 : 0;
+    const parentIndex = depth === 0 ? null : index - 1;
+    const id = `phase-b-${scope}-nb-${index.toString().padStart(4, "0")}`;
+    const parentId = parentIndex === null
+      ? null
+      : `phase-b-${scope}-nb-${parentIndex.toString().padStart(4, "0")}`;
+    const isExpanded = expansion === "all" || index < 4 ? 1 : 0;
+    insertNotebook.run(
+      id,
+      user.id,
+      scope === "team" ? workspaceId : null,
+      parentId,
+      `Phase B Notebook ${index}`,
+      index,
+      isExpanded,
+    );
+    if (withNotes) {
+      insertNote.run(
+        `phase-b-${scope}-note-${index.toString().padStart(4, "0")}`,
+        user.id,
+        scope === "team" ? workspaceId : null,
+        id,
+        `Phase B Note ${index}`,
+        `Notebook ${index} note`,
+      );
+    }
+  }
+});
+
+reset();
+db.close();
+console.log(JSON.stringify({ dbPath, count, shape, expansion, scope, withNotes }));

--- a/backend/src/routes/notebooks.ts
+++ b/backend/src/routes/notebooks.ts
@@ -18,6 +18,7 @@ import {
 } from "../services/workspaceNotebookTransfer";
 
 const app = new Hono();
+const notebookPerfDiagnosticsEnabled = process.env.NOTEBOOK_PERF_DIAGNOSTICS === "1";
 
 function parseNotebookMemberRole(role: unknown): "editor" | "viewer" | null {
   return role === "editor" || role === "viewer" ? role : null;
@@ -418,9 +419,12 @@ app.delete("/:id/members/:memberUserId", (c) => {
 
 // 创建笔记本
 app.post("/", async (c) => {
+  const perfEnabled = notebookPerfDiagnosticsEnabled;
+  const routeStartedAt = perfEnabled ? performance.now() : 0;
   const db = getDb();
   const userId = c.req.header("X-User-Id") || "";
   const body = await c.req.json();
+  const parsedAt = perfEnabled ? performance.now() : 0;
   const workspaceId: string | null = body.workspaceId || null;
 
   // 如果指定了工作区，必须是 editor 以上角色
@@ -430,6 +434,7 @@ app.post("/", async (c) => {
       return c.json({ error: "您在该工作区无创建权限" }, 403);
     }
   }
+  const permissionCheckedAt = perfEnabled ? performance.now() : 0;
 
   // v14：父笔记本若已被软删（在回收站里），不允许在其下创建子笔记本——
   // 否则新建的子笔记本会立刻 "看不见"（被父级 isDeleted 过滤掉）。
@@ -445,6 +450,7 @@ app.post("/", async (c) => {
       );
     }
   }
+  const parentCheckedAt = perfEnabled ? performance.now() : 0;
 
   const id = uuid();
   db.prepare(
@@ -460,7 +466,24 @@ app.post("/", async (c) => {
     body.color || null,
     body.sortOrder || 0,
   );
+  const insertedAt = perfEnabled ? performance.now() : 0;
   const notebook = db.prepare("SELECT * FROM notebooks WHERE id = ?").get(id);
+  if (perfEnabled) {
+    const selectedAt = performance.now();
+    const timings = {
+      parse: parsedAt - routeStartedAt,
+      permission: permissionCheckedAt - parsedAt,
+      parent: parentCheckedAt - permissionCheckedAt,
+      insert: insertedAt - parentCheckedAt,
+      select: selectedAt - insertedAt,
+      route: selectedAt - routeStartedAt,
+    };
+    c.header(
+      "Server-Timing",
+      Object.entries(timings).map(([name, duration]) => `${name};dur=${duration.toFixed(3)}`).join(", "),
+    );
+    console.info("[phase-b:notebook-create]", JSON.stringify({ id, workspaceId, parentId: body.parentId || null, ...timings }));
+  }
   return c.json(notebook, 201);
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "perf:phase-a": "vitest run src/components/__tests__/CodeBlockView.performance.test.tsx src/components/__tests__/MarkdownCodeBlock.performance.test.tsx src/lib/__tests__/codeBlockHighlightPlugin.test.ts --reporter=verbose",
+    "perf:phase-b": "vitest run src/lib/__tests__/notebookCreatePhaseB.performance.test.ts --reporter=verbose",
     "cap:sync": "npx cap sync android",
     "cap:build": "npm run build && npx cap sync android",
     "cap:open": "npx cap open android",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -62,17 +62,49 @@ import {
   getNotebookDragHint,
   getNotebookSortPrefForParent,
   notebookSortKey,
+  notebookTreeContainsId,
+  notebookTreeMapChanged,
+  notebookTreeSetChanged,
   normalizeNotebookSortPref,
   reorderNotebooksForDrop,
+  reuseNotebookTreeReferences,
   ROOT_NOTEBOOK_SORT_KEY,
   type NotebookDropZone,
   type NotebookSortBy,
   type NotebookSortPref,
   type NotebookSortPrefMap,
 } from "@/lib/notebookSort";
+import {
+  cleanupCancelledNotebook,
+  createOptimisticNotebook,
+  EMPTY_NOTEBOOK_CREATE_STATE,
+  findNotebookCreateOperation,
+  isTemporaryNotebookId,
+  notebookCreateReducer,
+  TEMP_NOTEBOOK_ID_PREFIX,
+  withoutTemporaryNotebooks,
+  type NotebookCreateAction,
+  type NotebookCreateOperation,
+  type NotebookCreateState,
+} from "@/lib/notebookCreateState";
 import { SIDEBAR_TREE_INDENT, sidebarNotebookDisclosureChrome, sidebarNotebookPaddingLeft, sidebarNotebookRowPaddingY, sidebarNotebookShowsDragHandle, sidebarTreeContentMinWidth, sidebarTreeRowMinWidth } from "@/lib/sidebarLayout";
+import {
+  forgetPhaseBCreateTrace,
+  installPhaseBBrowserInteractionObserver,
+  installPhaseBLongTaskObserver,
+  PHASE_B_PERF_ENABLED,
+  recordPhaseBPerfEvent,
+  rememberPhaseBCreateTrace,
+  takePhaseBCreateTrace,
+} from "@/lib/phaseBPerfDiagnostics";
 
 const NOTEBOOK_SORT_STORAGE_KEY = "nowen.notebookTree.sort";
+
+function useStableEvent<Args extends unknown[], Result>(handler: (...args: Args) => Result) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+  return useCallback((...args: Args) => handlerRef.current(...args), []);
+}
 
 function loadNotebookSortPrefs(): NotebookSortPrefMap {
   try {
@@ -199,7 +231,7 @@ function MoveNotebookModal({
   };
   collect(notebook.id);
 
-  const tree = buildNotebookTree(allNotebooks);
+  const tree = buildNotebookTree(withoutTemporaryNotebooks(allNotebooks));
   const currentParentId = notebook.parentId ?? null;
   // 有效选中目标（包含 root）
   const selectedTarget: string | null | undefined =
@@ -500,6 +532,7 @@ function NotebookItem({
   showNotes, notesByNotebookId, loadingNotebookIds, activeNoteId, onSelectNote, onNoteContextMenu,
   onNoteDragStart, onNoteDragOver, onNoteDragEnd, onNoteDrop, onNoteItemDragOver, onNoteItemDrop,
   onCreateNote, onCreateMarkdownNote, onCreateWordNote,
+  createOperations, onRetryCreate, onCancelCreate,
   constrainWidth = false,
   showNoteTime = true,
 }: {
@@ -547,10 +580,20 @@ function NotebookItem({
   onCreateNote?: NotebookCreateHandler;
   onCreateMarkdownNote?: NotebookCreateHandler;
   onCreateWordNote?: NotebookCreateHandler;
+  createOperations?: ReadonlyMap<string, NotebookCreateOperation>;
+  onRetryCreate?: (operationId: string) => void;
+  onCancelCreate?: (operationId: string) => void;
   constrainWidth?: boolean;
   showNoteTime?: boolean;
 }) {
   const { t } = useTranslation();
+  if (PHASE_B_PERF_ENABLED) {
+    recordPhaseBPerfEvent({
+      type: "notebook-item-render",
+      notebookId: notebook.id,
+      detail: { depth },
+    });
+  }
   const isSelected = selectedId === notebook.id;
   const hasChildren = notebook.children && notebook.children.length > 0;
   const notesLoading = !!loadingNotebookIds?.has(notebook.id);
@@ -564,13 +607,16 @@ function NotebookItem({
   const hasExpandableContent = hasChildren || hasNotes;
   const isExpanded = notebook.isExpanded === 1;
   const isEditing = editingId === notebook.id;
-  const rowDraggable = canDragInParent ? canDragInParent(notebook.parentId ?? null) : !!draggable;
+  const createOperation = createOperations?.get(notebook.id);
+  const rowDraggable = !createOperation
+    && (canDragInParent ? canDragInParent(notebook.parentId ?? null) : !!draggable);
   const isDragOver = dragOverId === notebook.id;
   const isNoteDragOver = noteDragOverId === notebook.id;
   const showBeforeIndicator = isDragOver && dragOverZone === "before";
   const showInsideIndicator = isDragOver && dragOverZone === "inside";
   const showAfterIndicator = isDragOver && dragOverZone === "after";
   const inputRef = useRef<HTMLInputElement>(null);
+  const cancelEditRef = useRef(false);
   const iconRef = useRef<HTMLButtonElement>(null);
   const [showIconPicker, setShowIconPicker] = useState(false);
   const [showCreateMenu, setShowCreateMenu] = useState(false);
@@ -613,8 +659,16 @@ function NotebookItem({
     if (isEditing && inputRef.current) {
       inputRef.current.focus();
       inputRef.current.select();
+      const traceId = takePhaseBCreateTrace(notebook.id);
+      if (traceId) {
+        recordPhaseBPerfEvent({
+          type: "create-input-focused",
+          notebookId: notebook.id,
+          detail: { traceId },
+        });
+      }
     }
-  }, [isEditing]);
+  }, [isEditing, notebook.id]);
 
   const getIconPickerPos = () => {
     if (iconRef.current) {
@@ -652,11 +706,11 @@ function NotebookItem({
           paddingBottom: `${sidebarNotebookRowPaddingY(constrainWidth)}px`,
           minWidth: constrainWidth ? undefined : `${sidebarTreeRowMinWidth(depth)}px`,
         }}
-        onClick={() => onSelect(notebook.id)}
-        onContextMenu={(e) => onContextMenu(e, notebook.id)}
+        onClick={() => { if (!createOperation) onSelect(notebook.id); }}
+        onContextMenu={(e) => { if (!createOperation) onContextMenu(e, notebook.id); }}
         title={!rowDraggable ? dragHint : undefined}
         onTouchStart={(e) => {
-          if (isEditing || !onLongPress) return;
+          if (isEditing || createOperation || !onLongPress) return;
           const touch = e.touches[0];
           if (!touch) return;
           longPressStart.current = { x: touch.clientX, y: touch.clientY };
@@ -689,6 +743,7 @@ function NotebookItem({
         // 因此用 `as any` 绕过 TS 的手势签名约束，运行时行为与原生 DnD 一致。
         onDragStart={((e: React.DragEvent) => { e.stopPropagation(); onDragStart?.(e, notebook.id); }) as any}
         onDragOver={((e: React.DragEvent) => {
+          if (createOperation) return;
           e.preventDefault();
           e.stopPropagation();
           if (e.dataTransfer.types.includes("application/x-nowen-note")) {
@@ -699,6 +754,7 @@ function NotebookItem({
         }) as any}
         onDragEnd={() => onDragEnd?.()}
         onDrop={(e: React.DragEvent) => {
+          if (createOperation) return;
           e.preventDefault();
           e.stopPropagation();
           if (e.dataTransfer.types.includes("application/x-nowen-note")) {
@@ -744,6 +800,7 @@ function NotebookItem({
           <button
             ref={iconRef}
             onClick={(e) => { e.stopPropagation(); setShowIconPicker(true); }}
+            disabled={!!createOperation}
             className="text-base hover:scale-125 transition-transform shrink-0"
             title={t("sidebar.changeIcon")}
           >
@@ -766,10 +823,23 @@ function NotebookItem({
             value={editValue}
             onChange={(e) => onEditChange(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") onEditSubmit();
-              if (e.key === "Escape") onEditCancel();
+              if (e.key === "Enter") {
+                e.preventDefault();
+                e.currentTarget.blur();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                cancelEditRef.current = true;
+                onEditCancel();
+              }
             }}
-            onBlur={onEditSubmit}
+            onBlur={() => {
+              if (cancelEditRef.current) {
+                cancelEditRef.current = false;
+                return;
+              }
+              onEditSubmit();
+            }}
             className="flex-1 text-sm bg-transparent border border-accent-primary/50 rounded px-1 py-0 outline-none text-tx-primary"
             onClick={(e) => e.stopPropagation()}
           />
@@ -781,7 +851,7 @@ function NotebookItem({
                 <span className="text-[10px] text-tx-tertiary tabular-nums shrink-0">{notebook.noteCount}</span>
               )}
             </span>
-            {showNotes && onCreateNote && (
+            {showNotes && onCreateNote && !createOperation && (
               <div className={cn(
                 "sticky right-1 ml-auto flex shrink-0 items-center gap-0.5 rounded-md bg-app-sidebar/95 pl-1",
                 sortMenuOpenId === notebook.id ? "z-[90]" : "z-10"
@@ -833,6 +903,33 @@ function NotebookItem({
             )}
           </>
         )}
+        {createOperation?.status === "pending" && (
+          <span className="shrink-0 text-[10px] text-tx-tertiary" aria-label="正在创建">…</span>
+        )}
+        {createOperation?.status === "failed" && (
+          <span className="shrink-0 flex items-center gap-1" title={createOperation.error}>
+            <button
+              type="button"
+              className="text-[10px] text-accent-primary hover:underline"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRetryCreate?.(createOperation.operationId);
+              }}
+            >
+              重试
+            </button>
+            <button
+              type="button"
+              className="text-[10px] text-danger hover:underline"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCancelCreate?.(createOperation.operationId);
+              }}
+            >
+              取消
+            </button>
+          </span>
+        )}
       </motion.div>
       {showAfterIndicator && (
         <div
@@ -854,7 +951,7 @@ function NotebookItem({
               style={{ left: `${depth * SIDEBAR_TREE_INDENT + 35}px` }}
             />
             {notebook.children!.map((child) => (
-              <NotebookItem
+              <MemoizedNotebookItem
                 key={child.id}
                 notebook={child}
                 depth={depth + 1}
@@ -903,6 +1000,9 @@ function NotebookItem({
                   onCreateMarkdownNote,
                   onCreateWordNote,
                 })}
+                createOperations={createOperations}
+                onRetryCreate={onRetryCreate}
+                onCancelCreate={onCancelCreate}
                 constrainWidth={constrainWidth}
                 showNoteTime={showNoteTime}
               />
@@ -931,6 +1031,48 @@ function NotebookItem({
   );
 }
 
+const MemoizedNotebookItem = React.memo(NotebookItem, (previous, next) => {
+  if (previous.notebook !== next.notebook) return false;
+  if (previous.selectedId !== next.selectedId
+    && (notebookTreeContainsId(next.notebook, previous.selectedId)
+      || notebookTreeContainsId(next.notebook, next.selectedId))) return false;
+  if (previous.editingId !== next.editingId
+    && (notebookTreeContainsId(next.notebook, previous.editingId)
+      || notebookTreeContainsId(next.notebook, next.editingId))) return false;
+  if (previous.editValue !== next.editValue
+    && (notebookTreeContainsId(next.notebook, previous.editingId)
+      || notebookTreeContainsId(next.notebook, next.editingId))) return false;
+  if (notebookTreeMapChanged(
+    next.notebook,
+    previous.notesByNotebookId,
+    next.notesByNotebookId,
+  )) return false;
+  if (notebookTreeSetChanged(
+    next.notebook,
+    previous.loadingNotebookIds,
+    next.loadingNotebookIds,
+  )) return false;
+  if (notebookTreeMapChanged(
+    next.notebook,
+    previous.createOperations,
+    next.createOperations,
+  )) return false;
+
+  const ignored = new Set([
+    "notebook",
+    "selectedId",
+    "editingId",
+    "editValue",
+    "notesByNotebookId",
+    "loadingNotebookIds",
+    "createOperations",
+  ]);
+  for (const key of Object.keys(previous) as Array<keyof typeof previous>) {
+    if (!ignored.has(key) && previous[key] !== next[key]) return false;
+  }
+  return true;
+});
+
 // 笔记本右键菜单项 - 在组件内使用 t() 动态生成
 
 /**
@@ -956,6 +1098,20 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   const { t } = useTranslation();
   const { prefs: userPrefs } = useUserPreferences();
   const showNotesInNotebookTree = userPrefs.showNotesInNotebookTree;
+  if (PHASE_B_PERF_ENABLED) {
+    recordPhaseBPerfEvent({
+      type: "sidebar-render",
+      detail: { notebookCount: state.notebooks.length, variant },
+    });
+  }
+  useEffect(() => {
+    if (!PHASE_B_PERF_ENABLED) return;
+    return installPhaseBLongTaskObserver();
+  }, []);
+  useEffect(() => {
+    if (!PHASE_B_PERF_ENABLED) return;
+    return installPhaseBBrowserInteractionObserver();
+  }, []);
   // v16 P3 后续：Rail 三档视觉模式（icon / label / hidden），仅桌面变体使用。
   // 入口约定：Sidebar Header 那个按钮 = 循环切换到下一档，tooltip 提示下一档是什么。
   // 约束（在 App.tsx 实施）：sidebarCollapsed=true 时即便 mode=hidden 也强制显示 Rail，
@@ -1005,6 +1161,17 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     }
   });
   const [sharedNotebooks, setSharedNotebooks] = useState<Notebook[]>([]);
+  const createTraceSequenceRef = useRef(0);
+
+  const beginCreatePerfTrace = useCallback((parentId: string | null) => {
+    if (!PHASE_B_PERF_ENABLED) return undefined;
+    const traceId = `create-${++createTraceSequenceRef.current}`;
+    recordPhaseBPerfEvent({
+      type: "create-click",
+      detail: { traceId, parentId: parentId ?? "root" },
+    });
+    return traceId;
+  }, []);
 
   // v15 信息架构改造前：导航区是一个可折叠的扁平 8 项列表（与笔记本/标签的折叠策略一致），
   // 用 navExpanded + nowen-nav-expanded localStorage 控制。改造后导航被拆为
@@ -1117,6 +1284,53 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   // 重命名状态
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
+  const editingIdRef = useRef<string | null>(null);
+  editingIdRef.current = editingId;
+  const [createOperations, setCreateOperations] = useState<NotebookCreateState>(
+    EMPTY_NOTEBOOK_CREATE_STATE,
+  );
+  const createOperationsRef = useRef<NotebookCreateState>(EMPTY_NOTEBOOK_CREATE_STATE);
+  const cancelledCreateOperationsRef = useRef(new Set<string>());
+  const sidebarMountedRef = useRef(true);
+  const updateCreateOperation = useCallback((action: NotebookCreateAction) => {
+    const next = notebookCreateReducer(createOperationsRef.current, action);
+    createOperationsRef.current = next;
+    if (sidebarMountedRef.current) setCreateOperations(next);
+    return next;
+  }, []);
+  const createOperationsByNotebookId = useMemo(() => {
+    const result = new Map<string, NotebookCreateOperation>();
+    Object.values(createOperations).forEach((operation) => {
+      result.set(operation.tempId, operation);
+      if (operation.serverId) result.set(operation.serverId, operation);
+    });
+    return result;
+  }, [createOperations]);
+  useEffect(() => {
+    sidebarMountedRef.current = true;
+    return () => {
+      sidebarMountedRef.current = false;
+      Object.values(createOperationsRef.current).forEach((operation) => {
+        forgetPhaseBCreateTrace(operation.tempId);
+      });
+    };
+  }, []);
+  useEffect(() => {
+    const removePendingRowsFromPreviousWorkspace = () => {
+      Object.values(createOperationsRef.current).forEach((operation) => {
+        actions.removeNotebook(operation.tempId);
+        forgetPhaseBCreateTrace(operation.tempId);
+        if (operation.status !== "pending") {
+          updateCreateOperation({ type: "finish", operationId: operation.operationId });
+        }
+      });
+      setEditingId(null);
+    };
+    window.addEventListener("nowen:workspace-changed", removePendingRowsFromPreviousWorkspace);
+    return () => {
+      window.removeEventListener("nowen:workspace-changed", removePendingRowsFromPreviousWorkspace);
+    };
+  }, [actions, updateCreateOperation]);
 
   // 更换图标状态
   const [iconPickerId, setIconPickerId] = useState<string | null>(null);
@@ -1176,7 +1390,21 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     [getNotebookSortPref],
   );
   const notebookDragHint = getNotebookDragHint(rootNotebookSortPref.by === "manual");
-  const tree = useMemo(() => buildNotebookTree(state.notebooks, getNotebookSortPref), [getNotebookSortPref, state.notebooks]);
+  const previousNotebookTreeRef = useRef<Notebook[]>([]);
+  const tree = useMemo(() => {
+    const startedAt = PHASE_B_PERF_ENABLED ? performance.now() : 0;
+    const builtTree = buildNotebookTree(state.notebooks, getNotebookSortPref);
+    const nextTree = reuseNotebookTreeReferences(builtTree, previousNotebookTreeRef.current);
+    previousNotebookTreeRef.current = nextTree;
+    if (PHASE_B_PERF_ENABLED) {
+      recordPhaseBPerfEvent({
+        type: "build-notebook-tree",
+        durationMs: performance.now() - startedAt,
+        detail: { notebookCount: state.notebooks.length },
+      });
+    }
+    return nextTree;
+  }, [getNotebookSortPref, state.notebooks]);
   const notebookTreeMinWidth = useMemo(
     () => sidebarTreeContentMinWidth(getMaxNotebookDepth(tree)),
     [tree]
@@ -1324,6 +1552,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
 
   // 更换笔记本图标
   const handleIconChange = useCallback(async (id: string, emoji: string) => {
+    if (isTemporaryNotebookId(id)) return;
     await api.updateNotebook(id, { icon: emoji }).catch(console.error);
     actions.setNotebooks(
       state.notebooks.map((nb) => nb.id === id ? { ...nb, icon: emoji } : nb)
@@ -1349,7 +1578,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   // 笔记本拖拽：按鼠标垂直位置区分 before / inside / after。
   const handleNbDragStart = useCallback((e: React.DragEvent, id: string) => {
     const source = state.notebooks.find((n) => n.id === id);
-    if (!source || !isManualNotebookGroup(source.parentId ?? null)) {
+    if (!source || isTemporaryNotebookId(id) || !isManualNotebookGroup(source.parentId ?? null)) {
       e.preventDefault();
       return;
     }
@@ -1365,7 +1594,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   const handleNbDragOver = useCallback((e: React.DragEvent, id: string) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
-    if (!dragNbId) {
+    if (!dragNbId || isTemporaryNotebookId(id) || isTemporaryNotebookId(dragNbId)) {
       setDragOverNbId(null);
       setDragOverNbZone(null);
       return;
@@ -1408,9 +1637,15 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     setDragNbId(null);
     setDragOverNbId(null);
     setDragOverNbZone(null);
-    if (!sourceId || sourceId === targetId || !zone) return;
+    if (!sourceId || sourceId === targetId || !zone
+      || isTemporaryNotebookId(sourceId) || isTemporaryNotebookId(targetId)) return;
 
-    const result = reorderNotebooksForDrop(state.notebooks, sourceId, targetId, zone);
+    const result = reorderNotebooksForDrop(
+      withoutTemporaryNotebooks(state.notebooks),
+      sourceId,
+      targetId,
+      zone,
+    );
     if (!result) return;
     if (!isManualNotebookGroup(result.movePayload.parentId)) return;
 
@@ -1449,7 +1684,8 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     e.stopPropagation();
     const noteId = e.dataTransfer.getData("application/x-nowen-note") || dragNoteId;
     const note = getCachedNote(noteId);
-    if (!note || note.notebookId === notebookId || note.isLocked === 1) {
+    if (!note || isTemporaryNotebookId(notebookId)
+      || note.notebookId === notebookId || note.isLocked === 1) {
       e.dataTransfer.dropEffect = "none";
       setDragOverNoteNotebookId(null);
       return;
@@ -1533,7 +1769,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     setDragOverNoteNotebookId(null);
     setDragOverSidebarNoteId(null);
     setDragOverSidebarNoteZone(null);
-    if (!noteId) return;
+    if (!noteId || isTemporaryNotebookId(targetNotebookId)) return;
 
     const note = getCachedNote(noteId);
     if (!note || note.notebookId === targetNotebookId) return;
@@ -1576,6 +1812,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   ]);
 
   const handleNotebookSelect = (id: string) => {
+    if (isTemporaryNotebookId(id)) return;
     actions.setSelectedNotebook(id);
     actions.setViewMode("notebook");
     if (showNotesInNotebookTree) {
@@ -1597,6 +1834,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   };
 
   const handleToggle = (id: string) => {
+    if (isTemporaryNotebookId(id)) return;
     const nb = state.notebooks.find((n) => n.id === id);
     if (nb) {
       const nextExpanded = nb.isExpanded === 1 ? 0 : 1;
@@ -1609,7 +1847,10 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   };
 
   const handleSetAllNotebooksExpanded = useCallback(async (expanded: NotebookExpandedState) => {
-    const { changed, nextNotebooks } = getNotebookExpansionChanges(state.notebooks, expanded);
+    const { changed, nextNotebooks } = getNotebookExpansionChanges(
+      withoutTemporaryNotebooks(state.notebooks),
+      expanded,
+    );
     if (changed.length === 0) return;
 
     actions.setNotebooks(nextNotebooks);
@@ -1885,20 +2126,221 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     }
   }, [actions, isDesktop]);
 
-  const handleCreateNotebook = async () => {
-    const nb = await api.createNotebook({ name: t('common.newNotebook'), icon: "📒" });
-    actions.setNotebooks([...state.notebooks, nb]);
-    // 自动进入重命名
-    setEditingId(nb.id);
-    setEditValue(nb.name);
-  };
+  const finishCreateOperation = useCallback(async (operationId: string) => {
+    const operation = createOperationsRef.current[operationId];
+    if (!operation?.serverNotebook) return;
+    const name = operation.name.trim() || operation.serverNotebook.name;
+    try {
+      let confirmedNotebook = operation.serverNotebook;
+      if (name !== operation.serverName) {
+        confirmedNotebook = await api.updateNotebook(operation.serverNotebook.id, { name });
+      }
+      if (getCurrentWorkspace() === operation.workspaceId) {
+        const localNotebook = { ...confirmedNotebook, name };
+        actions.replaceNotebook(operation.tempId, localNotebook);
+        actions.updateNotebook({ id: localNotebook.id, name });
+      } else {
+        actions.removeNotebook(operation.tempId);
+      }
+      updateCreateOperation({ type: "finish", operationId });
+      forgetPhaseBCreateTrace(operation.tempId);
+    } catch (error) {
+      if (!sidebarMountedRef.current) {
+        if (operation.serverNotebook && getCurrentWorkspace() === operation.workspaceId) {
+          actions.replaceNotebook(operation.tempId, operation.serverNotebook);
+        } else {
+          actions.removeNotebook(operation.tempId);
+        }
+        updateCreateOperation({ type: "finish", operationId });
+        forgetPhaseBCreateTrace(operation.tempId);
+        return;
+      }
+      updateCreateOperation({
+        type: "fail",
+        operationId,
+        error: error instanceof Error
+          ? error.message
+          : t("common.operationFailed") || "创建失败",
+      });
+    }
+  }, [actions, t, updateCreateOperation]);
+
+  const runCreateOperation = useCallback(async (operationId: string, traceId?: string) => {
+    const operation = createOperationsRef.current[operationId];
+    if (!operation) return;
+    if (traceId) recordPhaseBPerfEvent({ type: "create-request-start", detail: { traceId } });
+    try {
+      const notebook = await api.createNotebook({
+        name: operation.name,
+        icon: operation.parentId ? "📁" : "📒",
+        parentId: operation.parentId,
+        workspaceId: operation.workspaceId === "personal" ? null : operation.workspaceId,
+      });
+      if (traceId) {
+        recordPhaseBPerfEvent({ type: "create-response", notebookId: notebook.id, detail: { traceId } });
+      }
+      if (cancelledCreateOperationsRef.current.delete(operationId)
+        || !createOperationsRef.current[operationId]) {
+        forgetPhaseBCreateTrace(operation.tempId);
+        const cleanupResult = await cleanupCancelledNotebook(
+          operationId,
+          notebook.id,
+          api.deleteNotebook,
+          (failure) => console.error("[Sidebar] cancelled notebook cleanup failed", failure),
+        );
+        if (cleanupResult !== "failed") actions.removeNotebook(notebook.id);
+        return;
+      }
+      updateCreateOperation({ type: "confirm", operationId, notebook });
+      const latest = createOperationsRef.current[operationId];
+      if (!latest) return;
+      if (!sidebarMountedRef.current && !latest.submitted) {
+        updateCreateOperation({
+          type: "submit",
+          operationId,
+          name: latest.name,
+        });
+        await finishCreateOperation(operationId);
+        return;
+      }
+      if (getCurrentWorkspace() !== latest.workspaceId && !latest.submitted) {
+        actions.removeNotebook(latest.tempId);
+        updateCreateOperation({ type: "finish", operationId });
+        forgetPhaseBCreateTrace(latest.tempId);
+        return;
+      }
+      if (latest.submitted) await finishCreateOperation(operationId);
+    } catch (error) {
+      if (cancelledCreateOperationsRef.current.delete(operationId)) return;
+      const latest = createOperationsRef.current[operationId];
+      if (latest && getCurrentWorkspace() !== latest.workspaceId) {
+        updateCreateOperation({ type: "finish", operationId });
+        forgetPhaseBCreateTrace(latest.tempId);
+        return;
+      }
+      if (!sidebarMountedRef.current) {
+        if (latest) actions.removeNotebook(latest.tempId);
+        updateCreateOperation({ type: "cancel", operationId });
+        if (latest) forgetPhaseBCreateTrace(latest.tempId);
+        return;
+      }
+      updateCreateOperation({
+        type: "fail",
+        operationId,
+        error: error instanceof Error
+          ? error.message
+          : t("common.operationFailed") || "创建失败",
+      });
+    }
+  }, [actions, finishCreateOperation, t, updateCreateOperation]);
+
+  const startNotebookCreate = useCallback((parentId: string | null) => {
+    const currentEditingId = editingIdRef.current;
+    const currentOperation = currentEditingId
+      ? findNotebookCreateOperation(createOperationsRef.current, currentEditingId)
+      : undefined;
+    if (currentOperation && !currentOperation.submitted) {
+      updateCreateOperation({
+        type: "submit",
+        operationId: currentOperation.operationId,
+        name: currentOperation.name,
+      });
+      if (currentOperation.serverNotebook) {
+        void finishCreateOperation(currentOperation.operationId);
+      }
+    }
+
+    const traceId = beginCreatePerfTrace(parentId);
+    const operationId = crypto.randomUUID();
+    const tempId = `${TEMP_NOTEBOOK_ID_PREFIX}${operationId}`;
+    const workspaceId = getCurrentWorkspace() || "personal";
+    const operation: NotebookCreateOperation = {
+      operationId,
+      tempId,
+      parentId,
+      workspaceId,
+      name: t("common.newNotebook"),
+      status: "pending",
+      submitted: false,
+    };
+    updateCreateOperation({ type: "start", operation });
+    if (traceId) rememberPhaseBCreateTrace(tempId, traceId);
+    actions.addNotebook(createOptimisticNotebook(operation, parentId ? "📁" : "📒"));
+    if (parentId) {
+      actions.updateNotebook({ id: parentId, isExpanded: 1 });
+      void api.updateNotebook(parentId, { isExpanded: 1 }).catch(console.error);
+    }
+    if (traceId) {
+      recordPhaseBPerfEvent({
+        type: "create-state-dispatch",
+        notebookId: tempId,
+        detail: { traceId },
+      });
+    }
+    setEditingId(tempId);
+    setEditValue(operation.name);
+    void runCreateOperation(operationId, traceId);
+  }, [actions, beginCreatePerfTrace, finishCreateOperation, runCreateOperation, t, updateCreateOperation]);
+
+  const handleCreateNotebook = useCallback(() => {
+    startNotebookCreate(null);
+  }, [startNotebookCreate]);
+
+  const handleCancelCreate = useCallback(async (operationId: string) => {
+    const operation = createOperationsRef.current[operationId];
+    if (!operation) return;
+    if (operation.serverId) {
+      try {
+        await api.deleteNotebook(operation.serverId);
+      } catch (error) {
+        updateCreateOperation({
+          type: "fail",
+          operationId,
+          error: error instanceof Error
+            ? error.message
+            : t("common.operationFailed") || "取消失败",
+        });
+        return;
+      }
+    } else {
+      cancelledCreateOperationsRef.current.add(operationId);
+    }
+    actions.removeNotebook(operation.tempId);
+    if (operation.serverId) actions.removeNotebook(operation.serverId);
+    forgetPhaseBCreateTrace(operation.tempId);
+    updateCreateOperation({ type: "cancel", operationId });
+    setEditingId((current) =>
+      current === operation.tempId || current === operation.serverId ? null : current
+    );
+  }, [actions, t, updateCreateOperation]);
+
+  const handleRetryCreate = useCallback((operationId: string) => {
+    const operation = createOperationsRef.current[operationId];
+    if (!operation) return;
+    updateCreateOperation({ type: "pending", operationId });
+    if (operation.serverNotebook) {
+      void finishCreateOperation(operationId);
+    } else {
+      void runCreateOperation(operationId);
+    }
+  }, [finishCreateOperation, runCreateOperation, updateCreateOperation]);
+
+  const handleEditValueChange = useCallback((value: string) => {
+    setEditValue(value);
+    const currentEditingId = editingIdRef.current;
+    if (!currentEditingId) return;
+    const operation = findNotebookCreateOperation(createOperationsRef.current, currentEditingId);
+    if (operation) {
+      updateCreateOperation({ type: "name", operationId: operation.operationId, name: value });
+    }
+  }, [updateCreateOperation]);
 
 
   // 右键菜单操作分发
   const handleMenuAction = async (actionId: string) => {
     const targetId = menu.targetId;
     closeMenu();
-    if (!targetId) return;
+    if (!targetId || isTemporaryNotebookId(targetId)) return;
 
     const targetNb = state.notebooks.find((nb) => nb.id === targetId);
 
@@ -2031,17 +2473,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
         break;
       }
       case "new_sub": {
-        const sub = await api.createNotebook({ name: t('common.newNotebook'), icon: "📁", parentId: targetId } as any);
-        actions.setNotebooks([...state.notebooks, sub]);
-        // 展开父级
-        if (targetNb && targetNb.isExpanded !== 1) {
-          api.updateNotebook(targetId, { isExpanded: 1 } as any).catch(console.error);
-          actions.setNotebooks(
-            [...state.notebooks, sub].map((n) => n.id === targetId ? { ...n, isExpanded: 1 } : n)
-          );
-        }
-        setEditingId(sub.id);
-        setEditValue(sub.name);
+        startNotebookCreate(targetId);
         break;
       }
       case "rename": {
@@ -2119,20 +2551,43 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   // 重命名提交
   const handleEditSubmit = async () => {
     if (!editingId || !editValue.trim()) {
+      const emptyOperation = editingId
+        ? findNotebookCreateOperation(createOperationsRef.current, editingId)
+        : undefined;
+      if (emptyOperation) {
+        void handleCancelCreate(emptyOperation.operationId);
+      } else {
+        setEditingId(null);
+      }
+      return;
+    }
+    const createOperation = findNotebookCreateOperation(createOperationsRef.current, editingId);
+    if (createOperation) {
+      const name = editValue.trim();
+      updateCreateOperation({ type: "submit", operationId: createOperation.operationId, name });
+      actions.updateNotebook({ id: editingId, name });
       setEditingId(null);
+      if (createOperationsRef.current[createOperation.operationId]?.serverNotebook) {
+        await finishCreateOperation(createOperation.operationId);
+      }
       return;
     }
     const original = state.notebooks.find((nb) => nb.id === editingId);
     if (original && editValue.trim() !== original.name) {
       await api.updateNotebook(editingId, { name: editValue.trim() }).catch(console.error);
-      actions.setNotebooks(
-        state.notebooks.map((nb) => nb.id === editingId ? { ...nb, name: editValue.trim() } : nb)
-      );
+      actions.updateNotebook({ id: editingId, name: editValue.trim() });
     }
     setEditingId(null);
   };
 
   const handleEditCancel = () => {
+    if (editingId) {
+      const operation = findNotebookCreateOperation(createOperationsRef.current, editingId);
+      if (operation) {
+        void handleCancelCreate(operation.operationId);
+        return;
+      }
+    }
     setEditingId(null);
   };
 
@@ -2140,6 +2595,7 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   const handleMoveNotebookConfirm = async (newParentId: string | null) => {
     if (!moveNbTarget) return;
     const sourceId = moveNbTarget.id;
+    if (isTemporaryNotebookId(sourceId) || isTemporaryNotebookId(newParentId)) return;
     // 循环引用防护
     if (newParentId && isDescendant(sourceId, newParentId)) {
       toast.error(t('sidebar.moveCannotSelf'));
@@ -2320,7 +2776,45 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
   // v16：桌面端折叠态由 App.tsx 控制（隐藏整个 Sidebar 但保留 NavRail）。
   // 移动端没有折叠概念（抽屉显隐由 mobileSidebarOpen 控制），所以这里无需任何分支。
 
-
+  const stableNotebookSelect = useStableEvent(handleNotebookSelect);
+  const stableNotebookToggle = useStableEvent(handleToggle);
+  const stableNotebookContextMenu = useStableEvent(
+    (event: React.MouseEvent, id: string) => openMenu(event, id, "notebook"),
+  );
+  const stableNotebookLongPress = useStableEvent(
+    (x: number, y: number, id: string) => openMenuAt(x, y, id, "notebook"),
+  );
+  const stableEditChange = useStableEvent(handleEditValueChange);
+  const stableEditSubmit = useStableEvent(handleEditSubmit);
+  const stableEditCancel = useStableEvent(handleEditCancel);
+  const stableIconChange = useStableEvent(handleIconChange);
+  const stableNotebookDragStart = useStableEvent(handleNbDragStart);
+  const stableNotebookDragOver = useStableEvent(handleNbDragOver);
+  const stableNotebookDragEnd = useStableEvent(handleNbDragEnd);
+  const stableNotebookDrop = useStableEvent(handleNbDrop);
+  const stableGetSortValue = useStableEvent((id: string) => getNotebookSortPref(id));
+  const stableSortMenuToggle = useStableEvent((id: string) => {
+    setOpenNotebookSortParentId((current) => current === id ? null : id);
+  });
+  const stableSortChange = useStableEvent(
+    (id: string, next: NotebookSortPref) => setNotebookSortPrefForParent(id, next),
+  );
+  const stableSortClose = useStableEvent(() => setOpenNotebookSortParentId(null));
+  const stableSelectNote = useStableEvent(handleSelectSidebarNote);
+  const stableNoteContextMenu = useStableEvent(
+    (event: React.MouseEvent, id: string) => openMenu(event, id, "note"),
+  );
+  const stableNoteDragStart = useStableEvent(handleSidebarNoteDragStart);
+  const stableNoteDragOver = useStableEvent(handleSidebarNoteDragOver);
+  const stableNoteDragEnd = useStableEvent(handleSidebarNoteDragEnd);
+  const stableNoteDrop = useStableEvent(handleSidebarNoteDrop);
+  const stableNoteItemDragOver = useStableEvent(handleSidebarNoteItemDragOver);
+  const stableNoteItemDrop = useStableEvent(handleSidebarNoteItemDrop);
+  const stableCreateNote = useStableEvent(handleCreateSidebarNote);
+  const stableCreateMarkdownNote = useStableEvent(handleCreateSidebarMarkdownNote);
+  const stableCreateWordNote = useStableEvent(handleCreateSidebarWordNote);
+  const stableRetryCreate = useStableEvent(handleRetryCreate);
+  const stableCancelCreate = useStableEvent(handleCancelCreate);
 
   return (
     <div
@@ -2489,35 +2983,33 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
                 style={{ minWidth: constrainNotebookTreeWidth ? undefined : `${notebookTreeMinWidth}px` }}
               >
                 {tree.map((nb) => (
-                  <NotebookItem
+                  <MemoizedNotebookItem
                     key={nb.id}
                     notebook={nb}
                     depth={0}
-                    onSelect={handleNotebookSelect}
+                    onSelect={stableNotebookSelect}
                     selectedId={state.selectedNotebookId}
-                    onToggle={handleToggle}
-                    onContextMenu={(e, id) => openMenu(e, id, "notebook")}
-                    onLongPress={(x, y, id) => openMenuAt(x, y, id, "notebook")}
+                    onToggle={stableNotebookToggle}
+                    onContextMenu={stableNotebookContextMenu}
+                    onLongPress={stableNotebookLongPress}
                     editingId={editingId}
                     editValue={editValue}
-                    onEditChange={setEditValue}
-                    onEditSubmit={handleEditSubmit}
-                    onEditCancel={handleEditCancel}
-                    onIconChange={handleIconChange}
+                    onEditChange={stableEditChange}
+                    onEditSubmit={stableEditSubmit}
+                    onEditCancel={stableEditCancel}
+                    onIconChange={stableIconChange}
                     draggable={isManualNotebookGroup(null)}
                     dragHint={notebookDragHint}
                     canDragInParent={isManualNotebookGroup}
-                    getSortValue={(id) => getNotebookSortPref(id)}
+                    getSortValue={stableGetSortValue}
                     sortMenuOpenId={openNotebookSortParentId}
-                    onSortMenuToggle={(id) => {
-                      setOpenNotebookSortParentId((current) => current === id ? null : id);
-                    }}
-                    onSortChange={(id, next) => setNotebookSortPrefForParent(id, next)}
-                    onSortClose={() => setOpenNotebookSortParentId(null)}
-                    onDragStart={handleNbDragStart}
-                    onDragOver={handleNbDragOver}
-                    onDragEnd={handleNbDragEnd}
-                    onDrop={handleNbDrop}
+                    onSortMenuToggle={stableSortMenuToggle}
+                    onSortChange={stableSortChange}
+                    onSortClose={stableSortClose}
+                    onDragStart={stableNotebookDragStart}
+                    onDragOver={stableNotebookDragOver}
+                    onDragEnd={stableNotebookDragEnd}
+                    onDrop={stableNotebookDrop}
                     dragOverId={dragOverNbId}
                     dragOverZone={dragOverNbZone}
                     noteDragOverId={dragOverNoteNotebookId}
@@ -2527,17 +3019,20 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
                     notesByNotebookId={notesByNotebookId}
                     loadingNotebookIds={loadingNotebookIds}
                     activeNoteId={state.activeNote?.id ?? null}
-                    onSelectNote={handleSelectSidebarNote}
-                    onNoteContextMenu={(e, id) => openMenu(e, id, "note")}
-                    onNoteDragStart={handleSidebarNoteDragStart}
-                    onNoteDragOver={handleSidebarNoteDragOver}
-                    onNoteDragEnd={handleSidebarNoteDragEnd}
-                    onNoteDrop={handleSidebarNoteDrop}
-                    onNoteItemDragOver={handleSidebarNoteItemDragOver}
-                    onNoteItemDrop={handleSidebarNoteItemDrop}
-                    onCreateNote={handleCreateSidebarNote}
-                    onCreateMarkdownNote={handleCreateSidebarMarkdownNote}
-                    onCreateWordNote={handleCreateSidebarWordNote}
+                    onSelectNote={stableSelectNote}
+                    onNoteContextMenu={stableNoteContextMenu}
+                    onNoteDragStart={stableNoteDragStart}
+                    onNoteDragOver={stableNoteDragOver}
+                    onNoteDragEnd={stableNoteDragEnd}
+                    onNoteDrop={stableNoteDrop}
+                    onNoteItemDragOver={stableNoteItemDragOver}
+                    onNoteItemDrop={stableNoteItemDrop}
+                    onCreateNote={stableCreateNote}
+                    onCreateMarkdownNote={stableCreateMarkdownNote}
+                    onCreateWordNote={stableCreateWordNote}
+                    createOperations={createOperationsByNotebookId}
+                    onRetryCreate={stableRetryCreate}
+                    onCancelCreate={stableCancelCreate}
                     constrainWidth={constrainNotebookTreeWidth}
                     showNoteTime={userPrefs.showNoteListUpdatedTime}
                   />
@@ -2987,4 +3482,3 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
     </div>
   );
 }
-

--- a/frontend/src/lib/__tests__/notebookCreatePhaseB.performance.test.ts
+++ b/frontend/src/lib/__tests__/notebookCreatePhaseB.performance.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { Notebook } from "@/types";
+import { buildNotebookTree, reuseNotebookTreeReferences } from "@/lib/notebookSort";
+
+type Shape = "roots" | "four-level";
+type Expansion = "all" | "current-path";
+
+function makeNotebooks(count: number, shape: Shape, expansion: Expansion): Notebook[] {
+  const now = "2026-07-18T00:00:00.000Z";
+  return Array.from({ length: count }, (_, index) => {
+    const depth = shape === "four-level" ? index % 4 : 0;
+    const parentIndex = depth === 0 ? null : index - 1;
+    return {
+      id: `notebook-${index.toString().padStart(4, "0")}`,
+      userId: "phase-b-user",
+      workspaceId: null,
+      parentId: parentIndex === null ? null : `notebook-${parentIndex.toString().padStart(4, "0")}`,
+      name: `Notebook ${index}`,
+      description: null,
+      icon: "📒",
+      color: null,
+      sortOrder: index,
+      isExpanded: expansion === "all" || depth < 3 ? 1 : 0,
+      createdAt: now,
+      updatedAt: now,
+      noteCount: 0,
+    };
+  });
+}
+
+function percentile(values: number[], ratio: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * ratio) - 1));
+  return sorted[index];
+}
+
+describe("Phase B notebook tree baseline", () => {
+  it("records repeatable tree-build timings and reference churn", () => {
+    const results: Array<Record<string, string | number>> = [];
+
+    for (const count of [10, 100, 500, 1000]) {
+      for (const shape of ["roots", "four-level"] as const) {
+        for (const expansion of ["all", "current-path"] as const) {
+          const notebooks = makeNotebooks(count, shape, expansion);
+          for (let warmup = 0; warmup < 5; warmup += 1) buildNotebookTree(notebooks);
+
+          const samples: number[] = [];
+          let stableReferences = 0;
+          let previousTree = buildNotebookTree(notebooks);
+          for (let run = 0; run < 50; run += 1) {
+            const startedAt = performance.now();
+            const tree = reuseNotebookTreeReferences(buildNotebookTree(notebooks), previousTree);
+            samples.push(performance.now() - startedAt);
+            if (tree[0] === previousTree[0]) {
+              stableReferences += 1;
+            }
+            previousTree = tree;
+          }
+
+          results.push({
+            count,
+            shape,
+            expansion,
+            median: Number(percentile(samples, 0.5).toFixed(3)),
+            p75: Number(percentile(samples, 0.75).toFixed(3)),
+            p95: Number(percentile(samples, 0.95).toFixed(3)),
+            max: Number(Math.max(...samples).toFixed(3)),
+            samples: samples.length,
+            stableRootReferenceRuns: stableReferences,
+          });
+        }
+      }
+    }
+
+    console.log(`PHASE_B_TREE_OPTIMIZED ${JSON.stringify(results)}`);
+    expect(results).toHaveLength(16);
+    expect(results.every((result) => result.stableRootReferenceRuns === 50)).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/notebookCreateState.test.ts
+++ b/frontend/src/lib/__tests__/notebookCreateState.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  cleanupCancelledNotebook,
+  createOptimisticNotebook,
+  findNotebookCreateOperation,
+  isTemporaryNotebookId,
+  mergeAuthoritativeNotebooks,
+  notebookCreateReducer,
+  replaceOptimisticNotebook,
+  withoutTemporaryNotebooks,
+  type NotebookCreateOperation,
+} from "@/lib/notebookCreateState";
+import type { Notebook } from "@/types";
+
+function operation(id: string): NotebookCreateOperation {
+  return {
+    operationId: id,
+    tempId: `temp-notebook:${id}`,
+    parentId: null,
+    workspaceId: "personal",
+    name: "新笔记本",
+    status: "pending",
+    submitted: false,
+  };
+}
+
+function serverNotebook(id: string, name = "新笔记本"): Notebook {
+  return {
+    ...createOptimisticNotebook(operation(id), "📒", "2026-01-01T00:00:00.000Z"),
+    id: `server:${id}`,
+    name,
+  };
+}
+
+describe("notebook create state", () => {
+  it("keeps concurrent operations independent and preserves the latest typed name", () => {
+    let state = notebookCreateReducer({}, { type: "start", operation: operation("a") });
+    state = notebookCreateReducer(state, { type: "start", operation: operation("b") });
+    state = notebookCreateReducer(state, { type: "name", operationId: "a", name: "Alpha" });
+    state = notebookCreateReducer(state, { type: "submit", operationId: "a", name: "Alpha final" });
+    state = notebookCreateReducer(state, {
+      type: "confirm",
+      operationId: "a",
+      notebook: serverNotebook("a"),
+    });
+    state = notebookCreateReducer(state, { type: "fail", operationId: "b", error: "forbidden" });
+
+    expect(state.a).toMatchObject({
+      name: "Alpha final",
+      submitted: true,
+      status: "confirmed",
+      serverId: "server:a",
+    });
+    expect(state.b).toMatchObject({ status: "failed", error: "forbidden" });
+    expect(findNotebookCreateOperation(state, "temp-notebook:a")?.operationId).toBe("a");
+    expect(findNotebookCreateOperation(state, "server:a")?.operationId).toBe("a");
+  });
+
+  it("retries without losing input and removes only the finished or cancelled operation", () => {
+    let state = notebookCreateReducer({}, { type: "start", operation: operation("a") });
+    state = notebookCreateReducer(state, { type: "start", operation: operation("b") });
+    state = notebookCreateReducer(state, { type: "name", operationId: "a", name: "保留名称" });
+    state = notebookCreateReducer(state, { type: "fail", operationId: "a", error: "offline" });
+    state = notebookCreateReducer(state, { type: "pending", operationId: "a" });
+    expect(state.a).toMatchObject({ name: "保留名称", status: "pending" });
+    expect(state.a.error).toBeUndefined();
+
+    state = notebookCreateReducer(state, { type: "cancel", operationId: "a" });
+    expect(state.a).toBeUndefined();
+    expect(state.b).toBeDefined();
+    state = notebookCreateReducer(state, { type: "finish", operationId: "b" });
+    expect(state).toEqual({});
+  });
+
+  it("creates a temporary notebook in the requested workspace and parent", () => {
+    const nested = { ...operation("nested"), workspaceId: "team-1", parentId: "parent-1" };
+    expect(createOptimisticNotebook(nested, "📁", "2026-01-01T00:00:00.000Z")).toMatchObject({
+      id: "temp-notebook:nested",
+      workspaceId: "team-1",
+      parentId: "parent-1",
+      name: "新笔记本",
+      icon: "📁",
+      isExpanded: 0,
+    });
+  });
+
+  it("keeps temporary notebooks out of persisted notebook operations", () => {
+    const persisted = serverNotebook("persisted");
+    const temporary = createOptimisticNotebook(operation("temporary"), "📒");
+
+    expect(isTemporaryNotebookId(temporary.id)).toBe(true);
+    expect(withoutTemporaryNotebooks([persisted, temporary])).toEqual([persisted]);
+  });
+
+  it("preserves pending rows across authoritative refreshes without cloning them", () => {
+    const temporary = createOptimisticNotebook(operation("temporary"), "📒");
+    const authoritative = serverNotebook("authoritative");
+    const merged = mergeAuthoritativeNotebooks([temporary], [authoritative]);
+
+    expect(merged).toEqual([authoritative, temporary]);
+    expect(merged[1]).toBe(temporary);
+  });
+
+  it("deduplicates a broadcast server entity when replacing its temporary row", () => {
+    const temporary = createOptimisticNotebook(operation("temporary"), "📒");
+    const server = serverNotebook("temporary");
+    const sibling = serverNotebook("sibling");
+    const replaced = replaceOptimisticNotebook(
+      [sibling, temporary, server],
+      temporary.id,
+      server,
+    );
+
+    expect(replaced).toEqual([sibling, server]);
+    expect(replaced[0]).toBe(sibling);
+    expect(replaced[1]).toBe(server);
+  });
+});
+
+describe("cancelled notebook compensation", () => {
+  it("deletes only the exact server id acknowledged for that operation", async () => {
+    const deleteNotebook = vi.fn().mockResolvedValue(undefined);
+    const onFailure = vi.fn();
+
+    await expect(cleanupCancelledNotebook(
+      "operation-a",
+      "server-created-by-operation-a",
+      deleteNotebook,
+      onFailure,
+    )).resolves.toBe("deleted");
+    expect(deleteNotebook).toHaveBeenCalledTimes(1);
+    expect(deleteNotebook).toHaveBeenCalledWith("server-created-by-operation-a");
+    expect(deleteNotebook).not.toHaveBeenCalledWith("server-created-by-operation-b");
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it("treats 404 as already cleaned", async () => {
+    const deleteNotebook = vi.fn().mockRejectedValue(Object.assign(new Error("missing"), { status: 404 }));
+    const onFailure = vi.fn();
+
+    await expect(cleanupCancelledNotebook(
+      "operation-a",
+      "server-a",
+      deleteNotebook,
+      onFailure,
+    )).resolves.toBe("not-found");
+    expect(deleteNotebook).toHaveBeenCalledTimes(1);
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it.each([403, 409, 500, undefined])(
+    "reports status %s once without retrying or claiming success",
+    async (status) => {
+      const error = Object.assign(new Error("cleanup failed"), { status });
+      const deleteNotebook = vi.fn().mockRejectedValue(error);
+      const onFailure = vi.fn();
+
+      await expect(cleanupCancelledNotebook(
+        "operation-a",
+        "server-a",
+        deleteNotebook,
+        onFailure,
+      )).resolves.toBe("failed");
+      expect(deleteNotebook).toHaveBeenCalledTimes(1);
+      expect(onFailure).toHaveBeenCalledWith({
+        operationId: "operation-a",
+        notebookId: "server-a",
+        status,
+        error,
+      });
+    },
+  );
+});

--- a/frontend/src/lib/__tests__/notebookSort.test.ts
+++ b/frontend/src/lib/__tests__/notebookSort.test.ts
@@ -5,6 +5,9 @@ import {
   compareNotebooks,
   getNotebookDropZone,
   getNotebookDragHint,
+  notebookTreeContainsId,
+  notebookTreeMapChanged,
+  notebookTreeSetChanged,
   normalizeNotebookSortPref,
   reorderNotebooksForDrop,
 } from "@/lib/notebookSort";
@@ -95,6 +98,45 @@ describe("buildNotebookTree", () => {
 
     expect(buildNotebookTree(source, { by: "manual", dir: "desc" }).map((nb) => nb.id)).toEqual(["a", "b"]);
     expect(source[0].children).toBeUndefined();
+  });
+});
+
+describe("notebook subtree memo boundaries", () => {
+  const tree = buildNotebookTree([
+    notebook("root"),
+    notebook("child", { parentId: "root" }),
+    notebook("grandchild", { parentId: "child" }),
+  ])[0];
+
+  it("finds editing and selection ids below the current memoized row", () => {
+    expect(notebookTreeContainsId(tree, "grandchild")).toBe(true);
+    expect(notebookTreeContainsId(tree, "other-root")).toBe(false);
+  });
+
+  it("detects a changed create operation in a descendant only", () => {
+    const operation = { status: "pending" };
+    for (const nextOperation of [
+      { status: "confirmed" },
+      { status: "failed" },
+      { status: "pending", retry: 1 },
+      undefined,
+    ]) {
+      expect(notebookTreeMapChanged(
+        tree,
+        new Map([["grandchild", operation]]),
+        nextOperation ? new Map([["grandchild", nextOperation]]) : new Map(),
+      )).toBe(true);
+    }
+    expect(notebookTreeMapChanged(
+      tree,
+      new Map([["other-root", operation]]),
+      new Map([["other-root", { status: "confirmed" }]]),
+    )).toBe(false);
+  });
+
+  it("detects descendant loading membership without invalidating unrelated branches", () => {
+    expect(notebookTreeSetChanged(tree, new Set(), new Set(["child"]))).toBe(true);
+    expect(notebookTreeSetChanged(tree, new Set(), new Set(["other-root"]))).toBe(false);
   });
 });
 

--- a/frontend/src/lib/notebookCreateState.ts
+++ b/frontend/src/lib/notebookCreateState.ts
@@ -1,0 +1,174 @@
+import type { Notebook } from "@/types";
+
+export type NotebookCreateStatus = "pending" | "confirmed" | "failed";
+
+export type NotebookCreateOperation = {
+  operationId: string;
+  tempId: string;
+  parentId: string | null;
+  workspaceId: string;
+  name: string;
+  status: NotebookCreateStatus;
+  submitted: boolean;
+  serverId?: string;
+  serverName?: string;
+  serverNotebook?: Notebook;
+  error?: string;
+};
+
+export type NotebookCreateState = Record<string, NotebookCreateOperation>;
+
+export type NotebookCreateAction =
+  | { type: "start"; operation: NotebookCreateOperation }
+  | { type: "name"; operationId: string; name: string }
+  | { type: "submit"; operationId: string; name: string }
+  | { type: "pending"; operationId: string }
+  | { type: "confirm"; operationId: string; notebook: Notebook }
+  | { type: "fail"; operationId: string; error: string }
+  | { type: "finish" | "cancel"; operationId: string };
+
+export const EMPTY_NOTEBOOK_CREATE_STATE: NotebookCreateState = {};
+export const TEMP_NOTEBOOK_ID_PREFIX = "temp-notebook:";
+
+export function isTemporaryNotebookId(id: string | null | undefined): boolean {
+  return !!id?.startsWith(TEMP_NOTEBOOK_ID_PREFIX);
+}
+
+export function withoutTemporaryNotebooks(notebooks: Notebook[]): Notebook[] {
+  return notebooks.filter((notebook) => !isTemporaryNotebookId(notebook.id));
+}
+
+export function mergeAuthoritativeNotebooks(
+  current: Notebook[],
+  authoritative: Notebook[],
+): Notebook[] {
+  return [
+    ...authoritative,
+    ...current.filter(
+      (notebook) => isTemporaryNotebookId(notebook.id)
+        && !authoritative.some((incoming) => incoming.id === notebook.id),
+    ),
+  ];
+}
+
+export function replaceOptimisticNotebook(
+  notebooks: Notebook[],
+  temporaryId: string,
+  serverNotebook: Notebook,
+): Notebook[] {
+  const temporaryExists = notebooks.some((notebook) => notebook.id === temporaryId);
+  const serverExists = notebooks.some(
+    (notebook) => notebook.id === serverNotebook.id && notebook.id !== temporaryId,
+  );
+  if (!temporaryExists) return serverExists ? notebooks : [...notebooks, serverNotebook];
+  return notebooks.flatMap((notebook) => {
+    if (notebook.id === temporaryId) return serverExists ? [] : [serverNotebook];
+    return [notebook];
+  });
+}
+
+export type CancelledNotebookCleanupFailure = {
+  operationId: string;
+  notebookId: string;
+  status?: number;
+  error: unknown;
+};
+
+export async function cleanupCancelledNotebook(
+  operationId: string,
+  notebookId: string,
+  deleteNotebook: (id: string) => Promise<unknown>,
+  onFailure: (failure: CancelledNotebookCleanupFailure) => void,
+): Promise<"deleted" | "not-found" | "failed"> {
+  try {
+    await deleteNotebook(notebookId);
+    return "deleted";
+  } catch (error: unknown) {
+    const rawStatus = error && typeof error === "object"
+      ? (error as { status?: unknown }).status
+      : undefined;
+    const status = typeof rawStatus === "number" ? rawStatus : undefined;
+    if (status === 404) return "not-found";
+    onFailure({ operationId, notebookId, status, error });
+    return "failed";
+  }
+}
+
+export function notebookCreateReducer(
+  state: NotebookCreateState,
+  action: NotebookCreateAction,
+): NotebookCreateState {
+  if (action.type === "start") {
+    return { ...state, [action.operation.operationId]: action.operation };
+  }
+  if (action.type === "finish" || action.type === "cancel") {
+    if (!state[action.operationId]) return state;
+    const next = { ...state };
+    delete next[action.operationId];
+    return next;
+  }
+  const current = state[action.operationId];
+  if (!current) return state;
+  switch (action.type) {
+    case "name":
+      return { ...state, [action.operationId]: { ...current, name: action.name } };
+    case "submit":
+      return {
+        ...state,
+        [action.operationId]: { ...current, name: action.name, submitted: true },
+      };
+    case "pending":
+      return {
+        ...state,
+        [action.operationId]: { ...current, status: "pending", error: undefined },
+      };
+    case "confirm":
+      return {
+        ...state,
+        [action.operationId]: {
+          ...current,
+          status: "confirmed",
+          serverId: action.notebook.id,
+          serverName: action.notebook.name,
+          serverNotebook: action.notebook,
+          error: undefined,
+        },
+      };
+    case "fail":
+      return {
+        ...state,
+        [action.operationId]: { ...current, status: "failed", error: action.error },
+      };
+  }
+}
+
+export function findNotebookCreateOperation(
+  state: NotebookCreateState,
+  notebookId: string,
+): NotebookCreateOperation | undefined {
+  return Object.values(state).find(
+    (operation) => operation.tempId === notebookId || operation.serverId === notebookId,
+  );
+}
+
+export function createOptimisticNotebook(
+  operation: NotebookCreateOperation,
+  icon: string,
+  now = new Date().toISOString(),
+): Notebook {
+  return {
+    id: operation.tempId,
+    userId: "",
+    workspaceId: operation.workspaceId === "personal" ? null : operation.workspaceId,
+    parentId: operation.parentId,
+    name: operation.name,
+    description: null,
+    icon,
+    color: null,
+    sortOrder: 0,
+    isExpanded: 0,
+    createdAt: now,
+    updatedAt: now,
+    noteCount: 0,
+  };
+}

--- a/frontend/src/lib/notebookSort.ts
+++ b/frontend/src/lib/notebookSort.ts
@@ -92,6 +92,86 @@ export function buildNotebookTree(notebooks: Notebook[], pref: NotebookSortResol
   return roots;
 }
 
+function sameNotebookFields(a: Notebook, b: Notebook): boolean {
+  return a.id === b.id
+    && a.userId === b.userId
+    && a.workspaceId === b.workspaceId
+    && a.parentId === b.parentId
+    && a.name === b.name
+    && a.description === b.description
+    && a.icon === b.icon
+    && a.color === b.color
+    && a.sortOrder === b.sortOrder
+    && a.isExpanded === b.isExpanded
+    && a.createdAt === b.createdAt
+    && a.updatedAt === b.updatedAt
+    && a.noteCount === b.noteCount
+    && a.myRole === b.myRole
+    && a.permission === b.permission;
+}
+
+/**
+ * buildNotebookTree intentionally creates mutable children arrays while assembling the
+ * tree. Reconcile the finished tree with the previous immutable result so unchanged
+ * branches keep their object identity and memoized recursive rows can bail out.
+ */
+export function reuseNotebookTreeReferences(next: Notebook[], previous: Notebook[]): Notebook[] {
+  if (previous.length === 0) return next;
+  const previousById = new Map<string, Notebook>();
+  const indexPrevious = (nodes: Notebook[]) => {
+    for (const node of nodes) {
+      previousById.set(node.id, node);
+      if (node.children?.length) indexPrevious(node.children);
+    }
+  };
+  indexPrevious(previous);
+
+  const reconcile = (node: Notebook): Notebook => {
+    const nextChildren = (node.children || []).map(reconcile);
+    const previousNode = previousById.get(node.id);
+    const previousChildren = previousNode?.children || [];
+    const childrenUnchanged = previousChildren.length === nextChildren.length
+      && previousChildren.every((child, index) => child === nextChildren[index]);
+    if (previousNode && childrenUnchanged && sameNotebookFields(previousNode, node)) {
+      return previousNode;
+    }
+    return { ...node, children: nextChildren };
+  };
+
+  return next.map(reconcile);
+}
+
+export function notebookTreeContainsId(
+  notebook: Notebook,
+  id: string | null | undefined,
+): boolean {
+  if (!id) return false;
+  if (notebook.id === id) return true;
+  return notebook.children?.some((child) => notebookTreeContainsId(child, id)) ?? false;
+}
+
+export function notebookTreeMapChanged<T>(
+  notebook: Notebook,
+  previous: ReadonlyMap<string, T> | undefined,
+  next: ReadonlyMap<string, T> | undefined,
+): boolean {
+  if (previous?.get(notebook.id) !== next?.get(notebook.id)) return true;
+  return notebook.children?.some(
+    (child) => notebookTreeMapChanged(child, previous, next),
+  ) ?? false;
+}
+
+export function notebookTreeSetChanged(
+  notebook: Notebook,
+  previous: ReadonlySet<string> | undefined,
+  next: ReadonlySet<string> | undefined,
+): boolean {
+  if (previous?.has(notebook.id) !== next?.has(notebook.id)) return true;
+  return notebook.children?.some(
+    (child) => notebookTreeSetChanged(child, previous, next),
+  ) ?? false;
+}
+
 export function getNotebookDragHint(canDragSort: boolean): string {
   return canDragSort ? "拖动调整笔记本顺序" : "切换到手动排序后可拖动调整顺序";
 }

--- a/frontend/src/lib/phaseBPerfDiagnostics.ts
+++ b/frontend/src/lib/phaseBPerfDiagnostics.ts
@@ -1,0 +1,117 @@
+export type PhaseBPerfEvent = {
+  type:
+    | "sidebar-render"
+    | "notebook-item-render"
+    | "build-notebook-tree"
+    | "long-task"
+    | "create-click"
+    | "create-request-start"
+    | "create-response"
+    | "create-state-dispatch"
+    | "create-input-focused"
+    | "browser-interaction";
+  durationMs?: number;
+  notebookId?: string;
+  detail?: Record<string, string | number | boolean | null>;
+  timestamp?: number;
+};
+
+declare global {
+  var __NOWEN_PHASE_B_PERF_EVENTS__: PhaseBPerfEvent[] | undefined;
+  var __NOWEN_PHASE_B_PERF_SINK__: ((event: PhaseBPerfEvent) => void) | undefined;
+}
+
+export const PHASE_B_PERF_ENABLED = import.meta.env.MODE === "test"
+  || import.meta.env.VITE_PHASE_B_PERF === "1";
+
+const MAX_BROWSER_EVENTS = 100_000;
+const browserEvents: PhaseBPerfEvent[] = [];
+const createTraceByNotebookId = new Map<string, string>();
+let exposeTimer: number | null = null;
+
+export function rememberPhaseBCreateTrace(notebookId: string, traceId: string): void {
+  if (!PHASE_B_PERF_ENABLED) return;
+  createTraceByNotebookId.set(notebookId, traceId);
+}
+
+export function takePhaseBCreateTrace(notebookId: string): string | undefined {
+  if (!PHASE_B_PERF_ENABLED) return undefined;
+  const traceId = createTraceByNotebookId.get(notebookId);
+  createTraceByNotebookId.delete(notebookId);
+  return traceId;
+}
+
+export function forgetPhaseBCreateTrace(notebookId: string): void {
+  if (!PHASE_B_PERF_ENABLED) return;
+  createTraceByNotebookId.delete(notebookId);
+}
+
+function exposeBrowserEvents(): void {
+  if (import.meta.env.VITE_PHASE_B_PERF !== "1" || typeof document === "undefined" || exposeTimer !== null) return;
+  exposeTimer = window.setTimeout(() => {
+    exposeTimer = null;
+    let output = document.getElementById("nowen-phase-b-perf-data");
+    if (!output) {
+      output = document.createElement("script");
+      output.id = "nowen-phase-b-perf-data";
+      output.setAttribute("type", "application/json");
+      document.head.appendChild(output);
+    }
+    output.textContent = JSON.stringify(browserEvents.slice(-MAX_BROWSER_EVENTS));
+  }, 25);
+}
+
+export function recordPhaseBPerfEvent(event: PhaseBPerfEvent): void {
+  if (!PHASE_B_PERF_ENABLED) return;
+  const timestamped = { ...event, timestamp: event.timestamp ?? performance.now() };
+  globalThis.__NOWEN_PHASE_B_PERF_SINK__?.(timestamped);
+  if (import.meta.env.VITE_PHASE_B_PERF !== "1") return;
+  browserEvents.push(timestamped);
+  if (browserEvents.length > MAX_BROWSER_EVENTS) browserEvents.splice(0, 20_000);
+  globalThis.__NOWEN_PHASE_B_PERF_EVENTS__ = browserEvents;
+  exposeBrowserEvents();
+}
+
+export function installPhaseBLongTaskObserver(): () => void {
+  if (!PHASE_B_PERF_ENABLED || typeof PerformanceObserver === "undefined") return () => undefined;
+  let observer: PerformanceObserver | null = null;
+  try {
+    observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        recordPhaseBPerfEvent({
+          type: "long-task",
+          durationMs: entry.duration,
+          detail: { startTime: entry.startTime },
+        });
+      }
+    });
+    observer.observe({ entryTypes: ["longtask"] });
+  } catch {
+    observer = null;
+  }
+  return () => observer?.disconnect();
+}
+
+export function installPhaseBBrowserInteractionObserver(): () => void {
+  if (!PHASE_B_PERF_ENABLED || typeof document === "undefined") return () => undefined;
+  const eventTypes = ["pointerdown", "mousedown", "pointerup", "mouseup", "click", "focusin"];
+  const handleEvent = (event: Event) => {
+    const target = event.target instanceof HTMLElement ? event.target : null;
+    recordPhaseBPerfEvent({
+      type: "browser-interaction",
+      detail: {
+        name: event.type,
+        eventTimestamp: event.timeStamp,
+        target: target?.tagName.toLowerCase() || "unknown",
+      },
+    });
+  };
+  eventTypes.forEach((type) => document.addEventListener(type, handleEvent, true));
+  return () => {
+    eventTypes.forEach((type) => document.removeEventListener(type, handleEvent, true));
+    if (exposeTimer !== null) {
+      window.clearTimeout(exposeTimer);
+      exposeTimer = null;
+    }
+  };
+}

--- a/frontend/src/store/AppContext.tsx
+++ b/frontend/src/store/AppContext.tsx
@@ -4,6 +4,10 @@ import { api } from "@/lib/api";
 import { NOTEBOOKS_INVALIDATED_EVENT } from "@/lib/notebookInvalidation";
 import { PhaseAPerfProfiler } from "@/components/PhaseAPerfProfiler";
 import { recordPhaseAPerfEvent } from "@/lib/phaseAPerfDiagnostics";
+import {
+  mergeAuthoritativeNotebooks,
+  replaceOptimisticNotebook,
+} from "@/lib/notebookCreateState";
 
 export type SyncStatus = "idle" | "saving" | "saved" | "error" | "offline" | "queued";
 export type MobileView = "list" | "editor";
@@ -62,6 +66,10 @@ interface AppState {
 
 type Action =
   | { type: "SET_NOTEBOOKS"; payload: Notebook[] }
+  | { type: "ADD_NOTEBOOK"; payload: Notebook }
+  | { type: "REPLACE_NOTEBOOK"; payload: { id: string; notebook: Notebook } }
+  | { type: "UPDATE_NOTEBOOK"; payload: Partial<Notebook> & { id: string } }
+  | { type: "REMOVE_NOTEBOOK"; payload: string }
   | { type: "SET_NOTES"; payload: NoteListItem[] }
   | { type: "SET_ACTIVE_NOTE"; payload: Note | null }
   | { type: "SET_TAGS"; payload: Tag[] }
@@ -184,7 +192,30 @@ export { MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH, DEFAULT_SIDEBAR_WIDTH, MIN_NOTELI
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
     case "SET_NOTEBOOKS":
-      return { ...state, notebooks: action.payload };
+      return {
+        ...state,
+        notebooks: mergeAuthoritativeNotebooks(state.notebooks, action.payload),
+      };
+    case "ADD_NOTEBOOK":
+      if (state.notebooks.some((notebook) => notebook.id === action.payload.id)) return state;
+      return { ...state, notebooks: [...state.notebooks, action.payload] };
+    case "REPLACE_NOTEBOOK": {
+      const notebooks = replaceOptimisticNotebook(
+        state.notebooks,
+        action.payload.id,
+        action.payload.notebook,
+      );
+      return notebooks === state.notebooks ? state : { ...state, notebooks };
+    }
+    case "UPDATE_NOTEBOOK":
+      return {
+        ...state,
+        notebooks: state.notebooks.map((notebook) =>
+          notebook.id === action.payload.id ? { ...notebook, ...action.payload } : notebook
+        ),
+      };
+    case "REMOVE_NOTEBOOK":
+      return { ...state, notebooks: state.notebooks.filter((notebook) => notebook.id !== action.payload) };
     case "SET_NOTES":
       return { ...state, notes: action.payload };
     case "SET_ACTIVE_NOTE":
@@ -417,6 +448,10 @@ export function useAppActions() {
   // 从而避免保存期间频繁 dispatch 导致的编辑器状态抖动（如光标跳行）。
   return useMemo(() => ({
     setNotebooks: (v: Notebook[]) => dispatch({ type: "SET_NOTEBOOKS", payload: v }),
+    addNotebook: (v: Notebook) => dispatch({ type: "ADD_NOTEBOOK", payload: v }),
+    replaceNotebook: (id: string, notebook: Notebook) => dispatch({ type: "REPLACE_NOTEBOOK", payload: { id, notebook } }),
+    updateNotebook: (v: Partial<Notebook> & { id: string }) => dispatch({ type: "UPDATE_NOTEBOOK", payload: v }),
+    removeNotebook: (id: string) => dispatch({ type: "REMOVE_NOTEBOOK", payload: id }),
     setNotes: (v: NoteListItem[]) => dispatch({ type: "SET_NOTES", payload: v }),
     setActiveNote: (v: Note | null) => dispatch({ type: "SET_ACTIVE_NOTE", payload: v }),
     setTags: (v: Tag[]) => dispatch({ type: "SET_TAGS", payload: v }),


### PR DESCRIPTION
## Summary

解决创建根级和子级笔记本时必须等待服务端请求完成、交互延迟明显的问题。

本次修改为笔记本创建增加独立的 optimistic 状态机。用户点击创建后会立即显示可编辑的临时节点，无需等待网络响应；创建成功后临时 ID 原位替换为服务端 ID，失败时保留名称并支持重试或取消。

Closes #333
Related to #210

## Problem

原创建流程为：

```text
点击创建
→ 等待 POST /api/notebooks
→ 更新完整 notebooks 数组
→ 重建侧栏树
→ 显示输入框并聚焦
```

因此：

- 网络延迟会被完整暴露为交互延迟；
- 1000ms 网络延迟下，输入框约 1.2 秒后才出现；
- 根级和子级创建使用不同逻辑；
- 完整数组替换容易使大量树节点引用失效；
- 快速连续创建存在旧闭包覆盖和状态串线风险；
- 失败时缺少可靠的重试、取消及用户输入保留机制。

## Changes

### Optimistic creation state machine

新增独立 operation 状态，覆盖 `pending`、`confirmed`、`failed`、`retry` 和 `cancel`。

每次操作使用独立的 `operationId` 和临时 ID：

```text
点击创建
→ 立即插入临时节点
→ 立即显示并聚焦名称输入框
→ 后台提交创建请求
→ 成功后原位替换服务端 ID
→ 失败后保留名称并显示重试/取消
```

覆盖根级/子级笔记本、个人/团队空间、并发创建、工作区切换、组件卸载、ACK 晚到、后台刷新以及失败重试和取消。

### Incremental notebook updates

为 AppContext 增加 `ADD`、`REPLACE`、`UPDATE`、`REMOVE` 增量操作，避免旧闭包中的完整数组替换，并保持未变化节点引用稳定。

### Sidebar render boundaries

- 未变化子树保持引用稳定；
- 相关祖先在后代状态变化时正确重渲染；
- 覆盖 pending、confirmed、failed、retry、cancel；
- 防止父节点 memo 阻断子节点 ACK；
- comparator 不使用 JSON 深比较。

### Temporary-node isolation

pending/failed 节点不会进入拖拽、排序持久化、移动目标、创建笔记、共享、权限、导出、复制链接、路由选择、普通删除或正常实时同步。

临时节点只允许输入名称、确认、重试和取消。

### Cancellation compensation

用户取消后，如果 POST 已成功或无法及时取消：

- 仅使用 REST ACK 返回的精确服务端 ID；
- 不按名称、父节点、时间或数组位置识别；
- 404 视为已清理；
- 403、409、500 和超时留下诊断；
- 不无限重试；
- 不恢复已取消临时节点。

### Server diagnostics

创建路由增加环境变量控制的阶段计时。诊断关闭时不记录敏感数据，也不修改 SQL、权限或事务语义。正常 production assets 不包含前端性能诊断标记。

## Performance

测试条件：production build、1000 个根级笔记本、人为增加 1000ms POST 延迟、相同 fixture 和浏览器环境。

| 指标 | 修改前 | 修改后 |
| --- | ---: | ---: |
| 外部点击到发现输入框 p50 | 约 1192ms | 约 363ms |
| 外部点击到发现输入框 p95 | 约 1203ms | 约 376ms |
| 应用内部 handler→focus p50 | 未独立记录 | 30.1ms |
| 应用内部 handler→focus p95 | 未独立记录 | 50.9ms |
| POST 响应 p50 | 约 1000ms+ | 1004.1ms |
| POST 响应 p95 | 约 1000ms+ | 1008.7ms |
| 树协调 median | — | 0.159ms |
| 树协调 p95 | — | 0.416ms |
| 未变化根节点引用稳定 | — | 50/50 |

外部指标包含 Playwright actionability、浏览器 RPC 和断言轮询；应用内部 React handler 到实际 `focusin` 为约 30–51ms。服务端路由通常低于 2ms，不是主要瓶颈。

## Tests

通过：

- Phase B 状态机、树和性能测试：32/32；
- 保存、同步、离线及 editor revision guards：33/33；
- 后端笔记本权限、树约束和数据库隔离：10/10；
- frontend TypeScript；
- production build；
- 新增和独立相关文件 ESLint；
- `git diff --check`；
- production assets 诊断标记扫描。

与已包含 Phase A 的最新 main 比较，全量测试没有新增稳定失败：

```text
前端：main 14 failed；Phase B 重复运行 14 failed
后端：main 26 failed；Phase B 重复运行 26 failed
```

首轮并行全量运行曾分别出现 15/28，重复运行恢复基线，属于仓库现有并行测试波动。专项测试稳定通过。

## Known limitations

- POST 已提交但响应完全丢失时，重试可能创建孤立重复实体；
- 补偿删除无法判断实体是否已被其他设备重命名、移动或使用；
- 后续建议引入 `clientOperationId`、服务端幂等创建和条件取消；
- 未来新增 notebook-create WebSocket 广播时需要 operation 协议或 tombstone；
- 超大并全部展开的树尚未虚拟化，本次只优化增量更新和渲染边界。

## Checklist

- [x] 点击后立即显示可编辑临时节点
- [x] 慢网络不阻塞名称输入
- [x] 根级和子级使用统一创建状态机
- [x] 支持并发创建
- [x] 支持失败重试和取消
- [x] tempId 原位替换为服务端 ID
- [x] 临时节点与正常业务操作隔离
- [x] 未变化子树保持引用稳定
- [x] 没有修改保存、冲突或离线同步语义
- [x] 没有新增稳定全量测试失败