### PR TITLE
feat: complete import/export round-trip restoration

### DIFF
--- a/backend/src/services/markdownExportJobs.ts
+++ b/backend/src/services/markdownExportJobs.ts
@@ -1,7 +1,5 @@
 import type { Context } from "hono";
 import {
-  createReliableMarkdownExportJob,
-  getReliableExportJob,
   handleReliableExportDownload,
   MAX_MARKDOWN_EXPORT_REQUEST_BYTES,
   ReliableExportBusyError,
@@ -14,6 +12,11 @@ import {
   type PreparedMarkdownNote,
   type ReliableExportJobSnapshot,
 } from "./reliableExportJobs";
+import {
+  createRoundTripMarkdownExportJob,
+  getRoundTripMarkdownExportJob,
+  handleRoundTripMarkdownDownload,
+} from "./roundTripMarkdownExportJobs";
 
 export type { PreparedMarkdownAsset, PreparedMarkdownNote };
 export type MarkdownExportJobSnapshot = ReliableExportJobSnapshot;
@@ -30,7 +33,6 @@ async function readRequestJsonWithLimit(request: Request, maxBytes: number): Pro
       "MARKDOWN_EXPORT_REQUEST_TOO_LARGE",
     );
   }
-
   const body = request.body;
   if (!body) return null;
   const reader = body.getReader();
@@ -53,20 +55,15 @@ async function readRequestJsonWithLimit(request: Request, maxBytes: number): Pro
   } finally {
     reader.releaseLock();
   }
-
   try {
-    const parsed = JSON.parse(
-      Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8"),
-    );
+    const parsed = JSON.parse(Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8"));
     if (Array.isArray(parsed?.notes)) validatePreparedMarkdownNotes(parsed.notes);
     return parsed;
   } catch (error) {
     if (
       error instanceof ReliableExportPayloadTooLargeError ||
       error instanceof ReliableExportValidationError
-    ) {
-      throw error;
-    }
+    ) throw error;
     throw new ReliableExportValidationError("导出请求 JSON 无效", "INVALID_EXPORT_JSON");
   }
 }
