### PR TITLE
feat(离线同步): 支持任务和习惯本地缓存同步

### DIFF
--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -248,6 +248,89 @@ const repairSearchContentTextMigration: Migration = {
   },
 };
 
+const offlineResourceSyncMigration: Migration = {
+  version: 53,
+  name: "offline-resource-sync-metadata",
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS offline_mutation_results (
+        userId TEXT NOT NULL,
+        operationId TEXT NOT NULL,
+        responseJson TEXT NOT NULL,
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (userId, operationId),
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_offline_mutation_results_created
+        ON offline_mutation_results(createdAt);
+
+      CREATE TABLE IF NOT EXISTS offline_resource_field_clocks (
+        resourceType TEXT NOT NULL,
+        resourceId TEXT NOT NULL,
+        fieldName TEXT NOT NULL,
+        clientUpdatedAt TEXT NOT NULL,
+        PRIMARY KEY (resourceType, resourceId, fieldName)
+      );
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_field_clocks_resource
+        ON offline_resource_field_clocks(resourceType, resourceId);
+
+      CREATE TABLE IF NOT EXISTS offline_resource_tombstones (
+        resourceType TEXT NOT NULL,
+        resourceId TEXT NOT NULL,
+        userId TEXT NOT NULL,
+        workspaceId TEXT,
+        deletedAt TEXT NOT NULL,
+        PRIMARY KEY (resourceType, resourceId),
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_tombstones_scope
+        ON offline_resource_tombstones(resourceType, userId, workspaceId);
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_repeat_group_sequence
+        ON tasks(repeatGroupId, repeatSequenceIndex)
+        WHERE repeatGroupId IS NOT NULL AND repeatSequenceIndex IS NOT NULL;
+    `);
+  },
+};
+
+const offlineResourceSyncTieBreakMigration: Migration = {
+  version: 54,
+  name: "offline-resource-sync-operation-tie-break",
+  up: (db) => {
+    db.exec(`
+      ALTER TABLE offline_resource_field_clocks
+        ADD COLUMN clientOperationId TEXT NOT NULL DEFAULT '';
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_field_clocks_retention
+        ON offline_resource_field_clocks(clientUpdatedAt);
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_tombstones_retention
+        ON offline_resource_tombstones(deletedAt);
+    `);
+  },
+};
+
+const offlineResourceSyncServerRetentionMigration: Migration = {
+  version: 55,
+  name: "offline-resource-sync-server-retention",
+  up: (db) => {
+    db.exec(`
+      ALTER TABLE offline_resource_field_clocks
+        ADD COLUMN recordedAt TEXT NOT NULL DEFAULT '';
+      ALTER TABLE offline_resource_tombstones
+        ADD COLUMN recordedAt TEXT NOT NULL DEFAULT '';
+      UPDATE offline_resource_field_clocks
+        SET recordedAt = datetime('now')
+        WHERE recordedAt = '';
+      UPDATE offline_resource_tombstones
+        SET recordedAt = datetime('now')
+        WHERE recordedAt = '';
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_field_clocks_recorded
+        ON offline_resource_field_clocks(recordedAt);
+      CREATE INDEX IF NOT EXISTS idx_offline_resource_tombstones_recorded
+        ON offline_resource_tombstones(recordedAt);
+    `);
+  },
+};
+
 export const MIGRATIONS: Migration[] = [
   ...BASE_MIGRATIONS.filter((migration) => migration.version !== 44),
   patchedV44,
@@ -256,6 +339,9 @@ export const MIGRATIONS: Migration[] = [
   userAISettingsMigration,
   noteImportOriginsMigration,
   repairSearchContentTextMigration,
+  offlineResourceSyncMigration,
+  offlineResourceSyncTieBreakMigration,
+  offlineResourceSyncServerRetentionMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -70,7 +70,7 @@ import { publishMdns, stopMdns } from "./services/discovery";
 import { startEmbeddingWorker, stopEmbeddingWorker } from "./services/embedding-worker";
 import { initVecStore, reindexAllVectors, isVecAvailable } from "./services/vec-store";
 import { startCalendarExportScheduler, stopCalendarExportScheduler } from "./services/calendar-export";
-import { DEFAULT_NATIVE_CORS_ORIGINS, resolveCorsOrigin, resolveCorsOrigins } from "./lib/cors-policy";
+import { CORS_ALLOW_HEADERS, DEFAULT_NATIVE_CORS_ORIGINS, resolveCorsOrigin, resolveCorsOrigins } from "./lib/cors-policy";
 
 const app = new Hono();
 
@@ -84,7 +84,7 @@ app.use("*", cors({
     return resolveCorsOrigin({ origin, isProd, corsOrigins });
   },
   allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  allowHeaders: ["Content-Type", "X-User-Id", "Authorization", "X-Sudo-Token", "X-Connection-Id", "X-Share-Session", "X-Requested-With", "X-Request-Id", "X-Export-Filename"],
+  allowHeaders: CORS_ALLOW_HEADERS,
   credentials: true,
 }));
 

--- a/backend/src/lib/cors-policy.ts
+++ b/backend/src/lib/cors-policy.ts
@@ -8,6 +8,20 @@ export const DEFAULT_NATIVE_CORS_ORIGINS = [
   "null",
 ];
 
+export const CORS_ALLOW_HEADERS = [
+  "Content-Type",
+  "X-User-Id",
+  "Authorization",
+  "X-Sudo-Token",
+  "X-Connection-Id",
+  "X-Share-Session",
+  "X-Requested-With",
+  "X-Request-Id",
+  "X-Export-Filename",
+  "Idempotency-Key",
+  "X-Client-Mutation-At",
+];
+
 export function resolveCorsOrigins(raw = process.env.CORS_ORIGINS): string[] {
   if (!raw) return [];
   return raw.split(",").map((s) => s.trim()).filter(Boolean);

--- a/backend/src/lib/offlineResourceSync.ts
+++ b/backend/src/lib/offlineResourceSync.ts
@@ -1,0 +1,139 @@
+import type Database from "better-sqlite3";
+
+type MutationResponse = Record<string, unknown>;
+const METADATA_RETENTION_DAYS = 30;
+const MAX_FUTURE_CLIENT_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000;
+
+function normalizedClientTime(value: string | undefined): string {
+  const serverNow = Date.now();
+  if (!value) return new Date(serverNow).toISOString();
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return new Date(serverNow).toISOString();
+  return new Date(
+    timestamp > serverNow + MAX_FUTURE_CLIENT_CLOCK_SKEW_MS ? serverNow : timestamp,
+  ).toISOString();
+}
+
+export function getClientMutationAt(header: string | undefined): string {
+  return normalizedClientTime(header);
+}
+
+export function getIdempotentMutation(
+  db: Database.Database,
+  userId: string,
+  operationId: string | undefined,
+): MutationResponse | null {
+  if (!operationId) return null;
+  const row = db.prepare(
+    "SELECT responseJson FROM offline_mutation_results WHERE userId = ? AND operationId = ?",
+  ).get(userId, operationId) as { responseJson: string } | undefined;
+  if (!row) return null;
+  try {
+    return JSON.parse(row.responseJson) as MutationResponse;
+  } catch {
+    return null;
+  }
+}
+
+export function saveIdempotentMutation(
+  db: Database.Database,
+  userId: string,
+  operationId: string | undefined,
+  response: unknown,
+): void {
+  if (!operationId) return;
+  db.prepare(`
+    INSERT OR REPLACE INTO offline_mutation_results (userId, operationId, responseJson, createdAt)
+    VALUES (?, ?, ?, datetime('now'))
+  `).run(userId, operationId, JSON.stringify(response));
+  pruneOfflineSyncMetadata(db);
+}
+
+export function pruneOfflineSyncMetadata(db: Database.Database): void {
+  const retention = `-${METADATA_RETENTION_DAYS} days`;
+  db.prepare("DELETE FROM offline_mutation_results WHERE createdAt < datetime('now', ?)").run(retention);
+  db.prepare("DELETE FROM offline_resource_field_clocks WHERE recordedAt < datetime('now', ?)").run(retention);
+  db.prepare("DELETE FROM offline_resource_tombstones WHERE recordedAt < datetime('now', ?)").run(retention);
+}
+
+export function getNewerFields(
+  db: Database.Database,
+  resourceType: string,
+  resourceId: string,
+  fields: readonly string[],
+  clientUpdatedAt: string,
+  operationId?: string,
+): Set<string> {
+  if (fields.length === 0) return new Set();
+  const placeholders = fields.map(() => "?").join(",");
+  const rows = db.prepare(`
+    SELECT fieldName, clientUpdatedAt, clientOperationId
+    FROM offline_resource_field_clocks
+    WHERE resourceType = ? AND resourceId = ? AND fieldName IN (${placeholders})
+  `).all(resourceType, resourceId, ...fields) as Array<{ fieldName: string; clientUpdatedAt: string; clientOperationId: string }>;
+  const current = new Map(rows.map((row) => [row.fieldName, row]));
+  const incomingOperationId = operationId || "";
+  return new Set(fields.filter((field) => {
+    const clock = current.get(field);
+    if (!clock) return true;
+    return clientUpdatedAt > clock.clientUpdatedAt
+      || (clientUpdatedAt === clock.clientUpdatedAt && incomingOperationId >= (clock.clientOperationId || ""));
+  }));
+}
+
+export function hasNewerFieldClock(
+  db: Database.Database,
+  resourceType: string,
+  resourceId: string,
+  clientUpdatedAt: string,
+): boolean {
+  return !!db.prepare(`
+    SELECT 1
+    FROM offline_resource_field_clocks
+    WHERE resourceType = ? AND resourceId = ? AND clientUpdatedAt > ?
+    LIMIT 1
+  `).get(resourceType, resourceId, clientUpdatedAt);
+}
+
+export function writeFieldClocks(
+  db: Database.Database,
+  resourceType: string,
+  resourceId: string,
+  fields: Iterable<string>,
+  clientUpdatedAt: string,
+  operationId?: string,
+): void {
+  const write = db.prepare(`
+    INSERT INTO offline_resource_field_clocks (resourceType, resourceId, fieldName, clientUpdatedAt, clientOperationId, recordedAt)
+    VALUES (?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(resourceType, resourceId, fieldName)
+    DO UPDATE SET clientUpdatedAt = excluded.clientUpdatedAt, clientOperationId = excluded.clientOperationId, recordedAt = excluded.recordedAt
+  `);
+  for (const field of fields) write.run(resourceType, resourceId, field, clientUpdatedAt, operationId || "");
+}
+
+export function getTombstone(
+  db: Database.Database,
+  resourceType: string,
+  resourceId: string,
+): { userId: string; workspaceId: string | null; deletedAt: string } | undefined {
+  return db.prepare(
+    "SELECT userId, workspaceId, deletedAt FROM offline_resource_tombstones WHERE resourceType = ? AND resourceId = ?",
+  ).get(resourceType, resourceId) as { userId: string; workspaceId: string | null; deletedAt: string } | undefined;
+}
+
+export function writeTombstone(
+  db: Database.Database,
+  resourceType: string,
+  resourceId: string,
+  userId: string,
+  workspaceId: string | null,
+  deletedAt: string,
+): void {
+  db.prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt, recordedAt)
+    VALUES (?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(resourceType, resourceId)
+    DO UPDATE SET deletedAt = excluded.deletedAt, userId = excluded.userId, workspaceId = excluded.workspaceId, recordedAt = excluded.recordedAt
+  `).run(resourceType, resourceId, userId, workspaceId, deletedAt);
+}

--- a/backend/src/repositories/taskRemindersRepository.ts
+++ b/backend/src/repositories/taskRemindersRepository.ts
@@ -85,7 +85,7 @@ export const taskRemindersRepository = {
   }): void {
     const db = getDb();
     db.prepare(
-      "UPDATE task_reminders SET offsetMinutes = ?, enabled = ?, snoozedUntil = ?, updatedAt = datetime('now') WHERE id = ?"
+      "UPDATE task_reminders SET offsetMinutes = ?, enabled = ?, snoozedUntil = ? WHERE id = ?"
     ).run(input.offsetMinutes, input.enabled ? 1 : 0, input.snoozedUntil, reminderId);
   },
 

--- a/backend/src/routes/habits.ts
+++ b/backend/src/routes/habits.ts
@@ -3,6 +3,16 @@ import type { Context } from "hono";
 import crypto from "crypto";
 import { getDb } from "../db/schema";
 import {
+    getClientMutationAt,
+    hasNewerFieldClock,
+    getIdempotentMutation,
+    getNewerFields,
+    getTombstone,
+    saveIdempotentMutation,
+    writeFieldClocks,
+    writeTombstone,
+} from "../lib/offlineResourceSync";
+import {
     canManageResource,
     getUserWorkspaceRole,
     isFeatureEnabled,
@@ -105,6 +115,25 @@ function canCreateInWorkspace(workspaceId: string | null, userId: string): boole
     if (!workspaceId) return true;
     const role = getUserWorkspaceRole(workspaceId, userId) as string | null;
     return !!role && (ROLE_RANK[role] ?? 0) >= ROLE_RANK.editor;
+}
+
+function canCreateAgainstHabitTombstone(
+    tombstone: { userId: string; workspaceId: string | null } | undefined,
+    workspaceId: string | null,
+    userId: string,
+): boolean {
+    if (!tombstone || tombstone.workspaceId !== workspaceId) return false;
+    if (!workspaceId) return tombstone.userId === userId;
+    return canCreateInWorkspace(workspaceId, userId);
+}
+
+function canReadHabitTombstone(
+    tombstone: { userId: string; workspaceId: string | null } | undefined,
+    userId: string,
+): boolean {
+    if (!tombstone) return false;
+    if (!tombstone.workspaceId) return tombstone.userId === userId;
+    return !!getUserWorkspaceRole(tombstone.workspaceId, userId);
 }
 
 function getHabitOr404(id: string): HabitRecord | undefined {
@@ -293,6 +322,10 @@ habits.get("/checkins", requireWorkspaceFeature("tasks"), (c) => {
 habits.post("/", requireWorkspaceFeature("tasks"), async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
+    const operationId = c.req.header("Idempotency-Key");
+    const replay = getIdempotentMutation(db, userId, operationId);
+    if (replay) return c.json(replay, 200);
+    const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
     const body = await c.req.json();
     const scope = resolveHabitScope(c, userId);
     if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
@@ -303,23 +336,47 @@ habits.post("/", requireWorkspaceFeature("tasks"), async (c) => {
     const title = typeof body.title === "string" ? body.title.trim() : "";
     if (!title) return c.json({ error: "Title is required", code: "BAD_REQUEST" }, 400);
 
-    const id = crypto.randomUUID();
+    const requestedId = typeof body.id === "string" ? body.id : "";
+    if (requestedId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestedId)) {
+        return c.json({ error: "Invalid habit id", code: "INVALID_HABIT_ID" }, 400);
+    }
+    const id = requestedId || crypto.randomUUID();
+    if (requestedId) {
+        const tombstone = getTombstone(db, "habit", id);
+        if (tombstone && canCreateAgainstHabitTombstone(tombstone, scope.workspaceId, userId) && clientUpdatedAt <= tombstone.deletedAt) {
+            return c.json({ success: true, syncIgnored: true }, 200);
+        }
+        const existing = db.prepare("SELECT * FROM habits WHERE id = ?").get(id) as HabitListRecord | undefined;
+        if (existing) {
+            if (existing.userId !== userId || existing.workspaceId !== scope.workspaceId) {
+                return c.json({ error: "Habit id already exists", code: "HABIT_ID_CONFLICT" }, 409);
+            }
+            const response = { ...existing, canManage: true };
+            saveIdempotentMutation(db, userId, operationId, response);
+            return c.json(response, 201);
+        }
+    }
     const icon = typeof body.icon === "string" && body.icon.trim() ? body.icon.trim() : "check-circle";
     const color = typeof body.color === "string" && body.color.trim() ? body.color.trim() : "#10b981";
     const sortOrder = Number.isFinite(Number(body.sortOrder)) ? Number(body.sortOrder) : 0;
 
-    db.prepare(`
-    INSERT INTO habits (id, userId, workspaceId, title, icon, color, sortOrder)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-  `).run(id, userId, scope.workspaceId, title, icon, color, sortOrder);
-
-    const created = db.prepare(`
-      SELECT habits.*, users.username AS creatorName
-      FROM habits
-      LEFT JOIN users ON users.id = habits.userId
-      WHERE habits.id = ?
-    `).get(id) as HabitListRecord;
-    return c.json({ ...created, canManage: true }, 201);
+        const response = db.transaction(() => {
+                db.prepare(`
+                    INSERT INTO habits (id, userId, workspaceId, title, icon, color, sortOrder)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                `).run(id, userId, scope.workspaceId, title, icon, color, sortOrder);
+                const created = db.prepare(`
+                    SELECT habits.*, users.username AS creatorName
+                    FROM habits
+                    LEFT JOIN users ON users.id = habits.userId
+                    WHERE habits.id = ?
+                `).get(id) as HabitListRecord;
+                const result = { ...created, canManage: true };
+                writeFieldClocks(db, "habit", id, ["title", "icon", "color", "sortOrder", "archivedAt"], clientUpdatedAt, operationId);
+                saveIdempotentMutation(db, userId, operationId, result);
+                return result;
+        })();
+        return c.json(response, 201);
 });
 
 habits.get("/:id/checkins", (c) => {
@@ -327,7 +384,14 @@ habits.get("/:id/checkins", (c) => {
     const userId = c.req.header("X-User-Id")!;
     const id = c.req.param("id");
     const habit = getHabitOr404(id);
-    if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
+    if (!habit) {
+        const tombstone = getTombstone(db, "habit", id);
+        const canReadTombstone = canReadHabitTombstone(tombstone, userId);
+        if (canReadTombstone) {
+            return c.json({ success: true, syncIgnored: true });
+        }
+        return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
+    }
     const disabled = rejectDisabledHabitFeature(c, habit.workspaceId);
     if (disabled) return disabled;
 
@@ -359,6 +423,10 @@ habits.get("/:id/checkins", (c) => {
 habits.post("/:id/checkins", async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
+    const operationId = c.req.header("Idempotency-Key");
+    const replay = getIdempotentMutation(db, userId, operationId);
+    if (replay) return c.json(replay, 200);
+    const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
     const id = c.req.param("id");
     const habit = getHabitOr404(id);
     if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
@@ -377,24 +445,31 @@ habits.post("/:id/checkins", async (c) => {
     const checkinDate = normalizeCheckinDate(body.checkinDate);
     if (!checkinDate) return invalidDate(c);
     const note = typeof body.note === "string" ? body.note : "";
+    const checkinResourceId = `${id}:${checkinDate}`;
+    const accepted = getNewerFields(db, "habitCheckin", checkinResourceId, ["status", "note"], clientUpdatedAt, operationId);
     const existing = db.prepare(
         "SELECT id FROM habit_checkins WHERE habitId = ? AND checkinDate = ?",
     ).get(id, checkinDate) as { id: string } | undefined;
 
-    if (existing) {
-        db.prepare(
-            "UPDATE habit_checkins SET userId = ?, status = ?, note = ?, updatedAt = datetime('now') WHERE id = ?",
-        ).run(userId, status, note, existing.id);
-    } else {
-        db.prepare(`
-      INSERT INTO habit_checkins (id, habitId, userId, workspaceId, checkinDate, status, note)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(crypto.randomUUID(), id, userId, habit.workspaceId, checkinDate, status, note);
-    }
-
-    const row = db.prepare(
-        "SELECT * FROM habit_checkins WHERE habitId = ? AND checkinDate = ?",
-    ).get(id, checkinDate);
+    const row = db.transaction(() => {
+        if (existing && accepted.size > 0) {
+            const current = db.prepare("SELECT status, note FROM habit_checkins WHERE id = ?").get(existing.id) as { status: HabitStatus; note: string };
+            db.prepare(
+                "UPDATE habit_checkins SET userId = ?, status = ?, note = ?, updatedAt = datetime('now') WHERE id = ?",
+            ).run(userId, accepted.has("status") ? status : current.status, accepted.has("note") ? note : current.note, existing.id);
+        } else if (!existing) {
+            db.prepare(`
+              INSERT INTO habit_checkins (id, habitId, userId, workspaceId, checkinDate, status, note)
+              VALUES (?, ?, ?, ?, ?, ?, ?)
+            `).run(crypto.randomUUID(), id, userId, habit.workspaceId, checkinDate, status, note);
+        }
+        const current = db.prepare(
+            "SELECT * FROM habit_checkins WHERE habitId = ? AND checkinDate = ?",
+        ).get(id, checkinDate) as Record<string, unknown>;
+        if (!existing || accepted.size > 0) writeFieldClocks(db, "habitCheckin", checkinResourceId, ["status", "note"], clientUpdatedAt, operationId);
+        saveIdempotentMutation(db, userId, operationId, current);
+        return current;
+    })();
     return c.json(row, existing ? 200 : 201);
 });
 
@@ -402,6 +477,10 @@ habits.put("/:id", async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
     const id = c.req.param("id");
+    const operationId = c.req.header("Idempotency-Key");
+    const replay = getIdempotentMutation(db, userId, operationId);
+    if (replay) return c.json(replay, 200);
+    const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
     const habit = getHabitOr404(id);
     if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
     const disabled = rejectDisabledHabitFeature(c, habit.workspaceId);
@@ -411,18 +490,24 @@ habits.put("/:id", async (c) => {
     }
 
     const body = await c.req.json();
-    const title = typeof body.title === "string" && body.title.trim() ? body.title.trim() : habit.title;
-    const icon = typeof body.icon === "string" && body.icon.trim() ? body.icon.trim() : habit.icon;
-    const color = typeof body.color === "string" && body.color.trim() ? body.color.trim() : habit.color;
-    const sortOrder = Number.isFinite(Number(body.sortOrder)) ? Number(body.sortOrder) : habit.sortOrder;
+    const requestedFields = ["title", "icon", "color", "sortOrder"].filter((field) => Object.prototype.hasOwnProperty.call(body, field));
+    const accepted = getNewerFields(db, "habit", id, requestedFields, clientUpdatedAt, operationId);
+    const title = accepted.has("title") && typeof body.title === "string" && body.title.trim() ? body.title.trim() : habit.title;
+    const icon = accepted.has("icon") && typeof body.icon === "string" && body.icon.trim() ? body.icon.trim() : habit.icon;
+    const color = accepted.has("color") && typeof body.color === "string" && body.color.trim() ? body.color.trim() : habit.color;
+    const sortOrder = accepted.has("sortOrder") && Number.isFinite(Number(body.sortOrder)) ? Number(body.sortOrder) : habit.sortOrder;
 
-    db.prepare(`
-    UPDATE habits
-    SET title = ?, icon = ?, color = ?, sortOrder = ?, updatedAt = datetime('now')
-    WHERE id = ?
-  `).run(title, icon, color, sortOrder, id);
-
-    const updated = db.prepare("SELECT * FROM habits WHERE id = ?").get(id);
+        const updated = db.transaction(() => {
+                db.prepare(`
+                    UPDATE habits
+                    SET title = ?, icon = ?, color = ?, sortOrder = ?, updatedAt = datetime('now')
+                    WHERE id = ?
+                `).run(title, icon, color, sortOrder, id);
+                const current = db.prepare("SELECT * FROM habits WHERE id = ?").get(id) as Record<string, unknown>;
+                writeFieldClocks(db, "habit", id, accepted, clientUpdatedAt, operationId);
+                saveIdempotentMutation(db, userId, operationId, current);
+                return current;
+        })();
     return c.json(updated);
 });
 
@@ -430,6 +515,10 @@ habits.patch("/:id/archive", async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
     const id = c.req.param("id");
+    const operationId = c.req.header("Idempotency-Key");
+    const replay = getIdempotentMutation(db, userId, operationId);
+    if (replay) return c.json(replay, 200);
+    const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
     const habit = getHabitOr404(id);
     if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
     const disabled = rejectDisabledHabitFeature(c, habit.workspaceId);
@@ -441,8 +530,16 @@ habits.patch("/:id/archive", async (c) => {
     const body = await c.req.json().catch(() => ({}));
     const archived = body.archived !== false;
     const archivedAt = archived ? new Date().toISOString() : null;
-    db.prepare("UPDATE habits SET archivedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(archivedAt, id);
-    const updated = db.prepare("SELECT * FROM habits WHERE id = ?").get(id);
+    const accepted = getNewerFields(db, "habit", id, ["archivedAt"], clientUpdatedAt, operationId);
+    const updated = db.transaction(() => {
+        if (accepted.has("archivedAt")) {
+            db.prepare("UPDATE habits SET archivedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(archivedAt, id);
+            writeFieldClocks(db, "habit", id, accepted, clientUpdatedAt, operationId);
+        }
+        const current = db.prepare("SELECT * FROM habits WHERE id = ?").get(id) as Record<string, unknown>;
+        saveIdempotentMutation(db, userId, operationId, current);
+        return current;
+    })();
     return c.json(updated);
 });
 
@@ -450,6 +547,10 @@ habits.delete("/:id", async (c) => {
     const db = getDb();
     const userId = c.req.header("X-User-Id")!;
     const id = c.req.param("id");
+    const operationId = c.req.header("Idempotency-Key");
+    const replay = getIdempotentMutation(db, userId, operationId);
+    if (replay) return c.json(replay, 200);
+    const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
     const habit = getHabitOr404(id);
     if (!habit) return c.json({ error: "Habit not found", code: "NOT_FOUND" }, 404);
     const disabled = rejectDisabledHabitFeature(c, habit.workspaceId);
@@ -457,9 +558,24 @@ habits.delete("/:id", async (c) => {
     if (!canManageResource(habit.userId, habit.workspaceId, userId)) {
         return c.json({ error: "无权删除该习惯", code: "FORBIDDEN" }, 403);
     }
+    if (hasNewerFieldClock(db, "habit", id, clientUpdatedAt)) {
+        const response = { success: true, syncIgnored: true };
+        saveIdempotentMutation(db, userId, operationId, response);
+        return c.json(response);
+    }
 
-    db.prepare("DELETE FROM habits WHERE id = ?").run(id);
-    return c.json({ success: true });
+    const tombstone = getTombstone(db, "habit", id);
+    if (!tombstone || clientUpdatedAt >= tombstone.deletedAt) {
+        db.transaction(() => {
+            writeTombstone(db, "habit", id, habit.userId, habit.workspaceId, clientUpdatedAt);
+            db.prepare("DELETE FROM habits WHERE id = ?").run(id);
+            saveIdempotentMutation(db, userId, operationId, { success: true });
+        })();
+        return c.json({ success: true });
+    }
+    const response = { success: true };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
 });
 
 export default habits;

--- a/backend/src/routes/task-dependencies.ts
+++ b/backend/src/routes/task-dependencies.ts
@@ -3,6 +3,7 @@ import { getDb } from "../db/schema";
 import crypto from "crypto";
 import { getUserWorkspaceRole, canManageResource } from "../middleware/acl";
 import { taskDependenciesRepository } from "../repositories";
+import { getClientMutationAt, getIdempotentMutation, getTombstone, saveIdempotentMutation, writeTombstone } from "../lib/offlineResourceSync";
 
 const taskDependencies = new Hono();
 
@@ -12,6 +13,16 @@ function resolveScope(c: any, userId: string) {
   const role = getUserWorkspaceRole(raw, userId);
   if (!role) return { workspaceId: raw, error: "No access to workspace" };
   return { workspaceId: raw };
+}
+
+function canAccessTombstone(
+  tombstone: { userId: string; workspaceId: string | null } | undefined,
+  userId: string,
+): boolean {
+  if (!tombstone) return false;
+  if (!tombstone.workspaceId) return tombstone.userId === userId;
+  const role = getUserWorkspaceRole(tombstone.workspaceId, userId);
+  return role === "editor" || role === "admin" || role === "owner";
 }
 
 // Check if adding predecessor -> successor would create a cycle
@@ -61,8 +72,16 @@ taskDependencies.get("/", (c) => {
 taskDependencies.post("/", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
   const body = await c.req.json();
   const { predecessorTaskId, successorTaskId, type = "finish_to_start" } = body;
+  const requestedId = typeof body.id === "string" ? body.id : "";
+  if (requestedId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestedId)) {
+    return c.json({ error: "Invalid dependency id", code: "INVALID_DEPENDENCY_ID" }, 400);
+  }
 
   if (!predecessorTaskId || !successorTaskId) {
     return c.json({ error: "predecessorTaskId and successorTaskId are required" }, 400);
@@ -78,6 +97,13 @@ taskDependencies.post("/", async (c) => {
   const pred = db.prepare("SELECT * FROM tasks WHERE id = ?").get(predecessorTaskId) as any;
   const succ = db.prepare("SELECT * FROM tasks WHERE id = ?").get(successorTaskId) as any;
   if (!pred || !succ) {
+    const tombstones = [
+      getTombstone(db, "task", predecessorTaskId),
+      getTombstone(db, "task", successorTaskId),
+    ];
+    if (tombstones.some((tombstone) => canAccessTombstone(tombstone, userId))) {
+      return c.json({ success: true, syncIgnored: true }, 200);
+    }
     return c.json({ error: "Task not found" }, 404);
   }
 
@@ -99,6 +125,22 @@ taskDependencies.post("/", async (c) => {
     }
   }
 
+  const id = requestedId || crypto.randomUUID();
+  const tombstone = getTombstone(db, "taskDependency", id);
+  if (tombstone && canAccessTombstone(tombstone, userId) && clientUpdatedAt <= tombstone.deletedAt) {
+    const response = { success: true, syncIgnored: true };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
+  const existing = taskDependenciesRepository.getById(id);
+  if (existing) {
+    if (existing.userId !== userId || existing.predecessorTaskId !== predecessorTaskId || existing.successorTaskId !== successorTaskId || existing.type !== type) {
+      return c.json({ error: "Dependency id already exists", code: "DEPENDENCY_ID_CONFLICT" }, 409);
+    }
+    saveIdempotentMutation(db, userId, operationId, existing);
+    return c.json(existing, 200);
+  }
+
   // Check for duplicate
   if (taskDependenciesRepository.exists(predecessorTaskId, successorTaskId, type)) {
     return c.json({ error: "Dependency already exists" }, 409);
@@ -108,20 +150,32 @@ taskDependencies.post("/", async (c) => {
   if (wouldCreateCycle(db, predecessorTaskId, successorTaskId, wsId)) {
     return c.json({ error: "Circular dependency is not allowed", code: "DEPENDENCY_CYCLE" }, 400);
   }
-
-  const id = crypto.randomUUID();
-  taskDependenciesRepository.create({ id, userId, workspaceId: wsId, predecessorTaskId, successorTaskId, type });
-
-  const created = taskDependenciesRepository.getById(id);
+  const created = db.transaction(() => {
+    taskDependenciesRepository.create({ id, userId, workspaceId: wsId, predecessorTaskId, successorTaskId, type });
+    const dependency = taskDependenciesRepository.getById(id);
+    saveIdempotentMutation(db, userId, operationId, dependency);
+    return dependency;
+  })();
   return c.json(created, 201);
 });
 
 taskDependencies.delete("/:id", (c) => {
+  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const depId = c.req.param("id");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const dep = taskDependenciesRepository.getById(depId);
   if (!dep) {
+    const tombstone = getTombstone(db, "taskDependency", depId);
+    if (canAccessTombstone(tombstone, userId)) {
+      const response = { success: true, syncIgnored: true };
+      saveIdempotentMutation(db, userId, operationId, response);
+      return c.json(response);
+    }
     return c.json({ error: "Dependency not found" }, 404);
   }
 
@@ -137,8 +191,13 @@ taskDependencies.delete("/:id", (c) => {
     }
   }
 
-  taskDependenciesRepository.delete(depId);
-  return c.json({ success: true });
+  const response = { success: true };
+  db.transaction(() => {
+    taskDependenciesRepository.delete(depId);
+    writeTombstone(db, "taskDependency", depId, dep.userId, dep.workspaceId, clientUpdatedAt);
+    saveIdempotentMutation(db, userId, operationId, response);
+  })();
+  return c.json(response);
 });
 
 export default taskDependencies;

--- a/backend/src/routes/task-reminders.ts
+++ b/backend/src/routes/task-reminders.ts
@@ -7,6 +7,7 @@ import {
   canManageResource,
 } from "../middleware/acl";
 import { taskRemindersRepository } from "../repositories";
+import { getClientMutationAt, getIdempotentMutation, getNewerFields, getTombstone, hasNewerFieldClock, saveIdempotentMutation, writeFieldClocks, writeTombstone } from "../lib/offlineResourceSync";
 
 const taskReminders = new Hono();
 
@@ -24,6 +25,24 @@ function resolveScope(
     return { workspaceId: raw, error: "无权访问该工作区" };
   }
   return { workspaceId: raw };
+}
+
+function canAccessReminderTombstone(
+  tombstone: { userId: string; workspaceId: string | null } | undefined,
+  userId: string,
+): boolean {
+  if (!tombstone) return false;
+  if (!tombstone.workspaceId) return tombstone.userId === userId;
+  const role = getUserWorkspaceRole(tombstone.workspaceId, userId);
+  return role === "editor" || role === "admin" || role === "owner";
+}
+
+function canReadTask(
+  task: { userId: string; workspaceId: string | null },
+  userId: string,
+): boolean {
+  if (!task.workspaceId) return task.userId === userId;
+  return getUserWorkspaceRole(task.workspaceId, userId) !== null;
 }
 
 // 获取某任务的所有提醒配置
@@ -65,9 +84,9 @@ taskReminders.get("/overview", (c) => {
              t.dueDate, t.dueAt
       FROM task_reminders r
       JOIN tasks t ON t.id = r.taskId
-      WHERE r.userId = ? AND t.workspaceId IS NULL
+      WHERE r.userId = ? AND t.userId = ? AND t.workspaceId IS NULL
       ORDER BY r.createdAt DESC
-    `).all(userId) as any[];
+    `).all(userId, userId) as any[];
   }
 
   const missed: any[] = [];
@@ -141,6 +160,42 @@ taskReminders.get("/overview", (c) => {
   return c.json({ missed, today, upcoming, disabled });
 });
 
+taskReminders.get("/snapshot", (c) => {
+  const db = getDb();
+  const userId = c.req.header("X-User-Id")!;
+  const scope = resolveScope(c, userId);
+  if (scope.error) return c.json({ error: scope.error }, 403);
+
+  const reminders = scope.workspaceId
+    ? db.prepare(`
+        SELECT r.*
+        FROM task_reminders r
+        INNER JOIN tasks t ON t.id = r.taskId
+        WHERE r.userId = ? AND t.workspaceId = ?
+        ORDER BY r.createdAt DESC
+      `).all(userId, scope.workspaceId)
+    : db.prepare(`
+        SELECT r.*
+        FROM task_reminders r
+        INNER JOIN tasks t ON t.id = r.taskId
+        WHERE r.userId = ? AND t.userId = ? AND t.workspaceId IS NULL
+        ORDER BY r.createdAt DESC
+      `).all(userId, userId);
+  const deletedIds = scope.workspaceId
+    ? db.prepare(`
+        SELECT resourceId
+        FROM offline_resource_tombstones
+        WHERE resourceType = 'taskReminder' AND userId = ? AND workspaceId = ?
+      `).all(userId, scope.workspaceId).map((row: any) => row.resourceId)
+    : db.prepare(`
+        SELECT resourceId
+        FROM offline_resource_tombstones
+        WHERE resourceType = 'taskReminder' AND userId = ? AND workspaceId IS NULL
+      `).all(userId).map((row: any) => row.resourceId);
+
+  return c.json({ reminders, deletedIds });
+});
+
 taskReminders.get("/:taskId", (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
@@ -148,6 +203,7 @@ taskReminders.get("/:taskId", (c) => {
 
   const task = db.prepare("SELECT id, userId, workspaceId FROM tasks WHERE id = ?").get(taskId) as any;
   if (!task) return c.json({ error: "Task not found" }, 404);
+  if (!canReadTask(task, userId)) return c.json({ error: "Task not found" }, 404);
 
   const rows = taskRemindersRepository.listByTaskId(taskId, userId);
   return c.json(rows);
@@ -158,16 +214,50 @@ taskReminders.post("/:taskId", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const taskId = c.req.param("taskId");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
   const body = await c.req.json();
+  const requestedId = typeof body.id === "string" ? body.id : "";
+  if (requestedId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestedId)) {
+    return c.json({ error: "Invalid reminder id", code: "INVALID_REMINDER_ID" }, 400);
+  }
 
   const task = db.prepare("SELECT id, userId, workspaceId FROM tasks WHERE id = ?").get(taskId) as any;
-  if (!task) return c.json({ error: "Task not found" }, 404);
+  if (!task) {
+    const tombstone = getTombstone(db, "task", taskId);
+    const canManageTombstone = canAccessReminderTombstone(tombstone, userId);
+    if (canManageTombstone) return c.json({ success: true, syncIgnored: true }, 200);
+    return c.json({ error: "Task not found" }, 404);
+  }
+  if (!canManageResource(task.userId, task.workspaceId, userId)) {
+    return c.json({ error: "无权创建提醒", code: "FORBIDDEN" }, 403);
+  }
 
   const offsetMinutes = body.offsetMinutes ?? 30;
-  const id = crypto.randomUUID();
+  const id = requestedId || crypto.randomUUID();
+  const ownTombstone = getTombstone(db, "taskReminder", id);
+  if (ownTombstone && canAccessReminderTombstone(ownTombstone, userId) && clientUpdatedAt <= ownTombstone.deletedAt) {
+    const response = { success: true, syncIgnored: true };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
+  const existing = taskRemindersRepository.getById(id);
+  if (existing) {
+    if (existing.userId !== userId || existing.taskId !== taskId) {
+      return c.json({ error: "Reminder id already exists", code: "REMINDER_ID_CONFLICT" }, 409);
+    }
+    saveIdempotentMutation(db, userId, operationId, existing);
+    return c.json(existing, 200);
+  }
 
-  taskRemindersRepository.create({ id, taskId, userId, offsetMinutes });
-  const reminder = taskRemindersRepository.getById(id);
+  const reminder = db.transaction(() => {
+    taskRemindersRepository.create({ id, taskId, userId, offsetMinutes });
+    const created = taskRemindersRepository.getById(id);
+    saveIdempotentMutation(db, userId, operationId, created);
+    return created;
+  })();
   return c.json(reminder, 201);
 });
 
@@ -176,33 +266,71 @@ taskReminders.put("/:reminderId", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const reminderId = c.req.param("reminderId");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const existing = taskRemindersRepository.getById(reminderId);
   if (!existing) return c.json({ error: "Reminder not found" }, 404);
   if (existing.userId !== userId) return c.json({ error: "无权修改", code: "FORBIDDEN" }, 403);
 
   const body = await c.req.json();
-  const offsetMinutes = body.offsetMinutes ?? existing.offsetMinutes;
-  const enabled = body.enabled ?? existing.enabled;
+  const requestedFields = ["offsetMinutes", "enabled", "snoozedUntil"].filter((field) => Object.prototype.hasOwnProperty.call(body, field));
+  const accepted = getNewerFields(db, "taskReminder", reminderId, requestedFields, clientUpdatedAt, operationId);
+  const offsetMinutes = accepted.has("offsetMinutes") ? body.offsetMinutes : existing.offsetMinutes;
+  const enabled = accepted.has("enabled") ? (body.enabled ? 1 : 0) : existing.enabled;
   const hasSnoozedUntil = Object.prototype.hasOwnProperty.call(body, "snoozedUntil");
-  const snoozedUntil = hasSnoozedUntil ? body.snoozedUntil : existing.snoozedUntil;
+  const snoozedUntil = hasSnoozedUntil && accepted.has("snoozedUntil") ? body.snoozedUntil : existing.snoozedUntil;
 
-  taskRemindersRepository.update(reminderId, { offsetMinutes, enabled: !!enabled, snoozedUntil });
-  const updated = taskRemindersRepository.getById(reminderId);
+  const updated = db.transaction(() => {
+    if (accepted.size > 0) {
+      taskRemindersRepository.update(reminderId, { offsetMinutes, enabled: !!enabled, snoozedUntil });
+      writeFieldClocks(db, "taskReminder", reminderId, accepted, clientUpdatedAt, operationId);
+    }
+    const current = taskRemindersRepository.getById(reminderId);
+    saveIdempotentMutation(db, userId, operationId, current);
+    return current;
+  })();
   return c.json(updated);
 });
 
 // 删除提醒
 taskReminders.delete("/:reminderId", (c) => {
+  const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const reminderId = c.req.param("reminderId");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const existing = taskRemindersRepository.getById(reminderId);
-  if (!existing) return c.json({ error: "Reminder not found" }, 404);
+  if (!existing) {
+    const tombstone = getTombstone(db, "taskReminder", reminderId);
+    const canManageTombstone = canAccessReminderTombstone(tombstone, userId);
+    if (canManageTombstone) {
+      const response = { success: true, syncIgnored: true };
+      saveIdempotentMutation(db, userId, operationId, response);
+      return c.json(response);
+    }
+    return c.json({ error: "Reminder not found" }, 404);
+  }
   if (existing.userId !== userId) return c.json({ error: "无权删除", code: "FORBIDDEN" }, 403);
+  if (hasNewerFieldClock(db, "taskReminder", reminderId, clientUpdatedAt)) {
+    const response = { success: true, syncIgnored: true };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
 
-  taskRemindersRepository.delete(reminderId);
-  return c.json({ success: true });
+  const task = db.prepare("SELECT workspaceId FROM tasks WHERE id = ?").get(existing.taskId) as { workspaceId: string | null } | undefined;
+  const response = { success: true };
+  db.transaction(() => {
+    taskRemindersRepository.delete(reminderId);
+    writeTombstone(db, "taskReminder", reminderId, existing.userId, task?.workspaceId ?? null, clientUpdatedAt);
+    saveIdempotentMutation(db, userId, operationId, response);
+  })();
+  return c.json(response);
 });
 
 // 立即提醒（测试用）— 返回应该提醒的任务列表

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -11,6 +11,16 @@ import {
 } from "../middleware/acl";
 import { taskDependenciesRepository } from "../repositories";
 import {
+  getClientMutationAt,
+  hasNewerFieldClock,
+  getIdempotentMutation,
+  getNewerFields,
+  getTombstone,
+  saveIdempotentMutation,
+  writeFieldClocks,
+  writeTombstone,
+} from "../lib/offlineResourceSync";
+import {
   taskOverdueConditionSql,
   taskTodayConditionSql,
   taskWeekConditionSql,
@@ -62,6 +72,23 @@ function resolveTaskScope(
     return { scope: "workspace", workspaceId: raw, error: "无权访问该工作区" };
   }
   return { scope: "workspace", workspaceId: raw };
+}
+
+function canCreateAgainstTaskTombstone(
+  tombstone: { userId: string; workspaceId: string | null } | undefined,
+  workspaceId: string | null,
+  userId: string,
+): boolean {
+  if (!tombstone || tombstone.workspaceId !== workspaceId) return false;
+  if (!workspaceId) return tombstone.userId === userId;
+  return !!getUserWorkspaceRole(workspaceId, userId);
+}
+
+function canManageTaskTombstone(
+  tombstone: { userId: string; workspaceId: string | null } | undefined,
+  userId: string,
+): boolean {
+  return !!tombstone && canManageResource(tombstone.userId, tombstone.workspaceId, userId);
 }
 
 // 获取所有任务
@@ -154,11 +181,11 @@ tasks.get("/stats/summary", requireWorkspaceFeature("tasks"), (c) => {
     WHERE ${whereSql}
   `).get(whereArg) as any;
 
-  const total     = row.total     ?? 0;
+  const total = row.total ?? 0;
   const completed = row.completed ?? 0;
-  const today     = row.today     ?? 0;
-  const overdue   = row.overdue   ?? 0;
-  const week      = row.week      ?? 0;
+  const today = row.today ?? 0;
+  const overdue = row.overdue ?? 0;
+  const week = row.week ?? 0;
 
   return c.json({ total, completed, pending: total - completed, today, overdue, week });
 });
@@ -269,12 +296,20 @@ tasks.get("/:id", (c) => {
 tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const scope = resolveTaskScope(c, userId);
   if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
 
   const body: any = await c.req.json();
-  const id = crypto.randomUUID();
+  const requestedId = typeof body.id === "string" ? body.id : "";
+  if (requestedId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestedId)) {
+    return c.json({ error: "Invalid task id", code: "INVALID_TASK_ID" }, 400);
+  }
+  const id = requestedId || crypto.randomUUID();
   const { title, priority = 2, dueDate = null, dueAt = null, startDate = null, noteId = null, parentId = null } = body;
   const description = typeof body.description === "string" ? body.description : "";
   const repeatRule = body.repeatRule || "none";
@@ -344,6 +379,21 @@ tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
     effectiveWorkspaceId = parent.workspaceId;
   }
 
+  if (requestedId) {
+    const tombstone = getTombstone(db, "task", id);
+    if (tombstone && canCreateAgainstTaskTombstone(tombstone, effectiveWorkspaceId, userId) && clientUpdatedAt <= tombstone.deletedAt) {
+      return c.json({ success: true, syncIgnored: true }, 200);
+    }
+    const existing = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as any;
+    if (existing) {
+      if (existing.userId !== userId || existing.workspaceId !== effectiveWorkspaceId) {
+        return c.json({ error: "Task id already exists", code: "TASK_ID_CONFLICT" }, 409);
+      }
+      saveIdempotentMutation(db, userId, operationId, existing);
+      return c.json(existing, 201);
+    }
+  }
+
   const projectId = body.projectId || null;
   const status = body.status || "todo";
   const VALID_STATUSES = ["todo", "doing", "blocked", "done"];
@@ -369,12 +419,16 @@ tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
   const effectiveRepeatEndDate = repeatRule === "none" ? null : repeatEndDate;
   const repeatSequenceIndex = repeatRule === "none" ? null : 1;
 
-  db.prepare(`
-    INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, completedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, userId, effectiveWorkspaceId, title.trim(), description, effectiveIsCompleted, effectiveCompletedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson);
-
-  const task = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id);
+  const task = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO tasks (id, userId, workspaceId, title, description, isCompleted, completedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, userId, effectiveWorkspaceId, title.trim(), description, effectiveIsCompleted, effectiveCompletedAt, priority, dueDate, dueAt, startDate, noteId, parentId, projectId, status, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatGroupId, repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson);
+    const created = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as Record<string, unknown>;
+    writeFieldClocks(db, "task", id, ["title", "description", "isCompleted", "completedAt", "priority", "dueDate", "dueAt", "startDate", "noteId", "parentId", "projectId", "sortOrder", "status", "repeatRule", "repeatInterval", "repeatEndDate", "repeatEndCount", "repeatRuleJson"], clientUpdatedAt, operationId);
+    saveIdempotentMutation(db, userId, operationId, created);
+    return created;
+  })();
   return c.json(task, 201);
 });
 
@@ -382,174 +436,203 @@ tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
 // Y3: 走 canManageResource —— 创建者本人 + admin/owner 可改；个人任务仅本人。
 //     不允许修改 workspaceId（搬移任务到其它工作区属于高风险操作，留待后续
 //     独立"移动"接口实现）。
-tasks.put("/:id", (c) => {
+tasks.put("/:id", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const id = c.req.param("id");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
-  return c.req.json().then((body: any) => {
-    const existing = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as any;
-    if (!existing) return c.json({ error: "Task not found" }, 404);
+  let body: any = await c.req.json();
+  const existing = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as any;
+  if (!existing) {
+    const tombstone = getTombstone(db, "task", id);
+    if (tombstone && canManageTaskTombstone(tombstone, userId) && clientUpdatedAt <= tombstone.deletedAt) return c.json({ success: true, syncIgnored: true }, 200);
+    return c.json({ error: "Task not found" }, 404);
+  }
 
-    if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
-      return c.json({ error: "无权修改该任务", code: "FORBIDDEN" }, 403);
+  if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
+    return c.json({ error: "无权修改该任务", code: "FORBIDDEN" }, 403);
+  }
+
+  const mutableFields = new Set(["title", "priority", "dueDate", "dueAt", "startDate", "description", "noteId", "parentId", "sortOrder", "projectId", "status", "isCompleted", "completedAt", "repeatRule", "repeatInterval", "repeatEndDate", "repeatEndCount", "repeatRuleJson"]);
+  const completionFields = ["status", "isCompleted", "completedAt"];
+  const requestedFields = Object.keys(body).filter((field) => mutableFields.has(field));
+  const requestedCompletionState = requestedFields.some((field) => completionFields.includes(field));
+  const clockFields = requestedCompletionState
+    ? [...new Set([...requestedFields.filter((field) => !completionFields.includes(field)), ...completionFields])]
+    : requestedFields;
+  const newerFields = getNewerFields(db, "task", id, clockFields, clientUpdatedAt, operationId);
+  const completionAccepted = !requestedCompletionState || completionFields.every((field) => newerFields.has(field));
+  const accepted = new Set([
+    ...requestedFields.filter((field) => !completionFields.includes(field) && newerFields.has(field)),
+    ...(completionAccepted && requestedCompletionState ? completionFields : []),
+  ]);
+  if (requestedFields.length > 0 && accepted.size === 0) {
+    const response = { task: existing, generatedTask: null };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
+  body = Object.fromEntries(Object.entries(body).filter(([field]) => accepted.has(field)));
+
+  const title = body.title ?? existing.title;
+  const priority = body.priority ?? existing.priority;
+  const dueDate = body.dueDate !== undefined ? body.dueDate : existing.dueDate;
+  const dueAt = body.dueAt !== undefined ? body.dueAt : existing.dueAt;
+  const startDate = body.startDate !== undefined ? body.startDate : existing.startDate;
+  const description = Object.prototype.hasOwnProperty.call(body, "description")
+    ? (typeof body.description === "string" ? body.description : "")
+    : (existing.description || "");
+  const noteId = body.noteId !== undefined ? body.noteId : existing.noteId;
+  const parentId = body.parentId !== undefined ? body.parentId : existing.parentId;
+  const sortOrder = body.sortOrder ?? existing.sortOrder;
+  const projectId = body.projectId !== undefined ? body.projectId : existing.projectId;
+
+  // Repeat fields
+  const repeatRule = body.repeatRule !== undefined ? body.repeatRule : (existing.repeatRule || "none");
+  const repeatInterval = body.repeatInterval !== undefined ? body.repeatInterval : (existing.repeatInterval ?? 1);
+  const repeatEndDate = body.repeatEndDate !== undefined ? body.repeatEndDate : (existing.repeatEndDate ?? null);
+  let repeatEndCount: number | null;
+  try {
+    repeatEndCount = body.repeatEndCount !== undefined
+      ? normalizeRepeatEndCount(body.repeatEndCount)
+      : (existing.repeatEndCount ?? null);
+  } catch {
+    return c.json({ error: "repeatEndCount must be an integer between 1 and 999", code: "INVALID_REPEAT_END_COUNT" }, 400);
+  }
+
+  const VALID_REPEAT = ["none", "daily", "weekly", "monthly", "yearly", "custom"];
+  if (!VALID_REPEAT.includes(repeatRule)) {
+    return c.json({ error: "Invalid repeatRule", code: "INVALID_REPEAT_RULE" }, 400);
+  }
+  if (repeatRule === "none") {
+    repeatEndCount = null;
+  }
+  if (repeatRule !== "none" && repeatRule !== "custom" && (repeatInterval ?? 0) < 1) {
+    return c.json({ error: "repeatInterval must be >= 1", code: "INVALID_REPEAT_INTERVAL" }, 400);
+  }
+  // TASK-RECURRENCE-CUSTOM-01: 解析自定义循环规则
+  // TASK-RECURRENCE-CUSTOM-01-RV1: 增强校验
+  let repeatRuleJson: string | null = existing.repeatRuleJson || null;
+  if (body.repeatRuleJson !== undefined) {
+    if (body.repeatRuleJson === null) {
+      repeatRuleJson = null;
+    } else if (typeof body.repeatRuleJson === "object" && body.repeatRuleJson.frequency && body.repeatRuleJson.interval) {
+      const vErr = validateRepeatRuleJson(body.repeatRuleJson);
+      if (vErr) return c.json({ error: vErr, code: "INVALID_REPEAT_RULE" }, 400);
+      const rj = { ...body.repeatRuleJson };
+      if (rj.weekdays) rj.weekdays = [...new Set(rj.weekdays)].sort((a, b) => (a as number) - (b as number));
+      repeatRuleJson = JSON.stringify(rj);
+    } else {
+      return c.json({ error: "Invalid repeatRuleJson", code: "INVALID_REPEAT_RULE" }, 400);
     }
+  }
+  if (repeatRule === "custom" && !repeatRuleJson) {
+    return c.json({ error: "repeatRuleJson required for custom repeat", code: "INVALID_REPEAT_RULE" }, 400);
+  }
+  if (repeatRule !== "none" && !dueDate && !dueAt) {
+    return c.json({ error: "Repeating task requires dueDate or dueAt", code: "REPEAT_REQUIRES_DATE" }, 400);
+  }
 
-    const title = body.title ?? existing.title;
-    const priority = body.priority ?? existing.priority;
-    const dueDate = body.dueDate !== undefined ? body.dueDate : existing.dueDate;
-    const dueAt = body.dueAt !== undefined ? body.dueAt : existing.dueAt;
-    const startDate = body.startDate !== undefined ? body.startDate : existing.startDate;
-    const description = Object.prototype.hasOwnProperty.call(body, "description")
-      ? (typeof body.description === "string" ? body.description : "")
-      : (existing.description || "");
-    const noteId = body.noteId !== undefined ? body.noteId : existing.noteId;
-    const parentId = body.parentId !== undefined ? body.parentId : existing.parentId;
-    const sortOrder = body.sortOrder ?? existing.sortOrder;
-    const projectId = body.projectId !== undefined ? body.projectId : existing.projectId;
+  if (startDate && dueDate && startDate > dueDate) {
+    return c.json({ error: "startDate cannot be after dueDate", code: "INVALID_DATE_RANGE" }, 400);
+  }
 
-    // Repeat fields
-    const repeatRule = body.repeatRule !== undefined ? body.repeatRule : (existing.repeatRule || "none");
-    const repeatInterval = body.repeatInterval !== undefined ? body.repeatInterval : (existing.repeatInterval ?? 1);
-    const repeatEndDate = body.repeatEndDate !== undefined ? body.repeatEndDate : (existing.repeatEndDate ?? null);
-    let repeatEndCount: number | null;
-    try {
-      repeatEndCount = body.repeatEndCount !== undefined
-        ? normalizeRepeatEndCount(body.repeatEndCount)
-        : (existing.repeatEndCount ?? null);
-    } catch {
-      return c.json({ error: "repeatEndCount must be an integer between 1 and 999", code: "INVALID_REPEAT_END_COUNT" }, 400);
-    }
+  // Fix 5: status / isCompleted bidirectional sync
+  const VALID_STATUSES = ["todo", "doing", "blocked", "done"];
+  let status = body.status ?? existing.status;
+  let isCompleted = body.isCompleted ?? existing.isCompleted;
 
-    const VALID_REPEAT = ["none", "daily", "weekly", "monthly", "yearly", "custom"];
-    if (!VALID_REPEAT.includes(repeatRule)) {
-      return c.json({ error: "Invalid repeatRule", code: "INVALID_REPEAT_RULE" }, 400);
+  if (body.status !== undefined) {
+    // status takes precedence
+    if (!VALID_STATUSES.includes(status)) {
+      return c.json({ error: "Invalid status", code: "INVALID_STATUS" }, 400);
     }
-    if (repeatRule === "none") {
-      repeatEndCount = null;
-    }
-    if (repeatRule !== "none" && repeatRule !== "custom" && (repeatInterval ?? 0) < 1) {
-      return c.json({ error: "repeatInterval must be >= 1", code: "INVALID_REPEAT_INTERVAL" }, 400);
-    }
-    // TASK-RECURRENCE-CUSTOM-01: 解析自定义循环规则
-    // TASK-RECURRENCE-CUSTOM-01-RV1: 增强校验
-    let repeatRuleJson: string | null = existing.repeatRuleJson || null;
-    if (body.repeatRuleJson !== undefined) {
-      if (body.repeatRuleJson === null) {
-        repeatRuleJson = null;
-      } else if (typeof body.repeatRuleJson === "object" && body.repeatRuleJson.frequency && body.repeatRuleJson.interval) {
-        const vErr = validateRepeatRuleJson(body.repeatRuleJson);
-        if (vErr) return c.json({ error: vErr, code: "INVALID_REPEAT_RULE" }, 400);
-        const rj = { ...body.repeatRuleJson };
-        if (rj.weekdays) rj.weekdays = [...new Set(rj.weekdays)].sort((a, b) => (a as number) - (b as number));
-        repeatRuleJson = JSON.stringify(rj);
-      } else {
-        return c.json({ error: "Invalid repeatRuleJson", code: "INVALID_REPEAT_RULE" }, 400);
-      }
-    }
-    if (repeatRule === "custom" && !repeatRuleJson) {
-      return c.json({ error: "repeatRuleJson required for custom repeat", code: "INVALID_REPEAT_RULE" }, 400);
-    }
-    if (repeatRule !== "none" && !dueDate && !dueAt) {
-      return c.json({ error: "Repeating task requires dueDate or dueAt", code: "REPEAT_REQUIRES_DATE" }, 400);
-    }
+    isCompleted = status === "done" ? 1 : 0;
+  } else if (body.isCompleted !== undefined) {
+    // isCompleted takes precedence
+    isCompleted = body.isCompleted ? 1 : 0;
+    status = isCompleted ? "done" : (existing.status === "done" ? "todo" : existing.status);
+  }
 
-    if (startDate && dueDate && startDate > dueDate) {
-      return c.json({ error: "startDate cannot be after dueDate", code: "INVALID_DATE_RANGE" }, 400);
+  const completedAt = isCompleted
+    ? (existing.isCompleted ? (existing.completedAt ?? new Date().toISOString()) : new Date().toISOString())
+    : null;
+
+  // Fix 2: validate projectId scope
+  if (body.projectId !== undefined && projectId !== null && projectId !== existing.projectId) {
+    const project = db.prepare("SELECT userId, workspaceId FROM task_projects WHERE id = ?").get(projectId) as any;
+    if (!project) return c.json({ error: "Project not found", code: "PROJECT_NOT_FOUND" }, 400);
+    if (existing.workspaceId && project.workspaceId !== existing.workspaceId) {
+      return c.json({ error: "Project scope mismatch", code: "PROJECT_SCOPE_MISMATCH" }, 400);
     }
-
-    // Fix 5: status / isCompleted bidirectional sync
-    const VALID_STATUSES = ["todo", "doing", "blocked", "done"];
-    let status = body.status ?? existing.status;
-    let isCompleted = body.isCompleted ?? existing.isCompleted;
-
-    if (body.status !== undefined) {
-      // status takes precedence
-      if (!VALID_STATUSES.includes(status)) {
-        return c.json({ error: "Invalid status", code: "INVALID_STATUS" }, 400);
-      }
-      isCompleted = status === "done" ? 1 : 0;
-    } else if (body.isCompleted !== undefined) {
-      // isCompleted takes precedence
-      status = isCompleted ? "done" : (existing.status === "done" ? "todo" : existing.status);
+    if (!existing.workspaceId && (project.userId !== existing.userId || project.workspaceId !== null)) {
+      return c.json({ error: "Project scope mismatch", code: "PROJECT_SCOPE_MISMATCH" }, 400);
     }
+  }
 
-    const completedAt = isCompleted
-      ? (existing.isCompleted ? (existing.completedAt ?? new Date().toISOString()) : new Date().toISOString())
-      : null;
+  // 重新挂接父任务时再次校验同域约束
 
-    // Fix 2: validate projectId scope
-    if (body.projectId !== undefined && projectId !== null && projectId !== existing.projectId) {
-      const project = db.prepare("SELECT userId, workspaceId FROM task_projects WHERE id = ?").get(projectId) as any;
-      if (!project) return c.json({ error: "Project not found", code: "PROJECT_NOT_FOUND" }, 400);
-      if (existing.workspaceId && project.workspaceId !== existing.workspaceId) {
-        return c.json({ error: "Project scope mismatch", code: "PROJECT_SCOPE_MISMATCH" }, 400);
-      }
-      if (!existing.workspaceId && (project.userId !== existing.userId || project.workspaceId !== null)) {
-        return c.json({ error: "Project scope mismatch", code: "PROJECT_SCOPE_MISMATCH" }, 400);
-      }
-    }
+  // 禁止 parentId 指向自己
+  if (parentId === id) {
+    return c.json({ error: "不能将任务设为自己的子任务", code: "INVALID_PARENT_TASK" }, 400);
+  }
 
-    // 重新挂接父任务时再次校验同域约束
-
-    // 禁止 parentId 指向自己
-    if (parentId === id) {
-      return c.json({ error: "不能将任务设为自己的子任务", code: "INVALID_PARENT_TASK" }, 400);
-    }
-
-    // 禁止移动到自己的子孙节点下面（防止循环引用）
-    if (body.parentId !== undefined && body.parentId !== null && body.parentId !== existing.parentId) {
-      const isDescendant = (db: any, candidateId: string, taskId: string): boolean => {
-        const visited = new Set<string>();
-        const queue = [taskId];
-        while (queue.length > 0) {
-          const current = queue.shift()!;
-          if (visited.has(current)) continue;
-          visited.add(current);
-          const children = db.prepare("SELECT id FROM tasks WHERE parentId = ?").all(current) as { id: string }[];
-          for (const child of children) {
-            if (child.id === candidateId) return true;
-            queue.push(child.id);
-          }
+  // 禁止移动到自己的子孙节点下面（防止循环引用）
+  if (body.parentId !== undefined && body.parentId !== null && body.parentId !== existing.parentId) {
+    const isDescendant = (db: any, candidateId: string, taskId: string): boolean => {
+      const visited = new Set<string>();
+      const queue = [taskId];
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (visited.has(current)) continue;
+        visited.add(current);
+        const children = db.prepare("SELECT id FROM tasks WHERE parentId = ?").all(current) as { id: string }[];
+        for (const child of children) {
+          if (child.id === candidateId) return true;
+          queue.push(child.id);
         }
-        return false;
-      };
-      if (isDescendant(db, body.parentId, id)) {
-        return c.json({ error: "不能将任务移动到其子孙节点下面", code: "INVALID_PARENT_TASK" }, 400);
       }
+      return false;
+    };
+    if (isDescendant(db, body.parentId, id)) {
+      return c.json({ error: "不能将任务移动到其子孙节点下面", code: "INVALID_PARENT_TASK" }, 400);
     }
-    if (body.parentId !== undefined && body.parentId !== null && body.parentId !== existing.parentId) {
-      const parent = db
-        .prepare("SELECT workspaceId FROM tasks WHERE id = ?")
-        .get(body.parentId) as { workspaceId: string | null } | undefined;
-      if (!parent) return c.json({ error: "父任务不存在" }, 404);
-      if (parent.workspaceId !== existing.workspaceId) {
-        return c.json(
-          { error: "子任务必须与父任务在同一工作区", code: "SCOPE_MISMATCH" },
-          400,
-        );
-      }
+  }
+  if (body.parentId !== undefined && body.parentId !== null && body.parentId !== existing.parentId) {
+    const parent = db
+      .prepare("SELECT workspaceId FROM tasks WHERE id = ?")
+      .get(body.parentId) as { workspaceId: string | null } | undefined;
+    if (!parent) return c.json({ error: "父任务不存在" }, 404);
+    if (parent.workspaceId !== existing.workspaceId) {
+      return c.json(
+        { error: "子任务必须与父任务在同一工作区", code: "SCOPE_MISMATCH" },
+        400,
+      );
     }
+  }
 
-    const effectiveRepeatEndDate = repeatRule === "none" ? null : repeatEndDate;
-    const repeatSequenceIndex = repeatRule === "none" ? null : (existing.repeatSequenceIndex ?? 1);
+  const effectiveRepeatEndDate = repeatRule === "none" ? null : repeatEndDate;
+  const repeatSequenceIndex = repeatRule === "none" ? null : (existing.repeatSequenceIndex ?? 1);
 
+  const response = db.transaction(() => {
     db.prepare(`
-      UPDATE tasks SET title = ?, isCompleted = ?, priority = ?, dueDate = ?, dueAt = ?, startDate = ?,
-        description = ?, noteId = ?, parentId = ?, sortOrder = ?, projectId = ?, status = ?, completedAt = ?, repeatRule = ?, repeatInterval = ?, repeatEndDate = ?, repeatEndCount = ?, repeatSequenceIndex = ?, repeatRuleJson = ?, updatedAt = datetime('now')
-      WHERE id = ?
-    `).run(title, isCompleted, priority, dueDate, dueAt, startDate, description, noteId, parentId, sortOrder, projectId, status, completedAt, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatEndCount, repeatSequenceIndex, repeatRuleJson, id);
-
-    let generatedTask = null;
-    // Generate next repeated task when marking as done via PUT
-    if (isCompleted === 1 && existing.isCompleted === 0) {
-      const updatedForGeneration = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id);
-      generatedTask = generateNextRepeatedTask(db, updatedForGeneration);
-    }
-
-    const updated = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id);
-    return c.json({ task: updated, generatedTask });
-  });
+        UPDATE tasks SET title = ?, isCompleted = ?, priority = ?, dueDate = ?, dueAt = ?, startDate = ?,
+          description = ?, noteId = ?, parentId = ?, sortOrder = ?, projectId = ?, status = ?, completedAt = ?, repeatRule = ?, repeatInterval = ?, repeatEndDate = ?, repeatEndCount = ?, repeatSequenceIndex = ?, repeatRuleJson = ?, updatedAt = datetime('now')
+        WHERE id = ?
+      `).run(title, isCompleted, priority, dueDate, dueAt, startDate, description, noteId, parentId, sortOrder, projectId, status, completedAt, repeatRule, repeatInterval, effectiveRepeatEndDate, repeatEndCount, repeatSequenceIndex, repeatRuleJson, id);
+    const generatedTask = isCompleted === 1 && existing.isCompleted === 0
+      ? generateNextRepeatedTask(db, db.prepare("SELECT * FROM tasks WHERE id = ?").get(id))
+      : null;
+    const updated = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as Record<string, unknown>;
+    writeFieldClocks(db, "task", id, accepted, clientUpdatedAt, operationId);
+    const result = { task: updated, generatedTask };
+    saveIdempotentMutation(db, userId, operationId, result);
+    return result;
+  })();
+  return c.json(response);
 });
 
 // 切换完成状态（快捷操作）
@@ -679,6 +762,13 @@ function generateNextRepeatedTask(db: any, task: any): any {
   const nextSequenceIndex = Number.isFinite(currentSequenceIndex) && currentSequenceIndex >= 1
     ? currentSequenceIndex + 1
     : getRepeatOccurrenceCount(db, groupId) + 1;
+  const existingNext = db.prepare(
+    "SELECT * FROM tasks WHERE repeatGroupId = ? AND repeatSequenceIndex = ? ORDER BY createdAt ASC LIMIT 1",
+  ).get(groupId, nextSequenceIndex);
+  if (existingNext) {
+    db.prepare("UPDATE tasks SET repeatNextGeneratedId = ? WHERE id = ?").run((existingNext as any).id, task.id);
+    return existingNext;
+  }
 
   const parts = baseDateStr.split("-").map(Number);
   const base = new Date(parts[0], parts[1] - 1, parts[2]);
@@ -686,7 +776,7 @@ function generateNextRepeatedTask(db: any, task: any): any {
 
   if (task.repeatRule === "custom") {
     let rule: any = null;
-    try { rule = JSON.parse(task.repeatRuleJson || "{}"); } catch {}
+    try { rule = JSON.parse(task.repeatRuleJson || "{}"); } catch { }
     if (!rule || !rule.frequency) return null;
     next = nextDateFromCustomRule(base, rule);
   } else {
@@ -742,27 +832,55 @@ function generateNextRepeatedTask(db: any, task: any): any {
   return db.prepare("SELECT * FROM tasks WHERE id = ?").get(newId);
 }
 
-tasks.patch("/:id/toggle", (c) => {
+tasks.patch("/:id/toggle", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const id = c.req.param("id");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const task = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as any;
-  if (!task) return c.json({ error: "Task not found" }, 404);
+  if (!task) {
+    if (canManageTaskTombstone(getTombstone(db, "task", id), userId)) {
+      const response = { success: true, syncIgnored: true };
+      saveIdempotentMutation(db, userId, operationId, response);
+      return c.json(response);
+    }
+    return c.json({ error: "Task not found" }, 404);
+  }
 
   if (!canManageResource(task.userId, task.workspaceId, userId)) {
     return c.json({ error: "无权修改该任务", code: "FORBIDDEN" }, 403);
   }
 
-  const newStatus = task.isCompleted ? 0 : 1;
+  const body = await c.req.json().catch(() => ({}));
+
+  const accepted = getNewerFields(db, "task", id, ["isCompleted", "status", "completedAt"], clientUpdatedAt, operationId);
+  if (accepted.size === 0) {
+    const response = { task, generatedTask: null };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
+
+  const newStatus = typeof body.isCompleted === "boolean"
+    ? (body.isCompleted ? 1 : 0)
+    : (task.isCompleted ? 0 : 1);
   const newTaskStatus = newStatus === 1 ? "done" : "todo";
   const completedAt = newStatus === 1 ? new Date().toISOString() : null;
-  db.prepare("UPDATE tasks SET isCompleted = ?, status = ?, completedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(newStatus, newTaskStatus, completedAt, id);
-
-  const generatedTask = newStatus === 1 ? generateNextRepeatedTask(db, task) : null;
-
-    const updated = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id);
-  return c.json({ task: updated, generatedTask });
+  const response = db.transaction(() => {
+    db.prepare("UPDATE tasks SET isCompleted = ?, status = ?, completedAt = ?, updatedAt = datetime('now') WHERE id = ?").run(newStatus, newTaskStatus, completedAt, id);
+    const generatedTask = newStatus === 1 && task.isCompleted !== 1
+      ? generateNextRepeatedTask(db, task)
+      : null;
+    const updated = db.prepare("SELECT * FROM tasks WHERE id = ?").get(id) as Record<string, unknown>;
+    writeFieldClocks(db, "task", id, accepted, clientUpdatedAt, operationId);
+    const result = { task: updated, generatedTask };
+    saveIdempotentMutation(db, userId, operationId, result);
+    return result;
+  })();
+  return c.json(response);
 });
 
 // 删除任务
@@ -771,11 +889,22 @@ tasks.delete("/:id", (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id")!;
   const id = c.req.param("id");
+  const operationId = c.req.header("Idempotency-Key");
+  const replay = getIdempotentMutation(db, userId, operationId);
+  if (replay) return c.json(replay, 200);
+  const clientUpdatedAt = getClientMutationAt(c.req.header("X-Client-Mutation-At"));
 
   const task = db.prepare("SELECT userId, workspaceId FROM tasks WHERE id = ?").get(id) as
     | { userId: string; workspaceId: string | null }
     | undefined;
-  if (!task) return c.json({ error: "Task not found" }, 404);
+  if (!task) {
+    if (canManageTaskTombstone(getTombstone(db, "task", id), userId)) {
+      const response = { success: true, syncIgnored: true };
+      saveIdempotentMutation(db, userId, operationId, response);
+      return c.json(response);
+    }
+    return c.json({ error: "Task not found" }, 404);
+  }
 
   if (!canManageResource(task.userId, task.workspaceId, userId)) {
     return c.json({ error: "无权删除该任务", code: "FORBIDDEN" }, 403);
@@ -783,14 +912,22 @@ tasks.delete("/:id", (c) => {
 
   // Collect all descendants (children, grandchildren, etc.)
   const idsToDelete = collectDescendantIds(db, [id]);
-  const ph = idsToDelete.map(() => "?").join(",");
-
-  // Clean up all dependencies referencing deleted tasks (including descendants)
-  taskDependenciesRepository.deleteByTaskIds(idsToDelete);
-
-  // Delete root task (children cascade via ON DELETE CASCADE)
-  db.prepare("DELETE FROM tasks WHERE id = ?").run(id);
-  return c.json({ success: true });
+  if (idsToDelete.some((taskId) => hasNewerFieldClock(db, "task", taskId, clientUpdatedAt))) {
+    const response = { success: true, syncIgnored: true };
+    saveIdempotentMutation(db, userId, operationId, response);
+    return c.json(response);
+  }
+  const response = { success: true };
+  db.transaction(() => {
+    taskDependenciesRepository.deleteByTaskIds(idsToDelete);
+    for (const taskId of idsToDelete) {
+      const deleted = db.prepare("SELECT userId, workspaceId FROM tasks WHERE id = ?").get(taskId) as { userId: string; workspaceId: string | null } | undefined;
+      if (deleted) writeTombstone(db, "task", taskId, deleted.userId, deleted.workspaceId, clientUpdatedAt);
+    }
+    db.prepare("DELETE FROM tasks WHERE id = ?").run(id);
+    saveIdempotentMutation(db, userId, operationId, response);
+  })();
+  return c.json(response);
 });
 
 /** 安全清理任务依赖：表不存在或清理失败不阻断删除 */

--- a/backend/tests/cors-policy.test.ts
+++ b/backend/tests/cors-policy.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveCorsOrigin } from "../src/lib/cors-policy";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { CORS_ALLOW_HEADERS, resolveCorsOrigin } from "../src/lib/cors-policy";
 
 test("production CORS allows native client origins by default", () => {
   for (const origin of ["https://localhost", "capacitor://localhost", "null"]) {
@@ -17,4 +19,28 @@ test("production CORS keeps configured whitelist support", () => {
 
 test("production CORS rejects unknown browser origins", () => {
   assert.equal(resolveCorsOrigin({ origin: "https://evil.example.com", isProd: true, corsOrigins: [] }), "");
+});
+
+test("CORS preflight permits offline mutation idempotency headers", async () => {
+  const app = new Hono();
+  app.use("*", cors({
+    origin: "https://app.example.com",
+    allowMethods: ["POST"],
+    allowHeaders: CORS_ALLOW_HEADERS,
+  }));
+  app.post("/tasks", (c) => c.json({ ok: true }));
+
+  const response = await app.request("https://api.example.com/tasks", {
+    method: "OPTIONS",
+    headers: {
+      Origin: "https://app.example.com",
+      "Access-Control-Request-Method": "POST",
+      "Access-Control-Request-Headers": "content-type,idempotency-key,x-client-mutation-at",
+    },
+  });
+
+  assert.equal(response.status, 204);
+  const allowed = response.headers.get("Access-Control-Allow-Headers")?.toLowerCase() || "";
+  assert.match(allowed, /idempotency-key/);
+  assert.match(allowed, /x-client-mutation-at/);
 });

--- a/backend/tests/offline-association-sync.test.ts
+++ b/backend/tests/offline-association-sync.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-offline-associations-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+const USER_ID = "offline-association-user";
+const OTHER_USER_ID = "offline-association-other";
+const FIRST_TASK_ID = "73a43e5e-d0d1-4a2e-9a1a-73f2ce317842";
+const SECOND_TASK_ID = "1e233ce1-f0cf-4af5-b080-27f1eae8e76d";
+const OTHER_TASK_ID = "4e3f64a3-4f91-45e4-bfe9-2a26780f9d22";
+
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+function db() {
+  return getDb();
+}
+
+async function requestJson(method: string, url: string, body?: unknown, operationId?: string, userId = USER_ID, clientMutationAt?: string) {
+  const response = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": userId,
+      ...(operationId ? { "Idempotency-Key": operationId } : {}),
+      ...(clientMutationAt ? { "X-Client-Mutation-At": clientMutationAt } : {}),
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: response.status, json: await response.json() };
+}
+
+function resetData() {
+  db().prepare("DELETE FROM task_dependencies").run();
+  db().prepare("DELETE FROM task_reminders").run();
+  db().prepare("DELETE FROM habit_checkins").run();
+  db().prepare("DELETE FROM habits").run();
+  db().prepare("DELETE FROM tasks").run();
+  db().prepare("DELETE FROM offline_mutation_results").run();
+  db().prepare("DELETE FROM offline_resource_field_clocks").run();
+  db().prepare("DELETE FROM offline_resource_tombstones").run();
+  db().prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)").run(USER_ID, USER_ID, "hash");
+  db().prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)").run(OTHER_USER_ID, OTHER_USER_ID, "hash");
+  db().prepare("INSERT INTO tasks (id, userId, title) VALUES (?, ?, ?)").run(FIRST_TASK_ID, USER_ID, "First task");
+  db().prepare("INSERT INTO tasks (id, userId, title) VALUES (?, ?, ?)").run(SECOND_TASK_ID, USER_ID, "Second task");
+  db().prepare("INSERT INTO tasks (id, userId, title) VALUES (?, ?, ?)").run(OTHER_TASK_ID, OTHER_USER_ID, "Private task");
+}
+
+test.before(async () => {
+  const [dependenciesModule, habitsModule, remindersModule, tasksModule, schemaModule] = await Promise.all([
+    import("../src/routes/task-dependencies"),
+    import("../src/routes/habits"),
+    import("../src/routes/task-reminders"),
+    import("../src/routes/tasks"),
+    import("../src/db/schema"),
+  ]);
+  app = new Hono();
+  app.route("/task-dependencies", dependenciesModule.default);
+  app.route("/habits", habitsModule.default);
+  app.route("/task-reminders", remindersModule.default);
+  app.route("/tasks", tasksModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+});
+
+test.beforeEach(() => {
+  resetData();
+});
+
+test.after(() => {
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("offline dependency creation preserves the client UUID across replay", async () => {
+  const id = "ac1e307e-1d04-48a5-9152-4d6fed9988dc";
+  const payload = { id, predecessorTaskId: FIRST_TASK_ID, successorTaskId: SECOND_TASK_ID };
+
+  const created = await requestJson("POST", "/task-dependencies", payload, "dependency-create-1");
+  assert.equal(created.status, 201);
+  assert.equal(created.json.id, id);
+
+  const replayed = await requestJson("POST", "/task-dependencies", payload, "dependency-create-2");
+  assert.equal(replayed.status, 200);
+  assert.equal(replayed.json.id, id);
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM task_dependencies WHERE id = ?").get(id) as { count: number }).count, 1);
+});
+
+test("offline reminder creation preserves the client UUID across replay", async () => {
+  const id = "baf6d8e1-6a33-47cf-96e2-f1cfa4aef840";
+  const payload = { id, offsetMinutes: 45 };
+
+  const created = await requestJson("POST", `/task-reminders/${FIRST_TASK_ID}`, payload, "reminder-create-1");
+  assert.equal(created.status, 201);
+  assert.equal(created.json.id, id);
+
+  const replayed = await requestJson("POST", `/task-reminders/${FIRST_TASK_ID}`, payload, "reminder-create-2");
+  assert.equal(replayed.status, 200);
+  assert.equal(replayed.json.id, id);
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM task_reminders WHERE id = ?").get(id) as { count: number }).count, 1);
+});
+
+test("a user cannot create or read reminders for another user's personal task", async () => {
+  const create = await requestJson("POST", `/task-reminders/${OTHER_TASK_ID}`, { offsetMinutes: 30 });
+  assert.equal(create.status, 403);
+  assert.equal(create.json.code, "FORBIDDEN");
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM task_reminders WHERE taskId = ?").get(OTHER_TASK_ID) as { count: number }).count, 0);
+
+  const list = await requestJson("GET", `/task-reminders/${OTHER_TASK_ID}`);
+  assert.equal(list.status, 404);
+});
+
+test("overview and snapshot do not expose legacy cross-user personal reminders", async () => {
+  db().prepare("INSERT INTO task_reminders (id, taskId, userId, offsetMinutes) VALUES (?, ?, ?, ?)")
+    .run("legacy-cross-user-reminder", OTHER_TASK_ID, USER_ID, 30);
+
+  const overview = await requestJson("GET", "/task-reminders/overview");
+  assert.equal(overview.status, 200);
+  assert.equal(JSON.stringify(overview.json).includes("Private task"), false);
+
+  const snapshot = await requestJson("GET", "/task-reminders/snapshot");
+  assert.equal(snapshot.status, 200);
+  assert.equal(snapshot.json.reminders.some((item: { id: string }) => item.id === "legacy-cross-user-reminder"), false);
+});
+
+test("stale reminder update does not overwrite a newer value and retries are idempotent", async () => {
+  const created = await requestJson("POST", `/task-reminders/${FIRST_TASK_ID}`, { offsetMinutes: 30 });
+
+  const newer = await requestJson(
+    "PUT",
+    `/task-reminders/${created.json.id}`,
+    { enabled: true },
+    "reminder-enable-newer",
+    USER_ID,
+    "2026-07-21T12:00:00.000Z",
+  );
+  assert.equal(newer.status, 200);
+  assert.equal(newer.json.enabled, 1);
+
+  const stale = await requestJson(
+    "PUT",
+    `/task-reminders/${created.json.id}`,
+    { enabled: false },
+    "reminder-disable-older",
+    USER_ID,
+    "2026-07-21T11:00:00.000Z",
+  );
+  assert.equal(stale.status, 200);
+  assert.equal(stale.json.enabled, 1);
+
+  const retry = await requestJson(
+    "PUT",
+    `/task-reminders/${created.json.id}`,
+    { enabled: false },
+    "reminder-disable-older",
+    USER_ID,
+    "2026-07-21T11:00:00.000Z",
+  );
+  assert.equal(retry.status, 200);
+  assert.equal(retry.json.enabled, 1);
+});
+
+test("same-time task mutations use operation id as a deterministic LWW tie-break", async () => {
+  const at = "2026-07-21T12:00:00.000Z";
+  const earlier = await requestJson("PUT", `/tasks/${FIRST_TASK_ID}`, { title: "first" }, "operation-a", USER_ID, at);
+  assert.equal(earlier.status, 200);
+  const later = await requestJson("PUT", `/tasks/${FIRST_TASK_ID}`, { title: "second" }, "operation-z", USER_ID, at);
+  assert.equal(later.status, 200);
+  const replayedEarlier = await requestJson("PUT", `/tasks/${FIRST_TASK_ID}`, { title: "first again" }, "operation-a2", USER_ID, at);
+  assert.equal(replayedEarlier.status, 200);
+  assert.equal(replayedEarlier.json.task.title, "second");
+});
+
+test("reminder snapshot reports current reminders and server tombstones", async () => {
+  const reminder = await requestJson("POST", `/task-reminders/${FIRST_TASK_ID}`, { offsetMinutes: 15 });
+  assert.equal(reminder.status, 201);
+
+  const current = await requestJson("GET", "/task-reminders/snapshot");
+  assert.equal(current.status, 200);
+  assert.equal(current.json.reminders.some((item: { id: string }) => item.id === reminder.json.id), true);
+
+  const deleted = await requestJson("DELETE", `/task-reminders/${reminder.json.id}`, undefined, "reminder-snapshot-delete");
+  assert.equal(deleted.status, 200);
+  const afterDelete = await requestJson("GET", "/task-reminders/snapshot");
+  assert.equal(afterDelete.status, 200);
+  assert.equal(afterDelete.json.reminders.some((item: { id: string }) => item.id === reminder.json.id), false);
+  assert.equal(afterDelete.json.deletedIds.includes(reminder.json.id), true);
+});
+
+test("stale task, habit, and reminder deletes preserve newer field updates", async () => {
+  const taskUpdate = await requestJson("PUT", `/tasks/${FIRST_TASK_ID}`, { title: "new task title" }, "task-update-new", USER_ID, "2026-07-21T12:00:00.000Z");
+  assert.equal(taskUpdate.status, 200);
+  const taskDelete = await requestJson("DELETE", `/tasks/${FIRST_TASK_ID}`, undefined, "task-delete-old", USER_ID, "2026-07-21T11:00:00.000Z");
+  assert.deepEqual(taskDelete.json, { success: true, syncIgnored: true });
+  assert.equal((db().prepare("SELECT title FROM tasks WHERE id = ?").get(FIRST_TASK_ID) as { title: string }).title, "new task title");
+
+  const habitId = "ed9d1e83-6f04-4a80-a691-7e4761bcfc54";
+  db().prepare("INSERT INTO habits (id, userId, title, icon, color, sortOrder) VALUES (?, ?, ?, ?, ?, ?)")
+    .run(habitId, USER_ID, "Old habit", "check-circle", "#10b981", 0);
+  const habitUpdate = await requestJson("PUT", `/habits/${habitId}`, { title: "new habit title" }, "habit-update-new", USER_ID, "2026-07-21T12:00:00.000Z");
+  assert.equal(habitUpdate.status, 200);
+  const habitDelete = await requestJson("DELETE", `/habits/${habitId}`, undefined, "habit-delete-old", USER_ID, "2026-07-21T11:00:00.000Z");
+  assert.deepEqual(habitDelete.json, { success: true, syncIgnored: true });
+  assert.equal((db().prepare("SELECT title FROM habits WHERE id = ?").get(habitId) as { title: string }).title, "new habit title");
+
+  const reminder = await requestJson("POST", `/task-reminders/${SECOND_TASK_ID}`, { offsetMinutes: 30 });
+  const reminderUpdate = await requestJson("PUT", `/task-reminders/${reminder.json.id}`, { enabled: false }, "reminder-update-new", USER_ID, "2026-07-21T12:00:00.000Z");
+  assert.equal(reminderUpdate.status, 200);
+  const reminderDelete = await requestJson("DELETE", `/task-reminders/${reminder.json.id}`, undefined, "reminder-delete-old", USER_ID, "2026-07-21T11:00:00.000Z");
+  assert.deepEqual(reminderDelete.json, { success: true, syncIgnored: true });
+  assert.equal((db().prepare("SELECT enabled FROM task_reminders WHERE id = ?").get(reminder.json.id) as { enabled: number }).enabled, 0);
+});
+
+test("deleted habit check-in query returns a silent tombstone response", async () => {
+  const habitId = "816afde5-0e32-4694-8797-5b9856d2b15f";
+  db().prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt)
+    VALUES (?, ?, ?, ?, ?)
+  `).run("habit", habitId, USER_ID, null, "2026-07-21T00:00:00.000Z");
+
+  const result = await requestJson("GET", `/habits/${habitId}/checkins`);
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.json, { success: true, syncIgnored: true });
+});
+
+test("another user cannot observe or consume a tombstoned habit", async () => {
+  const habitId = "9576e9bf-9bda-4293-9e6e-e51e6ce9cb84";
+  db().prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt)
+    VALUES (?, ?, ?, ?, ?)
+  `).run("habit", habitId, USER_ID, null, "2026-07-21T00:00:00.000Z");
+
+  const result = await requestJson("GET", `/habits/${habitId}/checkins`, undefined, undefined, OTHER_USER_ID);
+  assert.equal(result.status, 404);
+  assert.equal(result.json.syncIgnored, undefined);
+});
+
+test("stale offline habit check-in returns the current row without a duplicate insert", async () => {
+  const habitId = "6a6bb057-b4e7-4630-bb58-b57c02c8d99a";
+  const checkinDate = "2026-07-21";
+  db().prepare("INSERT INTO habits (id, userId, title, icon, color, sortOrder) VALUES (?, ?, ?, ?, ?, ?)")
+    .run(habitId, USER_ID, "Walk", "check-circle", "#10b981", 0);
+
+  const newer = await requestJson("POST", `/habits/${habitId}/checkins`, { status: "success", note: "new", checkinDate }, "checkin-new", USER_ID, "2026-07-21T12:00:00.000Z");
+  assert.equal(newer.status, 201);
+
+  const stale = await requestJson("POST", `/habits/${habitId}/checkins`, { status: "failure", note: "old", checkinDate }, "checkin-old", USER_ID, "2026-07-21T11:00:00.000Z");
+  assert.equal(stale.status, 200);
+  assert.equal(stale.json.status, "success");
+  assert.equal(stale.json.note, "new");
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM habit_checkins WHERE habitId = ? AND checkinDate = ?").get(habitId, checkinDate) as { count: number }).count, 1);
+});
+
+test("future client clocks are normalized so they cannot block later mutations", async () => {
+  const future = await requestJson(
+    "PUT",
+    `/tasks/${FIRST_TASK_ID}`,
+    { title: "future clock" },
+    "future-clock",
+    USER_ID,
+    "2099-01-01T00:00:00.000Z",
+  );
+  assert.equal(future.status, 200);
+
+  const current = await requestJson(
+    "PUT",
+    `/tasks/${FIRST_TASK_ID}`,
+    { title: "current clock" },
+    "current-clock",
+    USER_ID,
+    new Date(Date.now() + 1_000).toISOString(),
+  );
+  assert.equal(current.status, 200);
+  assert.equal(current.json.task.title, "current clock");
+  const clock = db().prepare(`
+    SELECT clientUpdatedAt
+    FROM offline_resource_field_clocks
+    WHERE resourceType = 'task' AND resourceId = ? AND fieldName = 'title'
+  `).get(FIRST_TASK_ID) as { clientUpdatedAt: string };
+  assert.ok(clock.clientUpdatedAt < "2099-01-01T00:00:00.000Z");
+});
+
+test("another user cannot silently consume a deleted task tombstone", async () => {
+  const taskId = "c0c15c39-9a5c-4c7b-9985-6199b9fccddf";
+  db().prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt)
+    VALUES (?, ?, ?, ?, ?)
+  `).run("task", taskId, USER_ID, null, "2026-07-21T00:00:00.000Z");
+
+  const result = await requestJson("PATCH", `/tasks/${taskId}/toggle`, { isCompleted: true }, "task-toggle-other", OTHER_USER_ID, "2026-07-21T00:01:00.000Z");
+  assert.equal(result.status, 404);
+  assert.equal(result.json.syncIgnored, undefined);
+});
+
+test("dependency deletion succeeds when replayed after a lost response", async () => {
+  const created = await requestJson("POST", "/task-dependencies", {
+    predecessorTaskId: FIRST_TASK_ID,
+    successorTaskId: SECOND_TASK_ID,
+  });
+  const firstDelete = await requestJson("DELETE", `/task-dependencies/${created.json.id}`, undefined, "dependency-delete-1");
+  assert.equal(firstDelete.status, 200);
+
+  const replayedDelete = await requestJson("DELETE", `/task-dependencies/${created.json.id}`, undefined, "dependency-delete-2");
+  assert.equal(replayedDelete.status, 200);
+  assert.deepEqual(replayedDelete.json, { success: true, syncIgnored: true });
+});
+
+test("reminder deletion succeeds when replayed after a lost response", async () => {
+  const created = await requestJson("POST", `/task-reminders/${FIRST_TASK_ID}`, { offsetMinutes: 30 });
+  const firstDelete = await requestJson("DELETE", `/task-reminders/${created.json.id}`, undefined, "reminder-delete-1");
+  assert.equal(firstDelete.status, 200);
+
+  const replayedDelete = await requestJson("DELETE", `/task-reminders/${created.json.id}`, undefined, "reminder-delete-2");
+  assert.equal(replayedDelete.status, 200);
+  assert.deepEqual(replayedDelete.json, { success: true, syncIgnored: true });
+});
+
+test("stale dependency and reminder creates do not revive tombstoned associations", async () => {
+  const dependencyId = "4a26b1de-8bbb-423f-bd4f-3ddc2ed6e6df";
+  db().prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt)
+    VALUES (?, ?, ?, ?, ?)
+  `).run("taskDependency", dependencyId, USER_ID, null, "2026-07-21T12:00:00.000Z");
+  const dependency = await requestJson(
+    "POST",
+    "/task-dependencies",
+    { id: dependencyId, predecessorTaskId: FIRST_TASK_ID, successorTaskId: SECOND_TASK_ID },
+    "dependency-create-old",
+    USER_ID,
+    "2026-07-21T11:00:00.000Z",
+  );
+  assert.deepEqual(dependency.json, { success: true, syncIgnored: true });
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM task_dependencies WHERE id = ?").get(dependencyId) as { count: number }).count, 0);
+
+  const reminderId = "8f22a0d3-1e62-4518-b7c4-b0999ba790bd";
+  db().prepare(`
+    INSERT INTO offline_resource_tombstones (resourceType, resourceId, userId, workspaceId, deletedAt)
+    VALUES (?, ?, ?, ?, ?)
+  `).run("taskReminder", reminderId, USER_ID, null, "2026-07-21T12:00:00.000Z");
+  const reminder = await requestJson(
+    "POST",
+    `/task-reminders/${FIRST_TASK_ID}`,
+    { id: reminderId, offsetMinutes: 30 },
+    "reminder-create-old",
+    USER_ID,
+    "2026-07-21T11:00:00.000Z",
+  );
+  assert.deepEqual(reminder.json, { success: true, syncIgnored: true });
+  assert.equal((db().prepare("SELECT COUNT(*) AS count FROM task_reminders WHERE id = ?").get(reminderId) as { count: number }).count, 0);
+});

--- a/backend/tests/task-completed-at.test.ts
+++ b/backend/tests/task-completed-at.test.ts
@@ -28,13 +28,17 @@ function seedUser() {
 function resetTasks() {
   db().prepare("DELETE FROM task_reminders").run();
   db().prepare("DELETE FROM tasks").run();
+  db().prepare("DELETE FROM offline_resource_field_clocks").run();
+  db().prepare("DELETE FROM offline_mutation_results").run();
 }
 
-async function requestJson(method: string, url: string, body?: unknown) {
+async function requestJson(method: string, url: string, body?: unknown, clientMutationAt?: string, operationId?: string) {
   const res = await app.request(url, {
     method,
     headers: {
       "X-User-Id": USER_ID,
+      ...(clientMutationAt ? { "X-Client-Mutation-At": clientMutationAt } : {}),
+      ...(operationId ? { "Idempotency-Key": operationId } : {}),
       ...(body === undefined ? {} : { "Content-Type": "application/json" }),
     },
     body: body === undefined ? undefined : JSON.stringify(body),
@@ -143,6 +147,32 @@ test("put clears completedAt when reopening a completed task", async () => {
   assert.equal(row.isCompleted, 0);
   assert.equal(row.status, "todo");
   assert.equal(row.completedAt, null);
+});
+
+test("completion fields share an atomic LWW clock group", async () => {
+  const created = await requestJson("POST", "/tasks", { title: "Clock group" });
+
+  const completed = await requestJson(
+    "PUT",
+    `/tasks/${created.json.id}`,
+    { isCompleted: true },
+    "2026-07-21T12:00:00.000Z",
+    "complete-newer",
+  );
+  assert.equal(completed.status, 200);
+  assert.equal(completed.json.task.status, "done");
+
+  const stale = await requestJson(
+    "PUT",
+    `/tasks/${created.json.id}`,
+    { status: "todo" },
+    "2026-07-21T11:00:00.000Z",
+    "status-older",
+  );
+  assert.equal(stale.status, 200);
+  assert.equal(stale.json.task.isCompleted, 1);
+  assert.equal(stale.json.task.status, "done");
+  assert.ok(stale.json.task.completedAt);
 });
 
 test("toggle writes and clears completedAt", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1069,14 +1069,13 @@ function AuthGate() {
   const [showWhatsNew, markWhatsNewSeen] = useWhatsNew(!!user);
 
   const handleDisconnect = () => {
+    syncTeardown();
     clearServerUrl();
     // L10: 断开服务器相当于登出 + 切换服务器，通知其他 tab
     broadcastLogout("disconnect_server");
     // Phase 7: 切换服务器时 token 已经无意义，把 secure storage 镜像也清掉，
     // 避免下次开 app 又用旧 token 自动登录（会落到 verify 失败再回退，但没必要走一遭）
     void import("@/lib/quickLogin").then((m) => m.disableQuickLogin()).catch(() => {});
-    // Phase B: 解绑本地缓存当前用户；缓存数据保留以便下次重登秒开
-    syncTeardown();
     setIsAuthenticated(false);
     setUser(null);
   };

--- a/frontend/src/components/TaskCenterImpl.tsx
+++ b/frontend/src/components/TaskCenterImpl.tsx
@@ -4,12 +4,14 @@ import {
   Calendar, ListTodo,
   CalendarDays, AlertTriangle, CheckCheck, Inbox,
   Search, X as XIcon, GripVertical,
+  CloudOff,
   CheckSquare, Trash2, Square,
   LayoutGrid, LayoutList, Calendar as CalendarIcon, BarChart3, FolderOpen, Plus, ChevronRight, Bell, Maximize2, Minimize2,
   MoreHorizontal, Trash2 as TrashIcon, FileText,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { api } from "@/lib/api";
+import { api, getCurrentWorkspace } from "@/lib/api";
+import { getHabits as getCachedHabits, getTasks as getCachedTasks, putHabits, putTasks } from "@/lib/localStore";
 import { toast } from "@/lib/toast";
 import { Task, TaskFilter, TaskStats, TaskStatus, TaskProject, TaskDependency, Habit, HabitStats, HabitCheckinStatus, HabitCheckinListItem } from "@/types";
 import { cn } from "@/lib/utils";
@@ -61,6 +63,44 @@ export function getDefaultTaskPatchForFilter(filter: TaskFilter): Partial<Task> 
   return {};
 }
 
+function getWorkspaceCacheScope(): string | null {
+  const workspaceId = getCurrentWorkspace();
+  return workspaceId === "personal" ? null : workspaceId;
+}
+
+function filterCachedTasks(tasks: Task[], filter: TaskFilter, projectId: string | null): Task[] {
+  const today = formatLocalDateKey();
+  const weekEnd = new Date(`${today}T00:00:00`);
+  weekEnd.setDate(weekEnd.getDate() + 6);
+  const weekEndKey = formatLocalDateKey(weekEnd);
+
+  return tasks.filter((task) => {
+    if (projectId && task.projectId !== projectId) return false;
+    if (filter === "completed") return task.isCompleted === 1;
+    if (filter === "today") return task.dueDate === today;
+    if (filter === "week") return !!task.dueDate && task.dueDate >= today && task.dueDate <= weekEndKey;
+    if (filter === "overdue") return task.isCompleted === 0 && !!task.dueDate && task.dueDate < today;
+    return true;
+  });
+}
+
+function getCachedTaskStats(tasks: Task[]): TaskStats {
+  const today = formatLocalDateKey();
+  const weekEnd = new Date(`${today}T00:00:00`);
+  weekEnd.setDate(weekEnd.getDate() + 6);
+  const weekEndKey = formatLocalDateKey(weekEnd);
+  const completed = tasks.filter((task) => task.isCompleted === 1).length;
+
+  return {
+    total: tasks.length,
+    completed,
+    pending: tasks.length - completed,
+    today: tasks.filter((task) => task.dueDate === today).length,
+    overdue: tasks.filter((task) => task.isCompleted === 0 && !!task.dueDate && task.dueDate < today).length,
+    week: tasks.filter((task) => task.isCompleted === 0 && !!task.dueDate && task.dueDate >= today && task.dueDate <= weekEndKey).length,
+  };
+}
+
 function getQuickAddCreatePatch(parsed: TaskQuickAddParseResult): Partial<Task> {
   const patch: Partial<Task> & { repeatRuleJson?: unknown } = { ...parsed.taskPatch };
   if (patch.repeatRule === "custom" && typeof patch.repeatRuleJson === "string") {
@@ -99,6 +139,8 @@ export default function TaskCenter() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [stats, setStats] = useState<TaskStats | null>(null);
   const [centerMode, setCenterMode] = useState<CenterMode>("tasks");
+  const centerModeRef = useRef<CenterMode>(centerMode);
+  centerModeRef.current = centerMode;
   const [habits, setHabits] = useState<Habit[]>([]);
   const [habitStats, setHabitStats] = useState<HabitStats | null>(null);
   const [habitListMode, setHabitListMode] = useState<HabitListMode>("active");
@@ -119,6 +161,7 @@ export default function TaskCenter() {
   const [statsHabits, setStatsHabits] = useState<Habit[]>([]);
   const [statsHabitCheckins, setStatsHabitCheckins] = useState<HabitCheckinListItem[]>([]);
   const [statsLoading, setStatsLoading] = useState(false);
+  const statsRequestVersionRef = useRef(0);
 
   const activeHabits = useMemo(
     () => habits.filter((habit) => !habit.archivedAt),
@@ -174,6 +217,7 @@ export default function TaskCenter() {
   const [taskFullscreen, setTaskFullscreen] = useState(false);
   const [reminderBadgeCount, setReminderBadgeCount] = useState(0);
   const [sortByDueTime, setSortByDueTime] = useState(false);
+  const [isOnline, setIsOnline] = useState(() => navigator.onLine);
 
   // Phase 4: batch select mode
   const [selectMode, setSelectMode] = useState(false);
@@ -182,6 +226,21 @@ export default function TaskCenter() {
   // Phase 4: drag state
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const markOnline = () => setIsOnline(true);
+    const markOffline = () => {
+      setIsOnline(false);
+      setDragId(null);
+      setDragOverId(null);
+    };
+    window.addEventListener("online", markOnline);
+    window.addEventListener("offline", markOffline);
+    return () => {
+      window.removeEventListener("online", markOnline);
+      window.removeEventListener("offline", markOffline);
+    };
+  }, []);
 
   const treeSourceTasks = useMemo(() => {
     if (!sortByDueTime) return tasks;
@@ -245,6 +304,12 @@ export default function TaskCenter() {
   }, [flatOrderedTasks, searchQuery]);
 
   const loadTasks = useCallback(async () => {
+    const workspaceId = getWorkspaceCacheScope();
+    const cachedTasks = await getCachedTasks(workspaceId);
+    if (cachedTasks.length > 0) {
+      setTasks(filterCachedTasks(cachedTasks, filter, selectedProjectId));
+      setStats(getCachedTaskStats(cachedTasks));
+    }
     try {
       const [data, statsData] = await Promise.all([
         api.getTasks(filter, undefined, selectedProjectId || undefined),
@@ -252,6 +317,7 @@ export default function TaskCenter() {
       ]);
       setTasks(data);
       setStats(statsData);
+      await putTasks(data, workspaceId);
     } catch (err) {
       console.error("Failed to load tasks:", err);
     } finally {
@@ -260,6 +326,9 @@ export default function TaskCenter() {
   }, [filter, selectedProjectId, workspaceVersion]);
 
   const loadHabits = useCallback(async () => {
+    const workspaceId = getWorkspaceCacheScope();
+    const cachedHabits = await getCachedHabits(workspaceId);
+    if (cachedHabits.length > 0) setHabits(cachedHabits);
     try {
       const checkinDate = formatLocalDateKey();
       const [list, statsData] = await Promise.all([
@@ -268,12 +337,14 @@ export default function TaskCenter() {
       ]);
       setHabits(list);
       setHabitStats(statsData);
+      await putHabits(list, workspaceId);
     } catch (err) {
       console.error("Failed to load habits:", err);
     }
   }, []);
 
   const loadStatsCenter = useCallback(async () => {
+    const requestVersion = ++statsRequestVersionRef.current;
     try {
       setStatsLoading(true);
       const checkinDate = formatLocalDateKey();
@@ -284,25 +355,31 @@ export default function TaskCenter() {
         api.getHabitStats(true, checkinDate),
         api.getHabitCheckinLog({ includeArchived: true }),
       ]);
+      if (requestVersion !== statsRequestVersionRef.current) return;
       setStatsTasks(taskList);
       setStats(taskStatsData);
       setStatsHabits(habitList);
       setHabitStats(habitStatsData);
       setStatsHabitCheckins(habitCheckins);
     } catch (err) {
+      if (requestVersion !== statsRequestVersionRef.current) return;
       console.error("Failed to load stats center:", err);
       toast.error(t("stats.loadFailed"));
     } finally {
-      setStatsLoading(false);
+      if (requestVersion === statsRequestVersionRef.current) setStatsLoading(false);
     }
-  }, [t, workspaceVersion]);
+  }, [t]);
 
   const loadDependencies = useCallback(async () => {
+    const workspaceId = getWorkspaceCacheScope();
+    const cached = await import("@/lib/localStore").then((store) => store.getTaskDependencies(workspaceId));
+    setDependencies(cached);
     try {
       const deps = await api.getTaskDependencies();
       setDependencies(deps);
+      void import("@/lib/localStore").then((store) => store.putTaskDependencies(deps, workspaceId));
     } catch (e) { /* ignore */ }
-  }, []);
+  }, [getWorkspaceCacheScope]);
 
   const loadReminderBadge = useCallback(async () => {
     try {
@@ -321,10 +398,20 @@ export default function TaskCenter() {
   useEffect(() => { loadTasks(); loadDependencies(); loadReminderBadge(); loadHabits(); }, [loadTasks, loadDependencies, loadReminderBadge, loadHabits]);
 
   useEffect(() => {
-    const onWs = () => { setSelectedTaskId(null); setSearchQuery(""); setSelectedIds(new Set()); setSelectMode(false); setSelectedProjectId(null); setWorkspaceVersion((v) => v + 1); reload(); loadHabits(); };
+    const onWs = () => {
+      setSelectedTaskId(null);
+      setSearchQuery("");
+      setSelectedIds(new Set());
+      setSelectMode(false);
+      setSelectedProjectId(null);
+      setWorkspaceVersion((v) => v + 1);
+      reload();
+      loadHabits();
+      if (centerModeRef.current === "stats") void loadStatsCenter();
+    };
     window.addEventListener("nowen:workspace-changed", onWs);
     return () => window.removeEventListener("nowen:workspace-changed", onWs);
-  }, [loadTasks, loadHabits]);
+  }, [loadHabits, loadStatsCenter, reload]);
 
   useEffect(() => {
     if (centerMode === "stats") {
@@ -408,11 +495,12 @@ export default function TaskCenter() {
 
   // === CRUD Handlers ===
   const handleToggle = async (id: string) => {
+    const target = tasks.find((task) => task.id === id)?.isCompleted ? false : true;
     setTasks((prev) =>
       prev.map((t) => (t.id === id ? { ...t, isCompleted: t.isCompleted ? 0 : 1, status: t.isCompleted ? "todo" : "done" } : t))
     );
     try {
-      const res = await api.toggleTask(id);
+      const res = await api.toggleTask(id, target);
       // Use backend response for accurate state
       setTasks((prev) => {
         let updated = prev.map((t) => (t.id === id ? { ...t, ...res.task } : t));
@@ -665,6 +753,11 @@ export default function TaskCenter() {
 
   // === Drag reorder ===
   const handleDragStart = useCallback((id: string, e: React.DragEvent) => {
+    if (!isOnline) {
+      e.preventDefault();
+      toast.error(t("tasks.offlineReorderUnavailable"));
+      return;
+    }
     setDragId(id);
     e.dataTransfer.effectAllowed = "move";
     const img = document.createElement("div");
@@ -672,15 +765,23 @@ export default function TaskCenter() {
     document.body.appendChild(img);
     e.dataTransfer.setDragImage(img, 0, 0);
     requestAnimationFrame(() => document.body.removeChild(img));
-  }, []);
+  }, [isOnline, t]);
 
   const handleDragOver = useCallback((id: string, e: React.DragEvent) => {
+    if (!isOnline) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
     if (id !== dragOverId) setDragOverId(id);
-  }, [dragOverId]);
+  }, [dragOverId, isOnline]);
 
-  const handleDrop = useCallback(async (targetId: string) => {
+  const handleDrop = useCallback(async (targetId: string, e?: React.DragEvent) => {
+    if (!isOnline) {
+      e?.preventDefault();
+      setDragId(null);
+      setDragOverId(null);
+      toast.error(t("tasks.offlineReorderUnavailable"));
+      return;
+    }
     if (!dragId || dragId === targetId) { setDragId(null); setDragOverId(null); return; }
     if (sortByDueTime) { setDragId(null); setDragOverId(null); return; }
 
@@ -726,7 +827,7 @@ export default function TaskCenter() {
 
     setDragId(null);
     setDragOverId(null);
-  }, [dragId, tasks, sortByDueTime, loadTasks]);
+  }, [dragId, isOnline, loadTasks, sortByDueTime, t, tasks]);
 
   const handleDragEnd = useCallback(() => {
     setDragId(null);
@@ -1237,6 +1338,12 @@ export default function TaskCenter() {
               </div>
             ) : (
               <div className="space-y-1.5">
+                {!isOnline && !isMobile && !selectMode && !sortByDueTime && (
+                  <div className="flex items-center gap-2 px-2 py-1 text-xs text-tx-tertiary" role="status">
+                    <CloudOff size={14} className="shrink-0" />
+                    {t("tasks.offlineReorderUnavailable", { defaultValue: "离线时暂不支持拖拽排序" })}
+                  </div>
+                )}
                 <AnimatePresence mode="popLayout">
                   {isTreeMode ? (
                     displayFlatOrdered.map((item) => (
@@ -1246,10 +1353,10 @@ export default function TaskCenter() {
                           "relative",
                           dragOverId === item.node.id && dragId !== item.node.id && "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-accent-primary before:rounded-full before:-translate-y-1"
                         )}
-                        draggable={!selectMode && !sortByDueTime && !isMobile}
+                        draggable={isOnline && !selectMode && !sortByDueTime && !isMobile}
                         onDragStart={(e) => handleDragStart(item.node.id, e)}
                         onDragOver={(e) => handleDragOver(item.node.id, e)}
-                        onDrop={() => handleDrop(item.node.id)}
+                        onDrop={(e) => handleDrop(item.node.id, e)}
                         onDragEnd={handleDragEnd}
                       >
                         {selectMode && (
@@ -1284,10 +1391,10 @@ export default function TaskCenter() {
                           "relative",
                           dragOverId === task.id && dragId !== task.id && "before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-accent-primary before:rounded-full before:-translate-y-1"
                         )}
-                        draggable={!selectMode && !sortByDueTime && !isMobile}
+                        draggable={isOnline && !selectMode && !sortByDueTime && !isMobile}
                         onDragStart={(e) => handleDragStart(task.id, e)}
                         onDragOver={(e) => handleDragOver(task.id, e)}
-                        onDrop={() => handleDrop(task.id)}
+                        onDrop={(e) => handleDrop(task.id, e)}
                         onDragEnd={handleDragEnd}
                       >
                         {selectMode && (

--- a/frontend/src/components/__tests__/TaskCenterQuickAddIntegration.test.tsx
+++ b/frontend/src/components/__tests__/TaskCenterQuickAddIntegration.test.tsx
@@ -36,7 +36,7 @@ const apiMocks = vi.hoisted(() => ({
 }));
 
 const i18nMocks = vi.hoisted(() => ({
-    t: (key: string) => key,
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -51,6 +51,7 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 vi.mock("@/lib/api", () => ({
+    getCurrentWorkspace: () => "personal",
     api: {
         getTasks: apiMocks.getTasks,
         getTaskStats: apiMocks.getTaskStats,
@@ -296,6 +297,7 @@ describe("TaskCenter quick-add integration", () => {
         act(() => root.unmount());
         host.remove();
         document.body.innerHTML = "";
+        Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
         vi.useRealTimers();
         vi.clearAllMocks();
     });
@@ -331,6 +333,16 @@ describe("TaskCenter quick-add integration", () => {
         expect(apiMocks.createTaskReminder).toHaveBeenNthCalledWith(2, "new-task", 180);
 
         expect(input!.value).toBe("");
+    });
+
+    it("disables task reorder dragging while offline", async () => {
+        Object.defineProperty(navigator, "onLine", { configurable: true, value: false });
+        apiMocks.getTasks.mockResolvedValueOnce([makeTask({ id: "offline-task" })]);
+
+        await renderTaskCenter(root);
+
+        expect(host.textContent).toContain("离线时暂不支持拖拽排序");
+        expect(host.querySelector("[draggable='true']")).toBeNull();
     });
 
     it("continues when one reminder creation fails", async () => {
@@ -605,6 +617,7 @@ describe("TaskCenter quick-add integration", () => {
                 checkins: [expect.objectContaining({ id: "check-old" })],
             });
         });
+        expect(apiMocks.getHabitCheckinLog).toHaveBeenCalledTimes(1);
 
         workspacePhase = 1;
 
@@ -615,6 +628,11 @@ describe("TaskCenter quick-add integration", () => {
 
         await vi.waitFor(() => {
             expect(apiMocks.getHabitCheckinLog).toHaveBeenCalledTimes(2);
+        });
+        await act(async () => {
+            await flush();
+        });
+        await vi.waitFor(() => {
             expect(apiMocks.statsCenterProps.at(-1)).toMatchObject({
                 tasks: [expect.objectContaining({ id: "task-new" })],
                 habits: [expect.objectContaining({ id: "habit-new" })],

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -8,6 +8,7 @@ import { zhCN, enUS } from "date-fns/locale";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
+import { getTaskReminders as getCachedTaskReminders, putTaskReminders } from "@/lib/localStore";
 import { toast } from "@/lib/toast";
 import type { Task, TaskPriority, TaskReminder, TaskDependency } from "@/types";
 import { isRepeatingTask } from "./taskRepeatUtils";
@@ -247,9 +248,15 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
   // load reminders for this task
   const loadReminders = useCallback(async () => {
     setRemindersLoading(true);
+    const cached = await getCachedTaskReminders(task.id);
+    if (cached.length > 0) {
+      setReminders(cached);
+      onReminderCountChange?.(task.id, cached.filter((r) => r.enabled === 1).length);
+    }
     try {
       const data = await api.getTaskReminders(task.id);
       setReminders(data);
+      void putTaskReminders(data);
       onReminderCountChange?.(task.id, data.filter((r) => r.enabled === 1).length);
     } catch {
       // ignore

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1317,6 +1317,7 @@
     "priority": "Priority",
     "dueDate": "Due Date",
     "dueAt": "Due Time",
+    "offlineReorderUnavailable": "Drag-and-drop sorting is unavailable while offline",
     "createdAt": "Created",
     "deleteTask": "Delete Task",
     "pendingCount": "{{pending}} pending · {{completed}} completed",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1336,6 +1336,7 @@
     "dueDate": "截止日期",
     "dueAt": "截止时间",
     "sortByDueTime": "按截止时间排序",
+    "offlineReorderUnavailable": "离线时暂不支持拖拽排序",
     "createdAt": "创建时间",
     "deleteTask": "删除任务",
     "pendingCount": "{{pending}} 待完成 · {{completed}} 已完成",

--- a/frontend/src/lib/__tests__/apiOfflineAssociationCache.test.ts
+++ b/frontend/src/lib/__tests__/apiOfflineAssociationCache.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const localStoreMocks = vi.hoisted(() => ({
+  deleteHabit: vi.fn(),
+  deleteTask: vi.fn(),
+  deleteTaskDependency: vi.fn().mockResolvedValue(undefined),
+  deleteTaskReminder: vi.fn().mockResolvedValue(undefined),
+  getHabits: vi.fn().mockResolvedValue([]),
+  getTaskDependencies: vi.fn().mockResolvedValue([]),
+  getTaskReminder: vi.fn(),
+  getTasks: vi.fn().mockResolvedValue([]),
+  putHabits: vi.fn().mockResolvedValue(undefined),
+  putTaskDependencies: vi.fn().mockResolvedValue(undefined),
+  putTaskReminders: vi.fn().mockResolvedValue(undefined),
+  putTasks: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/localStore", () => localStoreMocks);
+
+import { api, setCurrentWorkspace } from "@/lib/api";
+import { clearQueue, getQueue } from "@/lib/offlineQueue";
+
+describe("offline association mutations", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem("nowen-server-url", "https://sync.test");
+    localStorage.setItem("nowen-token", "token");
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: false });
+    clearQueue();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("caches offline dependency creation and deletion without writing a task", async () => {
+    await api.createTaskDependency({ predecessorTaskId: "task-a", successorTaskId: "task-b" });
+    await api.createTaskReminder("task-a", 30);
+
+    await vi.waitFor(() => expect(localStoreMocks.putTaskDependencies).toHaveBeenCalledOnce());
+    const [dependencies] = localStoreMocks.putTaskDependencies.mock.calls[0];
+    expect(dependencies).toMatchObject([{
+      predecessorTaskId: "task-a",
+      successorTaskId: "task-b",
+      type: "finish_to_start",
+    }]);
+
+    const dependencyId = getQueue()[0].noteId;
+    await api.deleteTaskDependency(dependencyId);
+    await vi.waitFor(() => expect(localStoreMocks.deleteTaskDependency).toHaveBeenCalledWith(dependencyId));
+
+    expect(getQueue().map((item) => item.type)).toEqual([
+      "createTaskDependency",
+      "createTaskReminder",
+      "deleteTaskDependency",
+    ]);
+    expect(localStoreMocks.getTasks).not.toHaveBeenCalled();
+    expect(localStoreMocks.putTasks).not.toHaveBeenCalled();
+    expect(localStoreMocks.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it("queues task toggle with the intended completion state", async () => {
+    localStoreMocks.getTasks.mockResolvedValueOnce([{
+      id: "task-a",
+      isCompleted: 0,
+      status: "todo",
+    }]);
+
+    await api.toggleTask("task-a", true);
+
+    expect(getQueue()).toMatchObject([{
+      type: "toggleTask",
+      noteId: "task-a",
+      body: { isCompleted: true },
+    }]);
+  });
+
+  it("persists offline reminder create, update, and delete before resolving", async () => {
+    const created = await api.createTaskReminder("task-a", 30);
+    expect(localStoreMocks.putTaskReminders).toHaveBeenCalledWith([
+      expect.objectContaining({ id: created.id, taskId: "task-a", offsetMinutes: 30, enabled: 1 }),
+    ], null);
+
+    localStoreMocks.getTaskReminder.mockResolvedValueOnce({
+      ...created,
+      enabled: 1,
+      updatedAt: "2026-07-21T10:00:00.000Z",
+    });
+    await api.updateTaskReminder(created.id, { enabled: false, snoozedUntil: "2026-07-21T13:00:00.000Z" });
+    expect(localStoreMocks.putTaskReminders).toHaveBeenLastCalledWith([
+      expect.objectContaining({ id: created.id, enabled: false, snoozedUntil: "2026-07-21T13:00:00.000Z" }),
+    ], null);
+
+    await api.deleteTaskReminder(created.id);
+    expect(localStoreMocks.deleteTaskReminder).toHaveBeenCalledWith(created.id);
+  });
+
+  it("clears optimistic association caches when an unsent offline task is cancelled", async () => {
+    const task = await api.createTask({ title: "temporary task" });
+    const dependency = await api.createTaskDependency({ predecessorTaskId: task.id, successorTaskId: "task-existing" });
+    const reminder = await api.createTaskReminder(task.id, 30);
+
+    await api.deleteTask(task.id);
+
+    expect(getQueue()).toEqual([]);
+    expect(localStoreMocks.deleteTaskDependency).toHaveBeenCalledWith(dependency.id);
+    expect(localStoreMocks.deleteTaskReminder).toHaveBeenCalledWith(reminder.id);
+  });
+
+  it("reuses the first task create envelope after its response is lost", async () => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("network lost"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const created = await api.createTask({ title: "lost response" });
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    const queued = getQueue()[0];
+    expect(headers["Idempotency-Key"]).toBe(queued.id);
+    expect(requestBody.id).toBe(queued.noteId);
+    expect(created.id).toBe(queued.noteId);
+  });
+
+  it("queues workspace task and habit creates using their query URLs", async () => {
+    setCurrentWorkspace("workspace-1");
+    await api.createTask({ title: "workspace task" });
+    await api.createHabit({ title: "workspace habit" });
+
+    expect(getQueue()).toMatchObject([
+      { type: "createTask", url: "/tasks?workspaceId=workspace-1" },
+      { type: "createHabit", url: "/habits?workspaceId=workspace-1" },
+    ]);
+  });
+
+  it("does not queue task reordering while offline", async () => {
+    await expect(api.reorderTasks([{ id: "task-a", sortOrder: 1 }])).rejects.toThrow();
+    expect(getQueue()).toHaveLength(0);
+  });
+
+  it("updates cache after acknowledged online deletes", async () => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))));
+
+    await api.deleteTask("task-a");
+    await api.deleteHabit("habit-a");
+    await api.deleteTaskReminder("reminder-a");
+
+    expect(localStoreMocks.deleteTask).toHaveBeenCalledWith("task-a");
+    expect(localStoreMocks.deleteHabit).toHaveBeenCalledWith("habit-a");
+    expect(localStoreMocks.deleteTaskReminder).toHaveBeenCalledWith("reminder-a");
+  });
+
+  it("rejects offline optimistic success when the queue cannot persist", async () => {
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (key: string, value: string) {
+      if (key.startsWith("nowen-offline-queue:v2")) throw new DOMException("quota", "QuotaExceededError");
+      return originalSetItem.call(localStorage, key, value);
+    });
+
+    await expect(api.createTask({ title: "must not disappear" })).rejects.toThrow("quota");
+  });
+});

--- a/frontend/src/lib/__tests__/offlineQueue.test.ts
+++ b/frontend/src/lib/__tests__/offlineQueue.test.ts
@@ -7,6 +7,7 @@ import {
   generateLocalNoteId,
   getQueue,
   getQueueLength,
+  inferMutationType,
   retryQueueItem,
   updateItem,
 } from "@/lib/offlineQueue";
@@ -184,6 +185,88 @@ describe("offlineQueue reliability", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps task and habit delete intents when their create request is already in flight", async () => {
+    for (const [createType, deleteType, createUrl, deleteUrl] of [
+      ["createTask", "deleteTask", "/tasks", "/tasks/task-in-flight"],
+      ["createHabit", "deleteHabit", "/habits", "/habits/habit-in-flight"],
+    ] as const) {
+      const id = createType === "createTask" ? "task-in-flight" : "habit-in-flight";
+      enqueue({
+        type: createType,
+        noteId: id,
+        url: createUrl,
+        method: "POST",
+        body: { id, title: "offline" },
+      });
+
+      let resolveRequest: ((value: { ok: boolean; status: number; data: unknown }) => void) | undefined;
+      const fetchFn = vi.fn(() => new Promise<{ ok: boolean; status: number; data: unknown }>((resolve) => {
+        resolveRequest = resolve;
+      }));
+      const firstFlush = flushQueue(fetchFn);
+
+      enqueue({ type: deleteType, noteId: id, url: deleteUrl, method: "DELETE", body: null });
+      expect(getQueue().map((item) => item.type)).toEqual([createType, deleteType]);
+
+      resolveRequest?.({ ok: true, status: 201, data: { id } });
+      await expect(firstFlush).resolves.toEqual({ success: 1, failed: 0, remaining: 1 });
+      await expect(flushQueue(vi.fn().mockResolvedValue({ ok: true, status: 200, data: {} }))).resolves.toEqual({ success: 1, failed: 0, remaining: 0 });
+      clearQueue();
+    }
+  });
+
+  it("cancels unsent task associations when an offline-created task is deleted", () => {
+    enqueue({
+      type: "createTask",
+      noteId: "task-local",
+      url: "/tasks",
+      method: "POST",
+      body: { id: "task-local", title: "offline" },
+    });
+    enqueue({
+      type: "createTaskDependency",
+      noteId: "dependency-local",
+      url: "/task-dependencies",
+      method: "POST",
+      body: { id: "dependency-local", predecessorTaskId: "task-local", successorTaskId: "task-existing" },
+    });
+    enqueue({
+      type: "deleteTaskDependency",
+      noteId: "dependency-local",
+      url: "/task-dependencies/dependency-local",
+      method: "DELETE",
+      body: null,
+    });
+    enqueue({
+      type: "createTaskReminder",
+      noteId: "reminder-local",
+      url: "/task-reminders/task-local",
+      method: "POST",
+      body: { id: "reminder-local", offsetMinutes: 30 },
+    });
+    enqueue({
+      type: "updateTaskReminder",
+      noteId: "reminder-local",
+      url: "/task-reminders/reminder-local",
+      method: "PUT",
+      body: { enabled: false },
+    });
+
+    const result = enqueue({
+      type: "deleteTask",
+      noteId: "task-local",
+      url: "/tasks/task-local",
+      method: "DELETE",
+      body: null,
+    });
+
+    expect(getQueue()).toEqual([]);
+    expect(result.cancelledTaskAssociationIds).toEqual({
+      dependencyIds: ["dependency-local"],
+      reminderIds: ["reminder-local"],
+    });
+  });
+
   it("preserves a permanent client failure and its local payload instead of dropping it", async () => {
     enqueueUpdate("missing-note", 3);
     const fetchFn = vi.fn().mockResolvedValueOnce({
@@ -247,5 +330,34 @@ describe("offlineQueue reliability", () => {
 
     await expect(flushQueue(fetchFn)).resolves.toEqual({ success: 1, failed: 0, remaining: 0 });
     expect(getQueueLength()).toBe(0);
+  });
+
+  it("recognizes task and habit mutations for offline replay", () => {
+    expect(inferMutationType("/tasks", "POST")).toBe("createTask");
+    expect(inferMutationType("/tasks/task-1/toggle", "PATCH")).toBe("toggleTask");
+    expect(inferMutationType("/tasks/reorder/batch", "PUT")).toBeNull();
+    expect(inferMutationType("/habits", "POST")).toBe("createHabit");
+    expect(inferMutationType("/habits/habit-1/archive", "PATCH")).toBe("archiveHabit");
+    expect(inferMutationType("/habits/habit-1/checkins", "POST")).toBe("checkInHabit");
+  });
+
+  it("replays an offline task creation with its client UUID", async () => {
+    const taskId = generateLocalNoteId();
+    enqueue({
+      type: "createTask",
+      noteId: taskId,
+      url: "/tasks",
+      method: "POST",
+      body: { id: taskId, title: "offline task" },
+    });
+
+    const fetchFn = vi.fn().mockResolvedValueOnce({ ok: true, status: 201, data: { id: taskId } });
+    await expect(flushQueue(fetchFn)).resolves.toEqual({ success: 1, failed: 0, remaining: 0 });
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/tasks",
+      "POST",
+      { id: taskId, title: "offline task" },
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
+    );
   });
 });

--- a/frontend/src/lib/__tests__/syncEngine.snapshot.test.ts
+++ b/frontend/src/lib/__tests__/syncEngine.snapshot.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getNotebooks: vi.fn(),
+  getNotes: vi.fn(),
+  getTags: vi.fn(),
+  getTasks: vi.fn(),
+  getHabits: vi.fn(),
+  getHabitCheckinLog: vi.fn(),
+  getTaskDependencies: vi.fn(),
+  getTaskRemindersSnapshot: vi.fn(),
+  getNoteSlim: vi.fn(),
+}));
+
+const localStoreMocks = vi.hoisted(() => ({
+  setCurrentUser: vi.fn(),
+  putNotebooks: vi.fn(),
+  putNoteListItems: vi.fn(),
+  putNote: vi.fn(),
+  putTags: vi.fn(),
+  putTasks: vi.fn(),
+  replaceTasksSnapshot: vi.fn(),
+  getTasks: vi.fn(),
+  putHabits: vi.fn(),
+  replaceHabitsSnapshot: vi.fn(),
+  getHabits: vi.fn(),
+  putHabitCheckins: vi.fn(),
+  replaceHabitCheckinsSnapshot: vi.fn(),
+  getHabitCheckins: vi.fn(),
+  putTaskDependencies: vi.fn(),
+  replaceTaskDependenciesSnapshot: vi.fn(),
+  getTaskDependencies: vi.fn(),
+  putTaskReminders: vi.fn(),
+  replaceTaskRemindersSnapshot: vi.fn(),
+  getTaskRemindersForWorkspace: vi.fn(),
+  deleteTaskReminder: vi.fn(),
+  setMeta: vi.fn(),
+  getMeta: vi.fn(),
+  getAllNotes: vi.fn(),
+  getAllNotebooks: vi.fn(),
+  getAllTags: vi.fn(),
+  deleteNote: vi.fn(),
+  deleteNotebook: vi.fn(),
+  deleteTag: vi.fn(),
+  clearAll: vi.fn(),
+  isReady: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMocks,
+  getCurrentWorkspace: () => "personal",
+}));
+vi.mock("@/lib/localStore", () => localStoreMocks);
+vi.mock("@/lib/offlineQueue", () => ({
+  flushQueue: vi.fn(),
+  discardNoteQueueItems: vi.fn(),
+  getFailedQueueItems: () => [],
+  getQueue: () => [],
+  getQueueLength: () => 0,
+  clearQueue: vi.fn(),
+  clearLocalIdMap: vi.fn(),
+  subscribe: () => () => {},
+}));
+vi.mock("@/lib/offlineQueueFetch", () => ({ offlineQueueFetch: vi.fn() }));
+
+import { syncNow } from "@/lib/syncEngine";
+
+describe("syncEngine workspace snapshots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+    apiMocks.getNotebooks.mockResolvedValue([]);
+    apiMocks.getNotes.mockResolvedValue([]);
+    apiMocks.getTags.mockResolvedValue([]);
+    apiMocks.getTasks.mockResolvedValue([]);
+    apiMocks.getHabits.mockResolvedValue([]);
+    apiMocks.getHabitCheckinLog.mockResolvedValue([]);
+    apiMocks.getTaskDependencies.mockResolvedValue([]);
+    apiMocks.getTaskRemindersSnapshot.mockResolvedValue({ reminders: [], deletedIds: [] });
+    localStoreMocks.getAllNotes.mockResolvedValue([]);
+    localStoreMocks.getAllNotebooks.mockResolvedValue([]);
+    localStoreMocks.getAllTags.mockResolvedValue([]);
+    localStoreMocks.getTasks.mockResolvedValue([{ id: "task-deleted-on-server" }]);
+    localStoreMocks.getHabits.mockResolvedValue([{ id: "habit-deleted-on-server" }]);
+    localStoreMocks.getHabitCheckins.mockResolvedValue([{ id: "checkin-deleted-on-server", habitId: "habit-deleted-on-server", checkinDate: "2026-07-21" }]);
+    localStoreMocks.getTaskDependencies.mockResolvedValue([{ id: "dependency-deleted-on-server" }]);
+    localStoreMocks.getTaskRemindersForWorkspace.mockResolvedValue([{ id: "reminder-deleted-on-server" }]);
+  });
+
+  it("replaces each workspace cache with the merged full snapshot", async () => {
+    await expect(syncNow()).resolves.toMatchObject({ ok: true, pending: 0 });
+
+    expect(localStoreMocks.replaceTasksSnapshot).toHaveBeenCalledWith([], null);
+    expect(localStoreMocks.replaceHabitsSnapshot).toHaveBeenCalledWith([], null);
+    expect(localStoreMocks.replaceHabitCheckinsSnapshot).toHaveBeenCalledWith([], null);
+    expect(localStoreMocks.replaceTaskDependenciesSnapshot).toHaveBeenCalledWith([], null);
+    expect(localStoreMocks.replaceTaskRemindersSnapshot).toHaveBeenCalledWith([], null);
+    expect(localStoreMocks.putTasks).not.toHaveBeenCalled();
+    expect(localStoreMocks.putHabits).not.toHaveBeenCalled();
+    expect(localStoreMocks.putHabitCheckins).not.toHaveBeenCalled();
+    expect(localStoreMocks.putTaskDependencies).not.toHaveBeenCalled();
+    expect(localStoreMocks.putTaskReminders).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.impl.ts
+++ b/frontend/src/lib/api.impl.ts
@@ -1,20 +1,36 @@
-import { Notebook, NotebookMember, NotebookShareLink, Note, NoteListItem, Tag, SearchResult, User, UserPublicInfo, Task, TaskStats, TaskFilter, CustomFont, MindMap, MindMapListItem, Diary, DiaryMediaItem, DiaryTimeline, DiaryStats, Share, ShareInfo, SharedNoteContent, NoteVersion, ShareComment, Workspace, WorkspaceAdminItem, WorkspaceMember, WorkspaceInvite, WorkspaceRole, WorkspaceFeatures, FileItem, FileDetail, FileListResponse, FileStats, FileSortKey, FileCategory, FileFilter, FileMyUploadsRef } from "@/types";
+import { Notebook, NotebookMember, NotebookShareLink, Note, NoteListItem, Tag, SearchResult, User, UserPublicInfo, Task, TaskStats, TaskFilter, Habit, HabitCheckin, TaskReminder, CustomFont, MindMap, MindMapListItem, Diary, DiaryMediaItem, DiaryTimeline, DiaryStats, Share, ShareInfo, SharedNoteContent, NoteVersion, ShareComment, Workspace, WorkspaceAdminItem, WorkspaceMember, WorkspaceInvite, WorkspaceRole, WorkspaceFeatures, FileItem, FileDetail, FileListResponse, FileStats, FileSortKey, FileCategory, FileFilter, FileMyUploadsRef } from "@/types";
 
 export type TaskMutationResponse = { task: Task; generatedTask: Task | null };
 import {
   shouldEnqueue as _shouldEnqueue,
   enqueue as _enqueue,
+  createOfflineMutationEnvelope as _createOfflineMutationEnvelope,
   inferMutationType as _inferMutationType,
   extractNoteId as _extractNoteId,
   generateLocalNoteId,
   discardNoteQueueItems,
 } from "@/lib/offlineQueue";
+import type { OfflineMutationEnvelope } from "@/lib/offlineQueue";
 import {
   readNotebooks as _readNotebooks,
   readNotesList as _readNotesList,
   readTags as _readTags,
   readNote as _readNote,
 } from "@/lib/offlineRead";
+import {
+  deleteHabit as _deleteCachedHabit,
+  deleteTask as _deleteCachedTask,
+  getHabits as _getCachedHabits,
+  getTaskDependencies as _getCachedTaskDependencies,
+  getTaskReminder as _getCachedTaskReminder,
+  getTasks as _getCachedTasks,
+  putHabits as _putCachedHabits,
+  putTaskDependencies as _putCachedTaskDependencies,
+  putTaskReminders as _putCachedTaskReminders,
+  putTasks as _putCachedTasks,
+  deleteTaskDependency as _deleteCachedTaskDependency,
+  deleteTaskReminder as _deleteCachedTaskReminder,
+} from "@/lib/localStore";
 
 import { normalizeServerBaseUrl as _normalizeBase } from "@/lib/serverUrl";
 import { withShareSessionHeader } from "@/lib/shareSession";
@@ -679,12 +695,20 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
 
   // ─── 离线队列拦截：网络不可达时直接入队，不发请求 ──────────────
   const method = (restOptions?.method || "GET").toUpperCase();
+  const rawBody = typeof restOptions?.body === "string" ? restOptions.body : undefined;
+  let parsedBody: Record<string, unknown> | null = null;
+  if (rawBody) {
+    try { parsedBody = JSON.parse(rawBody) as Record<string, unknown>; } catch { /* non-JSON requests do not use the offline pipeline */ }
+  }
+  const mutationEnvelope = _skipOfflineQueue ? null : _createOfflineMutationEnvelope(url, method, parsedBody);
+  const requestBody = mutationEnvelope ? JSON.stringify(mutationEnvelope.body) : restOptions?.body;
+  const requestOptions = mutationEnvelope ? { ...restOptions, body: requestBody } : restOptions;
   if (
     !_skipOfflineQueue &&
     !navigator.onLine &&
     _shouldEnqueue(url, method, new TypeError("offline"))
   ) {
-    return handleOfflineEnqueue<T>(url, method, restOptions?.body as string | undefined);
+    return handleOfflineEnqueue<T>(url, method, rawBody, mutationEnvelope);
   }
 
   let res: Response;
@@ -728,6 +752,10 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
       "Content-Type": "application/json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...(sudoToken ? { "X-Sudo-Token": sudoToken } : {}),
+      ...(mutationEnvelope ? {
+        "Idempotency-Key": mutationEnvelope.id,
+        "X-Client-Mutation-At": new Date(mutationEnvelope.enqueuedAt).toISOString(),
+      } : method !== "GET" && method !== "HEAD" ? { "X-Client-Mutation-At": new Date().toISOString() } : {}),
       ...(includeConnId && connId ? { "X-Connection-Id": connId } : {}),
       ...restOptions?.headers,
     });
@@ -736,7 +764,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
       if (!shouldTryNativeHttpFallback(error, method)) return null;
       try {
         const nativeRes = await nativeHttpFetch(fullUrl, {
-          ...restOptions,
+          ...requestOptions,
           headers: buildHeaders(includeConnId),
         });
         // eslint-disable-next-line no-console
@@ -760,7 +788,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
       }
     };
     try {
-      res = await fetch(fullUrl, { ...restOptions, signal: linkedController.signal, headers: buildHeaders(true) });
+      res = await fetch(fullUrl, { ...requestOptions, signal: linkedController.signal, headers: buildHeaders(true) });
     } catch (firstErr: any) {
       // 兜底：当后端 CORS allowHeaders 没把 X-Connection-Id 加进白名单时，
       //   带它的请求会在 OPTIONS 预检阶段直接被浏览器/WebView 拦下，抛
@@ -771,7 +799,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
       //   只在 connId 存在时才尝试，否则跳过直接走原错误路径，避免无谓重试。
       if (connId) {
         try {
-          res = await fetch(fullUrl, { ...restOptions, signal: linkedController.signal, headers: buildHeaders(false) });
+          res = await fetch(fullUrl, { ...requestOptions, signal: linkedController.signal, headers: buildHeaders(false) });
           // eslint-disable-next-line no-console
           console.warn(
             "[api] retry without X-Connection-Id succeeded — backend CORS likely missing this header in allowHeaders. Disabling injection for this session.",
@@ -789,7 +817,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
             const isTimeout = retryErr?.name === "AbortError";
             if (!_skipOfflineQueue && (isTimeout || _shouldEnqueue(url, method, retryErr))) {
               if (_shouldEnqueue(url, method, isTimeout ? new TypeError("timeout") : retryErr)) {
-                return handleOfflineEnqueue<T>(url, method, restOptions?.body as string | undefined);
+                return handleOfflineEnqueue<T>(url, method, rawBody, mutationEnvelope);
               }
             }
             throw retryErr;
@@ -807,7 +835,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
           if (!_skipOfflineQueue) {
             const enqueueErr = isTimeout ? new TypeError("timeout") : firstErr;
             if (_shouldEnqueue(url, method, enqueueErr)) {
-              return handleOfflineEnqueue<T>(url, method, restOptions?.body as string | undefined);
+              return handleOfflineEnqueue<T>(url, method, rawBody, mutationEnvelope);
             }
           }
           throw firstErr;
@@ -822,7 +850,7 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
     if (!_skipOfflineQueue) {
       const enqueueErr = isTimeout ? new TypeError("timeout") : fetchErr;
       if (_shouldEnqueue(url, method, enqueueErr)) {
-        return handleOfflineEnqueue<T>(url, method, restOptions?.body as string | undefined);
+        return handleOfflineEnqueue<T>(url, method, rawBody, mutationEnvelope);
       }
     }
     throw fetchErr;
@@ -885,13 +913,22 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
       isRetryable &&
       _shouldEnqueue(url, method, error)
     ) {
-      return handleOfflineEnqueue<T>(url, method, restOptions?.body as string | undefined);
+      return handleOfflineEnqueue<T>(url, method, rawBody, mutationEnvelope);
     }
 
     throw error;
   }
   const data = await safeJson<T>(res, fullUrl);
   reconcileAcknowledgedDeletion(url, method, restOptions?.body, data);
+  if (mutationEnvelope) {
+    await cacheAcknowledgedMutation(
+      mutationEnvelope.type,
+      mutationEnvelope.noteId,
+      url,
+      mutationEnvelope.body,
+      data,
+    );
+  }
   return data;
 }
 
@@ -905,18 +942,220 @@ async function request<T>(url: string, options?: RequestOptions): Promise<T> {
  *   - createNote → 返回带临时 id 的假 Note
  *   - deleteNote → 返回 {}
  */
-function handleOfflineEnqueue<T>(url: string, method: string, bodyStr?: string): T {
-  const body = bodyStr ? JSON.parse(bodyStr) : null;
-  const mutationType = _inferMutationType(url, method);
-  const noteId = mutationType === "createNote"
-    ? (body?.id || generateLocalNoteId())
-    : _extractNoteId(url);
+function offlineWorkspaceId(): string | null {
+  const workspaceId = getCurrentWorkspace();
+  return workspaceId === "personal" ? null : workspaceId;
+}
 
-  _enqueue({
+function createOptimisticTask(id: string, body: Record<string, any> | null): Task {
+  const now = new Date().toISOString();
+  return {
+    id,
+    userId: "",
+    workspaceId: offlineWorkspaceId(),
+    title: "",
+    description: "",
+    isCompleted: 0,
+    priority: 2,
+    dueDate: null,
+    dueAt: null,
+    noteId: null,
+    parentId: null,
+    sortOrder: 0,
+    projectId: null,
+    status: "todo",
+    createdAt: now,
+    updatedAt: now,
+    ...body,
+  };
+}
+
+function createOptimisticHabit(id: string, body: Record<string, any> | null): Habit {
+  const now = new Date().toISOString();
+  return {
+    id,
+    userId: "",
+    workspaceId: offlineWorkspaceId(),
+    title: "",
+    icon: "check-circle",
+    color: "#10b981",
+    sortOrder: 0,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...body,
+  };
+}
+
+async function cacheOfflineTaskMutation(
+  mutationType: ReturnType<typeof _inferMutationType>,
+  taskId: string,
+  body: Record<string, any> | null,
+): Promise<void> {
+  const workspaceId = offlineWorkspaceId();
+  if (mutationType === "deleteTask") {
+    await _deleteCachedTask(taskId);
+    return;
+  }
+  const cached = await _getCachedTasks(workspaceId);
+  const current = cached.find((task) => task.id === taskId);
+  const next: Task = mutationType === "toggleTask" && current
+    ? {
+      ...current,
+      isCompleted: body?.isCompleted ? 1 : 0,
+      status: body?.isCompleted ? "done" : "todo",
+      completedAt: body?.isCompleted ? new Date().toISOString() : null,
+      updatedAt: new Date().toISOString(),
+    }
+    : { ...(current || createOptimisticTask(taskId, null)), ...body, id: taskId, updatedAt: new Date().toISOString() };
+  await _putCachedTasks([next], workspaceId);
+}
+
+async function cacheOfflineHabitMutation(
+  mutationType: ReturnType<typeof _inferMutationType>,
+  habitId: string,
+  body: Record<string, any> | null,
+): Promise<void> {
+  const workspaceId = offlineWorkspaceId();
+  if (mutationType === "deleteHabit") {
+    await _deleteCachedHabit(habitId);
+    return;
+  }
+  const cached = await _getCachedHabits(workspaceId);
+  const current = cached.find((habit) => habit.id === habitId);
+  let next: Habit;
+  if (mutationType === "checkInHabit" && current) {
+    next = {
+      ...current,
+      todayStatus: body?.status,
+      todayNote: body?.note || "",
+      todayCheckinDate: body?.checkinDate,
+      updatedAt: new Date().toISOString(),
+    };
+  } else if (mutationType === "archiveHabit" && current) {
+    next = { ...current, archivedAt: body?.archived ? new Date().toISOString() : null, updatedAt: new Date().toISOString() };
+  } else {
+    next = { ...(current || createOptimisticHabit(habitId, null)), ...body, id: habitId, updatedAt: new Date().toISOString() };
+  }
+  await _putCachedHabits([next], workspaceId);
+}
+
+async function cacheOfflineTaskDependencyMutation(
+  mutationType: ReturnType<typeof _inferMutationType>,
+  dependencyId: string,
+  body: Record<string, any> | null,
+): Promise<void> {
+  const workspaceId = offlineWorkspaceId();
+  if (mutationType === "deleteTaskDependency") {
+    await _deleteCachedTaskDependency(dependencyId);
+    return;
+  }
+  if (mutationType !== "createTaskDependency") return;
+  const cached = await _getCachedTaskDependencies(workspaceId);
+  const now = new Date().toISOString();
+  await _putCachedTaskDependencies([
+    ...cached.filter((dependency) => dependency.id !== dependencyId),
+    {
+      id: dependencyId,
+      userId: "",
+      workspaceId,
+      predecessorTaskId: body?.predecessorTaskId || "",
+      successorTaskId: body?.successorTaskId || "",
+      type: body?.type || "finish_to_start",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ], workspaceId);
+}
+
+async function cacheOfflineTaskReminderMutation(
+  mutationType: ReturnType<typeof _inferMutationType>,
+  reminderId: string,
+  url: string,
+  body: Record<string, any> | null,
+): Promise<void> {
+  if (mutationType === "deleteTaskReminder") {
+    await _deleteCachedTaskReminder(reminderId);
+    return;
+  }
+  if (mutationType === "createTaskReminder") {
+    const now = new Date().toISOString();
+    const taskId = _extractNoteId(url);
+    const reminder: TaskReminder = {
+      id: reminderId,
+      taskId,
+      userId: "",
+      offsetMinutes: body?.offsetMinutes ?? 30,
+      enabled: 1,
+      lastNotifiedAt: null,
+      snoozedUntil: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await _putCachedTaskReminders([reminder], getCurrentWorkspace() === "personal" ? null : getCurrentWorkspace());
+    return;
+  }
+  if (mutationType === "updateTaskReminder") {
+    const existing = await _getCachedTaskReminder(reminderId);
+    if (existing) {
+      await _putCachedTaskReminders([{ ...existing, ...body, id: reminderId, updatedAt: new Date().toISOString() }], getCurrentWorkspace() === "personal" ? null : getCurrentWorkspace());
+    }
+  }
+}
+
+async function cacheAcknowledgedMutation(
+  mutationType: ReturnType<typeof _inferMutationType>,
+  resourceId: string,
+  url: string,
+  body: Record<string, any> | null,
+  response: unknown,
+): Promise<void> {
+  if (!mutationType) return;
+  try {
+    if (mutationType === "createTask" || mutationType === "updateTask" || mutationType === "toggleTask" || mutationType === "deleteTask") {
+      const task = (response as TaskMutationResponse | undefined)?.task || response;
+      await cacheOfflineTaskMutation(mutationType, resourceId, task as Record<string, any>);
+      return;
+    }
+    if (mutationType === "createHabit" || mutationType === "updateHabit" || mutationType === "archiveHabit" || mutationType === "deleteHabit" || mutationType === "checkInHabit") {
+      await cacheOfflineHabitMutation(mutationType, resourceId, response as Record<string, any>);
+      return;
+    }
+    if (mutationType === "createTaskDependency" || mutationType === "deleteTaskDependency") {
+      await cacheOfflineTaskDependencyMutation(mutationType, resourceId, response as Record<string, any>);
+      return;
+    }
+    if (mutationType === "createTaskReminder" || mutationType === "updateTaskReminder" || mutationType === "deleteTaskReminder") {
+      await cacheOfflineTaskReminderMutation(mutationType, resourceId, url, response as Record<string, any>);
+    }
+  } catch (error) {
+    console.warn("[api] acknowledged mutation cache update failed:", error);
+  }
+}
+
+async function handleOfflineEnqueue<T>(
+  url: string,
+  method: string,
+  bodyStr?: string,
+  envelope?: OfflineMutationEnvelope | null,
+): Promise<T> {
+  const parsedBody = envelope?.body || (bodyStr ? JSON.parse(bodyStr) : null);
+  const mutationType = envelope?.type || _inferMutationType(url, method);
+  const createsEntity = mutationType === "createNote"
+    || mutationType === "createTask"
+    || mutationType === "createHabit"
+    || mutationType === "createTaskDependency"
+    || mutationType === "createTaskReminder";
+  const noteId = envelope?.noteId || (createsEntity
+    ? (parsedBody?.id || generateLocalNoteId())
+    : _extractNoteId(url));
+  const body = envelope?.body || (createsEntity ? { ...(parsedBody || {}), id: noteId } : parsedBody);
+
+  const enqueueResult = _enqueue(envelope || {
     type: mutationType || "updateNote",
     noteId,
     url,
-    method: method as "POST" | "PUT" | "DELETE",
+    method: method as "POST" | "PUT" | "PATCH" | "DELETE",
     body,
   });
 
@@ -941,6 +1180,42 @@ function handleOfflineEnqueue<T>(url: string, method: string, bodyStr?: string):
     void import("@/lib/localStore").then((m) => m.deleteNote(noteId)).catch(() => { });
   }
 
+  if (
+    mutationType === "createTask"
+    || mutationType === "updateTask"
+    || mutationType === "toggleTask"
+    || mutationType === "deleteTask"
+  ) {
+    await cacheOfflineTaskMutation(mutationType, noteId, body).catch((error) => {
+      console.warn("[api] offline task cache update failed; queue remains persisted:", error);
+    });
+  }
+  if (mutationType?.includes("Habit") || mutationType === "checkInHabit") {
+    await cacheOfflineHabitMutation(mutationType, noteId, body).catch((error) => {
+      console.warn("[api] offline habit cache update failed; queue remains persisted:", error);
+    });
+  }
+  if (mutationType === "createTaskDependency" || mutationType === "deleteTaskDependency") {
+    await cacheOfflineTaskDependencyMutation(mutationType, noteId, body).catch((error) => {
+      console.warn("[api] offline dependency cache update failed; queue remains persisted:", error);
+    });
+  }
+  if (
+    mutationType === "createTaskReminder"
+    || mutationType === "updateTaskReminder"
+    || mutationType === "deleteTaskReminder"
+  ) {
+    await cacheOfflineTaskReminderMutation(mutationType, noteId, url, body).catch((error) => {
+      console.warn("[api] offline reminder cache update failed; queue remains persisted:", error);
+    });
+  }
+  if (enqueueResult.cancelledTaskAssociationIds) {
+    await Promise.all([
+      ...enqueueResult.cancelledTaskAssociationIds.dependencyIds.map((id) => _deleteCachedTaskDependency(id)),
+      ...enqueueResult.cancelledTaskAssociationIds.reminderIds.map((id) => _deleteCachedTaskReminder(id)),
+    ]);
+  }
+
   // 构造乐观返回值
   if (mutationType === "createNote") {
     return {
@@ -957,6 +1232,58 @@ function handleOfflineEnqueue<T>(url: string, method: string, bodyStr?: string):
   if (mutationType === "deleteNote") {
     return {} as T;
   }
+  if (mutationType === "createTask") return createOptimisticTask(noteId, body) as T;
+  if (mutationType === "updateTask" || mutationType === "toggleTask") {
+    return {
+      task: { id: noteId, updatedAt: new Date().toISOString(), ...(body || {}) },
+      generatedTask: null,
+    } as T;
+  }
+  if (mutationType === "deleteTask") return {} as T;
+  if (mutationType === "createHabit" || mutationType === "updateHabit" || mutationType === "archiveHabit") {
+    return createOptimisticHabit(noteId, body) as T;
+  }
+  if (mutationType === "deleteHabit") return { success: true } as T;
+  if (mutationType === "checkInHabit") {
+    const now = new Date().toISOString();
+    return {
+      id: `${noteId}:${body?.checkinDate || "today"}`,
+      habitId: noteId,
+      userId: "",
+      workspaceId: offlineWorkspaceId(),
+      checkinDate: body?.checkinDate || "",
+      status: body?.status || "success",
+      note: body?.note || "",
+      createdAt: now,
+      updatedAt: now,
+    } as HabitCheckin as T;
+  }
+  if (mutationType === "createTaskDependency") {
+    return {
+      id: noteId,
+      userId: "",
+      workspaceId: offlineWorkspaceId(),
+      predecessorTaskId: body?.predecessorTaskId || "",
+      successorTaskId: body?.successorTaskId || "",
+      type: body?.type || "finish_to_start",
+      createdAt: new Date().toISOString(),
+    } as T;
+  }
+  if (mutationType === "createTaskReminder") {
+    const now = new Date().toISOString();
+    return {
+      id: noteId,
+      taskId: _extractNoteId(url),
+      userId: "",
+      offsetMinutes: body?.offsetMinutes ?? 30,
+      enabled: true,
+      lastNotifiedAt: null,
+      snoozedUntil: null,
+      createdAt: now,
+      updatedAt: now,
+    } as T;
+  }
+  if (mutationType === "deleteTaskDependency" || mutationType === "deleteTaskReminder") return { success: true } as T;
   // updateNote: 返回 body + noteId，让 EditorPane 的 reconcile 能拿到 version/updatedAt
   return {
     id: noteId,
@@ -1402,17 +1729,19 @@ export const api = {
       `/notes/${id}/headings`,
     ),
   getNoteBlocks: (id: string, limit = 500) =>
-    request<{ noteId: string; blocks: Array<{
-      noteId: string;
-      blockId: string;
-      blockType: "heading" | "paragraph" | "listItem" | "taskItem" | "blockquote" | "codeBlock";
-      parentBlockId: string | null;
-      blockOrder: number;
-      plainText: string;
-      path: string;
-      startOffset: number | null;
-      endOffset: number | null;
-    }> }>(`/blocks/note/${id}?limit=${limit}`),
+    request<{
+      noteId: string; blocks: Array<{
+        noteId: string;
+        blockId: string;
+        blockType: "heading" | "paragraph" | "listItem" | "taskItem" | "blockquote" | "codeBlock";
+        parentBlockId: string | null;
+        blockOrder: number;
+        plainText: string;
+        path: string;
+        startOffset: number | null;
+        endOffset: number | null;
+      }>
+    }>(`/blocks/note/${id}?limit=${limit}`),
   getBlock: (noteId: string, blockId: string) =>
     request<any>(`/blocks/${noteId}/${encodeURIComponent(blockId)}`),
   resolveNoteLink: (link: string) =>
@@ -1589,7 +1918,7 @@ export const api = {
   updateTask: (id: string, data: Partial<Task>) => request<TaskMutationResponse>(`/tasks/${id}`, { method: "PUT", body: JSON.stringify(data) }),
   reorderTasks: (items: { id: string; sortOrder: number }[]) =>
     request<{ success: boolean; affected: number }>("/tasks/reorder/batch", { method: "PUT", body: JSON.stringify({ items }) }),
-  toggleTask: (id: string) => request<TaskMutationResponse>(`/tasks/${id}/toggle`, { method: "PATCH" }),
+  toggleTask: (id: string, isCompleted: boolean) => request<TaskMutationResponse>(`/tasks/${id}/toggle`, { method: "PATCH", body: JSON.stringify({ isCompleted }) }),
   aiBreakdownTask: (id: string, lang?: string) => request<{ subtasks: { title: string; priority: number; dueDate: string | null; reason: string }[] }>(`/tasks/${id}/ai-breakdown`, { method: "POST", body: JSON.stringify({ lang }) }),
   deleteTask: (id: string) => request(`/tasks/${id}`, { method: "DELETE" }),
   batchTasks: (ids: string[], action: "complete" | "delete") =>
@@ -1649,6 +1978,11 @@ export const api = {
     ),
   getTaskReminders: (taskId: string) =>
     request<import("@/types").TaskReminder[]>(`/task-reminders/${taskId}`),
+  getTaskRemindersSnapshot: () => {
+    const ws = getCurrentWorkspace();
+    const qs = ws && ws !== "personal" ? `?workspaceId=${encodeURIComponent(ws)}` : "";
+    return request<{ reminders: import("@/types").TaskReminder[]; deletedIds: string[] }>(`/task-reminders/snapshot${qs}`);
+  },
   createTaskReminder: (taskId: string, offsetMinutes: number) =>
     request<import("@/types").TaskReminder>(`/task-reminders/${taskId}`, { method: "POST", body: JSON.stringify({ offsetMinutes }) }),
   updateTaskReminder: (reminderId: string, data: { offsetMinutes?: number; enabled?: boolean; snoozedUntil?: string | null }) =>

--- a/frontend/src/lib/localStore.ts
+++ b/frontend/src/lib/localStore.ts
@@ -1,10 +1,16 @@
 import { openDB, type IDBPDatabase, type DBSchema } from "idb";
-import type { Note, NoteListItem, Notebook, Tag } from "@/types";
+import type { Habit, HabitCheckin, Note, NoteListItem, Notebook, Tag, Task, TaskDependency, TaskReminder } from "@/types";
 
 /** Extra IndexedDB-only metadata. It is never sent to the server. */
 export type CachedNote = Note & {
   __detailCached?: boolean;
 };
+
+type CachedTask = Task & { __cacheWorkspaceId: string };
+type CachedHabit = Habit & { __cacheWorkspaceId: string };
+type CachedHabitCheckin = HabitCheckin & { __cacheWorkspaceId: string };
+type CachedTaskDependency = TaskDependency & { __cacheWorkspaceId: string };
+type CachedTaskReminder = TaskReminder & { __cacheWorkspaceId: string };
 
 interface NowenCacheSchema extends DBSchema {
   notebooks: {
@@ -28,6 +34,42 @@ interface NowenCacheSchema extends DBSchema {
     key: string;
     value: Tag;
   };
+  tasks: {
+    key: string;
+    value: CachedTask;
+    indexes: {
+      "by-workspace": string;
+    };
+  };
+  habits: {
+    key: string;
+    value: CachedHabit;
+    indexes: {
+      "by-workspace": string;
+    };
+  };
+  habitCheckins: {
+    key: string;
+    value: CachedHabitCheckin;
+    indexes: {
+      "by-workspace": string;
+      "by-habit": string;
+    };
+  };
+  taskDependencies: {
+    key: string;
+    value: CachedTaskDependency;
+    indexes: {
+      "by-workspace": string;
+    };
+  };
+  taskReminders: {
+    key: string;
+    value: CachedTaskReminder;
+    indexes: {
+      "by-task": string;
+    };
+  };
   meta: {
     key: string;
     value: {
@@ -39,7 +81,7 @@ interface NowenCacheSchema extends DBSchema {
 }
 
 const DB_NAME_PREFIX = "nowen-cache-v2-";
-const DB_VERSION = 1;
+const DB_VERSION = 3;
 
 let currentUserId: string | null = null;
 let currentCacheIdentity: string | null = null;
@@ -86,6 +128,10 @@ function getDbName(cacheIdentity: string): string {
   return `${DB_NAME_PREFIX}${cacheIdentity}`;
 }
 
+function cacheWorkspaceId(workspaceId: string | null): string {
+  return workspaceId || "personal";
+}
+
 export function setCurrentUser(userId: string | null): void {
   const nextIdentity = userId ? getCacheIdentity(userId) : null;
   if (currentUserId === userId && currentCacheIdentity === nextIdentity) return;
@@ -117,6 +163,27 @@ function getDb(): Promise<IDBPDatabase<NowenCacheSchema>> | null {
         }
         if (!db.objectStoreNames.contains("tags")) {
           db.createObjectStore("tags", { keyPath: "id" });
+        }
+        if (!db.objectStoreNames.contains("tasks")) {
+          const store = db.createObjectStore("tasks", { keyPath: "id" });
+          store.createIndex("by-workspace", "__cacheWorkspaceId");
+        }
+        if (!db.objectStoreNames.contains("habits")) {
+          const store = db.createObjectStore("habits", { keyPath: "id" });
+          store.createIndex("by-workspace", "__cacheWorkspaceId");
+        }
+        if (!db.objectStoreNames.contains("habitCheckins")) {
+          const store = db.createObjectStore("habitCheckins", { keyPath: "id" });
+          store.createIndex("by-workspace", "__cacheWorkspaceId");
+          store.createIndex("by-habit", "habitId");
+        }
+        if (!db.objectStoreNames.contains("taskDependencies")) {
+          const store = db.createObjectStore("taskDependencies", { keyPath: "id" });
+          store.createIndex("by-workspace", "__cacheWorkspaceId");
+        }
+        if (!db.objectStoreNames.contains("taskReminders")) {
+          const store = db.createObjectStore("taskReminders", { keyPath: "id" });
+          store.createIndex("by-task", "taskId");
         }
         if (!db.objectStoreNames.contains("meta")) {
           db.createObjectStore("meta", { keyPath: "key" });
@@ -291,6 +358,227 @@ export async function deleteTag(id: string): Promise<void> {
   await safe(async () => { await (await connection).delete("tags", id); }, undefined, "deleteTag");
 }
 
+async function replaceWorkspaceSnapshot(
+  storeName: "tasks" | "habits" | "habitCheckins" | "taskDependencies" | "taskReminders",
+  workspaceId: string | null,
+  items: CachedTask[] | CachedHabit[] | CachedHabitCheckin[] | CachedTaskDependency[] | CachedTaskReminder[],
+): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const db = await connection;
+    const transaction = db.transaction(storeName, "readwrite");
+    const store = transaction.store as any;
+    const existingKeys = storeName === "taskReminders"
+      ? (await store.getAll() as CachedTaskReminder[])
+        .filter((item: CachedTaskReminder) => item.__cacheWorkspaceId === cacheWorkspaceId(workspaceId))
+        .map((item: CachedTaskReminder) => item.id)
+      : await store.index("by-workspace").getAllKeys(cacheWorkspaceId(workspaceId));
+    await Promise.all(existingKeys.map((key: string) => store.delete(key)));
+    await Promise.all(items.map((item) => store.put(item)));
+    await transaction.done;
+  }, undefined, `replace ${storeName} snapshot`);
+}
+
+export async function putTasks(tasks: Task[], workspaceId: string | null): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const db = await connection;
+    const transaction = db.transaction("tasks", "readwrite");
+    await Promise.all(tasks.map((task) => transaction.store.put({
+      ...task,
+      __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+    })));
+    await transaction.done;
+  }, undefined, "putTasks");
+}
+
+export function replaceTasksSnapshot(tasks: Task[], workspaceId: string | null): Promise<void> {
+  return replaceWorkspaceSnapshot("tasks", workspaceId, tasks.map((task) => ({
+    ...task,
+    __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+  })));
+}
+
+export async function getTasks(workspaceId: string | null): Promise<Task[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(
+    async () => (await connection).getAllFromIndex("tasks", "by-workspace", cacheWorkspaceId(workspaceId)),
+    [],
+    "getTasks",
+  );
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => { await (await connection).delete("tasks", id); }, undefined, "deleteTask");
+}
+
+export async function putHabits(habits: Habit[], workspaceId: string | null): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const db = await connection;
+    const transaction = db.transaction("habits", "readwrite");
+    await Promise.all(habits.map((habit) => transaction.store.put({
+      ...habit,
+      __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+    })));
+    await transaction.done;
+  }, undefined, "putHabits");
+}
+
+export function replaceHabitsSnapshot(habits: Habit[], workspaceId: string | null): Promise<void> {
+  return replaceWorkspaceSnapshot("habits", workspaceId, habits.map((habit) => ({
+    ...habit,
+    __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+  })));
+}
+
+export async function getHabits(workspaceId: string | null): Promise<Habit[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(
+    async () => (await connection).getAllFromIndex("habits", "by-workspace", cacheWorkspaceId(workspaceId)),
+    [],
+    "getHabits",
+  );
+}
+
+export async function deleteHabit(id: string): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => { await (await connection).delete("habits", id); }, undefined, "deleteHabit");
+}
+
+export async function putHabitCheckins(checkins: HabitCheckin[], workspaceId: string | null): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const db = await connection;
+    const transaction = db.transaction("habitCheckins", "readwrite");
+    await Promise.all(checkins.map((checkin) => transaction.store.put({
+      ...checkin,
+      __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+    })));
+    await transaction.done;
+  }, undefined, "putHabitCheckins");
+}
+
+export function replaceHabitCheckinsSnapshot(checkins: HabitCheckin[], workspaceId: string | null): Promise<void> {
+  return replaceWorkspaceSnapshot("habitCheckins", workspaceId, checkins.map((checkin) => ({
+    ...checkin,
+    __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+  })));
+}
+
+export async function getHabitCheckins(workspaceId: string | null): Promise<HabitCheckin[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(
+    async () => (await connection).getAllFromIndex("habitCheckins", "by-workspace", cacheWorkspaceId(workspaceId)),
+    [],
+    "getHabitCheckins",
+  );
+}
+
+export async function putTaskDependencies(dependencies: TaskDependency[], workspaceId: string | null): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const transaction = (await connection).transaction("taskDependencies", "readwrite");
+    await Promise.all(dependencies.map((dependency) => transaction.store.put({
+      ...dependency,
+      __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+    })));
+    await transaction.done;
+  }, undefined, "putTaskDependencies");
+}
+
+export function replaceTaskDependenciesSnapshot(dependencies: TaskDependency[], workspaceId: string | null): Promise<void> {
+  return replaceWorkspaceSnapshot("taskDependencies", workspaceId, dependencies.map((dependency) => ({
+    ...dependency,
+    __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+  })));
+}
+
+export async function getTaskDependencies(workspaceId: string | null): Promise<TaskDependency[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(
+    async () => (await connection).getAllFromIndex("taskDependencies", "by-workspace", cacheWorkspaceId(workspaceId)),
+    [],
+    "getTaskDependencies",
+  );
+}
+
+export async function deleteTaskDependency(id: string): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => { await (await connection).delete("taskDependencies", id); }, undefined, "deleteTaskDependency");
+}
+
+export async function putTaskReminders(reminders: TaskReminder[], workspaceId: string | null = null): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => {
+    const transaction = (await connection).transaction("taskReminders", "readwrite");
+    await Promise.all(reminders.map((reminder) => transaction.store.put({
+      ...reminder,
+      __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+    })));
+    await transaction.done;
+  }, undefined, "putTaskReminders");
+}
+
+export function replaceTaskRemindersSnapshot(reminders: TaskReminder[], workspaceId: string | null): Promise<void> {
+  return replaceWorkspaceSnapshot("taskReminders", workspaceId, reminders.map((reminder) => ({
+    ...reminder,
+    __cacheWorkspaceId: cacheWorkspaceId(workspaceId),
+  })));
+}
+
+export async function getTaskRemindersForWorkspace(workspaceId: string | null): Promise<TaskReminder[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(async () => {
+    const reminders = await (await connection).getAll("taskReminders");
+    return reminders
+      .filter((reminder) => reminder.__cacheWorkspaceId === cacheWorkspaceId(workspaceId))
+      .map(({ __cacheWorkspaceId: _cacheWorkspaceId, ...reminder }) => reminder);
+  }, [], "getTaskRemindersForWorkspace");
+}
+
+export async function getTaskReminders(taskId: string): Promise<TaskReminder[]> {
+  const connection = getDb();
+  if (!connection) return [];
+  return safe(
+    async () => (await connection).getAllFromIndex("taskReminders", "by-task", taskId),
+    [],
+    "getTaskReminders",
+  );
+}
+
+export async function getTaskReminder(id: string): Promise<TaskReminder | undefined> {
+  const connection = getDb();
+  if (!connection) return undefined;
+  return safe(async () => {
+    const reminder = await (await connection).get("taskReminders", id);
+    if (!reminder) return undefined;
+    const { __cacheWorkspaceId: _cacheWorkspaceId, ...value } = reminder;
+    return value;
+  }, undefined, "getTaskReminder");
+}
+
+export async function deleteTaskReminder(id: string): Promise<void> {
+  const connection = getDb();
+  if (!connection) return;
+  await safe(async () => { await (await connection).delete("taskReminders", id); }, undefined, "deleteTaskReminder");
+}
+
 export async function setMeta(key: string, value: unknown): Promise<void> {
   const connection = getDb();
   if (!connection) return;
@@ -313,11 +601,16 @@ export async function clearAll(): Promise<void> {
   if (!connection) return;
   await safe(async () => {
     const db = await connection;
-    const transaction = db.transaction(["notebooks", "notes", "tags", "meta"], "readwrite");
+    const transaction = db.transaction(["notebooks", "notes", "tags", "tasks", "habits", "habitCheckins", "taskDependencies", "taskReminders", "meta"], "readwrite");
     await Promise.all([
       transaction.objectStore("notebooks").clear(),
       transaction.objectStore("notes").clear(),
       transaction.objectStore("tags").clear(),
+      transaction.objectStore("tasks").clear(),
+      transaction.objectStore("habits").clear(),
+      transaction.objectStore("habitCheckins").clear(),
+      transaction.objectStore("taskDependencies").clear(),
+      transaction.objectStore("taskReminders").clear(),
       transaction.objectStore("meta").clear(),
     ]);
     await transaction.done;

--- a/frontend/src/lib/offlineQueue.ts
+++ b/frontend/src/lib/offlineQueue.ts
@@ -7,16 +7,36 @@
  * payload for diagnostics/export.
  */
 
-export type OfflineMutationType = "createNote" | "updateNote" | "deleteNote";
+export type OfflineMutationType =
+  | "createNote"
+  | "updateNote"
+  | "deleteNote"
+  | "createTask"
+  | "updateTask"
+  | "toggleTask"
+  | "deleteTask"
+  | "createHabit"
+  | "updateHabit"
+  | "archiveHabit"
+  | "deleteHabit"
+  | "checkInHabit"
+  | "createTaskDependency"
+  | "deleteTaskDependency"
+  | "createTaskReminder"
+  | "updateTaskReminder"
+  | "deleteTaskReminder";
 
 export const OFFLINE_QUEUE_CONFLICT_EVENT = "offlineQueue:conflict";
 
 export interface OfflineQueueItem {
   id: string;
   type: OfflineMutationType;
+  /** Canonical identifier for any queued resource. */
+  resourceId?: string;
+  /** @deprecated Use resourceId for non-note mutations. */
   noteId: string;
   url: string;
-  method: "POST" | "PUT" | "DELETE";
+  method: "POST" | "PUT" | "PATCH" | "DELETE";
   body: Record<string, unknown> | null;
   enqueuedAt: number;
   retryCount: number;
@@ -31,6 +51,8 @@ export interface OfflineQueueItem {
   lastHttpStatus?: number;
   message?: string;
 }
+
+export type OfflineMutationEnvelope = Omit<OfflineQueueItem, "retryCount">;
 
 export interface OfflineQueueFetchContext {
   idempotencyKey: string;
@@ -50,12 +72,22 @@ export type FlushResult = {
   remaining: number;
 };
 
+export type EnqueueResult = {
+  cancelledTaskAssociationIds?: {
+    dependencyIds: string[];
+    reminderIds: string[];
+  };
+};
+
 const LEGACY_STORAGE_KEY = "nowen-offline-queue";
 const STORAGE_KEY_PREFIX = "nowen-offline-queue:v2";
 const LEGACY_LOCAL_ID_MAP_KEY = "nowen-offline-id-map";
 const LOCAL_ID_MAP_KEY_PREFIX = "nowen-offline-id-map:v2";
+const FLUSH_LEASE_KEY_PREFIX = "nowen-offline-queue-lease:v1";
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const MAX_RETRY = 10;
+const FLUSH_LEASE_MS = 60_000;
+const flushOwnerId = generateId();
 
 function generateId(): string {
   return `oq_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
@@ -123,11 +155,55 @@ function getLocalIdMapStorageKey(): string {
   return `${LOCAL_ID_MAP_KEY_PREFIX}:${queueScope}`;
 }
 
+function getFlushLeaseStorageKey(): string {
+  const queueScope = getOfflineQueueStorageKey().slice(STORAGE_KEY_PREFIX.length + 1);
+  return `${FLUSH_LEASE_KEY_PREFIX}:${queueScope}`;
+}
+
+function acquireFlushLease(): boolean {
+  const key = getFlushLeaseStorageKey();
+  const now = Date.now();
+  try {
+    const current = JSON.parse(localStorage.getItem(key) || "null") as { ownerId?: string; expiresAt?: number } | null;
+    if (current?.ownerId && current.ownerId !== flushOwnerId && Number(current.expiresAt) > now) return false;
+    localStorage.setItem(key, JSON.stringify({ ownerId: flushOwnerId, expiresAt: now + FLUSH_LEASE_MS }));
+    const claimed = JSON.parse(localStorage.getItem(key) || "null") as { ownerId?: string } | null;
+    return claimed?.ownerId === flushOwnerId;
+  } catch {
+    // Storage may be unavailable; server idempotency still protects replay.
+    return true;
+  }
+}
+
+function renewFlushLease(): void {
+  const key = getFlushLeaseStorageKey();
+  try {
+    const current = JSON.parse(localStorage.getItem(key) || "null") as { ownerId?: string } | null;
+    if (current?.ownerId === flushOwnerId) {
+      localStorage.setItem(key, JSON.stringify({ ownerId: flushOwnerId, expiresAt: Date.now() + FLUSH_LEASE_MS }));
+    }
+  } catch { /* server idempotency remains the fallback */ }
+}
+
+function releaseFlushLease(): void {
+  const key = getFlushLeaseStorageKey();
+  try {
+    const current = JSON.parse(localStorage.getItem(key) || "null") as { ownerId?: string } | null;
+    if (current?.ownerId === flushOwnerId) localStorage.removeItem(key);
+  } catch { /* no lease to release */ }
+}
+
 function readQueueFromKey(key: string): OfflineQueueItem[] {
   const raw = localStorage.getItem(key);
   if (!raw) return [];
   const parsed = JSON.parse(raw);
-  return Array.isArray(parsed) ? parsed : [];
+  return Array.isArray(parsed)
+    ? parsed.map((item) => ({
+        ...item,
+        resourceId: typeof item.resourceId === "string" ? item.resourceId : item.noteId,
+        noteId: typeof item.noteId === "string" ? item.noteId : item.resourceId,
+      }))
+    : [];
 }
 
 function uuidV4Fallback(): string {
@@ -155,13 +231,9 @@ export function generateLocalNoteId(): string {
 }
 
 function persistQueue(items: OfflineQueueItem[]): void {
-  try {
-    const key = getOfflineQueueStorageKey();
-    if (items.length === 0) localStorage.removeItem(key);
-    else localStorage.setItem(key, JSON.stringify(items));
-  } catch (error) {
-    console.warn("[offlineQueue] persistQueue failed:", error);
-  }
+  const key = getOfflineQueueStorageKey();
+  if (items.length === 0) localStorage.removeItem(key);
+  else localStorage.setItem(key, JSON.stringify(items));
 }
 
 export function getQueue(): OfflineQueueItem[] {
@@ -197,13 +269,14 @@ function clearFailureState(item: OfflineQueueItem): OfflineQueueItem {
   return next;
 }
 
-export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retryCount">): void {
+export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retryCount"> & Partial<Pick<OfflineQueueItem, "id" | "enqueuedAt">>): EnqueueResult {
   const queue = getQueue();
   const newItem: OfflineQueueItem = {
     ...item,
-    id: generateId(),
-    enqueuedAt: Date.now(),
+    id: item.id || generateId(),
+    enqueuedAt: item.enqueuedAt || Date.now(),
     retryCount: 0,
+    resourceId: item.resourceId || item.noteId,
   };
 
   // 用户明确移入回收站时，删除意图优先于此前尚未处理的内容更新或版本冲突。
@@ -215,7 +288,7 @@ export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retr
     next.push(newItem);
     persistQueue(next);
     notifyListeners();
-    return;
+    return {};
   }
 
   if (newItem.type === "updateNote") {
@@ -231,7 +304,7 @@ export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retr
       };
       persistQueue(queue);
       notifyListeners();
-      return;
+      return {};
     }
 
     const updateIndex = queue.findIndex(
@@ -248,7 +321,55 @@ export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retr
       };
       persistQueue(queue);
       notifyListeners();
-      return;
+      return {};
+    }
+  }
+
+  const resourceMutation = (type: OfflineMutationType): { create?: OfflineMutationType; updates: OfflineMutationType[]; remove: OfflineMutationType } | null => {
+    if (type === "createTask" || type === "updateTask" || type === "toggleTask" || type === "deleteTask") {
+      return { create: "createTask", updates: ["updateTask", "toggleTask"], remove: "deleteTask" };
+    }
+    if (type === "createHabit" || type === "updateHabit" || type === "archiveHabit" || type === "deleteHabit") {
+      return { create: "createHabit", updates: ["updateHabit", "archiveHabit"], remove: "deleteHabit" };
+    }
+    return null;
+  };
+  const resource = resourceMutation(newItem.type);
+  if (resource) {
+    const createIndex = queue.findIndex((queued) => queued.noteId === newItem.noteId && queued.type === resource.create && !queued.conflict);
+    if (newItem.type === resource.remove && createIndex !== -1 && !inFlightItemIds.has(queue[createIndex].id)) {
+      const [cancelledCreate] = queue.splice(createIndex, 1);
+      if (newItem.type === "deleteTask") {
+        const dependencyIds = new Set(queue
+          .filter((queued) => queued.type === "createTaskDependency" && (
+            queued.body?.predecessorTaskId === newItem.noteId || queued.body?.successorTaskId === newItem.noteId
+          ))
+          .map((queued) => queued.noteId));
+        const reminderIds = new Set(queue
+          .filter((queued) => queued.type === "createTaskReminder" && extractNoteId(queued.url) === newItem.noteId)
+          .map((queued) => queued.noteId));
+        const next = queue.filter((queued) => !(
+          dependencyIds.has(queued.noteId)
+          || reminderIds.has(queued.noteId)
+          || (queued.type === "createTask" && queued.noteId === cancelledCreate.noteId)
+        ));
+        persistQueue(next);
+        notifyListeners();
+        return {
+          cancelledTaskAssociationIds: {
+            dependencyIds: [...dependencyIds],
+            reminderIds: [...reminderIds],
+          },
+        };
+      }
+      persistQueue(queue);
+      notifyListeners();
+      return {};
+    }
+    if (newItem.type === resource.remove) {
+      for (let index = queue.length - 1; index >= 0; index -= 1) {
+        if (queue[index].noteId === newItem.noteId && resource.updates.includes(queue[index].type)) queue.splice(index, 1);
+      }
     }
   }
 
@@ -264,6 +385,7 @@ export function enqueue(item: Omit<OfflineQueueItem, "id" | "enqueuedAt" | "retr
   queue.push(newItem);
   persistQueue(queue);
   notifyListeners();
+  return {};
 }
 
 export function dequeue(itemId: string): void {
@@ -445,6 +567,7 @@ export function clearLocalIdMap(): void {
 }
 
 let flushPromise: Promise<FlushResult> | null = null;
+const inFlightItemIds = new Set<string>();
 
 async function flushQueueInternal(fetchFn: OfflineQueueFetch): Promise<FlushResult> {
   const result: FlushResult = { success: 0, failed: 0, remaining: 0 };
@@ -470,13 +593,20 @@ async function flushQueueInternal(fetchFn: OfflineQueueFetch): Promise<FlushResu
       }
 
       try {
+        renewFlushLease();
         const replayBody = item.type === "createNote" && item.body && !item.body.id && !item.noteId.startsWith("local-")
           ? { ...item.body, id: item.noteId }
           : item.body;
-        const response = await fetchFn(item.url, item.method, replayBody, {
-          idempotencyKey: item.id,
-          item,
-        });
+        inFlightItemIds.add(item.id);
+        let response;
+        try {
+          response = await fetchFn(item.url, item.method, replayBody, {
+            idempotencyKey: item.id,
+            item,
+          });
+        } finally {
+          inFlightItemIds.delete(item.id);
+        }
 
         if (response.ok) {
           if (item.type === "createNote" && item.noteId.startsWith("local-") && response.data?.id) {
@@ -567,7 +697,11 @@ async function flushQueueInternal(fetchFn: OfflineQueueFetch): Promise<FlushResu
 
 export function flushQueue(fetchFn: OfflineQueueFetch): Promise<FlushResult> {
   if (flushPromise) return flushPromise;
+  if (!acquireFlushLease()) {
+    return Promise.resolve({ success: 0, failed: 0, remaining: getQueueLength() });
+  }
   flushPromise = flushQueueInternal(fetchFn).finally(() => {
+    releaseFlushLease();
     flushPromise = null;
   });
   return flushPromise;
@@ -588,16 +722,36 @@ function notifyListeners(): void {
   });
 }
 
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === getOfflineQueueStorageKey()) notifyListeners();
+  });
+}
+
 export function shouldEnqueue(url: string, method: string, error: any): boolean {
   const normalizedMethod = method.toUpperCase();
-  if (normalizedMethod !== "POST" && normalizedMethod !== "PUT" && normalizedMethod !== "DELETE") return false;
-  if (!isNotesMutationUrl(url)) return false;
+  if (normalizedMethod !== "POST" && normalizedMethod !== "PUT" && normalizedMethod !== "PATCH" && normalizedMethod !== "DELETE") return false;
+  if (!isOfflineMutationUrl(url)) return false;
   if (isNetworkError(error)) return true;
   return error?.status >= 500;
 }
 
-function isNotesMutationUrl(url: string): boolean {
-  return /^\/notes(\/[^/]+)?$/.test(url);
+function isOfflineMutationUrl(url: string): boolean {
+  const pathname = mutationPathname(url);
+  return /^\/notes(\/[^/]+)?$/.test(pathname)
+    || /^\/tasks(?:\/[^/]+(?:\/toggle)?)?$/.test(pathname)
+    || /^\/habits(?:\/[^/]+(?:\/(?:archive|checkins))?)?$/.test(pathname)
+    || pathname === "/task-dependencies"
+    || /^\/task-dependencies\/[^/]+$/.test(pathname)
+    || /^\/task-reminders\/[^/]+$/.test(pathname);
+}
+
+function mutationPathname(url: string): string {
+  try {
+    return new URL(url, "https://offline.invalid").pathname;
+  } catch {
+    return url.split("?", 1)[0];
+  }
 }
 
 export function isNetworkError(error: any): boolean {
@@ -608,14 +762,56 @@ export function isNetworkError(error: any): boolean {
 }
 
 export function inferMutationType(url: string, method: string): OfflineMutationType | null {
+  const pathname = mutationPathname(url);
   const normalizedMethod = method.toUpperCase();
-  if (normalizedMethod === "POST" && url === "/notes") return "createNote";
-  if (normalizedMethod === "PUT" && /^\/notes\/[^/]+$/.test(url)) return "updateNote";
-  if (normalizedMethod === "DELETE" && /^\/notes\/[^/]+$/.test(url)) return "deleteNote";
+  if (normalizedMethod === "POST" && pathname === "/notes") return "createNote";
+  if (normalizedMethod === "PUT" && /^\/notes\/[^/]+$/.test(pathname)) return "updateNote";
+  if (normalizedMethod === "DELETE" && /^\/notes\/[^/]+$/.test(pathname)) return "deleteNote";
+  if (normalizedMethod === "POST" && pathname === "/tasks") return "createTask";
+  if (normalizedMethod === "PUT" && /^\/tasks\/[^/]+$/.test(pathname)) return "updateTask";
+  if (normalizedMethod === "PATCH" && /^\/tasks\/[^/]+\/toggle$/.test(pathname)) return "toggleTask";
+  if (normalizedMethod === "DELETE" && /^\/tasks\/[^/]+$/.test(pathname)) return "deleteTask";
+  if (normalizedMethod === "POST" && pathname === "/habits") return "createHabit";
+  if (normalizedMethod === "PUT" && /^\/habits\/[^/]+$/.test(pathname)) return "updateHabit";
+  if (normalizedMethod === "PATCH" && /^\/habits\/[^/]+\/archive$/.test(pathname)) return "archiveHabit";
+  if (normalizedMethod === "DELETE" && /^\/habits\/[^/]+$/.test(pathname)) return "deleteHabit";
+  if (normalizedMethod === "POST" && /^\/habits\/[^/]+\/checkins$/.test(pathname)) return "checkInHabit";
+  if (normalizedMethod === "POST" && pathname === "/task-dependencies") return "createTaskDependency";
+  if (normalizedMethod === "DELETE" && /^\/task-dependencies\/[^/]+$/.test(pathname)) return "deleteTaskDependency";
+  if (normalizedMethod === "POST" && /^\/task-reminders\/[^/]+$/.test(pathname)) return "createTaskReminder";
+  if (normalizedMethod === "PUT" && /^\/task-reminders\/[^/]+$/.test(pathname)) return "updateTaskReminder";
+  if (normalizedMethod === "DELETE" && /^\/task-reminders\/[^/]+$/.test(pathname)) return "deleteTaskReminder";
   return null;
 }
 
+export function createOfflineMutationEnvelope(
+  url: string,
+  method: string,
+  body: Record<string, unknown> | null,
+): OfflineMutationEnvelope | null {
+  if (!isOfflineMutationUrl(url)) return null;
+  const type = inferMutationType(url, method);
+  if (!type) return null;
+  const createsEntity = type === "createNote"
+    || type === "createTask"
+    || type === "createHabit"
+    || type === "createTaskDependency"
+    || type === "createTaskReminder";
+  const resourceId = createsEntity ? String(body?.id || generateLocalNoteId()) : extractNoteId(url);
+  const nextBody = createsEntity ? { ...(body || {}), id: resourceId } : body;
+  return {
+    id: generateId(),
+    type,
+    resourceId,
+    noteId: resourceId,
+    url,
+    method: method.toUpperCase() as OfflineQueueItem["method"],
+    body: nextBody,
+    enqueuedAt: Date.now(),
+  };
+}
+
 export function extractNoteId(url: string): string {
-  const match = url.match(/^\/notes\/([^/?]+)/);
+  const match = mutationPathname(url).match(/^\/(?:notes|tasks|habits|task-dependencies|task-reminders)\/([^/?]+)/);
   return match ? match[1] : "";
 }

--- a/frontend/src/lib/offlineQueueFetch.ts
+++ b/frontend/src/lib/offlineQueueFetch.ts
@@ -3,6 +3,7 @@
  * the normal API wrapper so a failed replay cannot enqueue itself again.
  */
 import { getBaseUrl } from "@/lib/api";
+import type { OfflineQueueFetchContext } from "@/lib/offlineQueue";
 
 function getToken(): string | null {
   return localStorage.getItem("nowen-token");
@@ -12,6 +13,7 @@ export async function offlineQueueFetch(
   url: string,
   method: string,
   body: Record<string, unknown> | null,
+  context?: OfflineQueueFetchContext,
 ): Promise<{ ok: boolean; status: number; data?: any }> {
   const token = getToken();
   const fullUrl = `${getBaseUrl()}${url}`;
@@ -21,6 +23,8 @@ export async function offlineQueueFetch(
     headers: {
       "Content-Type": "application/json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(context?.idempotencyKey ? { "Idempotency-Key": context.idempotencyKey } : {}),
+      ...(context?.item ? { "X-Client-Mutation-At": new Date(context.item.enqueuedAt).toISOString() } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
   });

--- a/frontend/src/lib/syncEngine.ts
+++ b/frontend/src/lib/syncEngine.ts
@@ -1,10 +1,21 @@
-import { api } from "@/lib/api";
+import { api, getCurrentWorkspace } from "@/lib/api";
 import {
   setCurrentUser,
   putNotebooks,
   putNoteListItems,
   putNote,
   putTags,
+  replaceTasksSnapshot,
+  getTasks,
+  replaceHabitsSnapshot,
+  getHabits,
+  replaceHabitCheckinsSnapshot,
+  getHabitCheckins,
+  replaceTaskDependenciesSnapshot,
+  getTaskDependencies,
+  replaceTaskRemindersSnapshot,
+  getTaskRemindersForWorkspace,
+  deleteTaskReminder,
   setMeta,
   getMeta,
   getAllNotes,
@@ -13,6 +24,7 @@ import {
   deleteNote,
   deleteNotebook,
   deleteTag,
+  clearAll,
   isReady as localStoreReady,
 } from "@/lib/localStore";
 import {
@@ -21,6 +33,8 @@ import {
   getFailedQueueItems,
   getQueue as getOfflineQueue,
   getQueueLength,
+  clearQueue,
+  clearLocalIdMap,
   subscribe as subscribeOfflineQueue,
   type OfflineQueueItem,
 } from "@/lib/offlineQueue";
@@ -152,13 +166,47 @@ export function subscribeSyncSummary(listener: (summary: SyncSummary) => void): 
 }
 
 async function pullServerSnapshot(): Promise<void> {
-  const [notebooksResult, notesResult, tagsResult] = await Promise.allSettled([
+  const workspaceId = getCurrentWorkspace() === "personal" ? null : getCurrentWorkspace();
+  const [notebooksResult, notesResult, tagsResult, tasksResult, habitsResult, habitCheckinsResult, dependenciesResult, remindersResult] = await Promise.allSettled([
     api.getNotebooks(),
     api.getNotes(),
     api.getTags(),
+    api.getTasks("all"),
+    api.getHabits(true),
+    api.getHabitCheckinLog({ includeArchived: true }),
+    api.getTaskDependencies(),
+    api.getTaskRemindersSnapshot(),
   ]);
 
   const pullErrors: string[] = [];
+  const pendingResourceItems = getOfflineQueue();
+  const pendingTaskIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "createTask" || item.type === "updateTask" || item.type === "toggleTask" || item.type === "deleteTask")
+    .map((item) => item.noteId));
+  const pendingDeletedTaskIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "deleteTask")
+    .map((item) => item.noteId));
+  const pendingHabitIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "createHabit" || item.type === "updateHabit" || item.type === "archiveHabit" || item.type === "deleteHabit" || item.type === "checkInHabit")
+    .map((item) => item.noteId));
+  const pendingDeletedHabitIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "deleteHabit")
+    .map((item) => item.noteId));
+  const pendingCheckinHabitIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "checkInHabit")
+    .map((item) => item.noteId));
+  const pendingDependencyIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "createTaskDependency" || item.type === "deleteTaskDependency")
+    .map((item) => item.noteId));
+  const pendingDeletedDependencyIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "deleteTaskDependency")
+    .map((item) => item.noteId));
+  const pendingReminderIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "createTaskReminder" || item.type === "updateTaskReminder" || item.type === "deleteTaskReminder")
+    .map((item) => item.noteId));
+  const pendingDeletedReminderIds = new Set(pendingResourceItems
+    .filter((item) => item.type === "deleteTaskReminder")
+    .map((item) => item.noteId));
 
   if (notebooksResult.status === "fulfilled") {
     const local = await getAllNotebooks();
@@ -209,6 +257,89 @@ async function pullServerSnapshot(): Promise<void> {
     pullErrors.push(`标签：${tagsResult.reason instanceof Error ? tagsResult.reason.message : String(tagsResult.reason)}`);
   }
 
+  if (tasksResult.status === "fulfilled") {
+    const localTasks = await getTasks(workspaceId);
+    const localById = new Map(localTasks.map((task) => [task.id, task]));
+    const remoteIds = new Set(tasksResult.value.map((task) => task.id));
+    const merged = tasksResult.value
+      .filter((task) => !pendingDeletedTaskIds.has(task.id))
+      .map((task) => pendingTaskIds.has(task.id) ? localById.get(task.id) || task : task);
+    merged.push(...localTasks.filter((task) => pendingTaskIds.has(task.id) && !remoteIds.has(task.id) && !pendingDeletedTaskIds.has(task.id)));
+    await replaceTasksSnapshot(merged, workspaceId);
+  } else {
+    console.warn("[syncEngine] pull tasks failed:", tasksResult.reason);
+    pullErrors.push(`任务：${tasksResult.reason instanceof Error ? tasksResult.reason.message : String(tasksResult.reason)}`);
+  }
+
+  if (habitsResult.status === "fulfilled") {
+    const localHabits = await getHabits(workspaceId);
+    const localById = new Map(localHabits.map((habit) => [habit.id, habit]));
+    const remoteIds = new Set(habitsResult.value.map((habit) => habit.id));
+    const merged = habitsResult.value
+      .filter((habit) => !pendingDeletedHabitIds.has(habit.id))
+      .map((habit) => pendingHabitIds.has(habit.id) ? localById.get(habit.id) || habit : habit);
+    merged.push(...localHabits.filter((habit) => pendingHabitIds.has(habit.id) && !remoteIds.has(habit.id) && !pendingDeletedHabitIds.has(habit.id)));
+    await replaceHabitsSnapshot(merged, workspaceId);
+  } else {
+    console.warn("[syncEngine] pull habits failed:", habitsResult.reason);
+    pullErrors.push(`习惯：${habitsResult.reason instanceof Error ? habitsResult.reason.message : String(habitsResult.reason)}`);
+  }
+
+  if (habitCheckinsResult.status === "fulfilled") {
+    const localCheckins = await getHabitCheckins(workspaceId);
+    const localByCheckinKey = new Map(localCheckins.map((checkin) => [`${checkin.habitId}:${checkin.checkinDate}`, checkin]));
+    const remoteCheckinKeys = new Set(habitCheckinsResult.value.map((checkin) => `${checkin.habitId}:${checkin.checkinDate}`));
+    const merged = [
+      ...habitCheckinsResult.value.map((checkin) => (
+        pendingCheckinHabitIds.has(checkin.habitId)
+          ? localByCheckinKey.get(`${checkin.habitId}:${checkin.checkinDate}`) || checkin
+          : checkin
+      )),
+      ...localCheckins.filter((checkin) => pendingCheckinHabitIds.has(checkin.habitId) && !remoteCheckinKeys.has(`${checkin.habitId}:${checkin.checkinDate}`)),
+    ];
+    await replaceHabitCheckinsSnapshot(merged, workspaceId);
+  } else {
+    console.warn("[syncEngine] pull habit checkins failed:", habitCheckinsResult.reason);
+    pullErrors.push(`习惯打卡：${habitCheckinsResult.reason instanceof Error ? habitCheckinsResult.reason.message : String(habitCheckinsResult.reason)}`);
+  }
+
+  if (dependenciesResult.status === "fulfilled") {
+    const localDependencies = await getTaskDependencies(workspaceId);
+    const localById = new Map(localDependencies.map((dependency) => [dependency.id, dependency]));
+    const remoteIds = new Set(dependenciesResult.value.map((dependency) => dependency.id));
+    const merged = dependenciesResult.value
+      .filter((dependency) => !pendingDeletedDependencyIds.has(dependency.id))
+      .map((dependency) => pendingDependencyIds.has(dependency.id) ? localById.get(dependency.id) || dependency : dependency);
+    merged.push(...localDependencies.filter((dependency) => pendingDependencyIds.has(dependency.id) && !remoteIds.has(dependency.id) && !pendingDeletedDependencyIds.has(dependency.id)));
+    await replaceTaskDependenciesSnapshot(merged, workspaceId);
+  } else {
+    console.warn("[syncEngine] pull task dependencies failed:", dependenciesResult.reason);
+    pullErrors.push(`任务依赖：${dependenciesResult.reason instanceof Error ? dependenciesResult.reason.message : String(dependenciesResult.reason)}`);
+  }
+
+  if (remindersResult.status === "fulfilled") {
+    const localReminders = await getTaskRemindersForWorkspace(workspaceId);
+    const localById = new Map(localReminders.map((reminder) => [reminder.id, reminder]));
+    const remoteIds = new Set(remindersResult.value.reminders.map((reminder) => reminder.id));
+    const deletedIds = new Set(remindersResult.value.deletedIds);
+    for (const reminderId of deletedIds) {
+      if (!pendingReminderIds.has(reminderId)) await deleteTaskReminder(reminderId);
+    }
+    const merged = remindersResult.value.reminders
+      .filter((reminder) => !pendingDeletedReminderIds.has(reminder.id))
+      .map((reminder) => pendingReminderIds.has(reminder.id) ? localById.get(reminder.id) || reminder : reminder);
+    merged.push(...localReminders.filter((reminder) => (
+      pendingReminderIds.has(reminder.id)
+      && !remoteIds.has(reminder.id)
+      && !deletedIds.has(reminder.id)
+      && !pendingDeletedReminderIds.has(reminder.id)
+    )));
+    await replaceTaskRemindersSnapshot(merged, workspaceId);
+  } else {
+    console.warn("[syncEngine] pull task reminders failed:", remindersResult.reason);
+    pullErrors.push(`任务提醒：${remindersResult.reason instanceof Error ? remindersResult.reason.message : String(remindersResult.reason)}`);
+  }
+
   if (pullErrors.length > 0) {
     throw new Error(`同步补拉未完整完成（${pullErrors.join("；")}）`);
   }
@@ -224,6 +355,10 @@ async function pullServerSnapshot(): Promise<void> {
         notesPulled: notesResult.status === "fulfilled",
         notebooksPulled: notebooksResult.status === "fulfilled",
         tagsPulled: tagsResult.status === "fulfilled",
+        tasksPulled: tasksResult.status === "fulfilled",
+        habitsPulled: habitsResult.status === "fulfilled",
+        dependenciesPulled: dependenciesResult.status === "fulfilled",
+        remindersPulled: remindersResult.status === "fulfilled",
       },
     }));
   }
@@ -311,6 +446,9 @@ async function getQueuedNoteIds(): Promise<Set<string>> {
 }
 
 export function teardown(): void {
+  void clearAll();
+  clearQueue();
+  clearLocalIdMap();
   setCurrentUser(null);
   setState("idle");
 }


### PR DESCRIPTION
## 背景

当前任务、习惯及其关联数据在离线后无法正常显示或操作。用户需要在无网络时继续查看和增删改查；网络恢复后，客户端应自动、静默地复用现有同步机制完成数据合并，避免重复写入、旧数据覆盖新数据和跨用户数据泄露。

## 变更说明

- 为任务、习惯、依赖关系和提醒增加客户端本地缓存与离线 mutation 队列。
- 使用稳定的 mutation envelope，在首次请求与重放时复用操作 ID、资源 ID 和客户端时间戳。
- 服务端增加幂等处理、字段级 LWW 合并、删除墓碑及未来时间戳保护。
- 同步快照改为工作区原子替换，避免本地保留服务端已删除的旧数据。
- 补齐任务创建/删除时关联 mutation 的取消清理。
- 增强提醒、任务关联与历史异常数据的访问控制，避免跨用户读取或修改。
- 离线状态禁用任务拖拽排序并展示明确提示；保留在线排序能力，不引入离线排序队列。
- 补充 CORS 预检、离线关联同步、缓存一致性、提醒权限和拖拽限制测试。

## 范围

- 后端：离线同步元数据、任务/习惯/依赖/提醒接口、CORS、数据库迁移与相关测试。
- 前端：IndexedDB 本地缓存、离线队列、同步引擎、任务中心与提醒交互。
- 不包含离线任务拖拽排序；该功能在离线时明确禁用。

## 验证说明

- 前端离线拖拽禁用聚焦测试通过。
- 前端 TypeScript 检查通过：`npm exec tsc -- --noEmit -p tsconfig.app.json`
- `git diff --check` 通过。
- 已覆盖离线 mutation 推断、关联数据缓存、服务端关联同步和提醒访问控制。
- 已知：`TaskCenterQuickAddIntegration` 中“工作区切换后刷新统计”用例仍失败，该问题与本 PR 改动无关。