@@ -76,15 +73,8 @@ if (typeof Request !== "undefined" && !globalFlags[REQUEST_JSON_PATCH_FLAG]) {
   const nativeJson = Request.prototype.json;
   Request.prototype.json = async function patchedJson(): Promise<any> {
     let pathname = "";
-    try {
-      pathname = new URL(this.url).pathname;
-    } catch {
-      // fall through to native parser
-    }
-    if (
-      this.method.toUpperCase() === "POST" &&
-      pathname.endsWith("/api/export/markdown-package/jobs")
-    ) {
+    try { pathname = new URL(this.url).pathname; } catch { /* use native parser */ }
+    if (this.method.toUpperCase() === "POST" && pathname.endsWith("/api/export/markdown-package/jobs")) {
       return readRequestJsonWithLimit(this, MAX_MARKDOWN_EXPORT_REQUEST_BYTES);
     }
     return nativeJson.call(this);
@@ -93,21 +83,15 @@ if (typeof Request !== "undefined" && !globalFlags[REQUEST_JSON_PATCH_FLAG]) {
 
 export class MarkdownExportBusyError extends Error {
   code: string;
-
-  constructor(
-    message = "已有导出任务正在生成，请等待当前任务完成",
-    code = "EXPORT_JOB_BUSY",
-  ) {
+  constructor(message = "已有导出任务正在生成，请等待当前任务完成", code = "EXPORT_JOB_BUSY") {
     super(message);
     this.code = code;
   }
 }
 
-function toRouteCompatibleError(error: unknown): never {
-  if (error instanceof ReliableExportBusyError) {
-    throw new MarkdownExportBusyError(error.message, error.code);
-  }
+function translateError(error: unknown): never {
   if (
+    error instanceof ReliableExportBusyError ||
     error instanceof ReliableExportPayloadTooLargeError ||
     error instanceof ReliableExportValidationError
   ) {
@@ -124,17 +108,14 @@ export function createMarkdownExportJob(params: {
   filenameBase?: string;
 }): MarkdownExportJobSnapshot {
   try {
-    return createReliableMarkdownExportJob(params);
+    return createRoundTripMarkdownExportJob(params);
   } catch (error) {
-    return toRouteCompatibleError(error);
+    return translateError(error);
   }
 }
 
-export function getMarkdownExportJob(
-  jobId: string,
-  userId: string,
-): MarkdownExportJobSnapshot | null {
-  return getReliableExportJob(jobId, userId);
+export function getMarkdownExportJob(jobId: string, userId: string): MarkdownExportJobSnapshot | null {
+  return getRoundTripMarkdownExportJob(jobId, userId);
 }
 
 function inferContentType(filename: string, fallback: string): string {
@@ -142,9 +123,7 @@ function inferContentType(filename: string, fallback: string): string {
   if (lower.endsWith(".zip")) return "application/zip";
   if (lower.endsWith(".md") || lower.endsWith(".markdown")) return "text/markdown";
   if (lower.endsWith(".pdf")) return "application/pdf";
-  if (lower.endsWith(".docx")) {
-    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-  }
+  if (lower.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
   return fallback;
 }
 
@@ -162,5 +141,5 @@ export async function stageGeneratedExport(params: {
 }
 
 export function handleMarkdownExportDownload(c: Context): Response {
-  return handleReliableExportDownload(c);
+  return handleRoundTripMarkdownDownload(c) || handleReliableExportDownload(c);
 }

--- a/backend/src/services/nowenPackageExport.ts
+++ b/backend/src/services/nowenPackageExport.ts
@@ -1,17 +1,27 @@
+import crypto from "crypto";
+import JSZip from "jszip";
+import path from "path";
+import { getDb, getDbSchemaVersion } from "../db/schema";
+import { getUserWorkspaceRole, isSystemAdmin } from "../middleware/acl";
+import { readAttachmentObject } from "./attachment-storage";
+
 /**
- * Nowen 数据包导出服务
+ * Nowen v2 round-trip package.
  *
- * 生成 .nowen.zip 私有迁移包，用于 nowen-note 到 nowen-note 的无损迁移。
- * 保留 Markdown 原文、富文本 Tiptap JSON、笔记本结构、标签、附件关系。
+ * Native packages keep the original content format. Markdown packages reuse the same private
+ * manifest and attachment graph, while also exposing a human-readable folder tree at ZIP root.
  */
 
-import { getDb, getDbSchemaVersion } from "../db/schema";
-import JSZip from "jszip";
-import * as fs from "fs";
-import * as path from "path";
-import * as crypto from "crypto";
-
-// ====== 类型定义 ======
+export interface PreparedMarkdownPackageNote {
+  id: string;
+  title: string;
+  notebookName: string | null;
+  createdAt: string;
+  updatedAt: string;
+  contentFormat?: string;
+  markdown: string;
+  inlineAssets?: Array<{ relPath: string; base64: string }>;
+}
 
 interface ExportParams {
   userId: string;
@@ -19,6 +29,14 @@ interface ExportParams {
   notebookId?: string;
   includeSubNotebooks?: boolean;
   includeTrashed?: boolean;
+  /** Exact note selection used by Markdown/single-note export. */
+  noteIds?: string[];
+  preparedMarkdown?: PreparedMarkdownPackageNote[];
+  packageKind?: "nowen" | "markdown";
+  includeHumanReadableTree?: boolean;
+  inlineImages?: boolean;
+  layout?: "notebooks" | "flat";
+  filenameBase?: string;
 }
 
 interface ExportStats {
@@ -40,6 +58,8 @@ interface ExportWarning {
 
 interface ExportNotebook {
   id: string;
+  userId?: string;
+  workspaceId?: string | null;
   parentId: string | null;
   name: string;
   description: string | null;
@@ -53,6 +73,8 @@ interface ExportNotebook {
 
 interface ExportNote {
   id: string;
+  userId?: string;
+  workspaceId?: string | null;
   notebookId: string;
   title: string;
   content: string;
@@ -85,59 +107,233 @@ interface ExportAttachment {
   createdAt: string;
 }
 
-// ====== 工具函数 ======
-
-function sanitizeFilename(name: string): string {
-  return name.replace(/[\/\\?<>:*|"]/g, "_").replace(/\s+/g, " ").trim() || "untitled";
+interface PackageAttachmentMeta {
+  id: string;
+  noteId: string;
+  filename: string;
+  mimeType: string | null;
+  size: number;
+  createdAt: string;
+  sha256: string;
+  packagePath: string;
+  referencedInContent: boolean;
+  synthetic?: boolean;
 }
 
-function getDataDir(): string {
-  return process.env.NOWEN_DATA_DIR || path.join(process.cwd(), "data");
-}
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
 
-function getAttachmentsDir(): string {
-  return path.join(getDataDir(), "attachments");
-}
-
-/** 安全校验：防止 path traversal */
-function isSafePath(filePath: string, baseDir: string): boolean {
-  const resolved = path.resolve(baseDir, filePath);
-  return resolved.startsWith(path.resolve(baseDir));
-}
-
-/** 读取附件物理文件 */
-function readAttachmentFile(attachmentPath: string): Buffer | null {
-  const attachmentsDir = getAttachmentsDir();
-
-  // 支持新年月路径：YYYY/MM/<uuid>.<ext>
-  const fullPath = path.join(attachmentsDir, attachmentPath);
-  if (isSafePath(attachmentPath, attachmentsDir) && fs.existsSync(fullPath)) {
-    return fs.readFileSync(fullPath);
+function sanitizeSegment(value: string, fallback = "未命名"): string {
+  let out = String(value || "")
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[. ]+$/g, "");
+  if (!out) out = fallback;
+  if (WINDOWS_RESERVED.test(out)) out = `_${out}`;
+  const chars = Array.from(out);
+  if (chars.length > 80) {
+    const hash = crypto.createHash("sha1").update(out).digest("hex").slice(0, 8);
+    out = `${chars.slice(0, 68).join("")}~${hash}`;
   }
-
-  // 支持旧平铺路径：<uuid>.<ext>（从 path 中提取文件名）
-  const fileName = path.basename(attachmentPath);
-  const flatPath = path.join(attachmentsDir, fileName);
-  if (fs.existsSync(flatPath)) {
-    return fs.readFileSync(flatPath);
-  }
-
-  return null;
+  return out;
 }
 
-/** 从笔记内容中提取附件 ID */
-function extractAttachmentIds(content: string): string[] {
+function normalizeInlinePath(value: string): string | null {
+  const normalized = String(value || "").replace(/\\/g, "/").replace(/^\.\//, "");
+  if (!normalized || normalized.startsWith("/") || /^[a-zA-Z]:/.test(normalized)) return null;
+  const parts = normalized.split("/").filter(Boolean);
+  if (!parts.length || parts.some((part) => part === "." || part === "..")) return null;
+  return parts.map((part) => sanitizeSegment(part)).join("/");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceAttachmentUrl(content: string, attachmentId: string, replacement: string): string {
+  const escaped = escapeRegExp(attachmentId);
+  return content.replace(
+    new RegExp(`(?:https?:\\/\\/[^\\s)\"'<>]+)?\\/api\\/attachments\\/${escaped}(?:\\?[^\\s)\"'<>]*)?`, "gi"),
+    replacement,
+  );
+}
+
+function contentReferencesAttachment(content: string, id: string): boolean {
+  return new RegExp(`\\/api\\/attachments\\/${escapeRegExp(id)}(?:[/?#\\s)\"'<>]|$)`, "i").test(content || "");
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  let index = 2;
+  while (used.has(`${base} (${index})`)) index += 1;
+  const value = `${base} (${index})`;
+  used.add(value);
+  return value;
+}
+
+function assertWorkspaceReadable(userId: string, workspaceId: string | null | undefined): void {
+  if (!workspaceId || isSystemAdmin(userId)) return;
+  if (!getUserWorkspaceRole(workspaceId, userId)) {
+    throw new Error("No permission to export this workspace");
+  }
+}
+
+function queryScopeNotebooks(userId: string, workspaceId: string | null | undefined): ExportNotebook[] {
+  const db = getDb();
+  if (workspaceId) {
+    return db.prepare(`
+      SELECT id, userId, workspaceId, parentId, name, description, icon, color,
+             sortOrder, isExpanded, createdAt, updatedAt
+        FROM notebooks
+       WHERE workspaceId = ? AND (isDeleted IS NULL OR isDeleted = 0)
+       ORDER BY parentId, sortOrder, createdAt, id
+    `).all(workspaceId) as ExportNotebook[];
+  }
+  return db.prepare(`
+    SELECT id, userId, workspaceId, parentId, name, description, icon, color,
+           sortOrder, isExpanded, createdAt, updatedAt
+      FROM notebooks
+     WHERE userId = ? AND workspaceId IS NULL AND (isDeleted IS NULL OR isDeleted = 0)
+     ORDER BY parentId, sortOrder, createdAt, id
+  `).all(userId) as ExportNotebook[];
+}
+
+function collectDescendants(rootId: string, byParent: Map<string | null, ExportNotebook[]>): Set<string> {
   const ids = new Set<string>();
-  // 匹配 /api/attachments/<id> 模式
-  const re = /\/api\/attachments\/([a-f0-9-]+)/gi;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(content)) !== null) {
-    ids.add(m[1]);
+  const stack = [rootId];
+  while (stack.length) {
+    const current = stack.pop()!;
+    if (ids.has(current)) continue;
+    ids.add(current);
+    for (const child of byParent.get(current) || []) stack.push(child.id);
   }
-  return Array.from(ids);
+  return ids;
 }
 
-// ====== 主导出函数 ======
+function selectNotebooks(
+  all: ExportNotebook[],
+  params: Pick<ExportParams, "notebookId" | "includeSubNotebooks" | "noteIds">,
+  selectedNoteNotebookIds: Set<string>,
+  allScopeNoteCount: number,
+  selectedNoteCount: number,
+): ExportNotebook[] {
+  const byId = new Map(all.map((item) => [item.id, item]));
+  const byParent = new Map<string | null, ExportNotebook[]>();
+  for (const item of all) {
+    const key = item.parentId && byId.has(item.parentId) ? item.parentId : null;
+    const bucket = byParent.get(key) || [];
+    bucket.push(item);
+    byParent.set(key, bucket);
+  }
+
+  if (params.notebookId) {
+    if (!byId.has(params.notebookId)) return [];
+    const ids = params.includeSubNotebooks === false
+      ? new Set([params.notebookId])
+      : collectDescendants(params.notebookId, byParent);
+    return all.filter((item) => ids.has(item.id));
+  }
+
+  if (!params.noteIds || selectedNoteCount === allScopeNoteCount) return all;
+
+  const ids = new Set<string>(selectedNoteNotebookIds);
+  // Keep all ancestors so a re-import has the same path.
+  for (const notebookId of Array.from(selectedNoteNotebookIds)) {
+    let cursor = byId.get(notebookId);
+    while (cursor?.parentId && byId.has(cursor.parentId)) {
+      ids.add(cursor.parentId);
+      cursor = byId.get(cursor.parentId);
+    }
+  }
+  // Preserve empty descendants below selected notebooks where they can be inferred safely.
+  for (const notebookId of selectedNoteNotebookIds) {
+    for (const id of collectDescendants(notebookId, byParent)) ids.add(id);
+  }
+  return all.filter((item) => ids.has(item.id));
+}
+
+function buildExportPaths(notebooks: ExportNotebook[]): {
+  pathById: Map<string, string>;
+  exportNameById: Map<string, string>;
+  roots: string[];
+} {
+  const byId = new Map(notebooks.map((item) => [item.id, item]));
+  const byParent = new Map<string | null, ExportNotebook[]>();
+  for (const item of notebooks) {
+    const parent = item.parentId && byId.has(item.parentId) ? item.parentId : null;
+    const bucket = byParent.get(parent) || [];
+    bucket.push(item);
+    byParent.set(parent, bucket);
+  }
+  for (const bucket of byParent.values()) {
+    bucket.sort((a, b) => a.sortOrder - b.sortOrder || a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  }
+
+  const exportNameById = new Map<string, string>();
+  for (const bucket of byParent.values()) {
+    const used = new Set<string>();
+    for (const item of bucket) exportNameById.set(item.id, uniqueName(sanitizeSegment(item.name), used));
+  }
+
+  const pathById = new Map<string, string>();
+  const resolving = new Set<string>();
+  const resolve = (id: string): string => {
+    const cached = pathById.get(id);
+    if (cached !== undefined) return cached;
+    if (resolving.has(id)) return exportNameById.get(id) || sanitizeSegment(byId.get(id)?.name || "未命名");
+    resolving.add(id);
+    const item = byId.get(id);
+    const own = exportNameById.get(id) || sanitizeSegment(item?.name || "未命名");
+    const parentPath = item?.parentId && byId.has(item.parentId) ? resolve(item.parentId) : "";
+    const result = parentPath ? `${parentPath}/${own}` : own;
+    pathById.set(id, result);
+    resolving.delete(id);
+    return result;
+  };
+  for (const item of notebooks) resolve(item.id);
+  const roots = notebooks
+    .filter((item) => !item.parentId || !byId.has(item.parentId))
+    .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+    .map((item) => item.id);
+  return { pathById, exportNameById, roots };
+}
+
+function extractDataImages(
+  content: string,
+  noteId: string,
+): { content: string; assets: Array<{ id: string; filename: string; mimeType: string; buffer: Buffer }> } {
+  const assets: Array<{ id: string; filename: string; mimeType: string; buffer: Buffer }> = [];
+  let index = 0;
+  const rewritten = String(content || "").replace(
+    /data:(image\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g,
+    (full, mime: string, base64: string) => {
+      try {
+        const buffer = Buffer.from(base64, "base64");
+        if (!buffer.length) return full;
+        index += 1;
+        const ext = mime.split("/")[1]?.replace(/[^a-zA-Z0-9]/g, "") || "png";
+        const id = `inline-${noteId}-${index}`;
+        assets.push({ id, filename: `inline-${index}.${ext}`, mimeType: mime, buffer });
+        return `/api/attachments/${id}`;
+      } catch {
+        return full;
+      }
+    },
+  );
+  return { content: rewritten, assets };
+}
+
+function replaceInlineAssetReference(content: string, relPath: string, replacement: string): string {
+  const normalized = relPath.replace(/\\/g, "/").replace(/^\.\//, "");
+  const escaped = escapeRegExp(normalized);
+  return content
+    .replace(new RegExp(`\\.\\/${escaped}`, "g"), replacement)
+    .replace(new RegExp(`(?<![A-Za-z0-9_./-])${escaped}`, "g"), replacement);
+}
 
 export async function createNowenPackageExport(params: ExportParams): Promise<{
   buffer: Buffer;
@@ -147,214 +343,234 @@ export async function createNowenPackageExport(params: ExportParams): Promise<{
   const db = getDb();
   const {
     userId,
-    workspaceId,
+    workspaceId = null,
     notebookId,
     includeSubNotebooks = true,
     includeTrashed = false,
+    noteIds,
+    preparedMarkdown = [],
+    packageKind = "nowen",
+    includeHumanReadableTree = packageKind === "markdown",
+    layout = "notebooks",
+    filenameBase,
   } = params;
 
+  assertWorkspaceReadable(userId, workspaceId);
   const warnings: ExportWarning[] = [];
-  const stats: ExportStats = {
-    notes: 0,
-    notebooks: 0,
-    tags: 0,
-    noteTags: 0,
-    attachments: 0,
-    warnings: 0,
-  };
+  const allScopeNotebooks = queryScopeNotebooks(userId, workspaceId);
+  const allScopeNotebookIds = new Set(allScopeNotebooks.map((item) => item.id));
 
-  // ── 1. 确定导出范围：笔记本 ──
-
-  let notebookIds: string[];
-
-  if (notebookId) {
-    // 导出指定笔记本及其子孙
-    if (includeSubNotebooks) {
-      const rows = db.prepare(`
-        WITH RECURSIVE descendants(id) AS (
-          SELECT id FROM notebooks WHERE id = ? AND userId = ? AND (isDeleted IS NULL OR isDeleted = 0)
-          UNION ALL
-          SELECT n.id FROM notebooks n
-          INNER JOIN descendants d ON n.parentId = d.id
-          WHERE n.userId = ? AND (n.isDeleted IS NULL OR n.isDeleted = 0)
-        )
-        SELECT id FROM descendants
-      `).all(notebookId, userId, userId) as { id: string }[];
-      notebookIds = rows.map((r) => r.id);
-    } else {
-      const nb = db.prepare("SELECT id FROM notebooks WHERE id = ? AND userId = ? AND (isDeleted IS NULL OR isDeleted = 0)").get(notebookId, userId) as { id: string } | undefined;
-      notebookIds = nb ? [nb.id] : [];
-    }
-  } else {
-    // 导出当前工作区所有笔记本
-    const wsCondition = workspaceId
-      ? "AND workspaceId = ?"
-      : "AND (workspaceId IS NULL)";
-    const wsParams = workspaceId ? [userId, workspaceId] : [userId];
-    const rows = db.prepare(`
-      SELECT id FROM notebooks
-      WHERE userId = ? AND (isDeleted IS NULL OR isDeleted = 0) ${wsCondition}
-    `).all(...wsParams) as { id: string }[];
-    notebookIds = rows.map((r) => r.id);
-  }
-
-  if (notebookIds.length === 0) {
-    throw new Error("No notebooks found in export scope");
-  }
-
-  // ── 2. 查询笔记 ──
-
-  const placeholders = notebookIds.map(() => "?").join(",");
-  const trashedCondition = includeTrashed ? "" : "AND isTrashed = 0";
-  const notes = db.prepare(`
-    SELECT id, notebookId, title, content, contentText, contentFormat,
-           isPinned, isFavorite, isLocked, isArchived, version, sortOrder,
-           createdAt, updatedAt
-    FROM notes
-    WHERE notebookId IN (${placeholders}) ${trashedCondition}
-  `).all(...notebookIds) as ExportNote[];
-
-  const noteIds = new Set(notes.map((n) => n.id));
-
-  // ── 3. 查询笔记本详情 ──
-
-  const notebooks = db.prepare(`
-    SELECT id, parentId, name, description, icon, color, sortOrder, isExpanded,
-           createdAt, updatedAt
-    FROM notebooks
-    WHERE id IN (${placeholders})
-  `).all(...notebookIds) as ExportNotebook[];
-
-  // ── 4. 查询标签关系 ──
-
-  const notePlaceholders = notes.map(() => "?").join(",") || "NULL";
-  const noteTags = notes.length > 0
+  const trashedSql = includeTrashed ? "" : "AND isTrashed = 0";
+  const scopeNotes = allScopeNotebookIds.size
     ? db.prepare(`
-        SELECT noteId, tagId FROM note_tags
-        WHERE noteId IN (${notePlaceholders})
-      `).all(...notes.map((n) => n.id)) as { noteId: string; tagId: string }[]
+        SELECT id, userId, workspaceId, notebookId, title, content, contentText, contentFormat,
+               isPinned, isFavorite, isLocked, isArchived, version, sortOrder, createdAt, updatedAt
+          FROM notes
+         WHERE notebookId IN (${Array.from(allScopeNotebookIds).map(() => "?").join(",")}) ${trashedSql}
+         ORDER BY notebookId, sortOrder, createdAt, id
+      `).all(...allScopeNotebookIds) as ExportNote[]
     : [];
 
-  // 收集使用到的标签 ID
-  const usedTagIds = new Set(noteTags.map((nt) => nt.tagId));
+  const selectedIdSet = noteIds ? new Set(noteIds) : null;
+  let notes = selectedIdSet ? scopeNotes.filter((note) => selectedIdSet.has(note.id)) : scopeNotes;
+  if (selectedIdSet && notes.length !== selectedIdSet.size) {
+    throw new Error("Some selected notes do not exist or are outside the export scope");
+  }
 
-  // 查询标签详情
-  const tags = usedTagIds.size > 0
-    ? db.prepare(`
-        SELECT id, name, color, createdAt FROM tags
-        WHERE id IN (${Array.from(usedTagIds).map(() => "?").join(",")})
-      `).all(...Array.from(usedTagIds)) as ExportTag[]
+  const selectedNoteNotebookIds = new Set(notes.map((note) => note.notebookId));
+  const notebooks = selectNotebooks(
+    allScopeNotebooks,
+    { notebookId, includeSubNotebooks, noteIds },
+    selectedNoteNotebookIds,
+    scopeNotes.length,
+    notes.length,
+  );
+  const notebookIds = new Set(notebooks.map((item) => item.id));
+  if (notebookId) notes = notes.filter((note) => notebookIds.has(note.notebookId));
+  if (!notebooks.length && notes.length) throw new Error("No notebooks found for selected notes");
+  if (!notebooks.length && !notes.length) throw new Error("No data found in export scope");
+
+  const preparedById = new Map(preparedMarkdown.map((item) => [item.id, item]));
+  if (packageKind === "markdown" && preparedById.size !== notes.length) {
+    throw new Error("Markdown conversion result is incomplete");
+  }
+
+  const noteIdList = notes.map((note) => note.id);
+  const notePlaceholders = noteIdList.map(() => "?").join(",") || "NULL";
+  const noteTags = noteIdList.length
+    ? db.prepare(`SELECT noteId, tagId FROM note_tags WHERE noteId IN (${notePlaceholders})`).all(...noteIdList) as Array<{ noteId: string; tagId: string }>
     : [];
-
-  // ── 5. 查询附件 ──
-
-  // 从 attachments 表查询（按 noteId 关联）
-  const dbAttachments = notes.length > 0
+  const tagIds = Array.from(new Set(noteTags.map((item) => item.tagId)));
+  const tags = tagIds.length
+    ? db.prepare(`SELECT id, name, color, createdAt FROM tags WHERE id IN (${tagIds.map(() => "?").join(",")})`).all(...tagIds) as ExportTag[]
+    : [];
+  const dbAttachments = noteIdList.length
     ? db.prepare(`
         SELECT id, noteId, filename, mimeType, size, path, createdAt
-        FROM attachments
-        WHERE noteId IN (${notePlaceholders})
-      `).all(...notes.map((n) => n.id)) as ExportAttachment[]
+          FROM attachments
+         WHERE noteId IN (${notePlaceholders})
+         ORDER BY noteId, createdAt, id
+      `).all(...noteIdList) as ExportAttachment[]
     : [];
 
-  // 从笔记内容中提取额外的附件 ID
-  const contentAttachmentIds = new Set<string>();
-  for (const note of notes) {
-    const ids = extractAttachmentIds(note.content || "");
-    ids.forEach((id) => contentAttachmentIds.add(id));
-  }
-
-  // 计算 content 中引用但不在 dbAttachments 中的附件 ID
-  const dbAttachmentIds = new Set(dbAttachments.map((a) => a.id));
-  const extraAttachmentIds = Array.from(contentAttachmentIds).filter((id) => !dbAttachmentIds.has(id));
-
-  // 查询额外附件（必须加 userId 限制，避免越权）
-  let extraAttachments: ExportAttachment[] = [];
-  if (extraAttachmentIds.length > 0) {
-    extraAttachments = db.prepare(`
-      SELECT id, noteId, filename, mimeType, size, path, createdAt
-      FROM attachments
-      WHERE id IN (${extraAttachmentIds.map(() => "?").join(",")}) AND userId = ?
-    `).all(...extraAttachmentIds, userId) as ExportAttachment[];
-
-    // 对 content 里引用但 attachments 表查不到的 id，记录 warning
-    const foundIds = new Set(extraAttachments.map((a) => a.id));
-    for (const id of extraAttachmentIds) {
-      if (!foundIds.has(id)) {
-        warnings.push({
-          type: "attachment_row_missing",
-          attachmentId: id,
-          message: `Attachment ${id} referenced in content but not found in attachments table`,
-        });
-      }
-    }
-  }
-
-  const allAttachments = [...dbAttachments, ...extraAttachments];
-
-  // ── 6. 生成 zip ──
-
+  const { pathById, exportNameById, roots } = buildExportPaths(notebooks);
   const zip = new JSZip();
+  const packageAttachments: PackageAttachmentMeta[] = [];
+  const attachmentBufferById = new Map<string, Buffer>();
+  const attachmentById = new Map(dbAttachments.map((item) => [item.id, item]));
 
-  // 6.1 notebooks.json
-  zip.file("notebooks.json", JSON.stringify(notebooks, null, 2));
-  stats.notebooks = notebooks.length;
+  for (const attachment of dbAttachments) {
+    if (!attachment.path) {
+      warnings.push({ type: "attachment_no_path", attachmentId: attachment.id, noteId: attachment.noteId, message: "Attachment has no storage path" });
+      continue;
+    }
+    try {
+      const buffer = await readAttachmentObject(attachment.path);
+      if (!buffer) {
+        warnings.push({ type: "missing_attachment_file", attachmentId: attachment.id, noteId: attachment.noteId, path: attachment.path, message: "Attachment object not found" });
+        continue;
+      }
+      attachmentBufferById.set(attachment.id, buffer);
+    } catch (error) {
+      warnings.push({ type: "attachment_read_failed", attachmentId: attachment.id, noteId: attachment.noteId, path: attachment.path, message: error instanceof Error ? error.message : String(error) });
+    }
+  }
 
-  // 6.2 tags.json
-  zip.file("tags.json", JSON.stringify(tags, null, 2));
-  stats.tags = tags.length;
-
-  // 6.3 note_tags.json
-  zip.file("note_tags.json", JSON.stringify(noteTags, null, 2));
-  stats.noteTags = noteTags.length;
-
-  // 6.4 notes/
+  const humanUsedNotePaths = new Set<string>();
   const formatStats = { markdown: 0, richText: 0, html: 0 };
+  const noteManifest: Array<Record<string, unknown>> = [];
+  const attachmentIdsByNote = new Map<string, string[]>();
+
+  // Empty directories are explicit ZIP entries and are also represented by tree.json.
+  if (includeHumanReadableTree && layout !== "flat") {
+    for (const notebook of notebooks) zip.folder(pathById.get(notebook.id) || sanitizeSegment(notebook.name));
+  }
 
   for (const note of notes) {
-    const noteDir = `notes/${sanitizeFilename(note.id)}`;
+    const prepared = preparedById.get(note.id);
+    const sourceFormat = note.contentFormat || "tiptap-json";
+    const effectiveFormat = packageKind === "markdown" ? "markdown" : sourceFormat;
+    let privateContent = packageKind === "markdown" ? prepared!.markdown : (note.content || "");
+    let humanMarkdown = packageKind === "markdown" ? prepared!.markdown : "";
+    const noteAttachmentIds = new Set<string>();
 
-    // 确定内容文件名
-    let contentFile: string;
-    const cf = note.contentFormat || "tiptap-json";
-    const knownFormats = ["markdown", "tiptap-json", "html"];
-    if (cf === "markdown") {
-      contentFile = "content.md";
-      formatStats.markdown++;
-    } else if (cf === "html") {
-      contentFile = "content.html";
-      formatStats.html++;
-    } else {
-      // 未知格式或 tiptap-json 都按富文本处理
-      contentFile = "content.tiptap.json";
-      formatStats.richText++;
-      // 记录未知格式 warning
-      if (note.contentFormat && !knownFormats.includes(note.contentFormat)) {
-        warnings.push({
-          type: "unknown_content_format",
+    for (const attachment of dbAttachments.filter((item) => item.noteId === note.id)) {
+      const buffer = attachmentBufferById.get(attachment.id);
+      if (!buffer) continue;
+      noteAttachmentIds.add(attachment.id);
+      const ext = path.extname(attachment.filename) || ".bin";
+      const safeExt = ext.replace(/[^a-zA-Z0-9.]/g, "") || ".bin";
+      let packagePath: string;
+      if (includeHumanReadableTree) {
+        const folder = layout === "flat" ? "" : (pathById.get(note.notebookId) || "未分类");
+        const assetName = `att-${sanitizeSegment(attachment.id)}-${sanitizeSegment(attachment.filename)}`;
+        packagePath = `${folder ? `${folder}/` : ""}assets/${assetName}`;
+        if (packageKind === "markdown") {
+          humanMarkdown = replaceAttachmentUrl(humanMarkdown, attachment.id, `./assets/${assetName}`);
+        }
+      } else {
+        packagePath = `attachments/${sanitizeSegment(attachment.id)}/file${safeExt}`;
+      }
+      zip.file(packagePath, buffer);
+      const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+      packageAttachments.push({
+        id: attachment.id,
+        noteId: attachment.noteId,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        size: buffer.length,
+        createdAt: attachment.createdAt,
+        sha256,
+        packagePath,
+        referencedInContent: contentReferencesAttachment(note.content || "", attachment.id) || contentReferencesAttachment(privateContent, attachment.id),
+      });
+      if (!includeHumanReadableTree) {
+        zip.file(`attachments/${sanitizeSegment(attachment.id)}/meta.json`, JSON.stringify({
+          ...attachment,
+          file: path.basename(packagePath),
+          sha256,
+          packagePath,
+        }, null, 2));
+      }
+    }
+
+    if (packageKind === "markdown" && prepared) {
+      let inlineIndex = 0;
+      for (const asset of prepared.inlineAssets || []) {
+        const relPath = normalizeInlinePath(asset.relPath);
+        if (!relPath) {
+          warnings.push({ type: "invalid_inline_asset_path", noteId: note.id, path: asset.relPath, message: "Inline asset path is invalid" });
+          continue;
+        }
+        let buffer: Buffer;
+        try {
+          buffer = Buffer.from(asset.base64, "base64");
+        } catch {
+          warnings.push({ type: "invalid_inline_asset", noteId: note.id, path: relPath, message: "Inline asset is not valid base64" });
+          continue;
+        }
+        if (!buffer.length) continue;
+        inlineIndex += 1;
+        const syntheticId = `inline-${note.id}-${inlineIndex}`;
+        const folder = layout === "flat" ? "" : (pathById.get(note.notebookId) || "未分类");
+        const packagePath = `${folder ? `${folder}/` : ""}${relPath}`;
+        zip.file(packagePath, buffer);
+        privateContent = replaceInlineAssetReference(privateContent, relPath, `/api/attachments/${syntheticId}`);
+        noteAttachmentIds.add(syntheticId);
+        packageAttachments.push({
+          id: syntheticId,
           noteId: note.id,
-          message: `Unknown contentFormat "${note.contentFormat}", exported as tiptap-json`,
+          filename: path.basename(relPath),
+          mimeType: null,
+          size: buffer.length,
+          createdAt: note.updatedAt,
+          sha256: crypto.createHash("sha256").update(buffer).digest("hex"),
+          packagePath,
+          referencedInContent: true,
+          synthetic: true,
+        });
+      }
+
+      const extracted = extractDataImages(privateContent, note.id);
+      privateContent = extracted.content;
+      for (const asset of extracted.assets) {
+        const folder = layout === "flat" ? "" : (pathById.get(note.notebookId) || "未分类");
+        const packagePath = `${folder ? `${folder}/` : ""}assets/${sanitizeSegment(asset.id)}-${sanitizeSegment(asset.filename)}`;
+        zip.file(packagePath, asset.buffer);
+        noteAttachmentIds.add(asset.id);
+        packageAttachments.push({
+          id: asset.id,
+          noteId: note.id,
+          filename: asset.filename,
+          mimeType: asset.mimeType,
+          size: asset.buffer.length,
+          createdAt: note.updatedAt,
+          sha256: crypto.createHash("sha256").update(asset.buffer).digest("hex"),
+          packagePath,
+          referencedInContent: true,
+          synthetic: true,
         });
       }
     }
 
-    // 写内容文件
-    zip.file(`${noteDir}/${contentFile}`, note.content || "");
+    const contentFileName = effectiveFormat === "markdown"
+      ? "content.md"
+      : effectiveFormat === "html"
+        ? "content.html"
+        : "content.tiptap.json";
+    if (effectiveFormat === "markdown") formatStats.markdown += 1;
+    else if (effectiveFormat === "html") formatStats.html += 1;
+    else formatStats.richText += 1;
 
-    // 收集该笔记的附件 ID
-    const noteAttachmentIds = new Set(
-      allAttachments.filter((a) => a.noteId === note.id).map((a) => a.id)
-    );
-    // 从内容中提取的附件 ID 也加上
-    extractAttachmentIds(note.content || "").forEach((id) => noteAttachmentIds.add(id));
-
-    // 写 meta.json
+    const noteDir = `notes/${sanitizeSegment(note.id)}`;
+    zip.file(`${noteDir}/${contentFileName}`, privateContent);
     const meta = {
       id: note.id,
       notebookId: note.notebookId,
       title: note.title,
-      contentFormat: cf,
-      contentFile,
+      contentFormat: effectiveFormat,
+      sourceContentFormat: sourceFormat,
+      contentFile: contentFileName,
       contentText: note.contentText || "",
       isPinned: note.isPinned,
       isFavorite: note.isFavorite,
@@ -364,84 +580,87 @@ export async function createNowenPackageExport(params: ExportParams): Promise<{
       sortOrder: note.sortOrder,
       createdAt: note.createdAt,
       updatedAt: note.updatedAt,
-      tagIds: noteTags.filter((nt) => nt.noteId === note.id).map((nt) => nt.tagId),
+      tagIds: noteTags.filter((item) => item.noteId === note.id).map((item) => item.tagId),
       attachmentIds: Array.from(noteAttachmentIds),
     };
     zip.file(`${noteDir}/meta.json`, JSON.stringify(meta, null, 2));
-    stats.notes++;
-  }
+    noteManifest.push({ ...meta, contentPath: `${noteDir}/${contentFileName}` });
+    attachmentIdsByNote.set(note.id, Array.from(noteAttachmentIds));
 
-  // 6.5 attachments/
-  for (const att of allAttachments) {
-    const attDir = `attachments/${sanitizeFilename(att.id)}`;
-
-    // 写 meta.json
-    const attMeta = {
-      id: att.id,
-      noteId: att.noteId,
-      filename: att.filename,
-      mimeType: att.mimeType,
-      size: att.size,
-      path: att.path,
-      createdAt: att.createdAt,
-    };
-
-    // 读取物理文件
-    if (att.path) {
-      const fileBuffer = readAttachmentFile(att.path);
-      if (fileBuffer) {
-        const ext = path.extname(att.filename) || ".bin";
-        const safeExt = ext.replace(/[^a-zA-Z0-9.]/g, "");
-        const fileName = `file${safeExt}`;
-
-        // 计算 sha256
-        const sha256 = crypto.createHash("sha256").update(fileBuffer).digest("hex");
-        (attMeta as any).file = fileName;
-        (attMeta as any).sha256 = sha256;
-
-        zip.file(`${attDir}/${fileName}`, fileBuffer);
-        zip.file(`${attDir}/meta.json`, JSON.stringify(attMeta, null, 2));
-        stats.attachments++;
-      } else {
-        warnings.push({
-          type: "missing_attachment_file",
-          attachmentId: att.id,
-          noteId: att.noteId,
-          path: att.path,
-          message: `Attachment file not found on disk: ${att.path}`,
-        });
-        // 仍然写 meta.json，但不写文件
-        zip.file(`${attDir}/meta.json`, JSON.stringify(attMeta, null, 2));
-      }
-    } else {
-      warnings.push({
-        type: "attachment_no_path",
-        attachmentId: att.id,
-        noteId: att.noteId,
-        message: "Attachment has no path in database",
-      });
-      zip.file(`${attDir}/meta.json`, JSON.stringify(attMeta, null, 2));
+    if (includeHumanReadableTree) {
+      const folder = layout === "flat" ? "" : (pathById.get(note.notebookId) || "未分类");
+      const prefix = folder ? `${folder}/` : "";
+      const baseName = sanitizeSegment(note.title);
+      let fileName = `${baseName}.md`;
+      let index = 2;
+      while (humanUsedNotePaths.has(`${prefix}${fileName}`)) fileName = `${baseName} (${index++}).md`;
+      humanUsedNotePaths.add(`${prefix}${fileName}`);
+      const frontmatter = [
+        "---",
+        `title: ${JSON.stringify(note.title)}`,
+        `contentFormat: ${JSON.stringify("markdown")}`,
+        `sourceContentFormat: ${JSON.stringify(sourceFormat)}`,
+        `sourceId: ${JSON.stringify(note.id)}`,
+        `created: ${note.createdAt}`,
+        `updated: ${note.updatedAt}`,
+        "---",
+        "",
+      ].join("\n");
+      zip.file(`${prefix}${fileName}`, frontmatter + humanMarkdown);
     }
   }
 
-  // 6.6 warnings.json
-  stats.warnings = warnings.length;
-  zip.file("warnings.json", JSON.stringify({ version: 1, items: warnings }, null, 2));
+  const tree = notebooks.map((notebook) => ({
+    sourceId: notebook.id,
+    type: "notebook",
+    parentSourceId: notebook.parentId && notebookIds.has(notebook.parentId) ? notebook.parentId : null,
+    name: notebook.name,
+    exportName: exportNameById.get(notebook.id) || sanitizeSegment(notebook.name),
+    exportPath: pathById.get(notebook.id) || sanitizeSegment(notebook.name),
+    description: notebook.description,
+    icon: notebook.icon,
+    color: notebook.color,
+    sortOrder: notebook.sortOrder,
+    isExpanded: notebook.isExpanded,
+    createdAt: notebook.createdAt,
+    updatedAt: notebook.updatedAt,
+  }));
 
-  // 6.7 manifest.json
+  // Compatibility files remain for v1 clients; v2 readers use tree/notes/attachments manifests.
+  zip.file("notebooks.json", JSON.stringify(notebooks, null, 2));
+  zip.file("tree.json", JSON.stringify({ version: 1, roots, nodes: tree }, null, 2));
+  zip.file("notes.json", JSON.stringify({ version: 1, items: noteManifest }, null, 2));
+  zip.file("attachments.json", JSON.stringify({ version: 1, items: packageAttachments }, null, 2));
+  zip.file("tags.json", JSON.stringify(tags, null, 2));
+  zip.file("note_tags.json", JSON.stringify(noteTags, null, 2));
+
+  const stats: ExportStats = {
+    notes: notes.length,
+    notebooks: notebooks.length,
+    tags: tags.length,
+    noteTags: noteTags.length,
+    attachments: packageAttachments.length,
+    warnings: warnings.length,
+  };
+  zip.file("warnings.json", JSON.stringify({ version: 1, items: warnings }, null, 2));
   const now = new Date().toISOString();
-  const schemaVersion = getDbSchemaVersion();
+  const exportBatchId = crypto.randomUUID();
   const manifest = {
     format: "nowen-package",
-    formatVersion: 1,
+    formatVersion: 2,
+    packageKind,
     app: "nowen-note",
-    schemaVersion,
+    schemaVersion: getDbSchemaVersion(),
     exportedAt: now,
+    exportBatchId,
+    sourceInstanceId: process.env.NOWEN_INSTANCE_ID || null,
     scope: {
-      type: notebookId ? "notebook" : "all",
+      type: notebookId ? "notebook" : noteIds ? "selection" : "all",
+      workspaceId: workspaceId || null,
       notebookId: notebookId || null,
       includeSubNotebooks,
       includeTrashed,
+      rootSourceIds: roots,
     },
     counts: {
       notebooks: stats.notebooks,
@@ -452,22 +671,35 @@ export async function createNowenPackageExport(params: ExportParams): Promise<{
     },
     formatStats,
     warnings: {
-      missingAttachments: warnings.filter((w) => w.type === "missing_attachment_file").length,
-      unknownContentFormat: warnings.filter((w) => w.type === "unknown_content_format").length,
+      total: warnings.length,
+      missingAttachments: warnings.filter((item) => item.type.includes("attachment") && item.type.includes("missing")).length,
     },
   };
   zip.file("manifest.json", JSON.stringify(manifest, null, 2));
-
-  // ── 7. 生成 zip buffer ──
+  if (includeHumanReadableTree) {
+    zip.file("metadata.json", JSON.stringify({
+      version: "3.0",
+      packageVersion: 2,
+      app: "nowen-note",
+      roundTripPackage: true,
+      exportedAt: now,
+      totalNotes: notes.length,
+      totalNotebooks: notebooks.length,
+      totalAttachments: packageAttachments.length,
+      warnings: warnings.length,
+    }, null, 2));
+  }
 
   const buffer = await zip.generateAsync({
     type: "nodebuffer",
     compression: "DEFLATE",
     compressionOptions: { level: 6 },
   });
-
-  const dateStr = now.slice(0, 10);
-  const filename = `nowen-package-${dateStr}.nowen.zip`;
-
+  const date = now.slice(0, 10);
+  const filename = filenameBase
+    ? `${sanitizeSegment(filenameBase)}.zip`
+    : packageKind === "markdown"
+      ? `nowen-note_backup_${date}.zip`
+      : `nowen-package-${date}.nowen.zip`;
   return { buffer, filename, stats };
 }

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -1,18 +1,15 @@
-/**
- * Nowen 数据包导入服务
- *
- * 导入 .nowen.zip 私有迁移包，支持 dry-run 预检和正式导入。
- * 通过 oldId → newId 映射重建关系，附件复制到当前实例。
- */
-
-import { getDb, getDbSchemaVersion } from "../db/schema";
-import { v4 as uuid } from "uuid";
-import * as fs from "fs";
-import * as path from "path";
-import * as crypto from "crypto";
+import crypto from "crypto";
+import path from "path";
 import JSZip from "jszip";
-
-// ====== 类型定义 ======
+import { v4 as uuid } from "uuid";
+import { getDb, getDbSchemaVersion } from "../db/schema";
+import { getUserWorkspaceRole, hasRole, isSystemAdmin } from "../middleware/acl";
+import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
+import {
+  deleteAttachmentObject,
+  getUploadMonthPath,
+  writeAttachmentObject,
+} from "./attachment-storage";
 
 interface ImportParams {
   userId: string;
@@ -22,10 +19,18 @@ interface ImportParams {
   dryRun?: boolean;
 }
 
+interface ImportWarning {
+  type: string;
+  message: string;
+  id?: string;
+  path?: string;
+}
+
 interface ImportResult {
   success: boolean;
   dryRun: boolean;
   rootNotebookId?: string;
+  rootNotebookIds?: string[];
   package?: {
     format: string;
     formatVersion: number;
@@ -33,6 +38,7 @@ interface ImportResult {
     exportedAt: string;
     counts: { notebooks: number; notes: number; tags: number; attachments: number };
     formatStats: { markdown: number; richText: number; html: number };
+    packageKind?: string;
   };
   counts?: {
     notebooks: number;
@@ -40,16 +46,11 @@ interface ImportResult {
     tags: number;
     noteTags: number;
     attachments: number;
+    renamedRoots?: number;
   };
+  conflicts?: Array<{ sourceId: string; originalName: string; importedName: string; parentId: string | null }>;
   warnings: ImportWarning[];
   errors: string[];
-}
-
-interface ImportWarning {
-  type: string;
-  message: string;
-  id?: string;
-  path?: string;
 }
 
 interface Manifest {
@@ -58,8 +59,13 @@ interface Manifest {
   schemaVersion?: number;
   app: string;
   exportedAt: string;
-  scope: { type: string; notebookId: string | null };
-  counts: { notebooks: number; notes: number; tags: number; noteTags: number; attachments: number };
+  packageKind?: string;
+  scope?: {
+    type?: string;
+    notebookId?: string | null;
+    rootSourceIds?: string[];
+  };
+  counts: { notebooks: number; notes: number; tags: number; noteTags?: number; attachments: number };
   formatStats: { markdown: number; richText: number; html: number };
 }
 
@@ -74,6 +80,23 @@ interface NotebookMeta {
   isExpanded: number;
   createdAt: string;
   updatedAt: string;
+}
+
+interface TreeFile {
+  version?: number;
+  roots?: string[];
+  nodes?: Array<{
+    sourceId: string;
+    parentSourceId: string | null;
+    name: string;
+    description?: string | null;
+    icon?: string | null;
+    color?: string | null;
+    sortOrder?: number;
+    isExpanded?: number;
+    createdAt?: string;
+    updatedAt?: string;
+  }>;
 }
 
 interface NoteMeta {
@@ -108,492 +131,522 @@ interface AttachmentMeta {
   filename: string;
   mimeType: string | null;
   size: number | null;
-  path: string | null;
   createdAt: string;
   file?: string;
   sha256?: string;
+  packagePath?: string;
+  referencedInContent?: boolean;
+  synthetic?: boolean;
 }
 
-interface PendingAttachment {
+interface ValidAttachment {
   oldId: string;
   newId: string;
   oldNoteId: string;
+  newNoteId: string;
   meta: AttachmentMeta;
-  filePath: string;
+  buffer: Buffer;
+  storagePath: string;
   sha256: string;
-  size: number;
-}
-
-// ====== 工具函数 ======
-
-function getDataDir(): string {
-  return process.env.NOWEN_DATA_DIR || path.join(process.cwd(), "data");
-}
-
-function getAttachmentsDir(): string {
-  return path.join(getDataDir(), "attachments");
 }
 
 function isSafeZipPath(filePath: string): boolean {
-  if (/\.\./.test(filePath)) return false;
+  if (!filePath || /\.\./.test(filePath)) return false;
   if (path.isAbsolute(filePath)) return false;
   if (/^\/|^[a-zA-Z]:/.test(filePath)) return false;
-  return true;
+  return !filePath.split(/[\\/]+/).some((segment) => segment === ".." || segment === ".");
 }
 
-/** 重写 content 中的附件引用（只使用有效的附件映射） */
-function rewriteAttachmentRefs(
-  content: string,
-  effectiveMap: Map<string, string>,
-): { content: string; unmappedIds: string[] } {
-  if (!content) return { content: "", unmappedIds: [] };
-  const unmappedIds: string[] = [];
-  const seen = new Set<string>();
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
-  const result = content.replace(
-    /\/api\/attachments\/([a-f0-9-]+)/gi,
-    (match, oldId) => {
-      const newId = effectiveMap.get(oldId);
-      if (newId) return `/api/attachments/${newId}`;
-      if (!seen.has(oldId)) {
-        seen.add(oldId);
-        unmappedIds.push(oldId);
-      }
+function rewriteIdReferences(content: string, attachmentMap: Map<string, string>, noteMap: Map<string, string>): {
+  content: string;
+  unmappedAttachmentIds: string[];
+} {
+  let out = String(content || "");
+  const unmapped = new Set<string>();
+  out = out.replace(/\/api\/attachments\/([^/?#\s)"'<>]+)/gi, (match, encodedId: string) => {
+    let oldId = encodedId;
+    try { oldId = decodeURIComponent(encodedId); } catch { /* keep raw */ }
+    const newId = attachmentMap.get(oldId);
+    if (!newId) {
+      unmapped.add(oldId);
       return match;
-    },
-  );
-
-  return { content: result, unmappedIds };
-}
-
-/** 保存附件文件到磁盘 */
-function saveAttachmentFile(fileBuffer: Buffer, newId: string, filename: string): { filePath: string; sha256: string } {
-  const attachmentsDir = getAttachmentsDir();
-  const now = new Date();
-  const year = String(now.getFullYear());
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const dir = path.join(attachmentsDir, year, month);
-
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  const ext = path.extname(filename) || ".bin";
-  const safeExt = ext.replace(/[^a-zA-Z0-9.]/g, "");
-  const fileFullName = `${newId}${safeExt}`;
-  const fullPath = path.join(dir, fileFullName);
-
-  fs.writeFileSync(fullPath, fileBuffer);
-
-  const sha256 = crypto.createHash("sha256").update(fileBuffer).digest("hex");
-  const relativePath = `${year}/${month}/${fileFullName}`;
-
-  return { filePath: relativePath, sha256 };
-}
-
-/** 删除已导入的附件文件（事务回滚时使用） */
-function cleanupImportedFiles(files: string[]): void {
-  for (const file of files) {
-    try {
-      const fullPath = path.join(getAttachmentsDir(), file);
-      if (fs.existsSync(fullPath)) {
-        fs.unlinkSync(fullPath);
-      }
-    } catch (err) {
-      console.warn("[nowenPackageImport] Failed to cleanup file:", file, err);
     }
+    return `/api/attachments/${newId}`;
+  });
+
+  for (const [oldId, newId] of noteMap) {
+    const escaped = escapeRegExp(oldId);
+    out = out
+      .replace(new RegExp(`note:${escaped}(?=[$#?\\s)\"'<>]|$)`, "g"), `note:${newId}`)
+      .replace(new RegExp(`nowen:\\/\\/note\\/${escaped}(?=[$#?\\s)\"'<>]|$)`, "g"), `nowen://note/${newId}`);
+  }
+  return { content: out, unmappedAttachmentIds: Array.from(unmapped) };
+}
+
+function safeExtension(filename: string): string {
+  const ext = path.extname(filename || "") || ".bin";
+  const cleaned = ext.replace(/[^a-zA-Z0-9.]/g, "");
+  return cleaned && cleaned !== "." ? cleaned : ".bin";
+}
+
+function assertWorkspaceWritable(userId: string, workspaceId: string | null): void {
+  if (!workspaceId || isSystemAdmin(userId)) return;
+  if (!hasRole(getUserWorkspaceRole(workspaceId, userId), "editor")) {
+    throw new Error("No permission to import into this workspace");
   }
 }
 
-// ====== 主导入函数 ======
+function sortNotebooks(notebooks: NotebookMeta[]): NotebookMeta[] {
+  const byId = new Map(notebooks.map((item) => [item.id, item]));
+  const result: NotebookMeta[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (item: NotebookMeta): void => {
+    if (visited.has(item.id)) return;
+    if (visiting.has(item.id)) throw new Error(`Notebook cycle detected at ${item.id}`);
+    visiting.add(item.id);
+    if (item.parentId && byId.has(item.parentId)) visit(byId.get(item.parentId)!);
+    visiting.delete(item.id);
+    visited.add(item.id);
+    result.push(item);
+  };
+  for (const item of notebooks) visit(item);
+  return result;
+}
+
+function uniqueSiblingName(
+  db: ReturnType<typeof getDb>,
+  userId: string,
+  workspaceId: string | null,
+  parentId: string | null,
+  desired: string,
+  reserved: Set<string>,
+): string {
+  const existingRows = workspaceId
+    ? db.prepare(`
+        SELECT name FROM notebooks
+         WHERE workspaceId = ? AND parentId IS ? AND (isDeleted IS NULL OR isDeleted = 0)
+      `).all(workspaceId, parentId) as Array<{ name: string }>
+    : db.prepare(`
+        SELECT name FROM notebooks
+         WHERE userId = ? AND workspaceId IS NULL AND parentId IS ? AND (isDeleted IS NULL OR isDeleted = 0)
+      `).all(userId, parentId) as Array<{ name: string }>;
+  const used = new Set(existingRows.map((row) => row.name));
+  for (const name of reserved) used.add(name);
+  if (!used.has(desired)) {
+    reserved.add(desired);
+    return desired;
+  }
+  let index = 2;
+  while (used.has(`${desired} (${index})`)) index += 1;
+  const result = `${desired} (${index})`;
+  reserved.add(result);
+  return result;
+}
+
+async function readJson<T>(zip: JSZip, filename: string): Promise<T | null> {
+  const entry = zip.file(filename);
+  if (!entry) return null;
+  try {
+    return JSON.parse(await entry.async("string")) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function readAttachmentEntries(
+  zip: JSZip,
+  manifestVersion: number,
+  warnings: ImportWarning[],
+  errors: string[],
+): Promise<Map<string, { meta: AttachmentMeta; buffer: Buffer | null }>> {
+  const result = new Map<string, { meta: AttachmentMeta; buffer: Buffer | null }>();
+  const attachmentManifest = await readJson<{ items?: AttachmentMeta[] }>(zip, "attachments.json");
+  if (manifestVersion >= 2 && Array.isArray(attachmentManifest?.items)) {
+    for (const meta of attachmentManifest!.items!) {
+      if (!meta?.id || !meta.noteId || !meta.packagePath || !isSafeZipPath(meta.packagePath)) {
+        errors.push(`Invalid attachment manifest entry: ${meta?.id || "unknown"}`);
+        continue;
+      }
+      const entry = zip.file(meta.packagePath);
+      if (!entry) {
+        errors.push(`Attachment file not found: ${meta.packagePath}`);
+        result.set(meta.id, { meta, buffer: null });
+        continue;
+      }
+      const buffer = Buffer.from(await entry.async("arraybuffer"));
+      const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+      if (meta.sha256 && meta.sha256 !== sha256) {
+        errors.push(`Attachment checksum mismatch: ${meta.filename || meta.id}`);
+      }
+      if (meta.size != null && Number(meta.size) !== buffer.length) {
+        errors.push(`Attachment size mismatch: ${meta.filename || meta.id}`);
+      }
+      result.set(meta.id, { meta: { ...meta, sha256 }, buffer });
+    }
+    return result;
+  }
+
+  const folder = zip.folder("attachments");
+  if (!folder) return result;
+  for (const name of Object.keys(folder.files)) {
+    if (!name.endsWith("/meta.json")) continue;
+    const attachmentId = name.split("/")[1];
+    if (!attachmentId) continue;
+    const meta = await readJson<AttachmentMeta>(zip, `attachments/${attachmentId}/meta.json`);
+    if (!meta) {
+      warnings.push({ type: "invalid_attachment_meta", id: attachmentId, message: `Failed to parse ${name}` });
+      continue;
+    }
+    let buffer: Buffer | null = null;
+    if (meta.file) {
+      const packagePath = `attachments/${attachmentId}/${meta.file}`;
+      const entry = zip.file(packagePath);
+      if (!entry) {
+        errors.push(`Attachment file not found: ${packagePath}`);
+      } else {
+        buffer = Buffer.from(await entry.async("arraybuffer"));
+        const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+        if (meta.sha256 && meta.sha256 !== sha256) errors.push(`Attachment checksum mismatch: ${meta.filename || meta.id}`);
+        meta.packagePath = packagePath;
+        meta.sha256 = sha256;
+      }
+    }
+    result.set(meta.id, { meta, buffer });
+  }
+  return result;
+}
 
 export async function importNowenPackage(zipBuffer: Buffer, params: ImportParams): Promise<ImportResult> {
   const {
     userId,
-    workspaceId,
+    workspaceId = null,
     targetNotebookId,
     importMode = "new-root",
     dryRun = false,
   } = params;
-
   const warnings: ImportWarning[] = [];
   const errors: string[] = [];
-
-  // ── 1. 解析 zip ──
 
   let zip: JSZip;
   try {
     zip = await JSZip.loadAsync(zipBuffer);
-  } catch (err: any) {
-    return { success: false, dryRun, warnings, errors: [`Failed to parse zip: ${err.message}`] };
+  } catch (error) {
+    return { success: false, dryRun, warnings, errors: [`Failed to parse ZIP: ${error instanceof Error ? error.message : String(error)}`] };
   }
-
-  // ── 2. 安全检查：禁止敏感文件 ──
 
   const forbiddenFiles = [
     "db.sqlite", ".jwt_secret", "users.json", "passwordHash",
     "system_settings", "system_settings.json", "shares.json", "shareToken",
   ];
-  for (const name of forbiddenFiles) {
-    if (zip.file(name)) {
-      return { success: false, dryRun, warnings, errors: [`Package contains forbidden file: ${name}`] };
-    }
+  for (const filename of forbiddenFiles) {
+    if (zip.file(filename)) return { success: false, dryRun, warnings, errors: [`Package contains forbidden file: ${filename}`] };
+  }
+  for (const filename of Object.keys(zip.files)) {
+    if (!isSafeZipPath(filename)) return { success: false, dryRun, warnings, errors: [`Unsafe path in package: ${filename}`] };
   }
 
-  // ── 3. 检查 zip entry 路径安全 ──
-
-  for (const [name] of Object.entries(zip.files)) {
-    if (!isSafeZipPath(name)) {
-      return { success: false, dryRun, warnings, errors: [`Unsafe path in package: ${name}`] };
-    }
-  }
-
-  // ── 4. 读取 manifest.json ──
-
-  const manifestFile = zip.file("manifest.json");
-  if (!manifestFile) {
-    return { success: false, dryRun, warnings, errors: ["manifest.json not found in package"] };
-  }
-
-  let manifest: Manifest;
-  try {
-    manifest = JSON.parse(await manifestFile.async("string"));
-  } catch (err: any) {
-    return { success: false, dryRun, warnings, errors: [`Failed to parse manifest.json: ${err.message}`] };
-  }
-
-  if (manifest.format !== "nowen-package") {
-    return { success: false, dryRun, warnings, errors: [`Invalid format: ${manifest.format}`] };
-  }
-  if (manifest.formatVersion !== 1) {
+  const manifest = await readJson<Manifest>(zip, "manifest.json");
+  if (!manifest) return { success: false, dryRun, warnings, errors: ["manifest.json not found or invalid"] };
+  if (manifest.format !== "nowen-package") return { success: false, dryRun, warnings, errors: [`Invalid package format: ${manifest.format}`] };
+  if (![1, 2].includes(manifest.formatVersion)) {
     return { success: false, dryRun, warnings, errors: [`Unsupported formatVersion: ${manifest.formatVersion}`] };
   }
-
-  // 检查 schemaVersion
-  if (manifest.schemaVersion) {
-    const currentSchema = getDbSchemaVersion();
-    if (manifest.schemaVersion > currentSchema) {
-      return {
-        success: false, dryRun, warnings,
-        errors: [`Package schemaVersion (${manifest.schemaVersion}) is newer than current (${currentSchema}). Please upgrade first.`],
-      };
-    }
+  if (manifest.schemaVersion && manifest.schemaVersion > getDbSchemaVersion()) {
+    return { success: false, dryRun, warnings, errors: [`Package schemaVersion (${manifest.schemaVersion}) is newer than current (${getDbSchemaVersion()}). Please upgrade first.`] };
   }
 
-  // ── 5. 读取辅助文件 ──
-
-  async function readJsonFile<T>(name: string): Promise<T | null> {
-    const file = zip.file(name);
-    if (!file) return null;
-    try {
-      return JSON.parse(await file.async("string")) as T;
-    } catch {
-      return null;
+  let notebooks = await readJson<NotebookMeta[]>(zip, "notebooks.json") || [];
+  if (manifest.formatVersion >= 2) {
+    const tree = await readJson<TreeFile>(zip, "tree.json");
+    if (Array.isArray(tree?.nodes)) {
+      notebooks = tree!.nodes!.map((node) => ({
+        id: node.sourceId,
+        parentId: node.parentSourceId || null,
+        name: node.name,
+        description: node.description || null,
+        icon: node.icon || null,
+        color: node.color || null,
+        sortOrder: Number(node.sortOrder) || 0,
+        isExpanded: Number(node.isExpanded) || 0,
+        createdAt: node.createdAt || new Date().toISOString(),
+        updatedAt: node.updatedAt || node.createdAt || new Date().toISOString(),
+      }));
     }
   }
-
-  const notebooks = await readJsonFile<NotebookMeta[]>("notebooks.json") || [];
-  const tags = await readJsonFile<TagMeta[]>("tags.json") || [];
-  const noteTags = await readJsonFile<{ noteId: string; tagId: string }[]>("note_tags.json") || [];
-
-  // dryRun 校验：必要文件缺失应报错
-  if (!zip.file("notebooks.json")) errors.push("notebooks.json not found");
-  if (!zip.file("tags.json")) errors.push("tags.json not found");
-  if (!zip.file("note_tags.json")) errors.push("note_tags.json not found");
-
-  // ── 6. 校验笔记和附件 ──
+  const tags = await readJson<TagMeta[]>(zip, "tags.json") || [];
+  const noteTags = await readJson<Array<{ noteId: string; tagId: string }>>(zip, "note_tags.json") || [];
+  if (!zip.file("notebooks.json") && !zip.file("tree.json")) errors.push("Notebook tree manifest is missing");
 
   const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
-  const noteFolder = zip.folder("notes");
-
-  if (noteFolder) {
-    for (const [name] of Object.entries(noteFolder.files)) {
+  const notesFolder = zip.folder("notes");
+  if (notesFolder) {
+    for (const name of Object.keys(notesFolder.files)) {
       if (!name.endsWith("/meta.json")) continue;
       const noteId = name.split("/")[1];
       if (!noteId) continue;
-
-      const meta = await readJsonFile<NoteMeta>(`notes/${noteId}/meta.json`);
+      const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
       if (!meta) {
-        warnings.push({ type: "invalid_note_meta", id: noteId, message: `Failed to parse notes/${noteId}/meta.json` });
+        errors.push(`Invalid note metadata: ${noteId}`);
         continue;
       }
-
-      const contentFile = zip.file(`notes/${noteId}/${meta.contentFile}`);
-      if (!contentFile) {
-        errors.push(`notes/${noteId}/${meta.contentFile} not found`);
+      if (!isSafeZipPath(meta.contentFile)) {
+        errors.push(`Unsafe note content path: ${meta.contentFile}`);
         continue;
       }
-
-      const content = await contentFile.async("string");
-      noteContents.set(noteId, { content, meta });
+      const contentPath = `notes/${noteId}/${meta.contentFile}`;
+      const entry = zip.file(contentPath);
+      if (!entry) {
+        errors.push(`Note content not found: ${contentPath}`);
+        continue;
+      }
+      noteContents.set(noteId, { meta, content: await entry.async("string") });
     }
   }
-
-  const attachmentData = new Map<string, { meta: AttachmentMeta; buffer: Buffer | null }>();
-  const attFolder = zip.folder("attachments");
-
-  if (attFolder) {
-    for (const [name] of Object.entries(attFolder.files)) {
-      if (!name.endsWith("/meta.json")) continue;
-      const attId = name.split("/")[1];
-      if (!attId) continue;
-
-      const meta = await readJsonFile<AttachmentMeta>(`attachments/${attId}/meta.json`);
-      if (!meta) {
-        warnings.push({ type: "invalid_attachment_meta", id: attId, message: `Failed to parse attachments/${attId}/meta.json` });
-        continue;
-      }
-
-      let buffer: Buffer | null = null;
-      if (meta.file) {
-        const fileEntry = zip.file(`attachments/${attId}/${meta.file}`);
-        if (fileEntry) {
-          buffer = Buffer.from(await fileEntry.async("arraybuffer"));
-        } else {
-          warnings.push({ type: "missing_attachment_file", id: attId, path: meta.file, message: `File not found: attachments/${attId}/${meta.file}` });
-        }
-      }
-
-      attachmentData.set(attId, { meta, buffer });
-    }
-  }
-
-  // ── 7. 检查目标笔记本 ──
+  const attachmentData = await readAttachmentEntries(zip, manifest.formatVersion, warnings, errors);
 
   const db = getDb();
-  let resolvedWorkspaceId: string | null = workspaceId ?? null;
-
-  if (importMode === "into-target" && targetNotebookId) {
-    const target = db.prepare(
-      "SELECT id, userId, isDeleted, workspaceId FROM notebooks WHERE id = ? AND userId = ?"
-    ).get(targetNotebookId, userId) as { id: string; userId: string; isDeleted: number; workspaceId: string | null } | undefined;
-
-    if (!target) {
-      return { success: false, dryRun, warnings, errors: ["Target notebook not found or not owned by user"] };
-    }
-    if (target.isDeleted === 1) {
-      return { success: false, dryRun, warnings, errors: ["Target notebook is deleted"] };
-    }
-    // 以 target notebook 的 workspaceId 为准
-    resolvedWorkspaceId = target.workspaceId;
+  let resolvedWorkspaceId = workspaceId;
+  try {
+    assertWorkspaceWritable(userId, resolvedWorkspaceId);
+  } catch (error) {
+    return { success: false, dryRun, warnings, errors: [error instanceof Error ? error.message : String(error)] };
   }
 
-  // ── 8. dryRun 返回 ──
+  let targetParentId: string | null = null;
+  if (importMode === "into-target") {
+    if (!targetNotebookId) errors.push("Target notebook is required for into-target mode");
+    else {
+      const target = db.prepare(`
+        SELECT id, userId, workspaceId, isDeleted FROM notebooks WHERE id = ?
+      `).get(targetNotebookId) as { id: string; userId: string; workspaceId: string | null; isDeleted: number } | undefined;
+      if (!target || target.isDeleted === 1) errors.push("Target notebook not found or deleted");
+      else if (!target.workspaceId && target.userId !== userId) errors.push("No permission to import into target notebook");
+      else {
+        resolvedWorkspaceId = target.workspaceId || null;
+        try { assertWorkspaceWritable(userId, resolvedWorkspaceId); } catch (error) { errors.push(error instanceof Error ? error.message : String(error)); }
+        targetParentId = target.id;
+      }
+    }
+  }
 
-  if (dryRun) {
+  let sortedNotebooks: NotebookMeta[] = [];
+  try {
+    sortedNotebooks = sortNotebooks(notebooks);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+  const sourceNotebookIds = new Set(notebooks.map((item) => item.id));
+  const rootNotebooks = sortedNotebooks.filter((item) => !item.parentId || !sourceNotebookIds.has(item.parentId));
+  const reservedRootNames = new Set<string>();
+  const rootNamePlan = new Map<string, string>();
+  const conflicts: Array<{ sourceId: string; originalName: string; importedName: string; parentId: string | null }> = [];
+  for (const root of rootNotebooks) {
+    const planned = uniqueSiblingName(db, userId, resolvedWorkspaceId, targetParentId, root.name, reservedRootNames);
+    rootNamePlan.set(root.id, planned);
+    if (planned !== root.name) conflicts.push({ sourceId: root.id, originalName: root.name, importedName: planned, parentId: targetParentId });
+  }
+
+  for (const [attachmentId, item] of attachmentData) {
+    if (!noteContents.has(item.meta.noteId)) errors.push(`Attachment ${attachmentId} points to missing note ${item.meta.noteId}`);
+    if (!item.buffer) errors.push(`Attachment file is missing: ${item.meta.filename || attachmentId}`);
+  }
+
+  const packagePreview = {
+    format: manifest.format,
+    formatVersion: manifest.formatVersion,
+    schemaVersion: manifest.schemaVersion,
+    exportedAt: manifest.exportedAt,
+    counts: {
+      notebooks: notebooks.length,
+      notes: noteContents.size,
+      tags: tags.length,
+      attachments: Array.from(attachmentData.values()).filter((item) => !!item.buffer).length,
+    },
+    formatStats: manifest.formatStats || { markdown: 0, richText: 0, html: 0 },
+    packageKind: manifest.packageKind,
+  };
+
+  if (dryRun || errors.length) {
     return {
       success: errors.length === 0,
-      dryRun: true,
-      package: {
-        format: manifest.format,
-        formatVersion: manifest.formatVersion,
-        schemaVersion: manifest.schemaVersion,
-        exportedAt: manifest.exportedAt,
-        counts: manifest.counts,
-        formatStats: manifest.formatStats,
-      },
+      dryRun,
+      package: packagePreview,
+      conflicts,
       warnings,
       errors,
     };
   }
 
-  // ── 9. 正式导入 ──
-
-  // ID 映射
   const notebookIdMap = new Map<string, string>();
   const noteIdMap = new Map<string, string>();
   const tagIdMap = new Map<string, string>();
+  const attachmentIdMap = new Map<string, string>();
+  for (const notebook of sortedNotebooks) notebookIdMap.set(notebook.id, uuid());
+  for (const noteId of noteContents.keys()) noteIdMap.set(noteId, uuid());
 
-  // 有效的附件映射（只包含文件保存成功的附件）
-  const effectiveAttachmentIdMap = new Map<string, string>();
+  const validAttachments: ValidAttachment[] = [];
+  const writtenStoragePaths: string[] = [];
+  try {
+    for (const [oldId, { meta, buffer }] of attachmentData) {
+      if (!buffer) continue;
+      const newNoteId = noteIdMap.get(meta.noteId);
+      if (!newNoteId) continue;
+      const newId = uuid();
+      const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+      const storagePath = `${getUploadMonthPath()}/${newId}${safeExtension(meta.filename)}`;
+      await writeAttachmentObject(storagePath, buffer, meta.mimeType || "application/octet-stream");
+      writtenStoragePaths.push(storagePath);
+      attachmentIdMap.set(oldId, newId);
+      validAttachments.push({
+        oldId,
+        newId,
+        oldNoteId: meta.noteId,
+        newNoteId,
+        meta,
+        buffer,
+        storagePath,
+        sha256,
+      });
+    }
+  } catch (error) {
+    await Promise.all(writtenStoragePaths.map((storagePath) => deleteAttachmentObject(storagePath).catch(() => undefined)));
+    return { success: false, dryRun: false, package: packagePreview, conflicts, warnings, errors: [`Attachment restore failed: ${error instanceof Error ? error.message : String(error)}`] };
+  }
 
-  // 待插入附件记录（延迟到 notes 之后）
-  const pendingAttachments: PendingAttachment[] = [];
-
-  // 文件回滚列表
-  const importedFiles: string[] = [];
-
-  // rootNotebookId 需要在 try 块外声明，以便返回时使用
-  let rootNotebookId: string;
-
+  const importedRootIds: string[] = [];
   try {
     db.exec("BEGIN TRANSACTION");
 
-    // 9.1 创建导入根笔记本
-    const dateStr = new Date().toISOString().slice(0, 10);
-
-    if (importMode === "into-target" && targetNotebookId) {
-      rootNotebookId = targetNotebookId;
-    } else {
-      rootNotebookId = uuid();
-      const rootName = `导入的 Nowen 数据包 ${dateStr}`;
+    for (const notebook of sortedNotebooks) {
+      const newId = notebookIdMap.get(notebook.id)!;
+      const sourceParentMapped = notebook.parentId ? notebookIdMap.get(notebook.parentId) : null;
+      const parentId = sourceParentMapped || targetParentId;
+      const name = rootNamePlan.get(notebook.id) || notebook.name;
       db.prepare(`
-        INSERT INTO notebooks (id, userId, workspaceId, parentId, name, description, icon, color, sortOrder, isExpanded, isDeleted, createdAt, updatedAt)
-        VALUES (?, ?, ?, NULL, ?, NULL, NULL, NULL, 0, 1, 0, datetime('now'), datetime('now'))
-      `).run(rootNotebookId, userId, resolvedWorkspaceId, rootName);
+        INSERT INTO notebooks (
+          id, userId, workspaceId, parentId, name, description, icon, color,
+          sortOrder, isExpanded, isDeleted, createdAt, updatedAt
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+      `).run(
+        newId, userId, resolvedWorkspaceId, parentId, name, notebook.description,
+        notebook.icon, notebook.color, notebook.sortOrder, notebook.isExpanded,
+        notebook.createdAt, notebook.updatedAt,
+      );
+      if (!sourceParentMapped) importedRootIds.push(newId);
     }
 
-    // 9.2 导入 notebooks（拓扑排序，父级先插入）
-    const sortedNotebooks: NotebookMeta[] = [];
-    const visited = new Set<string>();
-    const notebookMap = new Map(notebooks.map((n) => [n.id, n]));
-
-    function visitNotebook(nb: NotebookMeta) {
-      if (visited.has(nb.id)) return;
-      visited.add(nb.id);
-      if (nb.parentId && notebookMap.has(nb.parentId)) {
-        visitNotebook(notebookMap.get(nb.parentId)!);
-      }
-      sortedNotebooks.push(nb);
-    }
-
-    for (const nb of notebooks) {
-      visitNotebook(nb);
-    }
-
-    for (const nb of sortedNotebooks) {
-      const newId = uuid();
-      notebookIdMap.set(nb.id, newId);
-
-      let parentId: string | null = null;
-      if (nb.parentId) {
-        parentId = notebookIdMap.get(nb.parentId) || rootNotebookId;
-        if (!notebookIdMap.has(nb.parentId)) {
-          warnings.push({ type: "notebook_parent_missing", id: nb.id, message: `Parent ${nb.parentId} not found, attached to root` });
-        }
-      } else {
-        parentId = rootNotebookId;
-      }
-
+    // A malformed package may contain notes without a notebook tree. Keep it recoverable under one
+    // unique fallback root rather than silently dropping the notes.
+    let fallbackRootId = importedRootIds[0] || targetParentId || null;
+    if (!fallbackRootId && noteContents.size) {
+      fallbackRootId = uuid();
+      const fallbackName = uniqueSiblingName(db, userId, resolvedWorkspaceId, null, "导入的内容", new Set());
       db.prepare(`
-        INSERT INTO notebooks (id, userId, workspaceId, parentId, name, description, icon, color, sortOrder, isExpanded, isDeleted, createdAt, updatedAt)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
-      `).run(newId, userId, resolvedWorkspaceId, parentId, nb.name, nb.description, nb.icon, nb.color, nb.sortOrder, nb.isExpanded, nb.createdAt, nb.updatedAt);
+        INSERT INTO notebooks (id, userId, workspaceId, parentId, name, icon, sortOrder, isExpanded, isDeleted)
+        VALUES (?, ?, ?, NULL, ?, ?, 0, 1, 0)
+      `).run(fallbackRootId, userId, resolvedWorkspaceId, fallbackName, "📥");
+      importedRootIds.push(fallbackRootId);
     }
 
-    // 9.3 导入 tags（同名复用）
     for (const tag of tags) {
       const existing = db.prepare("SELECT id FROM tags WHERE userId = ? AND name = ?").get(userId, tag.name) as { id: string } | undefined;
-      if (existing) {
-        tagIdMap.set(tag.id, existing.id);
-      } else {
+      if (existing) tagIdMap.set(tag.id, existing.id);
+      else {
         const newId = uuid();
         tagIdMap.set(tag.id, newId);
-        db.prepare("INSERT INTO tags (id, userId, name, color, createdAt) VALUES (?, ?, ?, ?, ?)").run(newId, userId, tag.name, tag.color, tag.createdAt);
+        db.prepare("INSERT INTO tags (id, userId, name, color, createdAt) VALUES (?, ?, ?, ?, ?)")
+          .run(newId, userId, tag.name, tag.color, tag.createdAt);
       }
     }
 
-    // 9.4 预生成 noteIdMap
-    for (const oldId of noteContents.keys()) {
-      noteIdMap.set(oldId, uuid());
-    }
-
-    // 9.5 复制附件文件，生成 pendingAttachments（不插入 attachments 表）
-    for (const [oldId, { meta, buffer }] of attachmentData) {
-      const newId = uuid();
-      const newNoteId = noteIdMap.get(meta.noteId);
-
-      if (!newNoteId) {
-        warnings.push({ type: "attachment_note_missing", id: oldId, message: `Note ${meta.noteId} not found for attachment ${oldId}` });
-        continue;
-      }
-
-      if (!buffer) {
-        // 文件缺失，跳过，不放入 effectiveAttachmentIdMap
-        continue;
-      }
-
-      try {
-        const { filePath, sha256 } = saveAttachmentFile(buffer, newId, meta.filename);
-        importedFiles.push(filePath);
-
-        pendingAttachments.push({
-          oldId,
-          newId,
-          oldNoteId: meta.noteId,
-          meta,
-          filePath,
-          sha256,
-          size: buffer.length,
-        });
-
-        // 只有保存成功的附件才进入 effectiveAttachmentIdMap
-        effectiveAttachmentIdMap.set(oldId, newId);
-      } catch (err: any) {
-        warnings.push({ type: "attachment_save_failed", id: oldId, message: `Failed to save: ${err.message}` });
-      }
-    }
-
-    // 9.6 导入 notes（使用 effectiveAttachmentIdMap 重写 content）
+    const rewrittenByNewNoteId = new Map<string, string>();
     for (const [oldId, { content, meta }] of noteContents) {
       const newId = noteIdMap.get(oldId)!;
-      const newNotebookId = notebookIdMap.get(meta.notebookId) || rootNotebookId;
-
-      // 重写附件引用（只重写有效附件）
-      const { content: rewrittenContent, unmappedIds } = rewriteAttachmentRefs(content, effectiveAttachmentIdMap);
-      for (const unmappedId of unmappedIds) {
-        warnings.push({ type: "attachment_ref_unmapped", id: unmappedId, message: `Attachment ${unmappedId} not in package or failed to save` });
+      const notebook = notebookIdMap.get(meta.notebookId) || fallbackRootId;
+      if (!notebook) throw new Error(`No target notebook for note ${oldId}`);
+      const rewritten = rewriteIdReferences(content, attachmentIdMap, noteIdMap);
+      for (const attachmentId of rewritten.unmappedAttachmentIds) {
+        warnings.push({ type: "attachment_ref_unmapped", id: attachmentId, message: `Attachment ${attachmentId} was not restored` });
       }
-
-      // 确定 contentFormat
-      const knownFormats = ["markdown", "tiptap-json", "html"];
-      const contentFormat = knownFormats.includes(meta.contentFormat) ? meta.contentFormat : "tiptap-json";
-      if (!knownFormats.includes(meta.contentFormat)) {
-        warnings.push({ type: "unknown_content_format", id: oldId, message: `Unknown contentFormat "${meta.contentFormat}", imported as tiptap-json` });
-      }
-
+      const knownFormats = new Set(["markdown", "tiptap-json", "html"]);
+      const contentFormat = knownFormats.has(meta.contentFormat) ? meta.contentFormat : "tiptap-json";
       db.prepare(`
-        INSERT INTO notes (id, userId, workspaceId, notebookId, title, content, contentText, contentFormat, isPinned, isFavorite, isLocked, isArchived, isTrashed, version, sortOrder, createdAt, updatedAt)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+        INSERT INTO notes (
+          id, userId, workspaceId, notebookId, title, content, contentText, contentFormat,
+          isPinned, isFavorite, isLocked, isArchived, isTrashed, version, sortOrder,
+          createdAt, updatedAt
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
       `).run(
-        newId, userId, resolvedWorkspaceId, newNotebookId,
-        meta.title, rewrittenContent, meta.contentText, contentFormat,
-        meta.isPinned, meta.isFavorite, meta.isLocked, meta.isArchived,
-        meta.version || 1, meta.sortOrder, meta.createdAt, meta.updatedAt,
+        newId, userId, resolvedWorkspaceId, notebook, meta.title, rewritten.content,
+        meta.contentText || "", contentFormat, meta.isPinned || 0, meta.isFavorite || 0,
+        meta.isLocked || 0, meta.isArchived || 0, meta.version || 1, meta.sortOrder || 0,
+        meta.createdAt, meta.updatedAt,
       );
+      rewrittenByNewNoteId.set(newId, rewritten.content);
     }
 
-    // 9.7 插入 attachments 表（notes 已存在，外键安全）
-    for (const pa of pendingAttachments) {
-      const newNoteId = noteIdMap.get(pa.oldNoteId)!;
+    for (const attachment of validAttachments) {
       db.prepare(`
         INSERT INTO attachments (id, userId, noteId, filename, mimeType, size, path, createdAt)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(pa.newId, userId, newNoteId, pa.meta.filename, pa.meta.mimeType, pa.size, pa.filePath, pa.meta.createdAt);
+      `).run(
+        attachment.newId, userId, attachment.newNoteId, attachment.meta.filename,
+        attachment.meta.mimeType, attachment.buffer.length, attachment.storagePath,
+        attachment.meta.createdAt,
+      );
     }
 
-    // 9.8 导入 note_tags
-    for (const nt of noteTags) {
-      const newNoteId = noteIdMap.get(nt.noteId);
-      const newTagId = tagIdMap.get(nt.tagId);
+    for (const relation of noteTags) {
+      const newNoteId = noteIdMap.get(relation.noteId);
+      const newTagId = tagIdMap.get(relation.tagId);
       if (newNoteId && newTagId) {
         db.prepare("INSERT OR IGNORE INTO note_tags (noteId, tagId) VALUES (?, ?)").run(newNoteId, newTagId);
       } else {
-        warnings.push({ type: "note_tag_missing", message: `noteId=${nt.noteId} or tagId=${nt.tagId} not found in mapping` });
+        warnings.push({ type: "note_tag_missing", message: `Unable to restore note/tag relation ${relation.noteId}/${relation.tagId}` });
       }
     }
 
-    db.exec("COMMIT");
-  } catch (err: any) {
-    try { db.exec("ROLLBACK"); } catch {}
-    cleanupImportedFiles(importedFiles);
-    return { success: false, dryRun: false, warnings, errors: [`Import failed: ${err.message}`] };
-  }
+    for (const [noteId, content] of rewrittenByNewNoteId) {
+      if (!content.includes("/api/attachments/")) continue;
+      try { syncAttachmentReferences(db, noteId, content); }
+      catch (error) { warnings.push({ type: "attachment_reference_index_failed", id: noteId, message: error instanceof Error ? error.message : String(error) }); }
+    }
 
-  // ── 10. 返回结果 ──
+    db.exec("COMMIT");
+  } catch (error) {
+    try { db.exec("ROLLBACK"); } catch { /* ignore */ }
+    await Promise.all(writtenStoragePaths.map((storagePath) => deleteAttachmentObject(storagePath).catch(() => undefined)));
+    return {
+      success: false,
+      dryRun: false,
+      package: packagePreview,
+      conflicts,
+      warnings,
+      errors: [`Import failed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
 
   return {
     success: true,
     dryRun: false,
-    rootNotebookId,
+    rootNotebookId: importedRootIds[0],
+    rootNotebookIds: importedRootIds,
+    package: packagePreview,
+    conflicts,
     counts: {
-      notebooks: notebookIdMap.size,
+      notebooks: notebookIdMap.size + (notebooks.length === 0 && noteContents.size ? 1 : 0),
       notes: noteIdMap.size,
       tags: tagIdMap.size,
       noteTags: noteTags.length,
-      attachments: effectiveAttachmentIdMap.size,
+      attachments: validAttachments.length,
+      renamedRoots: conflicts.length,
     },
     warnings,
-    errors,
+    errors: [],
   };
 }

--- a/backend/src/services/roundTripMarkdownExportJobs.ts
+++ b/backend/src/services/roundTripMarkdownExportJobs.ts
@@ -1,0 +1,204 @@
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Readable } from "stream";
+import type { Context } from "hono";
+import { getDb } from "../db/schema";
+import {
+  ReliableExportBusyError,
+  validatePreparedMarkdownNotes,
+  type PreparedMarkdownNote,
+  type ReliableExportJobSnapshot,
+} from "./reliableExportJobs";
+import { createNowenPackageExport } from "./nowenPackageExport";
+
+const TMP_PREFIX = "nowen-roundtrip-markdown-";
+const TTL_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+interface Job extends ReliableExportJobSnapshot {
+  userId: string;
+  tmpDir: string;
+  tmpPath: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const jobs = new Map<string, Job>();
+const tokens = new Map<string, string>();
+let lastCleanupAt = 0;
+
+function publicSnapshot(job: Job): ReliableExportJobSnapshot {
+  return {
+    id: job.id,
+    state: job.state,
+    current: job.current,
+    total: job.total,
+    message: job.message,
+    filename: job.filename,
+    downloadToken: job.downloadToken,
+    warnings: job.warnings,
+  };
+}
+
+function dispose(jobId: string, job: Job): void {
+  jobs.delete(jobId);
+  if (job.downloadToken) tokens.delete(job.downloadToken);
+  try { fs.rmSync(job.tmpDir, { recursive: true, force: true }); } catch { /* next cleanup */ }
+}
+
+function cleanup(force = false): void {
+  const now = Date.now();
+  if (!force && now - lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+  lastCleanupAt = now;
+  for (const [jobId, job] of jobs) {
+    if (job.expiresAt <= now) dispose(jobId, job);
+  }
+  try {
+    for (const entry of fs.readdirSync(os.tmpdir(), { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(TMP_PREFIX)) continue;
+      const target = path.join(os.tmpdir(), entry.name);
+      try {
+        if (now - fs.statSync(target).mtimeMs > TTL_MS * 2) fs.rmSync(target, { recursive: true, force: true });
+      } catch {
+        try { fs.rmSync(target, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    }
+  } catch { /* temp directory unavailable */ }
+}
+
+const cleanupTimer = setInterval(() => cleanup(true), CLEANUP_INTERVAL_MS);
+cleanupTimer.unref?.();
+cleanup(true);
+
+function inferWorkspaceId(userId: string, noteIds: string[]): string | null {
+  if (!noteIds.length) return null;
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT DISTINCT workspaceId
+      FROM notes
+     WHERE id IN (${noteIds.map(() => "?").join(",")})
+  `).all(...noteIds) as Array<{ workspaceId: string | null }>;
+  if (rows.length !== 1) throw new Error("Selected notes span multiple workspaces");
+  const workspaceId = rows[0]?.workspaceId || null;
+  if (!workspaceId) {
+    const count = db.prepare(`
+      SELECT COUNT(*) AS count FROM notes
+       WHERE id IN (${noteIds.map(() => "?").join(",")}) AND userId = ?
+    `).get(...noteIds, userId) as { count: number };
+    if (Number(count?.count) !== noteIds.length) throw new Error("Selected notes are not owned by the current user");
+  }
+  return workspaceId;
+}
+
+async function buildJob(
+  job: Job,
+  notes: PreparedMarkdownNote[],
+  inlineImages: boolean,
+  layout: "notebooks" | "flat",
+  filenameBase?: string,
+): Promise<void> {
+  try {
+    job.state = "building";
+    job.message = "正在生成完整目录与附件清单";
+    const noteIds = notes.map((note) => note.id);
+    const workspaceId = inferWorkspaceId(job.userId, noteIds);
+    const result = await createNowenPackageExport({
+      userId: job.userId,
+      workspaceId,
+      noteIds,
+      preparedMarkdown: notes,
+      packageKind: "markdown",
+      includeHumanReadableTree: true,
+      inlineImages,
+      layout,
+      filenameBase,
+    });
+    fs.writeFileSync(job.tmpPath, result.buffer);
+    job.filename = result.filename;
+    job.warnings = result.stats.warnings;
+    job.current = job.total;
+    job.state = "ready";
+    job.message = result.stats.warnings
+      ? `导出完成，${result.stats.warnings} 项需要检查`
+      : "导出完成";
+    job.downloadToken = crypto.randomBytes(32).toString("hex");
+    tokens.set(job.downloadToken, job.id);
+  } catch (error) {
+    job.state = "error";
+    job.message = error instanceof Error ? error.message : "生成 ZIP 失败";
+    job.expiresAt = Date.now() + TTL_MS;
+    try { fs.rmSync(job.tmpPath, { force: true }); } catch { /* ignore */ }
+  }
+}
+
+export function createRoundTripMarkdownExportJob(params: {
+  userId: string;
+  notes: PreparedMarkdownNote[];
+  inlineImages: boolean;
+  layout?: "notebooks" | "flat";
+  filenameBase?: string;
+}): ReliableExportJobSnapshot {
+  validatePreparedMarkdownNotes(params.notes);
+  cleanup();
+  for (const [jobId, job] of jobs) {
+    if (job.userId !== params.userId) continue;
+    if (job.state === "queued" || job.state === "building") throw new ReliableExportBusyError();
+    dispose(jobId, job);
+  }
+
+  const id = crypto.randomUUID();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), TMP_PREFIX));
+  const job: Job = {
+    id,
+    userId: params.userId,
+    state: "queued",
+    current: 0,
+    total: params.notes.length,
+    message: "等待生成 ZIP",
+    filename: params.filenameBase ? `${params.filenameBase}.zip` : undefined,
+    warnings: 0,
+    tmpDir,
+    tmpPath: path.join(tmpDir, "export.zip"),
+    createdAt: Date.now(),
+    expiresAt: Date.now() + TTL_MS,
+  };
+  jobs.set(id, job);
+  void buildJob(job, params.notes, params.inlineImages, params.layout || "notebooks", params.filenameBase);
+  return publicSnapshot(job);
+}
+
+export function getRoundTripMarkdownExportJob(jobId: string, userId: string): ReliableExportJobSnapshot | null {
+  cleanup();
+  const job = jobs.get(jobId);
+  if (!job || job.userId !== userId) return null;
+  return publicSnapshot(job);
+}
+
+export function handleRoundTripMarkdownDownload(c: Context): Response | null {
+  cleanup();
+  const token = c.req.param("token");
+  const jobId = tokens.get(token);
+  const job = jobId ? jobs.get(jobId) : undefined;
+  if (!job) return null;
+  if (job.state !== "ready" || job.downloadToken !== token || !fs.existsSync(job.tmpPath)) {
+    return new Response(JSON.stringify({ error: "下载链接无效或已过期" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
+  }
+  const stat = fs.statSync(job.tmpPath);
+  const stream = fs.createReadStream(job.tmpPath);
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Length": String(stat.size),
+      "Content-Encoding": "identity",
+      "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(job.filename || "nowen-note.zip")}`,
+      "Cache-Control": "private, no-store",
+      "X-Content-Type-Options": "nosniff",
+      "X-Nowen-Round-Trip-Package": "2",
+    },
+  });
+}

--- a/backend/tests/markdown-export-jobs.test.ts
+++ b/backend/tests/markdown-export-jobs.test.ts
@@ -37,15 +37,17 @@ test("export helpers reject traversal and rewrite attachment URLs", async () => 
   );
 });
 
-test("markdown export writes attachments to a ZIP file and keeps duplicate note titles", async () => {
+test("markdown export preserves the tree, attachments and duplicate note titles", async () => {
   const schema = await import("../src/db/schema");
   const service = await import("../src/services/markdownExportJobs");
   closeDb = schema.closeDb;
   const db = schema.getDb();
   db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
     .run("user-export", "user-export", "hash");
-  db.prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
-    .run("nb-export", "user-export", "笔记本");
+  db.prepare("INSERT INTO notebooks (id, userId, name, sortOrder) VALUES (?, ?, ?, ?)")
+    .run("nb-export", "user-export", "笔记本", 10);
+  db.prepare("INSERT INTO notebooks (id, userId, parentId, name, sortOrder) VALUES (?, ?, ?, ?, ?)")
+    .run("nb-empty", "user-export", "nb-export", "空目录", 20);
   for (const id of ["note-1", "note-2"]) {
     db.prepare("INSERT INTO notes (id, userId, notebookId, title) VALUES (?, ?, ?, ?)")
       .run(id, "user-export", "nb-export", "同名笔记");
@@ -84,7 +86,7 @@ test("markdown export writes attachments to a ZIP file and keeps duplicate note 
   });
 
   let snapshot = created;
-  for (let i = 0; i < 200 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
+  for (let i = 0; i < 300 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
     await new Promise((resolve) => setTimeout(resolve, 10));
     snapshot = service.getMarkdownExportJob(created.id, "user-export")!;
   }
@@ -100,7 +102,8 @@ test("markdown export writes attachments to a ZIP file and keeps duplicate note 
 
   const zip = await JSZip.loadAsync(await response.arrayBuffer());
   assert.ok(zip.file("笔记本/同名笔记.md"));
-  assert.ok(zip.file("笔记本/同名笔记_2.md"));
+  assert.ok(zip.file("笔记本/同名笔记 (2).md"));
+  assert.ok(zip.folder("笔记本/空目录"));
   assert.equal(
     await zip.file("笔记本/assets/att-att-1-附件.bin")!.async("string"),
     "streamed attachment",
@@ -109,6 +112,14 @@ test("markdown export writes attachments to a ZIP file and keeps duplicate note 
     await zip.file("笔记本/同名笔记.md")!.async("string"),
     /\[附件\]\(\.\/assets\/att-att-1-附件\.bin\)/,
   );
+  const manifest = JSON.parse(await zip.file("manifest.json")!.async("string"));
+  assert.equal(manifest.format, "nowen-package");
+  assert.equal(manifest.formatVersion, 2);
+  assert.equal(manifest.packageKind, "markdown");
+  const tree = JSON.parse(await zip.file("tree.json")!.async("string"));
+  assert.equal(tree.nodes.length, 2);
+  const attachments = JSON.parse(await zip.file("attachments.json")!.async("string"));
+  assert.equal(attachments.items.length, 1);
 });
 
 test("single-note flat export keeps the note and assets at ZIP root", async () => {
@@ -131,7 +142,7 @@ test("single-note flat export keeps the note and assets at ZIP root", async () =
   });
 
   let snapshot = created;
-  for (let i = 0; i < 200 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
+  for (let i = 0; i < 300 && snapshot.state !== "ready" && snapshot.state !== "error"; i++) {
     await new Promise((resolve) => setTimeout(resolve, 10));
     snapshot = service.getMarkdownExportJob(created.id, "user-export")!;
   }
@@ -215,7 +226,7 @@ test("markdown export route validates note ownership and exposes asynchronous st
   const createdBody = await created.json() as { job: { id: string } };
 
   let state = "queued";
-  for (let i = 0; i < 200 && state !== "ready" && state !== "error"; i++) {
+  for (let i = 0; i < 300 && state !== "ready" && state !== "error"; i++) {
     await new Promise((resolve) => setTimeout(resolve, 10));
     const status = await app.request(`/export/markdown-package/jobs/${createdBody.job.id}`, {
       headers: { "X-User-Id": "user-export" },

--- a/backend/tests/nowen-package-roundtrip.test.ts
+++ b/backend/tests/nowen-package-roundtrip.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-package-roundtrip-test-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+let closeDb: typeof import("../src/db/schema").closeDb;
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("Nowen package restores the same subtree, renames only the conflicting root and remaps attachments", async () => {
+  const schema = await import("../src/db/schema");
+  const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run("roundtrip-user", "roundtrip-user", "hash");
+  db.prepare(`
+    INSERT INTO notebooks (id, userId, parentId, name, sortOrder, isExpanded)
+    VALUES (?, ?, NULL, ?, ?, 1)
+  `).run("root-source", "roundtrip-user", "产品资料", 10);
+  db.prepare(`
+    INSERT INTO notebooks (id, userId, parentId, name, sortOrder, isExpanded)
+    VALUES (?, ?, ?, ?, ?, 1)
+  `).run("empty-source", "roundtrip-user", "root-source", "空目录", 20);
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, notebookId, title, content, contentText, contentFormat,
+      sortOrder, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "note-source",
+    "roundtrip-user",
+    "root-source",
+    "生产记录",
+    "[检测报告](/api/attachments/att-source)",
+    "生产记录",
+    "markdown",
+    30,
+    "2026-07-22 10:00:00",
+    "2026-07-22 11:00:00",
+  );
+
+  const attachmentDir = path.join(tmpDir, "attachments");
+  fs.mkdirSync(attachmentDir, { recursive: true });
+  fs.writeFileSync(path.join(attachmentDir, "source.pdf"), Buffer.from("pdf bytes"));
+  db.prepare(`
+    INSERT INTO attachments (id, userId, noteId, filename, mimeType, size, path, createdAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "att-source",
+    "roundtrip-user",
+    "note-source",
+    "检测报告.pdf",
+    "application/pdf",
+    9,
+    "source.pdf",
+    "2026-07-22 10:30:00",
+  );
+
+  const exported = await createNowenPackageExport({
+    userId: "roundtrip-user",
+    workspaceId: null,
+    packageKind: "nowen",
+  });
+  assert.equal(exported.stats.notebooks, 2);
+  assert.equal(exported.stats.notes, 1);
+  assert.equal(exported.stats.attachments, 1);
+
+  const preview = await importNowenPackage(exported.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "new-root",
+    dryRun: true,
+  });
+  assert.equal(preview.success, true, preview.errors.join("; "));
+  assert.equal(preview.conflicts?.length, 1);
+  assert.equal(preview.conflicts?.[0].importedName, "产品资料 (2)");
+
+  const imported = await importNowenPackage(exported.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "new-root",
+  });
+  assert.equal(imported.success, true, imported.errors.join("; "));
+  assert.equal(imported.counts?.renamedRoots, 1);
+  assert.equal(imported.counts?.notebooks, 2);
+  assert.equal(imported.counts?.notes, 1);
+  assert.equal(imported.counts?.attachments, 1);
+
+  const importedRoot = db.prepare(`
+    SELECT id, name, sortOrder FROM notebooks
+     WHERE userId = ? AND workspaceId IS NULL AND parentId IS NULL AND name = ?
+  `).get("roundtrip-user", "产品资料 (2)") as { id: string; name: string; sortOrder: number } | undefined;
+  assert.ok(importedRoot);
+  assert.equal(importedRoot.sortOrder, 10);
+
+  const importedEmpty = db.prepare(`
+    SELECT id, name, sortOrder FROM notebooks WHERE parentId = ? AND name = ?
+  `).get(importedRoot!.id, "空目录") as { id: string; name: string; sortOrder: number } | undefined;
+  assert.ok(importedEmpty, "empty child notebook must survive round-trip");
+  assert.equal(importedEmpty!.sortOrder, 20);
+
+  const importedNote = db.prepare(`
+    SELECT id, notebookId, title, content, contentFormat, sortOrder, createdAt, updatedAt
+      FROM notes
+     WHERE notebookId = ? AND title = ?
+  `).get(importedRoot!.id, "生产记录") as {
+    id: string;
+    notebookId: string;
+    title: string;
+    content: string;
+    contentFormat: string;
+    sortOrder: number;
+    createdAt: string;
+    updatedAt: string;
+  } | undefined;
+  assert.ok(importedNote);
+  assert.equal(importedNote!.contentFormat, "markdown");
+  assert.equal(importedNote!.sortOrder, 30);
+  assert.notEqual(importedNote!.id, "note-source");
+  assert.doesNotMatch(importedNote!.content, /att-source/);
+
+  const importedAttachment = db.prepare(`
+    SELECT id, noteId, filename, mimeType, size, path
+      FROM attachments
+     WHERE noteId = ? AND filename = ?
+  `).get(importedNote!.id, "检测报告.pdf") as {
+    id: string;
+    noteId: string;
+    filename: string;
+    mimeType: string;
+    size: number;
+    path: string;
+  } | undefined;
+  assert.ok(importedAttachment);
+  assert.match(importedNote!.content, new RegExp(`/api/attachments/${importedAttachment!.id}`));
+  assert.equal(importedAttachment!.size, 9);
+  assert.equal(fs.readFileSync(path.join(attachmentDir, importedAttachment!.path), "utf8"), "pdf bytes");
+});

--- a/frontend/src/lib/importService.base.ts
+++ b/frontend/src/lib/importService.base.ts
@@ -1,0 +1,1493 @@
+import { api } from "./api";
+import { marked, Renderer } from "marked";
+import i18n from "i18next";
+import { Editor, generateJSON, Extension } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import Image from "@tiptap/extension-image";
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import Underline from "@tiptap/extension-underline";
+import Highlight from "@tiptap/extension-highlight";
+import TaskList from "@tiptap/extension-task-list";
+import TaskItem from "@tiptap/extension-task-item";
+import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
+import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
+import TextAlign from "@tiptap/extension-text-align";
+import { common, createLowlight } from "lowlight";
+import { TextStyleKit } from "@/components/FontSizeExtension";
+import { Video as VideoExtension } from "@/components/VideoExtension";
+import { MathInline, MathBlock } from "@/components/MathExtensions";
+import { FootnoteReference, FootnoteDefinition } from "@/components/FootnoteExtensions";
+
+// BLOCK-ID-01-RV1: heading blockId 扩展（与 TiptapEditor / contentFormat 对齐）
+// 只声明 attrs，不带 appendTransaction plugin
+const BlockIdAttrs = Extension.create({
+  name: "blockId",
+  addGlobalAttributes() {
+    return [{
+      types: ["heading"],
+      attributes: {
+        blockId: {
+          default: null,
+          parseHTML: (element: HTMLElement) => element.getAttribute("data-block-id") || null,
+          renderHTML: (attributes: any) => {
+            if (!attributes.blockId) return {};
+            return { "data-block-id": attributes.blockId };
+          },
+        },
+      },
+    }];
+  },
+});
+
+const lowlight = createLowlight(common);
+
+// TipTap 扩展列表（与编辑器保持一致）
+// 导出供 tiptapSchemaRepair.ts 复用，避免再复制一份 schema 定义
+export const tiptapExtensions = [
+  StarterKit.configure({
+    codeBlock: false,
+    heading: { levels: [1, 2, 3, 4, 5, 6] },
+  }),
+  // BLOCK-LINKS-UI-01-RV3: 显式配置 Link 扩展，允许 note: 协议
+  // 避免 repairTiptapJson round-trip 时丢失 note link
+  Link.configure({
+    openOnClick: false,
+    autolink: true,
+    linkOnPaste: true,
+    protocols: ["http", "https", "mailto", "note"],
+    HTMLAttributes: {
+      target: "_blank",
+      rel: "noopener noreferrer nofollow",
+    },
+  }),
+  // 与 TiptapEditor 保持一致：图片是 inline 节点，必须位于 paragraph/listItem
+  // 等 inlineContent 容器内。否则 repairTiptapJson 会保留历史 doc > image 结构，
+  // 主编辑器加载后任意 transaction 都会触发 contentMatchAt 崩溃。
+  Image.configure({ inline: true, allowBase64: true }),
+  CodeBlockLowlight.configure({ lowlight }),
+  Underline,
+  Highlight.configure({ multicolor: true }),
+  TaskList,
+  TaskItem.configure({ nested: true }),
+  Table.configure({ resizable: false }),
+  TableRowWithHeight,
+  TableHeader,
+  TableCell,
+  // TextAlign：必须与 TiptapEditor 对齐，否则 repairTiptapJson round-trip
+  // 时段落/标题的 textAlign 属性会被 schema 静默过滤掉，刷新后段落对齐丢失。
+  TextAlign.configure({ types: ["heading", "paragraph"] }),
+  // TextStyle + Color + FontSize：与编辑器保持一致，否则导入近来的
+  // 带颜色/字号的 HTML 会被 generateJSON schema-filter 掉
+  ...TextStyleKit,
+  // 视频节点：与编辑器保持一致，否则导入/修复阶段 video 节点会被吃
+  VideoExtension,
+  // 数学公式（行内 / 块级）：必须与 TiptapEditor 对齐。
+  // 缺这两个时，含 LaTeX 公式的笔记走 repairTiptapJson → generateHTML 会因
+  // schema 不认识 mathInline / mathBlock 抛 RangeError，catch 兜底返回空 doc，
+  // 表现为"刷新后整篇内容消失"。
+  MathInline,
+  MathBlock,
+  // 脚注（引用 / 定义）：同 Math，含脚注节点的 doc 在 repair round-trip 时
+  // 会因 schema 缺失导致 generateHTML 抛错，刷新后笔记内容被清空。
+  FootnoteReference,
+  FootnoteDefinition,
+  // BLOCK-ID-01-RV1: heading blockId 属性，与 TiptapEditor / contentFormat 对齐
+  // 避免 schema 修复时 blockId 被过滤掉
+  BlockIdAttrs,
+];
+
+export interface ImportFileInfo {
+  name: string;
+  title: string;
+  content: string;
+  size: number;
+  selected: boolean;
+  source?: string; // 来源标识: "md" | "txt" | "html" | "xiaomi" | "oppo" | "vivo" | "oneplus" | "pdf" | "siyuan" | "siyuan-sy"
+  notebookName?: string; // （已废弃，仅为向后兼容）从路径/目录推导出的单层笔记本名
+  notebookPath?: string[]; // 笔记本层级路径（从根到子），如 ["我是文章2", "test2", "新笔记本"]
+  imageMap?: Record<string, string>; // 相对路径 -> base64 data URI（zip 内的图片资源）
+  contentFormat?: "tiptap-json" | "markdown" | "html";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+// 导入选项
+export interface ImportOptions {
+  /**
+   * 是否"为每个文件创建以文件名命名的外层笔记本"
+   * - true:  每个文件 → 建/找一个同名笔记本（清洗后的文件名）
+   * - false: 保持原逻辑（zip 目录派生；散文件归到"导入的笔记"或用户选的笔记本）
+   */
+  perFileNotebook?: boolean;
+  /**
+   * 当 perFileNotebook=true 时，同名笔记本的处理策略
+   * - "merge":  同名合并到同一笔记本（默认；依赖后端按名复用）
+   * - "unique": 在本批次内自动编号 ("name", "name (2)", "name (3)"...)
+   */
+  duplicateStrategy?: "merge" | "unique";
+  /** perFileNotebook 启用时，清洗后为空的回退名 */
+  fallbackNotebookName?: string;
+  /**
+   * 显式指定导入目标 workspace。
+   * - undefined → 走 api 默认（即当前激活工作区）
+   * - "personal" → 落到个人空间（notes.workspaceId 写 NULL）
+   * - <workspaceId> → 落到指定工作区
+   * 与 exportAllNotes 的 workspaceId 选项配对：DataManager 拆分"个人空间 / 工作区"
+   * Tab 后，每个 Tab 各自传 scope，避免依赖侧边栏当前选中的 workspace。
+   */
+  workspaceId?: string;
+}
+
+export type ImportProgress = {
+  phase: "reading" | "uploading" | "done" | "error";
+  current: number;
+  total: number;
+  message: string;
+};
+
+// 支持的文件扩展名
+const SUPPORTED_EXTENSIONS = [".md", ".txt", ".markdown", ".html", ".htm", ".pdf"];
+
+// PDF 单文件大小上限：50 MB
+// 超过此值会直接抛出错误，避免浏览器内存爆掉或 pdfjs 解析超时。
+export const MAX_PDF_SIZE = 50 * 1024 * 1024;
+
+function isSupportedFile(name: string): boolean {
+  return SUPPORTED_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
+}
+
+function isPdfFile(name: string): boolean {
+  return name.toLowerCase().endsWith(".pdf");
+}
+
+/**
+ * 用 pdfjs-dist 从 PDF 抽取文本层并组装成 HTML。
+ *
+ * 设计要点：
+ * 1. 纯前端、按需懒加载，避免影响首屏体积；
+ * 2. 仅依赖 PDF 的「文本层」(getTextContent)，不做 OCR——
+ *    扫描件 PDF 没有文本层时返回空字符串，由调用方决定如何提示用户；
+ * 3. 通过 y 坐标聚合同一行的 text item，再按段落空行切分，
+ *    保证导入后每段独立成 <p>，而不是整篇挤成一坨；
+ * 4. 不显式指定 workerSrc，使用 pdfjs 自带的 worker 入口；
+ *    若运行环境拒绝创建 worker，会回退到主线程解析（pdfjs 内部已处理）。
+ */
+async function extractPdfToHtml(buffer: ArrayBuffer): Promise<string> {
+  // 动态加载，避免与首屏耦合；这里用兼容版（legacy）以最大化浏览器/移动端兼容性
+  const pdfjs: any = await import("pdfjs-dist/legacy/build/pdf.mjs");
+
+  // pdfjs v4 强制要求显式指定 workerSrc（不再支持空字符串/fake worker），
+  // 否则会抛 'No "GlobalWorkerOptions.workerSrc" specified'。
+  // 使用 Vite 的 `?url` 后缀 import：Vite 会在构建期将 worker 文件作为独立资源
+  // 拷贝到 dist，并在开发期由 dev server 直接以正确的 MIME (module) 提供，
+  // 比硬编码 CDN 更稳，也无需联网。
+  if (pdfjs.GlobalWorkerOptions && !pdfjs.GlobalWorkerOptions.workerSrc) {
+    // Vite 的 `?url` 后缀 import 由 vite/client 提供类型声明，TS 能正确推断
+    const workerUrl = (await import("pdfjs-dist/legacy/build/pdf.worker.mjs?url")).default;
+    pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+  }
+
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(buffer),
+    // 关闭外部 cmap/standardFont 远程下载，离线/内网环境也能解析
+    isEvalSupported: false,
+    useSystemFonts: true,
+  });
+  const pdf = await loadingTask.promise;
+
+  const htmlParts: string[] = [];
+  // 跟踪是否抽取到任何可见文本。
+  //
+  // 历史 bug：早先只用 `html.trim()` 判断 PDF 是否有文本层，
+  // 但 `htmlParts` 在多页文档中会塞页分隔符 "<p></p>"——一份"扫描件 / 全图 PDF"
+  // 跑下来 lineTexts 全空，htmlParts 却堆了 N-1 个 "<p></p>"，
+  // `html.trim()` 不再为空，于是绕过 OCR 提示，建出一条**0 词 0 字符**的空笔记。
+  // 这里独立用 hasAnyText 计数，保证只统计实际有内容的行。
+  let hasAnyText = false;
+  let extractedLineCount = 0;
+
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+
+    // 把同一行的 item 按 y 坐标聚合（pdfjs 的 transform[5] 是 y）
+    // 行间允许 ±2 像素的浮动误差
+    type Line = { y: number; items: { x: number; str: string }[] };
+    const lines: Line[] = [];
+
+    for (const it of content.items as any[]) {
+      const str: string = typeof it.str === "string" ? it.str : "";
+      if (!str) continue;
+      const tr = it.transform as number[] | undefined;
+      const x = tr ? tr[4] : 0;
+      const y = tr ? tr[5] : 0;
+
+      // 找一条 y 接近的现有行
+      let target = lines.find((l) => Math.abs(l.y - y) < 2);
+      if (!target) {
+        target = { y, items: [] };
+        lines.push(target);
+      }
+      target.items.push({ x, str });
+      // 处理 pdfjs 标记的「行尾」hasEOL：手动断行
+      if (it.hasEOL) {
+        target = { y: y - 0.001, items: [] };
+        lines.push(target);
+      }
+    }
+
+    // 行内按 x 排序后拼接；行整体按 y 从大到小（PDF 坐标系自上而下 y 递减）
+    lines.sort((a, b) => b.y - a.y);
+    const lineTexts: string[] = lines
+      .map((line) => {
+        line.items.sort((a, b) => a.x - b.x);
+        // 行末尾的空白裁掉，但行内空白保留（中文 PDF 里空格分词常有意义）
+        return line.items.map((i) => i.str).join("").replace(/\s+$/g, "");
+      })
+      // 这里同时过滤"看起来非空但只有不可见字符"的行——
+      // 部分 PDF 的文本层会含 \u0000 / \u00A0 / \u200B（零宽空格）等，
+      // 视觉上是空，却让 .length > 0 通过。
+      .filter((t) => /\S/.test(t.replace(/[\u0000-\u001f\u007f\u200b\u200c\u200d\u2060\ufeff]/g, "")));
+
+    // 段落聚合：连续非空行视为同一段，遇到空行/原始空行边界则分段
+    // 由于上面已 filter 掉空行，这里把每个 lineText 视为独立段落即可
+    // —— 对于普通文本 PDF 这种处理已能得到清晰的段落分隔（每行一个 <p>）
+    for (const lt of lineTexts) {
+      const escaped = lt
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      htmlParts.push(`<p>${escaped}</p>`);
+      hasAnyText = true;
+      extractedLineCount++;
+    }
+
+    // 页与页之间空一行，便于后续编辑。
+    // 注意：仅在 hasAnyText 已经成立时才插入页分隔符——否则一份纯扫描件
+    // 会因为 N-1 个 "<p></p>" 让 html.trim() 看起来非空，绕过 OCR 提示。
+    if (pageNum < pdf.numPages && hasAnyText) {
+      htmlParts.push("<p></p>");
+    }
+  }
+
+  // 主动释放资源，避免 worker/document 句柄堆积
+  try { await pdf.destroy(); } catch { /* ignore */ }
+
+  // 真正没抽到任何可见文本——直接返回空串，由调用方抛 PDF_NO_TEXT_LAYER_FLAG，
+  // 弹"该 PDF 无可提取文本，请使用 OCR 工具处理后再导入"。
+  if (!hasAnyText) {
+    return "";
+  }
+
+  // 调试日志：抽到了多少行有效文本、文档总页数。
+  // 用户反馈"导入后笔记是空的"时，第一时间能在 console 看到 lineCount 区分
+  // "前端抽取阶段就空" vs "抽取正常但下游被吞"。
+  // 仅 dev 环境输出，避免线上 console 噪音；Vite 的 import.meta.env.DEV 在打包时被 inline。
+  if (import.meta.env.DEV) {
+    console.info(`[importService] PDF extracted: ${extractedLineCount} lines from ${pdf.numPages} page(s)`);
+  }
+
+  return htmlParts.join("\n");
+}
+
+// PDF 无可提取文本时抛出的错误标志（DataManager 层据此弹出 OCR 提示）
+export const PDF_NO_TEXT_LAYER_FLAG = "__PDF_NO_TEXT_LAYER__";
+
+// PDF 文件超过大小上限时抛出的错误标志
+export const PDF_TOO_LARGE_FLAG = "__PDF_TOO_LARGE__";
+
+// 笔记本名的最大长度（超出会被截断），与后端 notebooks.name 字段兼容
+const MAX_NOTEBOOK_NAME_LENGTH = 60;
+// 默认笔记本名（清洗后为空时的回退）
+const DEFAULT_FALLBACK_NOTEBOOK_NAME = "导入的笔记";
+
+/**
+ * 从文件名派生出一个合法的笔记本名
+ * 处理：
+ * 1. 去掉已知的笔记扩展名（.md/.txt/.markdown/.html/.htm）
+ * 2. 路径分隔符仅保留最后一段（兼容 webkitRelativePath）
+ * 3. 剥离 Windows/跨平台非法字符（<>:"/\|?*）和控制字符
+ * 4. 合并多余空白、裁剪首尾空白和点号
+ * 5. 长度超限则按视觉字符截断
+ * 6. 为空时返回 null（调用方决定回退）
+ */
+export function deriveNotebookNameFromFile(fileName: string): string | null {
+  if (!fileName || typeof fileName !== "string") return null;
+
+  // 只取最后一段（例如 webkitRelativePath: "folder/a.md" -> "a.md"）
+  const base = fileName.split(/[\\/]+/).pop() || fileName;
+
+  // 去掉支持的扩展名（含 .pdf）
+  let name = base;
+  for (const ext of SUPPORTED_EXTENSIONS) {
+    if (name.toLowerCase().endsWith(ext)) {
+      name = name.slice(0, -ext.length);
+      break;
+    }
+  }
+
+  // 剥离控制字符 + 跨平台非法字符
+  // eslint-disable-next-line no-control-regex
+  name = name.replace(/[\u0000-\u001f\u007f<>:"/\\|?*]+/g, " ");
+
+  // 合并空白 & 去首尾 .、空格（Windows 不允许以点号或空格结尾）
+  name = name.replace(/\s+/g, " ").replace(/^[\s.]+|[\s.]+$/g, "");
+
+  if (!name) return null;
+
+  // 长度裁剪（按 code point 计，避免截断到代理对中间）
+  if ([...name].length > MAX_NOTEBOOK_NAME_LENGTH) {
+    name = [...name].slice(0, MAX_NOTEBOOK_NAME_LENGTH).join("").trim();
+  }
+
+  return name || null;
+}
+
+/**
+ * 在批次内对同名笔记本自动编号：name -> name, name (2), name (3) ...
+ * 保持与 `getOrCreateNotebookByName` 幂等性兼容（后端按完整名字找/建）
+ */
+function uniquifyNotebookName(name: string, used: Map<string, number>): string {
+  const count = used.get(name) || 0;
+  used.set(name, count + 1);
+  if (count === 0) return name;
+  return `${name} (${count + 1})`;
+}
+
+function isHtmlFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower.endsWith(".html") || lower.endsWith(".htm");
+}
+
+// 检测 HTML 内容来源（手机品牌）
+function detectHtmlSource(html: string, fileName: string): string {
+  const lower = html.toLowerCase();
+  if (lower.includes("mi note") || lower.includes("小米笔记") || lower.includes("miui") || lower.includes("xiaomi")) return "xiaomi";
+  if (lower.includes("coloros") || lower.includes("oppo") || lower.includes("oplus")) return "oppo";
+  if (lower.includes("vivo") || lower.includes("funtouch") || lower.includes("originos")) return "vivo";
+  if (lower.includes("oneplus") || lower.includes("一加") || lower.includes("h2os") || lower.includes("oxygenos")) return "oneplus";
+  if (isHtmlFile(fileName)) return "html";
+  return "md";
+}
+
+// 清理 HTML 内容：去除多余标签、样式、脚本，保留核心内容
+function cleanHtmlContent(html: string): string {
+  let content = html;
+
+  // 移除 script 和 style 标签及其内容
+  content = content.replace(/<script[\s\S]*?<\/script>/gi, "");
+  content = content.replace(/<style[\s\S]*?<\/style>/gi, "");
+
+  // 移除 HTML 注释
+  content = content.replace(/<!--[\s\S]*?-->/g, "");
+
+  // 移除 head 部分
+  content = content.replace(/<head[\s\S]*?<\/head>/gi, "");
+
+  // 提取 body 内容（如果有）
+  const bodyMatch = content.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  if (bodyMatch) {
+    content = bodyMatch[1];
+  }
+
+  // 移除所有内联样式属性
+  content = content.replace(/\s+style="[^"]*"/gi, "");
+  content = content.replace(/\s+class="[^"]*"/gi, "");
+  content = content.replace(/\s+id="[^"]*"/gi, "");
+
+  // 移除 data-* 属性（保留 tiptap 需要的）
+  content = content.replace(/\s+data-(?!type|checked)[a-z-]+="[^"]*"/gi, "");
+
+  // 移除空的 span/div 标签
+  content = content.replace(/<span[^>]*>\s*<\/span>/gi, "");
+  content = content.replace(/<div[^>]*>\s*<\/div>/gi, "");
+
+  // 将 div 转为 p（常见于手机笔记）
+  content = content.replace(/<div[^>]*>/gi, "<p>");
+  content = content.replace(/<\/div>/gi, "</p>");
+
+  // 将 br 转为段落分隔
+  content = content.replace(/<br\s*\/?>\s*<br\s*\/?>/gi, "</p><p>");
+  content = content.replace(/<br\s*\/?>/gi, "</p><p>");
+
+  // 清理嵌套的空 p 标签
+  content = content.replace(/<p>\s*<\/p>/gi, "");
+
+  // 去除前后空白
+  content = content.trim();
+
+  // 如果清理后没有任何 HTML 标签，包裹在 p 中
+  if (!content.match(/<[a-z]/i)) {
+    content = content
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => `<p>${line.trim()}</p>`)
+      .join("\n");
+  }
+
+  return content;
+}
+
+// 从 HTML 中提取标题
+function extractTitleFromHtml(html: string, fallbackTitle: string): string {
+  // 尝试从 <title> 标签提取
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch && titleMatch[1].trim()) {
+    return titleMatch[1].trim();
+  }
+  // 尝试从第一个 h1/h2 提取
+  const headingMatch = html.match(/<h[12][^>]*>([\s\S]*?)<\/h[12]>/i);
+  if (headingMatch && headingMatch[1].trim()) {
+    return headingMatch[1].replace(/<[^>]+>/g, "").trim();
+  }
+  return fallbackTitle;
+}
+
+// 读取拖入的文件列表
+//
+// 增强：
+// 1. 同批次内的图片文件（png/jpg/gif/webp/svg/bmp/ico）会被读取为 base64 data URI，
+//    构建一个 imageMap 并附加到每个 md/txt/html 笔记上。
+//    这样用户"同时选中 md + 相对路径下的图片"即可恢复图片引用，不必先打成 zip。
+// 2. 若 File 带有 webkitRelativePath（来自 <input webkitdirectory> 或拖拽目录），
+//    会同时按相对路径与文件名建立两条索引，提高命中率。
+export async function readMarkdownFiles(
+  files: FileList | File[]
+): Promise<ImportFileInfo[]> {
+  const result: ImportFileInfo[] = [];
+  const fileArray = Array.from(files);
+
+  // —— 第一轮：扫描所有图片文件，构建 imageMap ——
+  const imageMap: Record<string, string> = {};
+  for (const file of fileArray) {
+    if (!isImageFile(file.name)) continue;
+    try {
+      // 读成 ArrayBuffer 再转 base64，避免 FileReader 的异步嵌套
+      const buf = await file.arrayBuffer();
+      const base64 = arrayBufferToBase64(buf);
+      const mime = getImageMime(file.name);
+      const dataUri = `data:${mime};base64,${base64}`;
+
+      // 键：文件名（不含路径），以及 webkitRelativePath 提供的相对路径
+      const relPath = (file as any).webkitRelativePath as string | undefined;
+      if (relPath) {
+        imageMap[relPath] = dataUri;
+        // 去掉顶层目录后的路径（与 md 里 `./images/a.png` 这种更接近）
+        const parts = relPath.split("/");
+        if (parts.length > 1) {
+          imageMap[parts.slice(1).join("/")] = dataUri;
+        }
+      }
+      if (!imageMap[file.name]) {
+        imageMap[file.name] = dataUri;
+      }
+    } catch (err) {
+      console.warn("读取本地图片失败:", file.name, err);
+    }
+  }
+  const hasImages = Object.keys(imageMap).length > 0;
+
+  // —— 第二轮：读取笔记文件 ——
+  for (const file of fileArray) {
+    if (!isSupportedFile(file.name)) continue;
+
+    const fileNameTitle = file.name.replace(/\.(md|txt|markdown|html|htm|pdf)$/i, "");
+
+    // PDF：单独走 pdfjs 抽取文本层
+    if (isPdfFile(file.name)) {
+      if (file.size > MAX_PDF_SIZE) {
+        const err = new Error(`${PDF_TOO_LARGE_FLAG}:${file.name}`);
+        (err as any).flag = PDF_TOO_LARGE_FLAG;
+        (err as any).fileName = file.name;
+        throw err;
+      }
+      try {
+        const buf = await file.arrayBuffer();
+        const html = await extractPdfToHtml(buf);
+        if (!html.trim()) {
+          const err = new Error(`${PDF_NO_TEXT_LAYER_FLAG}:${file.name}`);
+          (err as any).flag = PDF_NO_TEXT_LAYER_FLAG;
+          (err as any).fileName = file.name;
+          throw err;
+        }
+        result.push({
+          name: file.name,
+          title: fileNameTitle,
+          content: html,
+          size: file.size,
+          selected: true,
+          source: "pdf",
+          imageMap: hasImages ? imageMap : undefined,
+        });
+      } catch (err: any) {
+        // 已经携带 flag 的错误（无文本层 / 文件过大）原样上抛由 UI 提示
+        if (err && err.flag) throw err;
+        // 其他解析失败：包装成统一错误
+        console.error("PDF 解析失败:", file.name, err);
+        const wrapped = new Error(`PDF 解析失败：${file.name}`);
+        (wrapped as any).fileName = file.name;
+        throw wrapped;
+      }
+      continue;
+    }
+
+    const text = await file.text();
+
+    if (isHtmlFile(file.name)) {
+      const source = detectHtmlSource(text, file.name);
+      const title = extractTitleFromHtml(text, fileNameTitle);
+      result.push({
+        name: file.name,
+        title,
+        content: text,
+        size: file.size,
+        selected: true,
+        source,
+        imageMap: hasImages ? imageMap : undefined,
+      });
+    } else {
+      result.push({
+        name: file.name,
+        title: fileNameTitle,
+        content: text,
+        size: file.size,
+        selected: true,
+        source: file.name.endsWith(".txt") ? "txt" : "md",
+        imageMap: hasImages ? imageMap : undefined,
+      });
+    }
+  }
+
+  return result;
+}
+
+// 把 ArrayBuffer 编码成 base64（避免使用 FileReader 的链式回调）
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  return btoa(binary);
+}
+
+// 图片扩展名 → MIME 类型
+const IMAGE_MIME_MAP: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+};
+
+function isImageFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  const ext = lower.split(".").pop() || "";
+  return ext in IMAGE_MIME_MAP;
+}
+
+function getImageMime(name: string): string {
+  const ext = (name.toLowerCase().split(".").pop() || "") as string;
+  return IMAGE_MIME_MAP[ext] || "application/octet-stream";
+}
+
+// 从 zip 内部路径推导笔记本名（取第一级目录名）
+function deriveNotebookName(path: string): string | undefined {
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length < 2) return undefined; // 文件位于根目录
+  const first = parts[0];
+  // 过滤常见的无意义目录
+  if (first.startsWith(".") || first === "__MACOSX" || first.toLowerCase() === "assets" || first.toLowerCase() === "images") {
+    return undefined;
+  }
+  return first;
+}
+
+// 清洗单个路径片段（目录名），规则与 deriveNotebookNameFromFile 一致但不去扩展名
+function sanitizeSegment(segment: string): string | null {
+  if (!segment) return null;
+  let s = segment;
+  // 剥离控制字符 + 跨平台非法字符
+  // eslint-disable-next-line no-control-regex
+  s = s.replace(/[\u0000-\u001f\u007f<>:"/\\|?*]+/g, " ");
+  // 合并空白 & 去首尾 .、空格
+  s = s.replace(/\s+/g, " ").replace(/^[\s.]+|[\s.]+$/g, "");
+  if (!s) return null;
+  // 长度裁剪
+  if ([...s].length > MAX_NOTEBOOK_NAME_LENGTH) {
+    s = [...s].slice(0, MAX_NOTEBOOK_NAME_LENGTH).join("").trim();
+  }
+  return s || null;
+}
+
+/**
+ * 从 zip 内部路径推导完整的笔记本层级路径。
+ * 例如 path = "我是文章2/test2/新笔记本/note.md"
+ *      -> ["我是文章2", "test2", "新笔记本"]
+ * 返回的数组顺序为从根到叶。
+ *
+ * 过滤规则：
+ * - 跳过 "__MACOSX"、以 "." 开头的隐藏目录
+ * - 跳过 "assets" / "images" 等纯资源目录（仅当它们出现在中间或末端且不是唯一目录时）
+ * - 每段经过 sanitizeSegment 清洗
+ */
+function deriveNotebookPath(path: string, outerFolderName?: string): string[] {
+  const parts = path.split("/").filter(Boolean);
+  // 最后一段是文件名，不算笔记本
+  const dirParts = parts.slice(0, -1);
+
+  const result: string[] = [];
+  for (const raw of dirParts) {
+    // 过滤无意义目录
+    if (raw.startsWith(".") || raw === "__MACOSX") continue;
+    const lower = raw.toLowerCase();
+    if (lower === "assets" || lower === "images") continue;
+    const cleaned = sanitizeSegment(raw);
+    if (cleaned) result.push(cleaned);
+  }
+
+  // 如果提供了最外层文件夹名（zip 文件名派生），并且它还没作为第一段出现，则前置
+  if (outerFolderName) {
+    if (result.length === 0 || result[0] !== outerFolderName) {
+      result.unshift(outerFolderName);
+    }
+  }
+
+  return result;
+}
+
+// 从 ZIP 文件中读取笔记
+export async function readMarkdownFromZip(file: File): Promise<ImportFileInfo[]> {
+  const r = await readMarkdownFromZipWithMeta(file);
+  return r.files;
+}
+
+/**
+ * P1-2：从导出 zip 里同时拿到笔记 + metadata.json 内容。
+ *
+ * 旧 `readMarkdownFromZip` 只返回 ImportFileInfo[]，丢弃了 metadata.json 里
+ * `rootNotebookId / rootNotebookName / scope` 等信息——这些信息在"把同一份
+ * 备份导回原笔记本"的场景里非常有用：DataManager 可据此自动预选目标笔记本，
+ * 而不是每次都把内容塞进默认的"导入的笔记"。
+ *
+ * 设计取舍：
+ *   - 不强行把 metadata.json 暴露到 ImportFileInfo 里，保持原数据结构稳定；
+ *   - 旧调用方 `readMarkdownFromZip` 行为不变（continue 跳过 metadata.json）；
+ *   - 新调用方走 `readMarkdownFromZipWithMeta`，按需消费 metadata。
+ *
+ * metadata 字段说明（与 exportService 一致）：
+ *   { version, app, exportedAt,
+ *     scope?: "notebook" | undefined,           // 仅 exportNotebook 设置
+ *     rootNotebookId?: string,                  // 仅 exportNotebook 设置
+ *     rootNotebookName?: string,                // 仅 exportNotebook 设置
+ *     totalNotes: number,
+ *     notebooks: { name, count }[],
+ *     imageStats?: { ok, failed }                // 新增字段，旧包没有
+ *   }
+ */
+export interface ZipImportMeta {
+  version?: string;
+  app?: string;
+  exportedAt?: string;
+  scope?: string;
+  rootNotebookId?: string;
+  rootNotebookName?: string;
+  totalNotes?: number;
+  notebooks?: Array<{ name: string; count: number }>;
+  imageStats?: { ok: number; failed: number };
+}
+
+export async function readMarkdownFromZipWithMeta(
+  file: File,
+): Promise<{ files: ImportFileInfo[]; meta: ZipImportMeta | null }> {
+  const JSZip = (await import("jszip")).default;
+  const zip = await JSZip.loadAsync(file);
+  const result: ImportFileInfo[] = [];
+
+  // P1-2：先试读 metadata.json（如果是本应用导出的 zip，根目录会有）
+  let meta: ZipImportMeta | null = null;
+  const metaEntry = zip.file("metadata.json");
+  if (metaEntry) {
+    try {
+      const text = await metaEntry.async("text");
+      const parsed = JSON.parse(text) as ZipImportMeta;
+      // 轻量边界检查：只认可 nowen-note 自家导出的 metadata，避免被外部 zip
+      // 中的同名文件误认（用户可能上传个包含 metadata.json 的项目压缩包）。
+      if (parsed && parsed.app === "nowen-note") {
+        meta = parsed;
+      }
+    } catch (e) {
+      // 解析失败不中断导入，仅告知调用方 meta=null
+      console.warn("解析 metadata.json 失败，将忽略该文件：", e);
+    }
+  }
+
+  // 用 zip 文件名（去掉 .zip 扩展）作为最外层笔记本名，保证"导出前的顶层目录"在导入后依然存在
+  const rawZipBase = (file.name || "archive.zip").replace(/\.zip$/i, "");
+  const outerFolderName = sanitizeSegment(rawZipBase) || "导入的笔记";
+
+  // 第一轮：扫描所有图片文件，构建路径 → base64 的映射
+  const imageMap: Record<string, string> = {};
+  for (const [path, zipEntry] of Object.entries(zip.files)) {
+    if (zipEntry.dir) continue;
+    if (path.includes("__MACOSX") || path.startsWith(".")) continue;
+    if (!isImageFile(path)) continue;
+    try {
+      const base64 = await zipEntry.async("base64");
+      const mime = getImageMime(path);
+      const dataUri = `data:${mime};base64,${base64}`;
+      // 同时用完整路径和文件名做 key，提升相对路径匹配命中率
+      imageMap[path] = dataUri;
+      const fileName = path.split("/").pop();
+      if (fileName && !imageMap[fileName]) {
+        imageMap[fileName] = dataUri;
+      }
+    } catch (err) {
+      console.warn("读取 zip 图片失败:", path, err);
+    }
+  }
+
+  // 第二轮：扫描笔记文件
+  for (const [path, zipEntry] of Object.entries(zip.files)) {
+    if (zipEntry.dir) continue;
+    if (!isSupportedFile(path)) continue;
+    if (path === "metadata.json") continue;
+    if (path === "export-warnings.json") continue;
+    // 跳过 macOS 资源文件
+    if (path.includes("__MACOSX") || path.startsWith(".")) continue;
+
+    const fileName = path.split("/").pop() || path;
+    const fileNameTitle = fileName.replace(/\.(md|txt|markdown|html|htm|pdf)$/i, "");
+
+    // PDF：从 zip 内部条目走二进制 → pdfjs 抽文本
+    if (isPdfFile(fileName)) {
+      const notebookPath = deriveNotebookPath(path, outerFolderName);
+      const notebookName = notebookPath.length > 0 ? notebookPath[notebookPath.length - 1] : undefined;
+      try {
+        const arr = await zipEntry.async("uint8array");
+        if (arr.byteLength > MAX_PDF_SIZE) {
+          const err = new Error(`${PDF_TOO_LARGE_FLAG}:${fileName}`);
+          (err as any).flag = PDF_TOO_LARGE_FLAG;
+          (err as any).fileName = fileName;
+          throw err;
+        }
+        // 复制成独立 ArrayBuffer，避免 jszip 内部缓冲被复用
+        const buf = arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength);
+        const html = await extractPdfToHtml(buf);
+        if (!html.trim()) {
+          const err = new Error(`${PDF_NO_TEXT_LAYER_FLAG}:${fileName}`);
+          (err as any).flag = PDF_NO_TEXT_LAYER_FLAG;
+          (err as any).fileName = fileName;
+          throw err;
+        }
+        result.push({
+          name: path,
+          title: fileNameTitle,
+          content: html,
+          size: arr.byteLength,
+          selected: true,
+          source: "pdf",
+          notebookName,
+          notebookPath,
+          imageMap,
+        });
+      } catch (err: any) {
+        if (err && err.flag) throw err;
+        console.error("PDF 解析失败:", path, err);
+        const wrapped = new Error(`PDF 解析失败：${fileName}`);
+        (wrapped as any).fileName = fileName;
+        throw wrapped;
+      }
+      continue;
+    }
+
+    const text = await zipEntry.async("text");
+    // 完整层级：zip 文件名（最外层） + zip 内部所有中间目录
+    const notebookPath = deriveNotebookPath(path, outerFolderName);
+    // notebookName 保留为末级目录名（向后兼容 & 日志用）
+    const notebookName = notebookPath.length > 0 ? notebookPath[notebookPath.length - 1] : undefined;
+
+    if (isHtmlFile(fileName)) {
+      const source = detectHtmlSource(text, fileName);
+      const title = extractTitleFromHtml(text, fileNameTitle);
+      result.push({
+        name: path,
+        title,
+        content: text,
+        size: text.length,
+        selected: true,
+        source,
+        notebookName,
+        notebookPath,
+        imageMap,
+      });
+    } else {
+      result.push({
+        name: path,
+        title: fileNameTitle,
+        content: text,
+        size: text.length,
+        selected: true,
+        source: fileName.endsWith(".txt") ? "txt" : "md",
+        notebookName,
+        notebookPath,
+        imageMap,
+      });
+    }
+  }
+
+  return { files: result, meta };
+}
+
+// 从 YAML frontmatter 中提取日期信息
+function extractFrontmatterDates(md: string): { createdAt?: string; updatedAt?: string } {
+  const fmMatch = md.match(/^---\n([\s\S]*?)\n---/m);
+  if (!fmMatch) return {};
+
+  const fm = fmMatch[1];
+  let createdAt: string | undefined;
+  let updatedAt: string | undefined;
+
+  const createdMatch = fm.match(/^created:\s*(.+)$/m);
+  if (createdMatch) createdAt = createdMatch[1].trim();
+
+  const updatedMatch = fm.match(/^updated:\s*(.+)$/m);
+  if (updatedMatch) updatedAt = updatedMatch[1].trim();
+
+  return { createdAt, updatedAt };
+}
+
+// 脱壳：整段被 ```markdown ... ``` 外层围栏包裹的场景（常见于从博客/ChatGPT 复制）
+// 识别规则：首个非空行是 ```[markdown|md|空] 开围栏 + 末尾存在一个"单独成行的 ```"闭合围栏，
+// 且二者之间没有其他同级 lang=markdown/md 的开围栏（避免误剥真正的代码块）。
+function unwrapOuterMarkdownFence(content: string): string {
+  const lines = content.split("\n");
+  // 首个非空行
+  let start = 0;
+  while (start < lines.length && !lines[start].trim()) start++;
+  if (start >= lines.length) return content;
+
+  const opener = lines[start].trim();
+  const openMatch = opener.match(/^(`{3,}|~{3,})(.*)$/);
+  if (!openMatch) return content;
+  const fence = openMatch[1];
+  const fenceChar = fence[0];
+  const fenceLen = fence.length;
+  const langToken = (openMatch[2] || "").trim().split(/\s+/)[0] || "";
+  // 仅处理 lang 为 markdown/md/空 的外层围栏；其他语言（如 bash、js）不应被脱壳
+  if (langToken && !/^(markdown|md)$/i.test(langToken)) return content;
+
+  // 末尾非空行应是闭合围栏
+  let end = lines.length - 1;
+  while (end > start && !lines[end].trim()) end--;
+  if (end <= start) return content;
+
+  const isClosingFence = (rawLine: string): boolean => {
+    const t = rawLine.trim();
+    if (t.length < fenceLen) return false;
+    let k = 0;
+    while (k < t.length && t[k] === fenceChar) k++;
+    if (k < fenceLen) return false;
+    const rest = t.slice(k);
+    return rest.length === 0 || /^\s*$/.test(rest);
+  };
+  if (!isClosingFence(lines[end])) return content;
+
+  // 返回剥掉外层后的内容
+  return lines.slice(start + 1, end).join("\n");
+}
+
+// 将 Markdown 转为 HTML（用于存储到 Tiptap 格式）
+export function markdownToSimpleHtml(md: string, imageMap?: Record<string, string>): string {
+  // 去除 YAML frontmatter
+  // 注意：必须锁定"字符串最开头"且 --- 独占整行，否则会把文档中任意两个水平线
+  // `---` 之间的内容整段吃掉（曾导致粘贴含有多个 --- 分隔线的 MD 时大量内容丢失）。
+  let content = md.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "");
+
+  // 脱壳：整段被 ```markdown ... ``` 包裹时，剥掉外层
+  content = unwrapOuterMarkdownFence(content);
+
+  // 使用 marked 解析 Markdown → HTML
+  // marked 是业界成熟的 CommonMark 兼容解析器，正确处理嵌套围栏代码块、表格、任务列表等
+  const renderer = new Renderer();
+
+  // 图片：替换 imageMap 中的本地路径为 data URI
+  renderer.image = ({ href, title, text }: { href: string; title?: string | null; text: string }) => {
+    const resolvedSrc = resolveLocalAssetSrc(href, imageMap);
+    const titleAttr = title ? ` title="${title}"` : "";
+    return `<img src="${resolvedSrc}" alt="${text}"${titleAttr} />`;
+  };
+
+  // 代码块：输出 Tiptap 期望的 <pre><code class="language-xxx"> 格式
+  renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
+    const langClass = lang ? ` class="language-${lang}"` : "";
+    const escaped = text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+    return `<pre><code${langClass}>${escaped}</code></pre>`;
+  };
+
+  marked.use({ renderer, gfm: true, breaks: false });
+
+  const html = replaceLocalAssetSources(marked.parse(content) as string, imageMap);
+  // 规范化 marked 输出的 GFM 表格 HTML，使其符合 Tiptap table schema
+  // （否则带表格的 md 在下游 generateJSON 时会产出非法 content，触发
+  //  ProseMirror 的 "Called contentMatchAt on a node with invalid content"）
+  // 同时把 GFM 任务列表（- [x] / - [ ]）改写成 Tiptap TaskList 格式，
+  // 否则会被 schema 当成普通 <ul>，checkbox 直接丢失退化成无序列表。
+  return normalizeTaskListHtml(normalizeTableHtml(html));
+}
+
+function replaceLocalAssetSources(html: string, assetMap?: Record<string, string>): string {
+  if (!assetMap || !html || !/\s(?:src)=["']/i.test(html)) return html;
+
+  if (typeof DOMParser !== "undefined") {
+    try {
+      const doc = new DOMParser().parseFromString(`<div>${html}</div>`, "text/html");
+      const root = doc.body.firstElementChild;
+      if (!root) return html;
+      const elements = root.querySelectorAll("img[src], video[src], video source[src], audio[src], audio source[src]");
+      elements.forEach((el) => {
+        const src = el.getAttribute("src");
+        if (!src) return;
+        el.setAttribute("src", resolveLocalAssetSrc(src, assetMap));
+      });
+      return root.innerHTML;
+    } catch (e) {
+      console.warn("[importService] replaceLocalAssetSources DOM rewrite failed:", e);
+    }
+  }
+
+  return html.replace(
+    /(<(?:img|video|audio|source)\b[^>]*\ssrc=)(["'])([^"']+)(\2)/gi,
+    (_match, prefix: string, quote: string, src: string, suffix: string) =>
+      `${prefix}${quote}${resolveLocalAssetSrc(src, assetMap)}${suffix}`,
+  );
+}
+
+// 把 marked 输出的 GFM 任务列表 HTML 改写成 Tiptap TaskList/TaskItem 期望的形态。
+//
+// marked@14 输出（GFM 任务列表）：
+//   <ul>
+//     <li><input checked="" disabled="" type="checkbox"> 已完成项</li>
+//     <li><input disabled="" type="checkbox"> 未完成项</li>
+//   </ul>
+// Tiptap TaskList/TaskItem 期望的 parse 形态：
+//   <ul data-type="taskList">
+//     <li data-type="taskItem" data-checked="true"><p>已完成项</p></li>
+//     <li data-type="taskItem" data-checked="false"><p>未完成项</p></li>
+//   </ul>
+//
+// 不用正则是因为 li 内容可能含嵌套 <ul>（子任务）、链接、加粗等结构，
+// DOMParser 处理嵌套天然正确。在浏览器中开销 ~1ms，可接受。
+//
+// 关键规则：
+// - 只改写**直接子级含 <input type="checkbox"> 的 li**；普通 li 维持原样
+// - 包含至少一个 task li 的 ul 才标记为 taskList；纯无序列表不动
+// - data-checked 来源于 input 的 checked 属性
+// - input 节点本身从 li 中移除（Tiptap 渲染时会自己生成 checkbox）
+function normalizeTaskListHtml(html: string): string {
+  if (!html || html.indexOf("type=\"checkbox\"") === -1) return html;
+  // 服务端/测试环境无 DOMParser 时退化（不抛错，原样返回）
+  if (typeof DOMParser === "undefined") return html;
+
+  try {
+    const doc = new DOMParser().parseFromString(
+      `<div>${html}</div>`,
+      "text/html",
+    );
+    const root = doc.body.firstElementChild;
+    if (!root) return html;
+
+    // 自底向上遍历所有 ul：先处理嵌套的子 ul，再处理父 ul
+    // 这样父 li 被改写成 taskItem 时，里面已经处理过的子 taskList 不会被破坏
+    const allUls = Array.from(root.querySelectorAll("ul"));
+    for (const ul of allUls) {
+      const directLis = Array.from(ul.children).filter(
+        (el) => el.tagName === "LI",
+      ) as HTMLLIElement[];
+      let hasTaskItem = false;
+
+      for (const li of directLis) {
+        // li 的首个有效子元素必须是 input[type=checkbox] 才算任务项
+        const firstChild = li.firstElementChild;
+        if (
+          !firstChild ||
+          firstChild.tagName !== "INPUT" ||
+          (firstChild as HTMLInputElement).type !== "checkbox"
+        ) {
+          continue;
+        }
+        hasTaskItem = true;
+        const checked = (firstChild as HTMLInputElement).hasAttribute("checked");
+        // 移除 input，保留余下文本/元素作为 taskItem 的内容
+        firstChild.remove();
+        // marked 输出的 li 文本紧贴 input 后，通常是个空格开头，trim 掉
+        if (li.firstChild && li.firstChild.nodeType === 3) {
+          li.firstChild.nodeValue = (li.firstChild.nodeValue || "").replace(/^\s+/, "");
+        }
+        li.setAttribute("data-type", "taskItem");
+        li.setAttribute("data-checked", checked ? "true" : "false");
+        // Tiptap TaskItem schema 要求内容是 paragraph+。把直接子级的散文本/inline
+        // 节点包到一个 <p> 里；已经是 <p>/<ul>（嵌套子任务）等块级元素的不动。
+        wrapInlineChildrenInParagraph(li);
+      }
+
+      if (hasTaskItem) {
+        ul.setAttribute("data-type", "taskList");
+      }
+    }
+
+    return root.innerHTML;
+  } catch (e) {
+    console.warn("[importService] normalizeTaskListHtml failed:", e);
+    return html;
+  }
+}
+
+// 把元素的直接 inline 子节点（文本、<a>、<strong>、<code> 等）按相邻段聚合到
+// 单个 <p> 里。已经是块级（p/ul/ol/blockquote/pre/h1-h6/div）的子节点维持位置。
+// 用于满足 Tiptap TaskItem 的 "paragraph+ 内容" schema 要求。
+function wrapInlineChildrenInParagraph(el: Element): void {
+  const blockTags = new Set([
+    "P", "UL", "OL", "BLOCKQUOTE", "PRE", "H1", "H2", "H3", "H4", "H5", "H6",
+    "DIV", "TABLE", "HR",
+  ]);
+  const children = Array.from(el.childNodes);
+  let buffer: Node[] = [];
+  const flush = (insertBefore: Node | null) => {
+    if (buffer.length === 0) return;
+    // 全部为空白文本则不生成 <p>
+    const allWhitespace = buffer.every(
+      (n) => n.nodeType === 3 && !(n.nodeValue || "").trim(),
+    );
+    if (allWhitespace) {
+      buffer.forEach((n) => n.parentNode?.removeChild(n));
+      buffer = [];
+      return;
+    }
+    const p = el.ownerDocument!.createElement("p");
+    buffer.forEach((n) => p.appendChild(n));
+    el.insertBefore(p, insertBefore);
+    buffer = [];
+  };
+
+  for (const node of children) {
+    if (node.nodeType === 1 && blockTags.has((node as Element).tagName)) {
+      flush(node);
+    } else {
+      buffer.push(node);
+    }
+  }
+  flush(null);
+}
+
+// 规范化表格 HTML，让它能被 Tiptap 的 Table schema 接受。
+//
+// Tiptap 官方 @tiptap/extension-table 的 schema 要求：
+//   table > tableRow > (tableCell | tableHeader)
+// 它**不接受** <thead>/<tbody>/<tfoot> 作为 <table> 的直接子节点。
+//
+// 但 marked 在 gfm:true 下输出的标准表格是：
+//   <table><thead><tr>...</tr></thead><tbody><tr>...</tr></tbody></table>
+// 这会让 generateJSON 产出 schema 不合法的 JSON——init 时不报，但第一次
+// 经过 transaction 时（如 SearchReplacePanel 的 highlight decoration plugin）
+// 触发 contentMatchAt 抛错，整个编辑器白屏。
+//
+// 这里用最简的字符串替换把 <thead>/<tbody>/<tfoot> 标签剥掉（保留里面的
+// <tr>），并把 <th>/<td> 上的 align 属性删掉（Tiptap 默认表格不识别）。
+function normalizeTableHtml(html: string): string {
+  if (!html || html.indexOf("<table") === -1) return html;
+  return html
+    // 剥掉 <thead>/<tbody>/<tfoot> 包裹标签（保留内部 <tr>）
+    .replace(/<\/?(thead|tbody|tfoot)\b[^>]*>/gi, "")
+    // 删掉单元格上的 align 属性（marked 用来表示 :---: 对齐）
+    .replace(/(<t[hd])\s+align="[^"]*"/gi, "$1")
+    .replace(/(<t[hd])\s+align='[^']*'/gi, "$1");
+}
+
+// Layer 2 兜底：用一个离屏 Editor 把任意脏 HTML 修复成合 schema 的 JSON。
+//
+// 触发场景：normalizeTableHtml 没覆盖到的未知脏姿势（嵌套 list 异常、
+// 自定义标签、错配标签等）让 generateJSON 抛错，或产出空 doc。
+// ProseMirror 的 setContent 内置 schema fixup（丢非法子节点 / 补必需包裹），
+// 比手写规则鲁棒得多。代价：实例化一个 headless Editor，~10-20ms。
+//
+// 注意：Tiptap 4 的 Editor 构造函数在没传 element 时跑 headless 模式，
+// 不需要真实 DOM 节点。
+function repairHtmlViaHeadlessEditor(html: string): unknown | null {
+  let editor: Editor | null = null;
+  try {
+    editor = new Editor({
+      extensions: tiptapExtensions,
+      content: html,
+      // 静默丢弃非法内容而不是抛错；不设置时默认就是 false，这里写明意图
+      enableContentCheck: false,
+    });
+    return editor.getJSON();
+  } catch (e) {
+    console.warn("[importService] headless editor repair failed:", e);
+    return null;
+  } finally {
+    try { editor?.destroy(); } catch { /* ignore */ }
+  }
+}
+
+// 在 imageMap 中查找本地资源路径对应的 data URI
+function resolveLocalAssetSrc(src: string, imageMap?: Record<string, string>): string {
+  if (!imageMap) return src;
+  // 外链 / 绝对 URL / 已是 data URI，不处理
+  if (/^(https?:|data:|\/\/)/i.test(src)) return src;
+
+  // 去除查询参数和 hash
+  const clean = src.split(/[?#]/)[0];
+  // 直接命中
+  if (imageMap[clean]) return imageMap[clean];
+  // 规范化开头的 ./ 或 /
+  const normalized = clean.replace(/^\.\//, "").replace(/^\//, "");
+  if (imageMap[normalized]) return imageMap[normalized];
+  // 仅用文件名匹配
+  const base = normalized.split("/").pop();
+  if (base && imageMap[base]) return imageMap[base];
+  // 解码 URI（中文文件名在 md 中可能被 encode）
+  try {
+    const decoded = decodeURIComponent(normalized);
+    if (imageMap[decoded]) return imageMap[decoded];
+    const decodedBase = decoded.split("/").pop();
+    if (decodedBase && imageMap[decodedBase]) return imageMap[decodedBase];
+  } catch {
+    /* ignore */
+  }
+  return src;
+}
+
+function isSiyuanSource(source?: string): boolean {
+  return source === "siyuan" || source === "siyuan-sy";
+}
+
+function replaceMarkdownLocalAssets(md: string, imageMap?: Record<string, string>): string {
+  if (!imageMap || !md) return md;
+
+  const withMarkdownImages = md.replace(
+    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
+    (match, alt: string, rawSrc: string) => {
+      const src = String(rawSrc || "").trim();
+      if (/^(https?:|data:|\/\/)/i.test(src)) return match;
+      const resolved = resolveLocalAssetSrc(src, imageMap);
+      return `![${alt}](${resolved})`;
+    },
+  );
+
+  return replaceLocalAssetSources(withMarkdownImages, imageMap);
+}
+
+function convertSiyuanImportToMarkdown(fileInfo: ImportFileInfo): string {
+  let md = fileInfo.content || "";
+  md = md.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "");
+  md = replaceMarkdownLocalAssets(md, fileInfo.imageMap);
+  return md.trim();
+}
+
+// 处理行内 Markdown 语法
+function inlineMarkdown(text: string, imageMap?: Record<string, string>): string {
+  return (
+    text
+      // 图片（必须在链接之前处理）
+      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) => {
+        const resolved = resolveLocalAssetSrc(src.trim(), imageMap);
+        const escapedAlt = alt.replace(/"/g, "&quot;");
+        return `<img src="${resolved}" alt="${escapedAlt}" />`;
+      })
+      // 链接
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+      // 粗斜体
+      .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+      // 粗体
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      // 斜体
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      // 删除线
+      .replace(/~~(.+?)~~/g, "<s>$1</s>")
+      // 高亮
+      .replace(/==(.+?)==/g, "<mark>$1</mark>")
+      // 行内代码已废弃：剥离反引号，保留为纯文本（统一使用代码块）
+      .replace(/`([^`]+)`/g, "$1")
+  );
+}
+
+// 将纯文本转为 HTML
+function textToHtml(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return "";
+      // 转义 HTML 特殊字符
+      const escaped = trimmed
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      return `<p>${escaped}</p>`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+// 根据来源转换内容为 TipTap JSON 字符串
+export function convertToTiptapJson(fileInfo: ImportFileInfo): string {
+  const { content, source, imageMap } = fileInfo;
+
+  let html: string;
+  switch (source) {
+    case "pdf":
+      // PDF 在读取阶段已被组装成纯净的 <p> HTML，不需要再次清洗或解析
+      html = content;
+      break;
+    case "html":
+    case "xiaomi":
+    case "oppo":
+    case "vivo":
+    case "oneplus":
+      html = cleanHtmlContent(content);
+      break;
+    case "txt":
+      html = textToHtml(content);
+      break;
+    case "md":
+    default:
+      html = markdownToSimpleHtml(content, imageMap);
+      break;
+  }
+
+  // 将 HTML 转为 TipTap JSON 格式（与编辑器保存格式一致）
+  //
+  // 两层防御：
+  //   Layer 1（已在 markdownToSimpleHtml 末尾做）：normalizeTableHtml 把
+  //     marked 产出的 <thead>/<tbody> 剥成 Tiptap 接受的形态；
+  //   Layer 2（此处）：generateJSON 仍可能在未知脏 HTML 上产出"内部不合
+  //     schema 的 JSON"——init 时不报、transaction 时崩。这里用一个
+  //     headless Editor 让 ProseMirror 的 setContent 走自家 schema fixup
+  //     兜底，保证任何 html 都能产出合 schema 的 JSON。
+  try {
+    const json = generateJSON(html, tiptapExtensions);
+
+    // 防御：generateJSON 在 schema 命中失败时不会抛错，而是吐出
+    // `{ type: "doc", content: [{ type: "paragraph" }] }` 这样的"空 doc"。
+    // 此时如果原 html 其实非空，先尝试 headless Editor 修复；仍失败再
+    // 回退到 HTML 字符串。
+    const looksEmpty =
+      json &&
+      json.type === "doc" &&
+      Array.isArray(json.content) &&
+      (json.content.length === 0 ||
+        (json.content.length === 1 &&
+          json.content[0]?.type === "paragraph" &&
+          !json.content[0]?.content));
+    if (looksEmpty && html.replace(/<[^>]+>/g, "").trim().length > 0) {
+      console.warn("[importService] generateJSON produced empty doc, retrying via headless editor");
+      const repaired = repairHtmlViaHeadlessEditor(html);
+      if (repaired) return JSON.stringify(repaired);
+      return html;
+    }
+
+    return JSON.stringify(json);
+  } catch (err) {
+    // generateJSON 抛错（最常见：parseHTML 出来的内容不满足某个 node 的
+    // contentMatch）。先试 headless Editor 修复，再回退 HTML 字符串。
+    console.warn("[importService] generateJSON threw, retrying via headless editor:", err);
+    const repaired = repairHtmlViaHeadlessEditor(html);
+    if (repaired) return JSON.stringify(repaired);
+    return html;
+  }
+}
+
+// 提取纯文本用于搜索索引
+export function extractPlainText(fileInfo: ImportFileInfo): string {
+  const { content, source } = fileInfo;
+
+  if (source === "pdf" || source === "html" || source === "xiaomi" || source === "oppo" || source === "vivo" || source === "oneplus") {
+    return content
+      .replace(/<script[\s\S]*?<\/script>/gi, "")
+      .replace(/<style[\s\S]*?<\/style>/gi, "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/&nbsp;/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  // Markdown / txt
+  return content
+    .replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "")
+    .replace(/[#*_~`\[\]()>|-]/g, "")
+    .trim();
+}
+
+// 执行导入
+export async function importNotes(
+  fileInfos: ImportFileInfo[],
+  notebookId?: string,
+  onProgress?: (p: ImportProgress) => void,
+  options?: ImportOptions
+): Promise<{ success: boolean; count: number }> {
+  const selected = fileInfos.filter((f) => f.selected);
+
+  if (selected.length === 0) {
+    onProgress?.({ phase: "error", current: 0, total: 0, message: i18n.t('dataManager.noFilesSelected') });
+    return { success: false, count: 0 };
+  }
+
+  // 解析导入选项
+  // 当用户明确选了目标笔记本（notebookId）时，perFileNotebook 被忽略（保持 UI 层互斥约定的最终保险）
+  const perFileNotebook = !notebookId && !!options?.perFileNotebook;
+  const duplicateStrategy = options?.duplicateStrategy ?? "merge";
+  const fallbackNotebookName =
+    (options?.fallbackNotebookName && options.fallbackNotebookName.trim()) ||
+    DEFAULT_FALLBACK_NOTEBOOK_NAME;
+
+  // 批次内"名字 -> 已出现次数"，用于 duplicateStrategy=unique 时自动编号
+  const usedNotebookNames = new Map<string, number>();
+
+  try {
+    onProgress?.({ phase: "uploading", current: 0, total: selected.length, message: i18n.t('dataManager.uploadingProgress') });
+
+    const notes = selected.map((f) => {
+      const importAsMarkdown = isSiyuanSource(f.source);
+      const note: { title: string; content: string; contentText: string; contentFormat?: "tiptap-json" | "markdown" | "html"; createdAt?: string; updatedAt?: string; notebookName?: string; notebookPath?: string[] } = {
+        title: f.title,
+        content: importAsMarkdown ? convertSiyuanImportToMarkdown(f) : convertToTiptapJson(f),
+        contentText: extractPlainText(f),
+        contentFormat: importAsMarkdown ? "markdown" : "tiptap-json",
+      };
+      // 对 Markdown 文件尝试提取 frontmatter 中的日期
+      if (f.source === "md" || !f.source) {
+        const dates = extractFrontmatterDates(f.content);
+        if (dates.createdAt) note.createdAt = dates.createdAt;
+        if (dates.updatedAt) note.updatedAt = dates.updatedAt;
+      }
+      if (f.createdAt) note.createdAt = f.createdAt;
+      if (f.updatedAt) note.updatedAt = f.updatedAt;
+
+      // —— 决定该笔记的 notebookName / notebookPath ——
+      // 优先级：perFileNotebook（覆盖式） > zip 路径派生 f.notebookPath > 扁平 f.notebookName > 无
+      if (perFileNotebook) {
+        // 从原始文件名派生；失败则回退到标题；仍失败则用 fallback
+        const derived =
+          deriveNotebookNameFromFile(f.name) ||
+          deriveNotebookNameFromFile(f.title) ||
+          fallbackNotebookName;
+        const finalName =
+          duplicateStrategy === "unique"
+            ? uniquifyNotebookName(derived, usedNotebookNames)
+            : derived;
+        note.notebookName = finalName;
+        // per-file 模式下视为单层路径
+        note.notebookPath = [finalName];
+      } else if (f.notebookPath && f.notebookPath.length > 0) {
+        // zip 导入：透传完整层级路径，后端按层级逐级查找/创建
+        note.notebookPath = f.notebookPath;
+        note.notebookName = f.notebookPath[f.notebookPath.length - 1];
+      } else if (f.notebookName) {
+        // 向后兼容：没有 notebookPath 时仍透传单层名字
+        note.notebookName = f.notebookName;
+      }
+      return note;
+    });
+
+    const result = await api.importNotes(notes, notebookId, undefined, options?.workspaceId);
+
+    onProgress?.({
+      phase: "done",
+      current: result.count,
+      total: selected.length,
+      message: i18n.t('dataManager.importSuccessCount', { count: result.count }),
+    });
+
+    return { success: true, count: result.count };
+  } catch (error) {
+    console.error("导入失败:", error);
+    onProgress?.({
+      phase: "error",
+      current: 0,
+      total: selected.length,
+      message: i18n.t('dataManager.importFailed', { error: (error as Error).message }),
+    });
+    return { success: false, count: 0 };
+  }
+}
+
+// =============================================================================
+// 单文件快速导入（拖拽专用）
+// -----------------------------------------------------------------------------
+// 与 importNotes 不同：不走 dialog/选择/分组那套批量流程，
+// 直接把一份 .md / .markdown / .txt 转成一条笔记落库。
+// 用于 NoteList 的"拖文件进来即导入"快捷路径，逻辑要尽量轻。
+// =============================================================================
+export interface ImportMarkdownAsNoteResult {
+  note: import("@/types").Note;
+  previewText: string;
+}
+
+const IMPORT_TEXT_MAX_SIZE = 10 * 1024 * 1024; // 10MB，足够覆盖绝大多数手写笔记
+
+export async function importMarkdownAsNote(params: {
+  notebookId: string;
+  file: File;
+}): Promise<ImportMarkdownAsNoteResult> {
+  const { notebookId, file } = params;
+  if (!file) throw new Error("未选择文件");
+  if (file.size > IMPORT_TEXT_MAX_SIZE) {
+    throw new Error(
+      `文件过大（${(file.size / 1024 / 1024).toFixed(1)} MB），上限 ${IMPORT_TEXT_MAX_SIZE / 1024 / 1024} MB`,
+    );
+  }
+
+  const text = await file.text();
+  const lower = file.name.toLowerCase();
+  const isMd = lower.endsWith(".md") || lower.endsWith(".markdown");
+  const source: ImportFileInfo["source"] = isMd ? "md" : "txt";
+
+  // 标题：md 优先取首个一级标题；否则用文件名（去扩展名）
+  const fileBaseName = file.name.replace(/\.(md|markdown|txt)$/i, "");
+  let title = fileBaseName;
+  if (isMd) {
+    const m = text.match(/^\s*#\s+(.+?)\s*$/m);
+    if (m && m[1].trim()) title = m[1].trim();
+  }
+
+  const fileInfo: ImportFileInfo = {
+    name: file.name,
+    title,
+    content: text,
+    size: text.length,
+    selected: true,
+    source,
+  };
+
+  const content = convertToTiptapJson(fileInfo);
+  const previewText = extractPlainText(fileInfo).slice(0, 200);
+
+  // md frontmatter 里若有 createdAt / updatedAt 就尊重它
+  const dates = isMd ? extractFrontmatterDates(text) : {};
+
+  const baseNote = (await api.createNote({ notebookId, title })) as import("@/types").Note;
+  const updated = (await api.updateNote(baseNote.id, {
+    content,
+    contentText: previewText,
+    version: baseNote.version,
+    ...(dates.createdAt ? { createdAt: dates.createdAt } : {}),
+    ...(dates.updatedAt ? { updatedAt: dates.updatedAt } : {}),
+  } as Partial<import("@/types").Note>)) as import("@/types").Note;
+
+  return { note: updated, previewText };
+}

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -1,1493 +1,187 @@
-import { api } from "./api";
-import { marked, Renderer } from "marked";
-import i18n from "i18next";
-import { Editor, generateJSON, Extension } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Image from "@tiptap/extension-image";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import Underline from "@tiptap/extension-underline";
-import Highlight from "@tiptap/extension-highlight";
-import TaskList from "@tiptap/extension-task-list";
-import TaskItem from "@tiptap/extension-task-item";
-import { Table, TableHeader, TableCell } from "@tiptap/extension-table";
-import { TableRowWithHeight } from "@/components/extensions/TableRowResizable";
-import TextAlign from "@tiptap/extension-text-align";
-import { common, createLowlight } from "lowlight";
-import { TextStyleKit } from "@/components/FontSizeExtension";
-import { Video as VideoExtension } from "@/components/VideoExtension";
-import { MathInline, MathBlock } from "@/components/MathExtensions";
-import { FootnoteReference, FootnoteDefinition } from "@/components/FootnoteExtensions";
+import { getBaseUrl } from "./api";
+import {
+  readMarkdownFromZipWithMeta as readMarkdownFromZipWithMetaBase,
+  importNotes as importNotesBase,
+} from "./importService.base";
+import type {
+  ImportFileInfo,
+  ImportOptions,
+  ImportProgress,
+  ZipImportMeta,
+} from "./importService.base";
 
-// BLOCK-ID-01-RV1: heading blockId 扩展（与 TiptapEditor / contentFormat 对齐）
-// 只声明 attrs，不带 appendTransaction plugin
-const BlockIdAttrs = Extension.create({
-  name: "blockId",
-  addGlobalAttributes() {
-    return [{
-      types: ["heading"],
-      attributes: {
-        blockId: {
-          default: null,
-          parseHTML: (element: HTMLElement) => element.getAttribute("data-block-id") || null,
-          renderHTML: (attributes: any) => {
-            if (!attributes.blockId) return {};
-            return { "data-block-id": attributes.blockId };
-          },
-        },
-      },
-    }];
-  },
-});
+export {
+  tiptapExtensions,
+  MAX_PDF_SIZE,
+  PDF_NO_TEXT_LAYER_FLAG,
+  PDF_TOO_LARGE_FLAG,
+  deriveNotebookNameFromFile,
+  readMarkdownFiles,
+  markdownToSimpleHtml,
+  convertToTiptapJson,
+  extractPlainText,
+  importMarkdownAsNote,
+} from "./importService.base";
+export type {
+  ImportFileInfo,
+  ImportOptions,
+  ImportProgress,
+  ZipImportMeta,
+  ImportMarkdownAsNoteResult,
+} from "./importService.base";
 
-const lowlight = createLowlight(common);
-
-// TipTap 扩展列表（与编辑器保持一致）
-// 导出供 tiptapSchemaRepair.ts 复用，避免再复制一份 schema 定义
-export const tiptapExtensions = [
-  StarterKit.configure({
-    codeBlock: false,
-    heading: { levels: [1, 2, 3, 4, 5, 6] },
-  }),
-  // BLOCK-LINKS-UI-01-RV3: 显式配置 Link 扩展，允许 note: 协议
-  // 避免 repairTiptapJson round-trip 时丢失 note link
-  Link.configure({
-    openOnClick: false,
-    autolink: true,
-    linkOnPaste: true,
-    protocols: ["http", "https", "mailto", "note"],
-    HTMLAttributes: {
-      target: "_blank",
-      rel: "noopener noreferrer nofollow",
-    },
-  }),
-  // 与 TiptapEditor 保持一致：图片是 inline 节点，必须位于 paragraph/listItem
-  // 等 inlineContent 容器内。否则 repairTiptapJson 会保留历史 doc > image 结构，
-  // 主编辑器加载后任意 transaction 都会触发 contentMatchAt 崩溃。
-  Image.configure({ inline: true, allowBase64: true }),
-  CodeBlockLowlight.configure({ lowlight }),
-  Underline,
-  Highlight.configure({ multicolor: true }),
-  TaskList,
-  TaskItem.configure({ nested: true }),
-  Table.configure({ resizable: false }),
-  TableRowWithHeight,
-  TableHeader,
-  TableCell,
-  // TextAlign：必须与 TiptapEditor 对齐，否则 repairTiptapJson round-trip
-  // 时段落/标题的 textAlign 属性会被 schema 静默过滤掉，刷新后段落对齐丢失。
-  TextAlign.configure({ types: ["heading", "paragraph"] }),
-  // TextStyle + Color + FontSize：与编辑器保持一致，否则导入近来的
-  // 带颜色/字号的 HTML 会被 generateJSON schema-filter 掉
-  ...TextStyleKit,
-  // 视频节点：与编辑器保持一致，否则导入/修复阶段 video 节点会被吃
-  VideoExtension,
-  // 数学公式（行内 / 块级）：必须与 TiptapEditor 对齐。
-  // 缺这两个时，含 LaTeX 公式的笔记走 repairTiptapJson → generateHTML 会因
-  // schema 不认识 mathInline / mathBlock 抛 RangeError，catch 兜底返回空 doc，
-  // 表现为"刷新后整篇内容消失"。
-  MathInline,
-  MathBlock,
-  // 脚注（引用 / 定义）：同 Math，含脚注节点的 doc 在 repair round-trip 时
-  // 会因 schema 缺失导致 generateHTML 抛错，刷新后笔记内容被清空。
-  FootnoteReference,
-  FootnoteDefinition,
-  // BLOCK-ID-01-RV1: heading blockId 属性，与 TiptapEditor / contentFormat 对齐
-  // 避免 schema 修复时 blockId 被过滤掉
-  BlockIdAttrs,
-];
-
-export interface ImportFileInfo {
-  name: string;
-  title: string;
-  content: string;
-  size: number;
-  selected: boolean;
-  source?: string; // 来源标识: "md" | "txt" | "html" | "xiaomi" | "oppo" | "vivo" | "oneplus" | "pdf" | "siyuan" | "siyuan-sy"
-  notebookName?: string; // （已废弃，仅为向后兼容）从路径/目录推导出的单层笔记本名
-  notebookPath?: string[]; // 笔记本层级路径（从根到子），如 ["我是文章2", "test2", "新笔记本"]
-  imageMap?: Record<string, string>; // 相对路径 -> base64 data URI（zip 内的图片资源）
-  contentFormat?: "tiptap-json" | "markdown" | "html";
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-// 导入选项
-export interface ImportOptions {
-  /**
-   * 是否"为每个文件创建以文件名命名的外层笔记本"
-   * - true:  每个文件 → 建/找一个同名笔记本（清洗后的文件名）
-   * - false: 保持原逻辑（zip 目录派生；散文件归到"导入的笔记"或用户选的笔记本）
-   */
-  perFileNotebook?: boolean;
-  /**
-   * 当 perFileNotebook=true 时，同名笔记本的处理策略
-   * - "merge":  同名合并到同一笔记本（默认；依赖后端按名复用）
-   * - "unique": 在本批次内自动编号 ("name", "name (2)", "name (3)"...)
-   */
-  duplicateStrategy?: "merge" | "unique";
-  /** perFileNotebook 启用时，清洗后为空的回退名 */
-  fallbackNotebookName?: string;
-  /**
-   * 显式指定导入目标 workspace。
-   * - undefined → 走 api 默认（即当前激活工作区）
-   * - "personal" → 落到个人空间（notes.workspaceId 写 NULL）
-   * - <workspaceId> → 落到指定工作区
-   * 与 exportAllNotes 的 workspaceId 选项配对：DataManager 拆分"个人空间 / 工作区"
-   * Tab 后，每个 Tab 各自传 scope，避免依赖侧边栏当前选中的 workspace。
-   */
-  workspaceId?: string;
-}
-
-export type ImportProgress = {
-  phase: "reading" | "uploading" | "done" | "error";
-  current: number;
-  total: number;
-  message: string;
+type RoundTripImportFile = ImportFileInfo & {
+  __nowenRoundTripPackage?: File;
+  __nowenPackageVersion?: number;
+  __nowenPackageKind?: string;
 };
 
-// 支持的文件扩展名
-const SUPPORTED_EXTENSIONS = [".md", ".txt", ".markdown", ".html", ".htm", ".pdf"];
-
-// PDF 单文件大小上限：50 MB
-// 超过此值会直接抛出错误，避免浏览器内存爆掉或 pdfjs 解析超时。
-export const MAX_PDF_SIZE = 50 * 1024 * 1024;
-
-function isSupportedFile(name: string): boolean {
-  return SUPPORTED_EXTENSIONS.some((ext) => name.toLowerCase().endsWith(ext));
-}
-
-function isPdfFile(name: string): boolean {
-  return name.toLowerCase().endsWith(".pdf");
-}
-
-/**
- * 用 pdfjs-dist 从 PDF 抽取文本层并组装成 HTML。
- *
- * 设计要点：
- * 1. 纯前端、按需懒加载，避免影响首屏体积；
- * 2. 仅依赖 PDF 的「文本层」(getTextContent)，不做 OCR——
- *    扫描件 PDF 没有文本层时返回空字符串，由调用方决定如何提示用户；
- * 3. 通过 y 坐标聚合同一行的 text item，再按段落空行切分，
- *    保证导入后每段独立成 <p>，而不是整篇挤成一坨；
- * 4. 不显式指定 workerSrc，使用 pdfjs 自带的 worker 入口；
- *    若运行环境拒绝创建 worker，会回退到主线程解析（pdfjs 内部已处理）。
- */
-async function extractPdfToHtml(buffer: ArrayBuffer): Promise<string> {
-  // 动态加载，避免与首屏耦合；这里用兼容版（legacy）以最大化浏览器/移动端兼容性
-  const pdfjs: any = await import("pdfjs-dist/legacy/build/pdf.mjs");
-
-  // pdfjs v4 强制要求显式指定 workerSrc（不再支持空字符串/fake worker），
-  // 否则会抛 'No "GlobalWorkerOptions.workerSrc" specified'。
-  // 使用 Vite 的 `?url` 后缀 import：Vite 会在构建期将 worker 文件作为独立资源
-  // 拷贝到 dist，并在开发期由 dev server 直接以正确的 MIME (module) 提供，
-  // 比硬编码 CDN 更稳，也无需联网。
-  if (pdfjs.GlobalWorkerOptions && !pdfjs.GlobalWorkerOptions.workerSrc) {
-    // Vite 的 `?url` 后缀 import 由 vite/client 提供类型声明，TS 能正确推断
-    const workerUrl = (await import("pdfjs-dist/legacy/build/pdf.worker.mjs?url")).default;
-    pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
-  }
-
-  const loadingTask = pdfjs.getDocument({
-    data: new Uint8Array(buffer),
-    // 关闭外部 cmap/standardFont 远程下载，离线/内网环境也能解析
-    isEvalSupported: false,
-    useSystemFonts: true,
-  });
-  const pdf = await loadingTask.promise;
-
-  const htmlParts: string[] = [];
-  // 跟踪是否抽取到任何可见文本。
-  //
-  // 历史 bug：早先只用 `html.trim()` 判断 PDF 是否有文本层，
-  // 但 `htmlParts` 在多页文档中会塞页分隔符 "<p></p>"——一份"扫描件 / 全图 PDF"
-  // 跑下来 lineTexts 全空，htmlParts 却堆了 N-1 个 "<p></p>"，
-  // `html.trim()` 不再为空，于是绕过 OCR 提示，建出一条**0 词 0 字符**的空笔记。
-  // 这里独立用 hasAnyText 计数，保证只统计实际有内容的行。
-  let hasAnyText = false;
-  let extractedLineCount = 0;
-
-  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-    const page = await pdf.getPage(pageNum);
-    const content = await page.getTextContent();
-
-    // 把同一行的 item 按 y 坐标聚合（pdfjs 的 transform[5] 是 y）
-    // 行间允许 ±2 像素的浮动误差
-    type Line = { y: number; items: { x: number; str: string }[] };
-    const lines: Line[] = [];
-
-    for (const it of content.items as any[]) {
-      const str: string = typeof it.str === "string" ? it.str : "";
-      if (!str) continue;
-      const tr = it.transform as number[] | undefined;
-      const x = tr ? tr[4] : 0;
-      const y = tr ? tr[5] : 0;
-
-      // 找一条 y 接近的现有行
-      let target = lines.find((l) => Math.abs(l.y - y) < 2);
-      if (!target) {
-        target = { y, items: [] };
-        lines.push(target);
-      }
-      target.items.push({ x, str });
-      // 处理 pdfjs 标记的「行尾」hasEOL：手动断行
-      if (it.hasEOL) {
-        target = { y: y - 0.001, items: [] };
-        lines.push(target);
-      }
-    }
-
-    // 行内按 x 排序后拼接；行整体按 y 从大到小（PDF 坐标系自上而下 y 递减）
-    lines.sort((a, b) => b.y - a.y);
-    const lineTexts: string[] = lines
-      .map((line) => {
-        line.items.sort((a, b) => a.x - b.x);
-        // 行末尾的空白裁掉，但行内空白保留（中文 PDF 里空格分词常有意义）
-        return line.items.map((i) => i.str).join("").replace(/\s+$/g, "");
-      })
-      // 这里同时过滤"看起来非空但只有不可见字符"的行——
-      // 部分 PDF 的文本层会含 \u0000 / \u00A0 / \u200B（零宽空格）等，
-      // 视觉上是空，却让 .length > 0 通过。
-      .filter((t) => /\S/.test(t.replace(/[\u0000-\u001f\u007f\u200b\u200c\u200d\u2060\ufeff]/g, "")));
-
-    // 段落聚合：连续非空行视为同一段，遇到空行/原始空行边界则分段
-    // 由于上面已 filter 掉空行，这里把每个 lineText 视为独立段落即可
-    // —— 对于普通文本 PDF 这种处理已能得到清晰的段落分隔（每行一个 <p>）
-    for (const lt of lineTexts) {
-      const escaped = lt
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-      htmlParts.push(`<p>${escaped}</p>`);
-      hasAnyText = true;
-      extractedLineCount++;
-    }
-
-    // 页与页之间空一行，便于后续编辑。
-    // 注意：仅在 hasAnyText 已经成立时才插入页分隔符——否则一份纯扫描件
-    // 会因为 N-1 个 "<p></p>" 让 html.trim() 看起来非空，绕过 OCR 提示。
-    if (pageNum < pdf.numPages && hasAnyText) {
-      htmlParts.push("<p></p>");
-    }
-  }
-
-  // 主动释放资源，避免 worker/document 句柄堆积
-  try { await pdf.destroy(); } catch { /* ignore */ }
-
-  // 真正没抽到任何可见文本——直接返回空串，由调用方抛 PDF_NO_TEXT_LAYER_FLAG，
-  // 弹"该 PDF 无可提取文本，请使用 OCR 工具处理后再导入"。
-  if (!hasAnyText) {
-    return "";
-  }
-
-  // 调试日志：抽到了多少行有效文本、文档总页数。
-  // 用户反馈"导入后笔记是空的"时，第一时间能在 console 看到 lineCount 区分
-  // "前端抽取阶段就空" vs "抽取正常但下游被吞"。
-  // 仅 dev 环境输出，避免线上 console 噪音；Vite 的 import.meta.env.DEV 在打包时被 inline。
-  if (import.meta.env.DEV) {
-    console.info(`[importService] PDF extracted: ${extractedLineCount} lines from ${pdf.numPages} page(s)`);
-  }
-
-  return htmlParts.join("\n");
-}
-
-// PDF 无可提取文本时抛出的错误标志（DataManager 层据此弹出 OCR 提示）
-export const PDF_NO_TEXT_LAYER_FLAG = "__PDF_NO_TEXT_LAYER__";
-
-// PDF 文件超过大小上限时抛出的错误标志
-export const PDF_TOO_LARGE_FLAG = "__PDF_TOO_LARGE__";
-
-// 笔记本名的最大长度（超出会被截断），与后端 notebooks.name 字段兼容
-const MAX_NOTEBOOK_NAME_LENGTH = 60;
-// 默认笔记本名（清洗后为空时的回退）
-const DEFAULT_FALLBACK_NOTEBOOK_NAME = "导入的笔记";
-
-/**
- * 从文件名派生出一个合法的笔记本名
- * 处理：
- * 1. 去掉已知的笔记扩展名（.md/.txt/.markdown/.html/.htm）
- * 2. 路径分隔符仅保留最后一段（兼容 webkitRelativePath）
- * 3. 剥离 Windows/跨平台非法字符（<>:"/\|?*）和控制字符
- * 4. 合并多余空白、裁剪首尾空白和点号
- * 5. 长度超限则按视觉字符截断
- * 6. 为空时返回 null（调用方决定回退）
- */
-export function deriveNotebookNameFromFile(fileName: string): string | null {
-  if (!fileName || typeof fileName !== "string") return null;
-
-  // 只取最后一段（例如 webkitRelativePath: "folder/a.md" -> "a.md"）
-  const base = fileName.split(/[\\/]+/).pop() || fileName;
-
-  // 去掉支持的扩展名（含 .pdf）
-  let name = base;
-  for (const ext of SUPPORTED_EXTENSIONS) {
-    if (name.toLowerCase().endsWith(ext)) {
-      name = name.slice(0, -ext.length);
-      break;
-    }
-  }
-
-  // 剥离控制字符 + 跨平台非法字符
-  // eslint-disable-next-line no-control-regex
-  name = name.replace(/[\u0000-\u001f\u007f<>:"/\\|?*]+/g, " ");
-
-  // 合并空白 & 去首尾 .、空格（Windows 不允许以点号或空格结尾）
-  name = name.replace(/\s+/g, " ").replace(/^[\s.]+|[\s.]+$/g, "");
-
-  if (!name) return null;
-
-  // 长度裁剪（按 code point 计，避免截断到代理对中间）
-  if ([...name].length > MAX_NOTEBOOK_NAME_LENGTH) {
-    name = [...name].slice(0, MAX_NOTEBOOK_NAME_LENGTH).join("").trim();
-  }
-
-  return name || null;
-}
-
-/**
- * 在批次内对同名笔记本自动编号：name -> name, name (2), name (3) ...
- * 保持与 `getOrCreateNotebookByName` 幂等性兼容（后端按完整名字找/建）
- */
-function uniquifyNotebookName(name: string, used: Map<string, number>): string {
-  const count = used.get(name) || 0;
-  used.set(name, count + 1);
-  if (count === 0) return name;
-  return `${name} (${count + 1})`;
-}
-
-function isHtmlFile(name: string): boolean {
-  const lower = name.toLowerCase();
-  return lower.endsWith(".html") || lower.endsWith(".htm");
-}
-
-// 检测 HTML 内容来源（手机品牌）
-function detectHtmlSource(html: string, fileName: string): string {
-  const lower = html.toLowerCase();
-  if (lower.includes("mi note") || lower.includes("小米笔记") || lower.includes("miui") || lower.includes("xiaomi")) return "xiaomi";
-  if (lower.includes("coloros") || lower.includes("oppo") || lower.includes("oplus")) return "oppo";
-  if (lower.includes("vivo") || lower.includes("funtouch") || lower.includes("originos")) return "vivo";
-  if (lower.includes("oneplus") || lower.includes("一加") || lower.includes("h2os") || lower.includes("oxygenos")) return "oneplus";
-  if (isHtmlFile(fileName)) return "html";
-  return "md";
-}
-
-// 清理 HTML 内容：去除多余标签、样式、脚本，保留核心内容
-function cleanHtmlContent(html: string): string {
-  let content = html;
-
-  // 移除 script 和 style 标签及其内容
-  content = content.replace(/<script[\s\S]*?<\/script>/gi, "");
-  content = content.replace(/<style[\s\S]*?<\/style>/gi, "");
-
-  // 移除 HTML 注释
-  content = content.replace(/<!--[\s\S]*?-->/g, "");
-
-  // 移除 head 部分
-  content = content.replace(/<head[\s\S]*?<\/head>/gi, "");
-
-  // 提取 body 内容（如果有）
-  const bodyMatch = content.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-  if (bodyMatch) {
-    content = bodyMatch[1];
-  }
-
-  // 移除所有内联样式属性
-  content = content.replace(/\s+style="[^"]*"/gi, "");
-  content = content.replace(/\s+class="[^"]*"/gi, "");
-  content = content.replace(/\s+id="[^"]*"/gi, "");
-
-  // 移除 data-* 属性（保留 tiptap 需要的）
-  content = content.replace(/\s+data-(?!type|checked)[a-z-]+="[^"]*"/gi, "");
-
-  // 移除空的 span/div 标签
-  content = content.replace(/<span[^>]*>\s*<\/span>/gi, "");
-  content = content.replace(/<div[^>]*>\s*<\/div>/gi, "");
-
-  // 将 div 转为 p（常见于手机笔记）
-  content = content.replace(/<div[^>]*>/gi, "<p>");
-  content = content.replace(/<\/div>/gi, "</p>");
-
-  // 将 br 转为段落分隔
-  content = content.replace(/<br\s*\/?>\s*<br\s*\/?>/gi, "</p><p>");
-  content = content.replace(/<br\s*\/?>/gi, "</p><p>");
-
-  // 清理嵌套的空 p 标签
-  content = content.replace(/<p>\s*<\/p>/gi, "");
-
-  // 去除前后空白
-  content = content.trim();
-
-  // 如果清理后没有任何 HTML 标签，包裹在 p 中
-  if (!content.match(/<[a-z]/i)) {
-    content = content
-      .split("\n")
-      .filter((line) => line.trim())
-      .map((line) => `<p>${line.trim()}</p>`)
-      .join("\n");
-  }
-
-  return content;
-}
-
-// 从 HTML 中提取标题
-function extractTitleFromHtml(html: string, fallbackTitle: string): string {
-  // 尝试从 <title> 标签提取
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  if (titleMatch && titleMatch[1].trim()) {
-    return titleMatch[1].trim();
-  }
-  // 尝试从第一个 h1/h2 提取
-  const headingMatch = html.match(/<h[12][^>]*>([\s\S]*?)<\/h[12]>/i);
-  if (headingMatch && headingMatch[1].trim()) {
-    return headingMatch[1].replace(/<[^>]+>/g, "").trim();
-  }
-  return fallbackTitle;
-}
-
-// 读取拖入的文件列表
-//
-// 增强：
-// 1. 同批次内的图片文件（png/jpg/gif/webp/svg/bmp/ico）会被读取为 base64 data URI，
-//    构建一个 imageMap 并附加到每个 md/txt/html 笔记上。
-//    这样用户"同时选中 md + 相对路径下的图片"即可恢复图片引用，不必先打成 zip。
-// 2. 若 File 带有 webkitRelativePath（来自 <input webkitdirectory> 或拖拽目录），
-//    会同时按相对路径与文件名建立两条索引，提高命中率。
-export async function readMarkdownFiles(
-  files: FileList | File[]
-): Promise<ImportFileInfo[]> {
-  const result: ImportFileInfo[] = [];
-  const fileArray = Array.from(files);
-
-  // —— 第一轮：扫描所有图片文件，构建 imageMap ——
-  const imageMap: Record<string, string> = {};
-  for (const file of fileArray) {
-    if (!isImageFile(file.name)) continue;
-    try {
-      // 读成 ArrayBuffer 再转 base64，避免 FileReader 的异步嵌套
-      const buf = await file.arrayBuffer();
-      const base64 = arrayBufferToBase64(buf);
-      const mime = getImageMime(file.name);
-      const dataUri = `data:${mime};base64,${base64}`;
-
-      // 键：文件名（不含路径），以及 webkitRelativePath 提供的相对路径
-      const relPath = (file as any).webkitRelativePath as string | undefined;
-      if (relPath) {
-        imageMap[relPath] = dataUri;
-        // 去掉顶层目录后的路径（与 md 里 `./images/a.png` 这种更接近）
-        const parts = relPath.split("/");
-        if (parts.length > 1) {
-          imageMap[parts.slice(1).join("/")] = dataUri;
-        }
-      }
-      if (!imageMap[file.name]) {
-        imageMap[file.name] = dataUri;
-      }
-    } catch (err) {
-      console.warn("读取本地图片失败:", file.name, err);
-    }
-  }
-  const hasImages = Object.keys(imageMap).length > 0;
-
-  // —— 第二轮：读取笔记文件 ——
-  for (const file of fileArray) {
-    if (!isSupportedFile(file.name)) continue;
-
-    const fileNameTitle = file.name.replace(/\.(md|txt|markdown|html|htm|pdf)$/i, "");
-
-    // PDF：单独走 pdfjs 抽取文本层
-    if (isPdfFile(file.name)) {
-      if (file.size > MAX_PDF_SIZE) {
-        const err = new Error(`${PDF_TOO_LARGE_FLAG}:${file.name}`);
-        (err as any).flag = PDF_TOO_LARGE_FLAG;
-        (err as any).fileName = file.name;
-        throw err;
-      }
-      try {
-        const buf = await file.arrayBuffer();
-        const html = await extractPdfToHtml(buf);
-        if (!html.trim()) {
-          const err = new Error(`${PDF_NO_TEXT_LAYER_FLAG}:${file.name}`);
-          (err as any).flag = PDF_NO_TEXT_LAYER_FLAG;
-          (err as any).fileName = file.name;
-          throw err;
-        }
-        result.push({
-          name: file.name,
-          title: fileNameTitle,
-          content: html,
-          size: file.size,
-          selected: true,
-          source: "pdf",
-          imageMap: hasImages ? imageMap : undefined,
-        });
-      } catch (err: any) {
-        // 已经携带 flag 的错误（无文本层 / 文件过大）原样上抛由 UI 提示
-        if (err && err.flag) throw err;
-        // 其他解析失败：包装成统一错误
-        console.error("PDF 解析失败:", file.name, err);
-        const wrapped = new Error(`PDF 解析失败：${file.name}`);
-        (wrapped as any).fileName = file.name;
-        throw wrapped;
-      }
-      continue;
-    }
-
-    const text = await file.text();
-
-    if (isHtmlFile(file.name)) {
-      const source = detectHtmlSource(text, file.name);
-      const title = extractTitleFromHtml(text, fileNameTitle);
-      result.push({
-        name: file.name,
-        title,
-        content: text,
-        size: file.size,
-        selected: true,
-        source,
-        imageMap: hasImages ? imageMap : undefined,
-      });
-    } else {
-      result.push({
-        name: file.name,
-        title: fileNameTitle,
-        content: text,
-        size: file.size,
-        selected: true,
-        source: file.name.endsWith(".txt") ? "txt" : "md",
-        imageMap: hasImages ? imageMap : undefined,
-      });
-    }
-  }
-
-  return result;
-}
-
-// 把 ArrayBuffer 编码成 base64（避免使用 FileReader 的链式回调）
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  const chunkSize = 0x8000;
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode.apply(null, Array.from(chunk));
-  }
-  return btoa(binary);
-}
-
-// 图片扩展名 → MIME 类型
-const IMAGE_MIME_MAP: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  svg: "image/svg+xml",
-  bmp: "image/bmp",
-  ico: "image/x-icon",
-};
-
-function isImageFile(name: string): boolean {
-  const lower = name.toLowerCase();
-  const ext = lower.split(".").pop() || "";
-  return ext in IMAGE_MIME_MAP;
-}
-
-function getImageMime(name: string): string {
-  const ext = (name.toLowerCase().split(".").pop() || "") as string;
-  return IMAGE_MIME_MAP[ext] || "application/octet-stream";
-}
-
-// 从 zip 内部路径推导笔记本名（取第一级目录名）
-function deriveNotebookName(path: string): string | undefined {
-  const parts = path.split("/").filter(Boolean);
-  if (parts.length < 2) return undefined; // 文件位于根目录
-  const first = parts[0];
-  // 过滤常见的无意义目录
-  if (first.startsWith(".") || first === "__MACOSX" || first.toLowerCase() === "assets" || first.toLowerCase() === "images") {
-    return undefined;
-  }
-  return first;
-}
-
-// 清洗单个路径片段（目录名），规则与 deriveNotebookNameFromFile 一致但不去扩展名
-function sanitizeSegment(segment: string): string | null {
-  if (!segment) return null;
-  let s = segment;
-  // 剥离控制字符 + 跨平台非法字符
-  // eslint-disable-next-line no-control-regex
-  s = s.replace(/[\u0000-\u001f\u007f<>:"/\\|?*]+/g, " ");
-  // 合并空白 & 去首尾 .、空格
-  s = s.replace(/\s+/g, " ").replace(/^[\s.]+|[\s.]+$/g, "");
-  if (!s) return null;
-  // 长度裁剪
-  if ([...s].length > MAX_NOTEBOOK_NAME_LENGTH) {
-    s = [...s].slice(0, MAX_NOTEBOOK_NAME_LENGTH).join("").trim();
-  }
-  return s || null;
-}
-
-/**
- * 从 zip 内部路径推导完整的笔记本层级路径。
- * 例如 path = "我是文章2/test2/新笔记本/note.md"
- *      -> ["我是文章2", "test2", "新笔记本"]
- * 返回的数组顺序为从根到叶。
- *
- * 过滤规则：
- * - 跳过 "__MACOSX"、以 "." 开头的隐藏目录
- * - 跳过 "assets" / "images" 等纯资源目录（仅当它们出现在中间或末端且不是唯一目录时）
- * - 每段经过 sanitizeSegment 清洗
- */
-function deriveNotebookPath(path: string, outerFolderName?: string): string[] {
-  const parts = path.split("/").filter(Boolean);
-  // 最后一段是文件名，不算笔记本
-  const dirParts = parts.slice(0, -1);
-
-  const result: string[] = [];
-  for (const raw of dirParts) {
-    // 过滤无意义目录
-    if (raw.startsWith(".") || raw === "__MACOSX") continue;
-    const lower = raw.toLowerCase();
-    if (lower === "assets" || lower === "images") continue;
-    const cleaned = sanitizeSegment(raw);
-    if (cleaned) result.push(cleaned);
-  }
-
-  // 如果提供了最外层文件夹名（zip 文件名派生），并且它还没作为第一段出现，则前置
-  if (outerFolderName) {
-    if (result.length === 0 || result[0] !== outerFolderName) {
-      result.unshift(outerFolderName);
-    }
-  }
-
-  return result;
-}
-
-// 从 ZIP 文件中读取笔记
-export async function readMarkdownFromZip(file: File): Promise<ImportFileInfo[]> {
-  const r = await readMarkdownFromZipWithMeta(file);
-  return r.files;
-}
-
-/**
- * P1-2：从导出 zip 里同时拿到笔记 + metadata.json 内容。
- *
- * 旧 `readMarkdownFromZip` 只返回 ImportFileInfo[]，丢弃了 metadata.json 里
- * `rootNotebookId / rootNotebookName / scope` 等信息——这些信息在"把同一份
- * 备份导回原笔记本"的场景里非常有用：DataManager 可据此自动预选目标笔记本，
- * 而不是每次都把内容塞进默认的"导入的笔记"。
- *
- * 设计取舍：
- *   - 不强行把 metadata.json 暴露到 ImportFileInfo 里，保持原数据结构稳定；
- *   - 旧调用方 `readMarkdownFromZip` 行为不变（continue 跳过 metadata.json）；
- *   - 新调用方走 `readMarkdownFromZipWithMeta`，按需消费 metadata。
- *
- * metadata 字段说明（与 exportService 一致）：
- *   { version, app, exportedAt,
- *     scope?: "notebook" | undefined,           // 仅 exportNotebook 设置
- *     rootNotebookId?: string,                  // 仅 exportNotebook 设置
- *     rootNotebookName?: string,                // 仅 exportNotebook 设置
- *     totalNotes: number,
- *     notebooks: { name, count }[],
- *     imageStats?: { ok, failed }                // 新增字段，旧包没有
- *   }
- */
-export interface ZipImportMeta {
-  version?: string;
+interface PackageManifestPreview {
+  format?: string;
+  formatVersion?: number;
+  packageKind?: string;
   app?: string;
   exportedAt?: string;
-  scope?: string;
-  rootNotebookId?: string;
-  rootNotebookName?: string;
-  totalNotes?: number;
-  notebooks?: Array<{ name: string; count: number }>;
-  imageStats?: { ok: number; failed: number };
+  counts?: {
+    notebooks?: number;
+    notes?: number;
+    attachments?: number;
+  };
 }
 
+async function readRoundTripManifest(file: File): Promise<PackageManifestPreview | null> {
+  try {
+    const JSZip = (await import("jszip")).default;
+    const zip = await JSZip.loadAsync(file);
+    const entry = zip.file("manifest.json");
+    if (!entry) return null;
+    const manifest = JSON.parse(await entry.async("string")) as PackageManifestPreview;
+    if (
+      manifest?.format !== "nowen-package" ||
+      manifest?.app !== "nowen-note" ||
+      ![1, 2].includes(Number(manifest.formatVersion))
+    ) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Nowen 自己导出的 Markdown ZIP 和 .nowen.zip 都携带 round-trip manifest。
+ * 这类包不能再走“逐个 Markdown 文件推断目录”的旧链路，否则空目录、普通附件、
+ * 排序和稳定 ID 映射都会丢失。这里只返回一个包级占位项，正式导入交给服务端事务。
+ */
 export async function readMarkdownFromZipWithMeta(
   file: File,
 ): Promise<{ files: ImportFileInfo[]; meta: ZipImportMeta | null }> {
-  const JSZip = (await import("jszip")).default;
-  const zip = await JSZip.loadAsync(file);
-  const result: ImportFileInfo[] = [];
+  const manifest = await readRoundTripManifest(file);
+  if (!manifest) return readMarkdownFromZipWithMetaBase(file);
 
-  // P1-2：先试读 metadata.json（如果是本应用导出的 zip，根目录会有）
-  let meta: ZipImportMeta | null = null;
-  const metaEntry = zip.file("metadata.json");
-  if (metaEntry) {
-    try {
-      const text = await metaEntry.async("text");
-      const parsed = JSON.parse(text) as ZipImportMeta;
-      // 轻量边界检查：只认可 nowen-note 自家导出的 metadata，避免被外部 zip
-      // 中的同名文件误认（用户可能上传个包含 metadata.json 的项目压缩包）。
-      if (parsed && parsed.app === "nowen-note") {
-        meta = parsed;
-      }
-    } catch (e) {
-      // 解析失败不中断导入，仅告知调用方 meta=null
-      console.warn("解析 metadata.json 失败，将忽略该文件：", e);
-    }
-  }
-
-  // 用 zip 文件名（去掉 .zip 扩展）作为最外层笔记本名，保证"导出前的顶层目录"在导入后依然存在
-  const rawZipBase = (file.name || "archive.zip").replace(/\.zip$/i, "");
-  const outerFolderName = sanitizeSegment(rawZipBase) || "导入的笔记";
-
-  // 第一轮：扫描所有图片文件，构建路径 → base64 的映射
-  const imageMap: Record<string, string> = {};
-  for (const [path, zipEntry] of Object.entries(zip.files)) {
-    if (zipEntry.dir) continue;
-    if (path.includes("__MACOSX") || path.startsWith(".")) continue;
-    if (!isImageFile(path)) continue;
-    try {
-      const base64 = await zipEntry.async("base64");
-      const mime = getImageMime(path);
-      const dataUri = `data:${mime};base64,${base64}`;
-      // 同时用完整路径和文件名做 key，提升相对路径匹配命中率
-      imageMap[path] = dataUri;
-      const fileName = path.split("/").pop();
-      if (fileName && !imageMap[fileName]) {
-        imageMap[fileName] = dataUri;
-      }
-    } catch (err) {
-      console.warn("读取 zip 图片失败:", path, err);
-    }
-  }
-
-  // 第二轮：扫描笔记文件
-  for (const [path, zipEntry] of Object.entries(zip.files)) {
-    if (zipEntry.dir) continue;
-    if (!isSupportedFile(path)) continue;
-    if (path === "metadata.json") continue;
-    if (path === "export-warnings.json") continue;
-    // 跳过 macOS 资源文件
-    if (path.includes("__MACOSX") || path.startsWith(".")) continue;
-
-    const fileName = path.split("/").pop() || path;
-    const fileNameTitle = fileName.replace(/\.(md|txt|markdown|html|htm|pdf)$/i, "");
-
-    // PDF：从 zip 内部条目走二进制 → pdfjs 抽文本
-    if (isPdfFile(fileName)) {
-      const notebookPath = deriveNotebookPath(path, outerFolderName);
-      const notebookName = notebookPath.length > 0 ? notebookPath[notebookPath.length - 1] : undefined;
-      try {
-        const arr = await zipEntry.async("uint8array");
-        if (arr.byteLength > MAX_PDF_SIZE) {
-          const err = new Error(`${PDF_TOO_LARGE_FLAG}:${fileName}`);
-          (err as any).flag = PDF_TOO_LARGE_FLAG;
-          (err as any).fileName = fileName;
-          throw err;
-        }
-        // 复制成独立 ArrayBuffer，避免 jszip 内部缓冲被复用
-        const buf = arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength);
-        const html = await extractPdfToHtml(buf);
-        if (!html.trim()) {
-          const err = new Error(`${PDF_NO_TEXT_LAYER_FLAG}:${fileName}`);
-          (err as any).flag = PDF_NO_TEXT_LAYER_FLAG;
-          (err as any).fileName = fileName;
-          throw err;
-        }
-        result.push({
-          name: path,
-          title: fileNameTitle,
-          content: html,
-          size: arr.byteLength,
-          selected: true,
-          source: "pdf",
-          notebookName,
-          notebookPath,
-          imageMap,
-        });
-      } catch (err: any) {
-        if (err && err.flag) throw err;
-        console.error("PDF 解析失败:", path, err);
-        const wrapped = new Error(`PDF 解析失败：${fileName}`);
-        (wrapped as any).fileName = fileName;
-        throw wrapped;
-      }
-      continue;
-    }
-
-    const text = await zipEntry.async("text");
-    // 完整层级：zip 文件名（最外层） + zip 内部所有中间目录
-    const notebookPath = deriveNotebookPath(path, outerFolderName);
-    // notebookName 保留为末级目录名（向后兼容 & 日志用）
-    const notebookName = notebookPath.length > 0 ? notebookPath[notebookPath.length - 1] : undefined;
-
-    if (isHtmlFile(fileName)) {
-      const source = detectHtmlSource(text, fileName);
-      const title = extractTitleFromHtml(text, fileNameTitle);
-      result.push({
-        name: path,
-        title,
-        content: text,
-        size: text.length,
-        selected: true,
-        source,
-        notebookName,
-        notebookPath,
-        imageMap,
-      });
-    } else {
-      result.push({
-        name: path,
-        title: fileNameTitle,
-        content: text,
-        size: text.length,
-        selected: true,
-        source: fileName.endsWith(".txt") ? "txt" : "md",
-        notebookName,
-        notebookPath,
-        imageMap,
-      });
-    }
-  }
-
-  return { files: result, meta };
-}
-
-// 从 YAML frontmatter 中提取日期信息
-function extractFrontmatterDates(md: string): { createdAt?: string; updatedAt?: string } {
-  const fmMatch = md.match(/^---\n([\s\S]*?)\n---/m);
-  if (!fmMatch) return {};
-
-  const fm = fmMatch[1];
-  let createdAt: string | undefined;
-  let updatedAt: string | undefined;
-
-  const createdMatch = fm.match(/^created:\s*(.+)$/m);
-  if (createdMatch) createdAt = createdMatch[1].trim();
-
-  const updatedMatch = fm.match(/^updated:\s*(.+)$/m);
-  if (updatedMatch) updatedAt = updatedMatch[1].trim();
-
-  return { createdAt, updatedAt };
-}
-
-// 脱壳：整段被 ```markdown ... ``` 外层围栏包裹的场景（常见于从博客/ChatGPT 复制）
-// 识别规则：首个非空行是 ```[markdown|md|空] 开围栏 + 末尾存在一个"单独成行的 ```"闭合围栏，
-// 且二者之间没有其他同级 lang=markdown/md 的开围栏（避免误剥真正的代码块）。
-function unwrapOuterMarkdownFence(content: string): string {
-  const lines = content.split("\n");
-  // 首个非空行
-  let start = 0;
-  while (start < lines.length && !lines[start].trim()) start++;
-  if (start >= lines.length) return content;
-
-  const opener = lines[start].trim();
-  const openMatch = opener.match(/^(`{3,}|~{3,})(.*)$/);
-  if (!openMatch) return content;
-  const fence = openMatch[1];
-  const fenceChar = fence[0];
-  const fenceLen = fence.length;
-  const langToken = (openMatch[2] || "").trim().split(/\s+/)[0] || "";
-  // 仅处理 lang 为 markdown/md/空 的外层围栏；其他语言（如 bash、js）不应被脱壳
-  if (langToken && !/^(markdown|md)$/i.test(langToken)) return content;
-
-  // 末尾非空行应是闭合围栏
-  let end = lines.length - 1;
-  while (end > start && !lines[end].trim()) end--;
-  if (end <= start) return content;
-
-  const isClosingFence = (rawLine: string): boolean => {
-    const t = rawLine.trim();
-    if (t.length < fenceLen) return false;
-    let k = 0;
-    while (k < t.length && t[k] === fenceChar) k++;
-    if (k < fenceLen) return false;
-    const rest = t.slice(k);
-    return rest.length === 0 || /^\s*$/.test(rest);
+  const title = file.name.replace(/(?:\.nowen)?\.zip$/i, "") || "Nowen 数据包";
+  const packageEntry: RoundTripImportFile = {
+    name: file.name,
+    title,
+    content: "",
+    size: file.size,
+    selected: true,
+    source: "nowen-package",
+    __nowenRoundTripPackage: file,
+    __nowenPackageVersion: Number(manifest.formatVersion),
+    __nowenPackageKind: manifest.packageKind || "nowen",
   };
-  if (!isClosingFence(lines[end])) return content;
-
-  // 返回剥掉外层后的内容
-  return lines.slice(start + 1, end).join("\n");
+  const meta = {
+    version: String(manifest.formatVersion || ""),
+    app: "nowen-note",
+    exportedAt: manifest.exportedAt,
+    totalNotes: manifest.counts?.notes,
+    notebooks: [],
+  } as ZipImportMeta;
+  return { files: [packageEntry], meta };
 }
 
-// 将 Markdown 转为 HTML（用于存储到 Tiptap 格式）
-export function markdownToSimpleHtml(md: string, imageMap?: Record<string, string>): string {
-  // 去除 YAML frontmatter
-  // 注意：必须锁定"字符串最开头"且 --- 独占整行，否则会把文档中任意两个水平线
-  // `---` 之间的内容整段吃掉（曾导致粘贴含有多个 --- 分隔线的 MD 时大量内容丢失）。
-  let content = md.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "");
-
-  // 脱壳：整段被 ```markdown ... ``` 包裹时，剥掉外层
-  content = unwrapOuterMarkdownFence(content);
-
-  // 使用 marked 解析 Markdown → HTML
-  // marked 是业界成熟的 CommonMark 兼容解析器，正确处理嵌套围栏代码块、表格、任务列表等
-  const renderer = new Renderer();
-
-  // 图片：替换 imageMap 中的本地路径为 data URI
-  renderer.image = ({ href, title, text }: { href: string; title?: string | null; text: string }) => {
-    const resolvedSrc = resolveLocalAssetSrc(href, imageMap);
-    const titleAttr = title ? ` title="${title}"` : "";
-    return `<img src="${resolvedSrc}" alt="${text}"${titleAttr} />`;
-  };
-
-  // 代码块：输出 Tiptap 期望的 <pre><code class="language-xxx"> 格式
-  renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
-    const langClass = lang ? ` class="language-${lang}"` : "";
-    const escaped = text
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-    return `<pre><code${langClass}>${escaped}</code></pre>`;
-  };
-
-  marked.use({ renderer, gfm: true, breaks: false });
-
-  const html = replaceLocalAssetSources(marked.parse(content) as string, imageMap);
-  // 规范化 marked 输出的 GFM 表格 HTML，使其符合 Tiptap table schema
-  // （否则带表格的 md 在下游 generateJSON 时会产出非法 content，触发
-  //  ProseMirror 的 "Called contentMatchAt on a node with invalid content"）
-  // 同时把 GFM 任务列表（- [x] / - [ ]）改写成 Tiptap TaskList 格式，
-  // 否则会被 schema 当成普通 <ul>，checkbox 直接丢失退化成无序列表。
-  return normalizeTaskListHtml(normalizeTableHtml(html));
+export async function readMarkdownFromZip(file: File): Promise<ImportFileInfo[]> {
+  return (await readMarkdownFromZipWithMeta(file)).files;
 }
 
-function replaceLocalAssetSources(html: string, assetMap?: Record<string, string>): string {
-  if (!assetMap || !html || !/\s(?:src)=["']/i.test(html)) return html;
-
-  if (typeof DOMParser !== "undefined") {
-    try {
-      const doc = new DOMParser().parseFromString(`<div>${html}</div>`, "text/html");
-      const root = doc.body.firstElementChild;
-      if (!root) return html;
-      const elements = root.querySelectorAll("img[src], video[src], video source[src], audio[src], audio source[src]");
-      elements.forEach((el) => {
-        const src = el.getAttribute("src");
-        if (!src) return;
-        el.setAttribute("src", resolveLocalAssetSrc(src, assetMap));
-      });
-      return root.innerHTML;
-    } catch (e) {
-      console.warn("[importService] replaceLocalAssetSources DOM rewrite failed:", e);
-    }
+async function postRoundTripPackage(
+  file: File,
+  workspaceId: string | undefined,
+  dryRun: boolean,
+): Promise<any> {
+  const token = localStorage.getItem("nowen-token");
+  const params = new URLSearchParams();
+  if (workspaceId && workspaceId !== "personal") params.set("workspaceId", workspaceId);
+  params.set("importMode", "new-root");
+  if (dryRun) params.set("dryRun", "1");
+  const form = new FormData();
+  form.append("file", file);
+  const response = await fetch(`${getBaseUrl()}/export/import/nowen-package?${params.toString()}`, {
+    method: "POST",
+    credentials: "include",
+    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: form,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload?.success === false) {
+    const detail = Array.isArray(payload?.errors) && payload.errors.length
+      ? payload.errors.join("；")
+      : payload?.error;
+    throw new Error(detail || `HTTP ${response.status}`);
   }
-
-  return html.replace(
-    /(<(?:img|video|audio|source)\b[^>]*\ssrc=)(["'])([^"']+)(\2)/gi,
-    (_match, prefix: string, quote: string, src: string, suffix: string) =>
-      `${prefix}${quote}${resolveLocalAssetSrc(src, assetMap)}${suffix}`,
-  );
+  return payload;
 }
 
-// 把 marked 输出的 GFM 任务列表 HTML 改写成 Tiptap TaskList/TaskItem 期望的形态。
-//
-// marked@14 输出（GFM 任务列表）：
-//   <ul>
-//     <li><input checked="" disabled="" type="checkbox"> 已完成项</li>
-//     <li><input disabled="" type="checkbox"> 未完成项</li>
-//   </ul>
-// Tiptap TaskList/TaskItem 期望的 parse 形态：
-//   <ul data-type="taskList">
-//     <li data-type="taskItem" data-checked="true"><p>已完成项</p></li>
-//     <li data-type="taskItem" data-checked="false"><p>未完成项</p></li>
-//   </ul>
-//
-// 不用正则是因为 li 内容可能含嵌套 <ul>（子任务）、链接、加粗等结构，
-// DOMParser 处理嵌套天然正确。在浏览器中开销 ~1ms，可接受。
-//
-// 关键规则：
-// - 只改写**直接子级含 <input type="checkbox"> 的 li**；普通 li 维持原样
-// - 包含至少一个 task li 的 ul 才标记为 taskList；纯无序列表不动
-// - data-checked 来源于 input 的 checked 属性
-// - input 节点本身从 li 中移除（Tiptap 渲染时会自己生成 checkbox）
-function normalizeTaskListHtml(html: string): string {
-  if (!html || html.indexOf("type=\"checkbox\"") === -1) return html;
-  // 服务端/测试环境无 DOMParser 时退化（不抛错，原样返回）
-  if (typeof DOMParser === "undefined") return html;
-
-  try {
-    const doc = new DOMParser().parseFromString(
-      `<div>${html}</div>`,
-      "text/html",
-    );
-    const root = doc.body.firstElementChild;
-    if (!root) return html;
-
-    // 自底向上遍历所有 ul：先处理嵌套的子 ul，再处理父 ul
-    // 这样父 li 被改写成 taskItem 时，里面已经处理过的子 taskList 不会被破坏
-    const allUls = Array.from(root.querySelectorAll("ul"));
-    for (const ul of allUls) {
-      const directLis = Array.from(ul.children).filter(
-        (el) => el.tagName === "LI",
-      ) as HTMLLIElement[];
-      let hasTaskItem = false;
-
-      for (const li of directLis) {
-        // li 的首个有效子元素必须是 input[type=checkbox] 才算任务项
-        const firstChild = li.firstElementChild;
-        if (
-          !firstChild ||
-          firstChild.tagName !== "INPUT" ||
-          (firstChild as HTMLInputElement).type !== "checkbox"
-        ) {
-          continue;
-        }
-        hasTaskItem = true;
-        const checked = (firstChild as HTMLInputElement).hasAttribute("checked");
-        // 移除 input，保留余下文本/元素作为 taskItem 的内容
-        firstChild.remove();
-        // marked 输出的 li 文本紧贴 input 后，通常是个空格开头，trim 掉
-        if (li.firstChild && li.firstChild.nodeType === 3) {
-          li.firstChild.nodeValue = (li.firstChild.nodeValue || "").replace(/^\s+/, "");
-        }
-        li.setAttribute("data-type", "taskItem");
-        li.setAttribute("data-checked", checked ? "true" : "false");
-        // Tiptap TaskItem schema 要求内容是 paragraph+。把直接子级的散文本/inline
-        // 节点包到一个 <p> 里；已经是 <p>/<ul>（嵌套子任务）等块级元素的不动。
-        wrapInlineChildrenInParagraph(li);
-      }
-
-      if (hasTaskItem) {
-        ul.setAttribute("data-type", "taskList");
-      }
-    }
-
-    return root.innerHTML;
-  } catch (e) {
-    console.warn("[importService] normalizeTaskListHtml failed:", e);
-    return html;
-  }
-}
-
-// 把元素的直接 inline 子节点（文本、<a>、<strong>、<code> 等）按相邻段聚合到
-// 单个 <p> 里。已经是块级（p/ul/ol/blockquote/pre/h1-h6/div）的子节点维持位置。
-// 用于满足 Tiptap TaskItem 的 "paragraph+ 内容" schema 要求。
-function wrapInlineChildrenInParagraph(el: Element): void {
-  const blockTags = new Set([
-    "P", "UL", "OL", "BLOCKQUOTE", "PRE", "H1", "H2", "H3", "H4", "H5", "H6",
-    "DIV", "TABLE", "HR",
-  ]);
-  const children = Array.from(el.childNodes);
-  let buffer: Node[] = [];
-  const flush = (insertBefore: Node | null) => {
-    if (buffer.length === 0) return;
-    // 全部为空白文本则不生成 <p>
-    const allWhitespace = buffer.every(
-      (n) => n.nodeType === 3 && !(n.nodeValue || "").trim(),
-    );
-    if (allWhitespace) {
-      buffer.forEach((n) => n.parentNode?.removeChild(n));
-      buffer = [];
-      return;
-    }
-    const p = el.ownerDocument!.createElement("p");
-    buffer.forEach((n) => p.appendChild(n));
-    el.insertBefore(p, insertBefore);
-    buffer = [];
-  };
-
-  for (const node of children) {
-    if (node.nodeType === 1 && blockTags.has((node as Element).tagName)) {
-      flush(node);
-    } else {
-      buffer.push(node);
-    }
-  }
-  flush(null);
-}
-
-// 规范化表格 HTML，让它能被 Tiptap 的 Table schema 接受。
-//
-// Tiptap 官方 @tiptap/extension-table 的 schema 要求：
-//   table > tableRow > (tableCell | tableHeader)
-// 它**不接受** <thead>/<tbody>/<tfoot> 作为 <table> 的直接子节点。
-//
-// 但 marked 在 gfm:true 下输出的标准表格是：
-//   <table><thead><tr>...</tr></thead><tbody><tr>...</tr></tbody></table>
-// 这会让 generateJSON 产出 schema 不合法的 JSON——init 时不报，但第一次
-// 经过 transaction 时（如 SearchReplacePanel 的 highlight decoration plugin）
-// 触发 contentMatchAt 抛错，整个编辑器白屏。
-//
-// 这里用最简的字符串替换把 <thead>/<tbody>/<tfoot> 标签剥掉（保留里面的
-// <tr>），并把 <th>/<td> 上的 align 属性删掉（Tiptap 默认表格不识别）。
-function normalizeTableHtml(html: string): string {
-  if (!html || html.indexOf("<table") === -1) return html;
-  return html
-    // 剥掉 <thead>/<tbody>/<tfoot> 包裹标签（保留内部 <tr>）
-    .replace(/<\/?(thead|tbody|tfoot)\b[^>]*>/gi, "")
-    // 删掉单元格上的 align 属性（marked 用来表示 :---: 对齐）
-    .replace(/(<t[hd])\s+align="[^"]*"/gi, "$1")
-    .replace(/(<t[hd])\s+align='[^']*'/gi, "$1");
-}
-
-// Layer 2 兜底：用一个离屏 Editor 把任意脏 HTML 修复成合 schema 的 JSON。
-//
-// 触发场景：normalizeTableHtml 没覆盖到的未知脏姿势（嵌套 list 异常、
-// 自定义标签、错配标签等）让 generateJSON 抛错，或产出空 doc。
-// ProseMirror 的 setContent 内置 schema fixup（丢非法子节点 / 补必需包裹），
-// 比手写规则鲁棒得多。代价：实例化一个 headless Editor，~10-20ms。
-//
-// 注意：Tiptap 4 的 Editor 构造函数在没传 element 时跑 headless 模式，
-// 不需要真实 DOM 节点。
-function repairHtmlViaHeadlessEditor(html: string): unknown | null {
-  let editor: Editor | null = null;
-  try {
-    editor = new Editor({
-      extensions: tiptapExtensions,
-      content: html,
-      // 静默丢弃非法内容而不是抛错；不设置时默认就是 false，这里写明意图
-      enableContentCheck: false,
-    });
-    return editor.getJSON();
-  } catch (e) {
-    console.warn("[importService] headless editor repair failed:", e);
-    return null;
-  } finally {
-    try { editor?.destroy(); } catch { /* ignore */ }
-  }
-}
-
-// 在 imageMap 中查找本地资源路径对应的 data URI
-function resolveLocalAssetSrc(src: string, imageMap?: Record<string, string>): string {
-  if (!imageMap) return src;
-  // 外链 / 绝对 URL / 已是 data URI，不处理
-  if (/^(https?:|data:|\/\/)/i.test(src)) return src;
-
-  // 去除查询参数和 hash
-  const clean = src.split(/[?#]/)[0];
-  // 直接命中
-  if (imageMap[clean]) return imageMap[clean];
-  // 规范化开头的 ./ 或 /
-  const normalized = clean.replace(/^\.\//, "").replace(/^\//, "");
-  if (imageMap[normalized]) return imageMap[normalized];
-  // 仅用文件名匹配
-  const base = normalized.split("/").pop();
-  if (base && imageMap[base]) return imageMap[base];
-  // 解码 URI（中文文件名在 md 中可能被 encode）
-  try {
-    const decoded = decodeURIComponent(normalized);
-    if (imageMap[decoded]) return imageMap[decoded];
-    const decodedBase = decoded.split("/").pop();
-    if (decodedBase && imageMap[decodedBase]) return imageMap[decodedBase];
-  } catch {
-    /* ignore */
-  }
-  return src;
-}
-
-function isSiyuanSource(source?: string): boolean {
-  return source === "siyuan" || source === "siyuan-sy";
-}
-
-function replaceMarkdownLocalAssets(md: string, imageMap?: Record<string, string>): string {
-  if (!imageMap || !md) return md;
-
-  const withMarkdownImages = md.replace(
-    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
-    (match, alt: string, rawSrc: string) => {
-      const src = String(rawSrc || "").trim();
-      if (/^(https?:|data:|\/\/)/i.test(src)) return match;
-      const resolved = resolveLocalAssetSrc(src, imageMap);
-      return `![${alt}](${resolved})`;
-    },
-  );
-
-  return replaceLocalAssetSources(withMarkdownImages, imageMap);
-}
-
-function convertSiyuanImportToMarkdown(fileInfo: ImportFileInfo): string {
-  let md = fileInfo.content || "";
-  md = md.replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "");
-  md = replaceMarkdownLocalAssets(md, fileInfo.imageMap);
-  return md.trim();
-}
-
-// 处理行内 Markdown 语法
-function inlineMarkdown(text: string, imageMap?: Record<string, string>): string {
-  return (
-    text
-      // 图片（必须在链接之前处理）
-      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, src: string) => {
-        const resolved = resolveLocalAssetSrc(src.trim(), imageMap);
-        const escapedAlt = alt.replace(/"/g, "&quot;");
-        return `<img src="${resolved}" alt="${escapedAlt}" />`;
-      })
-      // 链接
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-      // 粗斜体
-      .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
-      // 粗体
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      // 斜体
-      .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      // 删除线
-      .replace(/~~(.+?)~~/g, "<s>$1</s>")
-      // 高亮
-      .replace(/==(.+?)==/g, "<mark>$1</mark>")
-      // 行内代码已废弃：剥离反引号，保留为纯文本（统一使用代码块）
-      .replace(/`([^`]+)`/g, "$1")
-  );
-}
-
-// 将纯文本转为 HTML
-function textToHtml(text: string): string {
-  return text
-    .split("\n")
-    .map((line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return "";
-      // 转义 HTML 特殊字符
-      const escaped = trimmed
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-      return `<p>${escaped}</p>`;
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-// 根据来源转换内容为 TipTap JSON 字符串
-export function convertToTiptapJson(fileInfo: ImportFileInfo): string {
-  const { content, source, imageMap } = fileInfo;
-
-  let html: string;
-  switch (source) {
-    case "pdf":
-      // PDF 在读取阶段已被组装成纯净的 <p> HTML，不需要再次清洗或解析
-      html = content;
-      break;
-    case "html":
-    case "xiaomi":
-    case "oppo":
-    case "vivo":
-    case "oneplus":
-      html = cleanHtmlContent(content);
-      break;
-    case "txt":
-      html = textToHtml(content);
-      break;
-    case "md":
-    default:
-      html = markdownToSimpleHtml(content, imageMap);
-      break;
-  }
-
-  // 将 HTML 转为 TipTap JSON 格式（与编辑器保存格式一致）
-  //
-  // 两层防御：
-  //   Layer 1（已在 markdownToSimpleHtml 末尾做）：normalizeTableHtml 把
-  //     marked 产出的 <thead>/<tbody> 剥成 Tiptap 接受的形态；
-  //   Layer 2（此处）：generateJSON 仍可能在未知脏 HTML 上产出"内部不合
-  //     schema 的 JSON"——init 时不报、transaction 时崩。这里用一个
-  //     headless Editor 让 ProseMirror 的 setContent 走自家 schema fixup
-  //     兜底，保证任何 html 都能产出合 schema 的 JSON。
-  try {
-    const json = generateJSON(html, tiptapExtensions);
-
-    // 防御：generateJSON 在 schema 命中失败时不会抛错，而是吐出
-    // `{ type: "doc", content: [{ type: "paragraph" }] }` 这样的"空 doc"。
-    // 此时如果原 html 其实非空，先尝试 headless Editor 修复；仍失败再
-    // 回退到 HTML 字符串。
-    const looksEmpty =
-      json &&
-      json.type === "doc" &&
-      Array.isArray(json.content) &&
-      (json.content.length === 0 ||
-        (json.content.length === 1 &&
-          json.content[0]?.type === "paragraph" &&
-          !json.content[0]?.content));
-    if (looksEmpty && html.replace(/<[^>]+>/g, "").trim().length > 0) {
-      console.warn("[importService] generateJSON produced empty doc, retrying via headless editor");
-      const repaired = repairHtmlViaHeadlessEditor(html);
-      if (repaired) return JSON.stringify(repaired);
-      return html;
-    }
-
-    return JSON.stringify(json);
-  } catch (err) {
-    // generateJSON 抛错（最常见：parseHTML 出来的内容不满足某个 node 的
-    // contentMatch）。先试 headless Editor 修复，再回退 HTML 字符串。
-    console.warn("[importService] generateJSON threw, retrying via headless editor:", err);
-    const repaired = repairHtmlViaHeadlessEditor(html);
-    if (repaired) return JSON.stringify(repaired);
-    return html;
-  }
-}
-
-// 提取纯文本用于搜索索引
-export function extractPlainText(fileInfo: ImportFileInfo): string {
-  const { content, source } = fileInfo;
-
-  if (source === "pdf" || source === "html" || source === "xiaomi" || source === "oppo" || source === "vivo" || source === "oneplus") {
-    return content
-      .replace(/<script[\s\S]*?<\/script>/gi, "")
-      .replace(/<style[\s\S]*?<\/style>/gi, "")
-      .replace(/<[^>]+>/g, "")
-      .replace(/&nbsp;/g, " ")
-      .replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<")
-      .replace(/&gt;/g, ">")
-      .replace(/&quot;/g, '"')
-      .replace(/\s+/g, " ")
-      .trim();
-  }
-
-  // Markdown / txt
-  return content
-    .replace(/^---\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, "")
-    .replace(/[#*_~`\[\]()>|-]/g, "")
-    .trim();
-}
-
-// 执行导入
+/**
+ * Round-trip package import is atomic and defaults to an independent copy. A conflicting source
+ * root is renamed by the server to “名称 (2)”, while the subtree itself remains unchanged.
+ */
 export async function importNotes(
   fileInfos: ImportFileInfo[],
   notebookId?: string,
-  onProgress?: (p: ImportProgress) => void,
-  options?: ImportOptions
+  onProgress?: (progress: ImportProgress) => void,
+  options?: ImportOptions,
 ): Promise<{ success: boolean; count: number }> {
-  const selected = fileInfos.filter((f) => f.selected);
-
-  if (selected.length === 0) {
-    onProgress?.({ phase: "error", current: 0, total: 0, message: i18n.t('dataManager.noFilesSelected') });
+  const selected = fileInfos.filter((item) => item.selected) as RoundTripImportFile[];
+  const packageItems = selected.filter((item) => item.__nowenRoundTripPackage instanceof File);
+  if (!packageItems.length) return importNotesBase(fileInfos, notebookId, onProgress, options);
+  if (packageItems.length !== 1 || selected.length !== 1) {
+    onProgress?.({ phase: "error", current: 0, total: selected.length, message: "Nowen 数据包必须单独导入" });
     return { success: false, count: 0 };
   }
 
-  // 解析导入选项
-  // 当用户明确选了目标笔记本（notebookId）时，perFileNotebook 被忽略（保持 UI 层互斥约定的最终保险）
-  const perFileNotebook = !notebookId && !!options?.perFileNotebook;
-  const duplicateStrategy = options?.duplicateStrategy ?? "merge";
-  const fallbackNotebookName =
-    (options?.fallbackNotebookName && options.fallbackNotebookName.trim()) ||
-    DEFAULT_FALLBACK_NOTEBOOK_NAME;
-
-  // 批次内"名字 -> 已出现次数"，用于 duplicateStrategy=unique 时自动编号
-  const usedNotebookNames = new Map<string, number>();
-
+  const file = packageItems[0].__nowenRoundTripPackage!;
   try {
-    onProgress?.({ phase: "uploading", current: 0, total: selected.length, message: i18n.t('dataManager.uploadingProgress') });
-
-    const notes = selected.map((f) => {
-      const importAsMarkdown = isSiyuanSource(f.source);
-      const note: { title: string; content: string; contentText: string; contentFormat?: "tiptap-json" | "markdown" | "html"; createdAt?: string; updatedAt?: string; notebookName?: string; notebookPath?: string[] } = {
-        title: f.title,
-        content: importAsMarkdown ? convertSiyuanImportToMarkdown(f) : convertToTiptapJson(f),
-        contentText: extractPlainText(f),
-        contentFormat: importAsMarkdown ? "markdown" : "tiptap-json",
-      };
-      // 对 Markdown 文件尝试提取 frontmatter 中的日期
-      if (f.source === "md" || !f.source) {
-        const dates = extractFrontmatterDates(f.content);
-        if (dates.createdAt) note.createdAt = dates.createdAt;
-        if (dates.updatedAt) note.updatedAt = dates.updatedAt;
-      }
-      if (f.createdAt) note.createdAt = f.createdAt;
-      if (f.updatedAt) note.updatedAt = f.updatedAt;
-
-      // —— 决定该笔记的 notebookName / notebookPath ——
-      // 优先级：perFileNotebook（覆盖式） > zip 路径派生 f.notebookPath > 扁平 f.notebookName > 无
-      if (perFileNotebook) {
-        // 从原始文件名派生；失败则回退到标题；仍失败则用 fallback
-        const derived =
-          deriveNotebookNameFromFile(f.name) ||
-          deriveNotebookNameFromFile(f.title) ||
-          fallbackNotebookName;
-        const finalName =
-          duplicateStrategy === "unique"
-            ? uniquifyNotebookName(derived, usedNotebookNames)
-            : derived;
-        note.notebookName = finalName;
-        // per-file 模式下视为单层路径
-        note.notebookPath = [finalName];
-      } else if (f.notebookPath && f.notebookPath.length > 0) {
-        // zip 导入：透传完整层级路径，后端按层级逐级查找/创建
-        note.notebookPath = f.notebookPath;
-        note.notebookName = f.notebookPath[f.notebookPath.length - 1];
-      } else if (f.notebookName) {
-        // 向后兼容：没有 notebookPath 时仍透传单层名字
-        note.notebookName = f.notebookName;
-      }
-      return note;
+    onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件和冲突…" });
+    const preview = await postRoundTripPackage(file, options?.workspaceId, true);
+    const conflicts = Array.isArray(preview?.conflicts) ? preview.conflicts.length : 0;
+    onProgress?.({
+      phase: "uploading",
+      current: 0,
+      total: 1,
+      message: conflicts > 0
+        ? `检测到 ${conflicts} 个根目录重名，将自动创建独立副本`
+        : "正在原样恢复目录和附件…",
     });
-
-    const result = await api.importNotes(notes, notebookId, undefined, options?.workspaceId);
-
+    const result = await postRoundTripPackage(file, options?.workspaceId, false);
+    const count = Number(result?.counts?.notes || 0);
+    const warningCount = Array.isArray(result?.warnings) ? result.warnings.length : 0;
     onProgress?.({
       phase: "done",
-      current: result.count,
-      total: selected.length,
-      message: i18n.t('dataManager.importSuccessCount', { count: result.count }),
+      current: count,
+      total: count,
+      message: warningCount > 0
+        ? `导入完成，共 ${count} 篇笔记，${warningCount} 项需要检查`
+        : `导入完成，共 ${count} 篇笔记`,
     });
-
-    return { success: true, count: result.count };
+    return { success: true, count };
   } catch (error) {
-    console.error("导入失败:", error);
     onProgress?.({
       phase: "error",
       current: 0,
-      total: selected.length,
-      message: i18n.t('dataManager.importFailed', { error: (error as Error).message }),
+      total: 1,
+      message: `导入失败：${error instanceof Error ? error.message : String(error)}`,
     });
     return { success: false, count: 0 };
   }
-}
-
-// =============================================================================
-// 单文件快速导入（拖拽专用）
-// -----------------------------------------------------------------------------
-// 与 importNotes 不同：不走 dialog/选择/分组那套批量流程，
-// 直接把一份 .md / .markdown / .txt 转成一条笔记落库。
-// 用于 NoteList 的"拖文件进来即导入"快捷路径，逻辑要尽量轻。
-// =============================================================================
-export interface ImportMarkdownAsNoteResult {
-  note: import("@/types").Note;
-  previewText: string;
-}
-
-const IMPORT_TEXT_MAX_SIZE = 10 * 1024 * 1024; // 10MB，足够覆盖绝大多数手写笔记
-
-export async function importMarkdownAsNote(params: {
-  notebookId: string;
-  file: File;
-}): Promise<ImportMarkdownAsNoteResult> {
-  const { notebookId, file } = params;
-  if (!file) throw new Error("未选择文件");
-  if (file.size > IMPORT_TEXT_MAX_SIZE) {
-    throw new Error(
-      `文件过大（${(file.size / 1024 / 1024).toFixed(1)} MB），上限 ${IMPORT_TEXT_MAX_SIZE / 1024 / 1024} MB`,
-    );
-  }
-
-  const text = await file.text();
-  const lower = file.name.toLowerCase();
-  const isMd = lower.endsWith(".md") || lower.endsWith(".markdown");
-  const source: ImportFileInfo["source"] = isMd ? "md" : "txt";
-
-  // 标题：md 优先取首个一级标题；否则用文件名（去扩展名）
-  const fileBaseName = file.name.replace(/\.(md|markdown|txt)$/i, "");
-  let title = fileBaseName;
-  if (isMd) {
-    const m = text.match(/^\s*#\s+(.+?)\s*$/m);
-    if (m && m[1].trim()) title = m[1].trim();
-  }
-
-  const fileInfo: ImportFileInfo = {
-    name: file.name,
-    title,
-    content: text,
-    size: text.length,
-    selected: true,
-    source,
-  };
-
-  const content = convertToTiptapJson(fileInfo);
-  const previewText = extractPlainText(fileInfo).slice(0, 200);
-
-  // md frontmatter 里若有 createdAt / updatedAt 就尊重它
-  const dates = isMd ? extractFrontmatterDates(text) : {};
-
-  const baseNote = (await api.createNote({ notebookId, title })) as import("@/types").Note;
-  const updated = (await api.updateNote(baseNote.id, {
-    content,
-    contentText: previewText,
-    version: baseNote.version,
-    ...(dates.createdAt ? { createdAt: dates.createdAt } : {}),
-    ...(dates.updatedAt ? { updatedAt: dates.updatedAt } : {}),
-  } as Partial<import("@/types").Note>)) as import("@/types").Note;
-
-  return { note: updated, previewText };
 }


### PR DESCRIPTION
Closes #371

实现统一 Round-trip 包协议：

- Markdown ZIP 与 Nowen 数据包共享 v2 manifest；
- 保留完整多级目录、空目录、排序和原始归属；
- 导出所有附件（含正文未引用附件），记录 SHA-256；
- 导入时校验并重建附件记录，重写附件与内部笔记 ID；
- 根目录冲突默认重命名为 `名称 (2)`，禁止静默合并；
- Markdown ZIP 仍保留可被 Obsidian/Typora 浏览的人类可读目录；
- 自家包自动走服务端事务恢复，旧普通 ZIP 继续走兼容导入；
- 增加目录、空目录、附件和冲突回归测试。