### PR TITLE
feat: add conflict-safe round-trip incremental sync

### DIFF
--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -12,6 +12,7 @@ import {
   MIGRATIONS as BASE_MIGRATIONS,
   type Migration,
 } from "./migrations.impl.js";
+import { roundTripImportLinksMigration } from "./roundtripImportLinksMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -256,6 +257,7 @@ export const MIGRATIONS: Migration[] = [
   userAISettingsMigration,
   noteImportOriginsMigration,
   repairSearchContentTextMigration,
+  roundTripImportLinksMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/db/postgres/migrations/0053-roundtrip-import-resource-links.sql
+++ b/backend/src/db/postgres/migrations/0053-roundtrip-import-resource-links.sql
@@ -1,0 +1,32 @@
+-- #376 / SQLite migration v53 parity
+-- Stable source-to-target resource mappings for safe Nowen package incremental sync.
+
+CREATE TABLE IF NOT EXISTS roundtrip_import_links (
+    id TEXT PRIMARY KEY,
+    "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    "workspaceId" TEXT,
+    "workspaceScope" TEXT NOT NULL,
+    "sourceInstanceId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL CHECK ("resourceType" IN ('notebook', 'note', 'attachment')),
+    "sourceResourceId" TEXT NOT NULL,
+    "targetResourceId" TEXT NOT NULL,
+    "sourceHash" TEXT,
+    "targetHash" TEXT,
+    "lastExportBatchId" TEXT,
+    "importedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    metadata TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roundtrip_links_source
+    ON roundtrip_import_links(
+        "userId",
+        "workspaceScope",
+        "sourceInstanceId",
+        "resourceType",
+        "sourceResourceId"
+    );
+CREATE INDEX IF NOT EXISTS idx_roundtrip_links_target
+    ON roundtrip_import_links("resourceType", "targetResourceId");
+CREATE INDEX IF NOT EXISTS idx_roundtrip_links_batch
+    ON roundtrip_import_links("lastExportBatchId");

--- a/backend/src/db/roundtripImportLinksMigration.ts
+++ b/backend/src/db/roundtripImportLinksMigration.ts
@@ -1,0 +1,43 @@
+import type Database from "better-sqlite3";
+import type { Migration } from "./migrations.impl";
+
+export function ensureRoundTripImportLinksSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS roundtrip_import_links (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      workspaceScope TEXT NOT NULL,
+      sourceInstanceId TEXT NOT NULL,
+      resourceType TEXT NOT NULL CHECK (resourceType IN ('notebook', 'note', 'attachment')),
+      sourceResourceId TEXT NOT NULL,
+      targetResourceId TEXT NOT NULL,
+      sourceHash TEXT,
+      targetHash TEXT,
+      lastExportBatchId TEXT,
+      importedAt TEXT NOT NULL DEFAULT (datetime('now')),
+      updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+      metadata TEXT,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_roundtrip_links_source
+      ON roundtrip_import_links(
+        userId,
+        workspaceScope,
+        sourceInstanceId,
+        resourceType,
+        sourceResourceId
+      );
+    CREATE INDEX IF NOT EXISTS idx_roundtrip_links_target
+      ON roundtrip_import_links(resourceType, targetResourceId);
+    CREATE INDEX IF NOT EXISTS idx_roundtrip_links_batch
+      ON roundtrip_import_links(lastExportBatchId);
+  `);
+}
+
+export const roundTripImportLinksMigration: Migration = {
+  version: 53,
+  name: "roundtrip-import-resource-links",
+  up: ensureRoundTripImportLinksSchema,
+};

--- a/backend/src/db/roundtripImportLinksMigration.ts
+++ b/backend/src/db/roundtripImportLinksMigration.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import type { Migration } from "./migrations.impl";
+import type { Migration } from "./migrations.impl.js";
 
 export function ensureRoundTripImportLinksSchema(db: Database.Database): void {
   db.exec(`

--- a/backend/src/services/nowenInstanceIdentity.ts
+++ b/backend/src/services/nowenInstanceIdentity.ts
@@ -1,0 +1,46 @@
+import crypto from "crypto";
+import { getDb } from "../db/schema";
+
+const INSTANCE_ID_KEY = "nowen_instance_id";
+const VALID_INSTANCE_ID = /^[A-Za-z0-9._:-]{8,160}$/;
+
+function normalized(value: unknown): string | null {
+  const candidate = String(value || "").trim();
+  return candidate && VALID_INSTANCE_ID.test(candidate) ? candidate : null;
+}
+
+/**
+ * Return a stable ID for the logical Nowen instance.
+ *
+ * Operators may pin NOWEN_INSTANCE_ID explicitly. Otherwise the first export creates a UUID in
+ * system_settings, so application restarts and ordinary upgrades keep the same source identity.
+ */
+export function getNowenInstanceId(): string {
+  const configured = normalized(process.env.NOWEN_INSTANCE_ID);
+  if (configured) return configured;
+
+  const db = getDb();
+  const existing = db.prepare("SELECT value FROM system_settings WHERE key = ?").get(INSTANCE_ID_KEY) as
+    | { value: string }
+    | undefined;
+  const stored = normalized(existing?.value);
+  if (stored) return stored;
+
+  const generated = crypto.randomUUID();
+  db.prepare(`
+    INSERT INTO system_settings (key, value, updatedAt)
+    VALUES (?, ?, datetime('now'))
+    ON CONFLICT(key) DO NOTHING
+  `).run(INSTANCE_ID_KEY, generated);
+  const persisted = db.prepare("SELECT value FROM system_settings WHERE key = ?").get(INSTANCE_ID_KEY) as
+    | { value: string }
+    | undefined;
+  return normalized(persisted?.value) || generated;
+}
+
+/** The existing exporter reads NOWEN_INSTANCE_ID while building manifest.json. */
+export function ensureNowenInstanceEnvironment(): string {
+  const id = getNowenInstanceId();
+  if (!normalized(process.env.NOWEN_INSTANCE_ID)) process.env.NOWEN_INSTANCE_ID = id;
+  return id;
+}

--- a/backend/src/services/nowenPackageExportStable.ts
+++ b/backend/src/services/nowenPackageExportStable.ts
@@ -1,0 +1,18 @@
+import {
+  createNowenPackageExport,
+  type PreparedMarkdownPackageNote,
+} from "./nowenPackageExport";
+import { ensureNowenInstanceEnvironment } from "./nowenInstanceIdentity";
+
+export type { PreparedMarkdownPackageNote };
+
+/**
+ * Ensure all user-facing Round-trip packages carry a stable sourceInstanceId.
+ * The underlying exporter keeps its existing ZIP layout and streaming/storage behavior.
+ */
+export async function createStableNowenPackageExport(
+  params: Parameters<typeof createNowenPackageExport>[0],
+): ReturnType<typeof createNowenPackageExport> {
+  ensureNowenInstanceEnvironment();
+  return createNowenPackageExport(params);
+}

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -1,7 +1,7 @@
-export {
-  importNowenPackageV2 as importNowenPackage,
-  type ImportConflict,
-  type ImportParams,
-  type RoundTripConflictStrategy,
-  type RoundTripImportMode,
-} from "./nowenPackageImportV2";
+export { importNowenPackageWithSync as importNowenPackage } from "./nowenRoundTripSync";
+export type {
+  RoundTripImportParams as ImportParams,
+  RoundTripSyncImportMode as RoundTripImportMode,
+  RoundTripSyncStrategy as RoundTripConflictStrategy,
+} from "./nowenRoundTripSync";
+export type { ImportConflict } from "./nowenPackageImportV2";

--- a/backend/src/services/nowenRoundTripSync.ts
+++ b/backend/src/services/nowenRoundTripSync.ts
@@ -1,0 +1,1377 @@
+import crypto from "crypto";
+import path from "path";
+import JSZip from "jszip";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
+import {
+  deleteAttachmentObject,
+  getUploadMonthPath,
+  writeAttachmentObject,
+} from "./attachment-storage";
+import { ensureRoundTripImportLinksSchema } from "../db/roundtripImportLinksMigration";
+import {
+  importNowenPackageV2,
+  type ImportConflict,
+  type ImportParams as V2ImportParams,
+} from "./nowenPackageImportV2";
+
+export type RoundTripSyncImportMode = "new-root" | "into-target" | "merge" | "sync";
+export type RoundTripSyncStrategy = "copy" | "merge" | "sync";
+
+export interface RoundTripImportParams extends Omit<V2ImportParams, "importMode"> {
+  importMode?: RoundTripSyncImportMode;
+}
+
+interface Manifest {
+  format: string;
+  formatVersion: number;
+  app: string;
+  exportedAt: string;
+  exportBatchId?: string;
+  sourceInstanceId?: string | null;
+  packageKind?: string;
+  schemaVersion?: number;
+  formatStats?: { markdown?: number; richText?: number; html?: number };
+}
+
+interface NotebookMeta {
+  id: string;
+  parentId: string | null;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  sortOrder: number;
+  isExpanded: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface NoteMeta {
+  id: string;
+  notebookId: string;
+  title: string;
+  contentFormat: string;
+  contentFile: string;
+  contentText: string;
+  isPinned: number;
+  isFavorite: number;
+  isLocked: number;
+  isArchived: number;
+  version: number;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  tagIds: string[];
+  attachmentIds: string[];
+}
+
+interface TagMeta {
+  id: string;
+  name: string;
+  color: string | null;
+  createdAt: string;
+}
+
+interface AttachmentMeta {
+  id: string;
+  noteId: string;
+  filename: string;
+  mimeType: string | null;
+  size: number | null;
+  createdAt: string;
+  sha256?: string;
+  packagePath?: string;
+}
+
+interface SourceNote {
+  meta: NoteMeta;
+  content: string;
+  sourceHash: string;
+}
+
+interface SourceAttachment {
+  meta: AttachmentMeta;
+  buffer: Buffer;
+  sourceHash: string;
+}
+
+interface PackageModel {
+  manifest: Manifest;
+  notebooks: NotebookMeta[];
+  notes: Map<string, SourceNote>;
+  tags: TagMeta[];
+  noteTags: Array<{ noteId: string; tagId: string }>;
+  attachments: Map<string, SourceAttachment>;
+}
+
+interface LinkRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  workspaceScope: string;
+  sourceInstanceId: string;
+  resourceType: "notebook" | "note" | "attachment";
+  sourceResourceId: string;
+  targetResourceId: string;
+  sourceHash: string | null;
+  targetHash: string | null;
+  lastExportBatchId: string | null;
+  metadata: string | null;
+}
+
+interface NotebookRow {
+  id: string;
+  parentId: string | null;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  sortOrder: number;
+  isExpanded: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface NoteRow {
+  id: string;
+  notebookId: string;
+  title: string;
+  content: string;
+  contentText: string;
+  contentFormat: string;
+  isPinned: number;
+  isFavorite: number;
+  isLocked: number;
+  isArchived: number;
+  version: number;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  rowid?: number;
+}
+
+interface AttachmentRow {
+  id: string;
+  noteId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  path: string;
+  hash: string | null;
+  createdAt: string;
+  rowid?: number;
+}
+
+export interface ImportTargetSnapshot {
+  notebookIds: Set<string>;
+  noteIds: Set<string>;
+  attachmentIds: Set<string>;
+}
+
+interface SyncNotebookPlan {
+  source: NotebookMeta;
+  sourceHash: string;
+  targetId: string;
+  parentTargetId: string | null;
+  importedName: string;
+  action: "create" | "recreate" | "update" | "unchanged" | "local-conflict";
+  link?: LinkRow;
+}
+
+interface SyncNotePlan {
+  source: SourceNote;
+  targetId: string;
+  notebookId: string;
+  importedTitle: string;
+  action: "create" | "recreate" | "update" | "unchanged" | "local-conflict";
+  link?: LinkRow;
+}
+
+interface SyncAttachmentPlan {
+  source: SourceAttachment;
+  targetId: string;
+  targetNoteId: string;
+  action: "create" | "replace" | "reuse" | "ignore";
+  storagePath?: string;
+  oldTargetId?: string;
+  link?: LinkRow;
+}
+
+const KNOWN_CONTENT_FORMATS = new Set(["markdown", "tiptap-json", "html"]);
+const SOURCE_INSTANCE_PATTERN = /^[A-Za-z0-9._:-]{8,160}$/;
+
+function workspaceScope(workspaceId: string | null | undefined): string {
+  return workspaceId || "personal";
+}
+
+function hash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function sourceNotebookHash(item: NotebookMeta): string {
+  return hash({
+    parentId: item.parentId,
+    name: item.name,
+    description: item.description,
+    icon: item.icon,
+    color: item.color,
+    sortOrder: item.sortOrder,
+    isExpanded: item.isExpanded,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  });
+}
+
+function targetNotebookHash(item: NotebookRow): string {
+  return hash({
+    parentId: item.parentId,
+    name: item.name,
+    description: item.description,
+    icon: item.icon,
+    color: item.color,
+    sortOrder: item.sortOrder,
+    isExpanded: item.isExpanded,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  });
+}
+
+function sourceNoteHash(
+  meta: NoteMeta,
+  content: string,
+  attachments: SourceAttachment[],
+): string {
+  return hash({
+    notebookId: meta.notebookId,
+    title: meta.title,
+    content,
+    contentText: meta.contentText,
+    contentFormat: meta.contentFormat,
+    isPinned: meta.isPinned,
+    isFavorite: meta.isFavorite,
+    isLocked: meta.isLocked,
+    isArchived: meta.isArchived,
+    sortOrder: meta.sortOrder,
+    createdAt: meta.createdAt,
+    updatedAt: meta.updatedAt,
+    tagIds: [...(meta.tagIds || [])].sort(),
+    attachments: attachments
+      .map((item) => ({
+        id: item.meta.id,
+        filename: item.meta.filename,
+        mimeType: item.meta.mimeType,
+        size: item.meta.size,
+        sha256: item.sourceHash,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  });
+}
+
+function targetNoteHash(db: ReturnType<typeof getDb>, noteId: string): string | null {
+  const note = db.prepare(`
+    SELECT id, notebookId, title, content, contentText, contentFormat,
+           isPinned, isFavorite, isLocked, isArchived, sortOrder, createdAt, updatedAt
+      FROM notes
+     WHERE id = ? AND (isTrashed IS NULL OR isTrashed = 0)
+  `).get(noteId) as NoteRow | undefined;
+  if (!note) return null;
+  const attachments = db.prepare(`
+    SELECT id, filename, mimeType, size, path, hash, createdAt
+      FROM attachments
+     WHERE noteId = ?
+     ORDER BY id
+  `).all(noteId) as Array<Omit<AttachmentRow, "noteId">>;
+  return hash({
+    notebookId: note.notebookId,
+    title: note.title,
+    content: note.content,
+    contentText: note.contentText,
+    contentFormat: note.contentFormat,
+    isPinned: note.isPinned,
+    isFavorite: note.isFavorite,
+    isLocked: note.isLocked,
+    isArchived: note.isArchived,
+    sortOrder: note.sortOrder,
+    createdAt: note.createdAt,
+    updatedAt: note.updatedAt,
+    attachments: attachments.map((item) => ({
+      filename: item.filename,
+      mimeType: item.mimeType,
+      size: item.size,
+      identity: item.hash || item.path,
+      createdAt: item.createdAt,
+    })),
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function rewriteIdReferences(
+  content: string,
+  attachmentMap: Map<string, string>,
+  noteMap: Map<string, string>,
+): { content: string; unmappedAttachmentIds: string[] } {
+  let out = String(content || "");
+  const unmapped = new Set<string>();
+  out = out.replace(/\/api\/attachments\/([^/?#\s)"'<>]+)/gi, (match, encodedId: string) => {
+    let sourceId = encodedId;
+    try { sourceId = decodeURIComponent(encodedId); } catch { /* keep raw */ }
+    const targetId = attachmentMap.get(sourceId);
+    if (!targetId) {
+      unmapped.add(sourceId);
+      return match;
+    }
+    return `/api/attachments/${targetId}`;
+  });
+  for (const [sourceId, targetId] of noteMap) {
+    const escaped = escapeRegExp(sourceId);
+    out = out
+      .replace(new RegExp(`note:${escaped}(?=[$#?\\s)\"'<>]|$)`, "g"), `note:${targetId}`)
+      .replace(new RegExp(`nowen:\\/\\/note\\/${escaped}(?=[$#?\\s)\"'<>]|$)`, "g"), `nowen://note/${targetId}`);
+  }
+  return { content: out, unmappedAttachmentIds: Array.from(unmapped) };
+}
+
+function safeExtension(filename: string): string {
+  const ext = path.extname(filename || "") || ".bin";
+  const cleaned = ext.replace(/[^a-zA-Z0-9.]/g, "");
+  return cleaned && cleaned !== "." ? cleaned : ".bin";
+}
+
+async function readJson<T>(zip: JSZip, filename: string): Promise<T | null> {
+  const entry = zip.file(filename);
+  if (!entry) return null;
+  try { return JSON.parse(await entry.async("string")) as T; }
+  catch { return null; }
+}
+
+function sortNotebooks(items: NotebookMeta[]): NotebookMeta[] {
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const output: NotebookMeta[] = [];
+  const visit = (item: NotebookMeta): void => {
+    if (visited.has(item.id)) return;
+    if (visiting.has(item.id)) throw new Error(`Notebook cycle detected at ${item.id}`);
+    visiting.add(item.id);
+    if (item.parentId && byId.has(item.parentId)) visit(byId.get(item.parentId)!);
+    visiting.delete(item.id);
+    visited.add(item.id);
+    output.push(item);
+  };
+  for (const item of items) visit(item);
+  return output;
+}
+
+async function parsePackage(zipBuffer: Buffer): Promise<PackageModel> {
+  const zip = await JSZip.loadAsync(zipBuffer);
+  const manifest = await readJson<Manifest>(zip, "manifest.json");
+  if (!manifest || manifest.format !== "nowen-package" || manifest.app !== "nowen-note") {
+    throw new Error("Invalid Nowen round-trip package manifest");
+  }
+
+  const tree = await readJson<{ nodes?: Array<Record<string, unknown>> }>(zip, "tree.json");
+  let notebooks: NotebookMeta[] = [];
+  if (Array.isArray(tree?.nodes)) {
+    notebooks = tree!.nodes!.map((raw) => ({
+      id: String(raw.sourceId || ""),
+      parentId: raw.parentSourceId ? String(raw.parentSourceId) : null,
+      name: String(raw.name || "未命名"),
+      description: raw.description == null ? null : String(raw.description),
+      icon: raw.icon == null ? null : String(raw.icon),
+      color: raw.color == null ? null : String(raw.color),
+      sortOrder: Number(raw.sortOrder) || 0,
+      isExpanded: Number(raw.isExpanded) || 0,
+      createdAt: String(raw.createdAt || ""),
+      updatedAt: String(raw.updatedAt || raw.createdAt || ""),
+    })).filter((item) => item.id);
+  } else {
+    notebooks = (await readJson<NotebookMeta[]>(zip, "notebooks.json")) || [];
+  }
+  notebooks = sortNotebooks(notebooks);
+
+  const attachmentManifest = await readJson<{ items?: AttachmentMeta[] }>(zip, "attachments.json");
+  const attachments = new Map<string, SourceAttachment>();
+  for (const meta of attachmentManifest?.items || []) {
+    if (!meta.id || !meta.noteId || !meta.packagePath) continue;
+    const entry = zip.file(meta.packagePath);
+    if (!entry) throw new Error(`Attachment file not found: ${meta.packagePath}`);
+    const buffer = Buffer.from(await entry.async("arraybuffer"));
+    const sourceHash = crypto.createHash("sha256").update(buffer).digest("hex");
+    if (meta.sha256 && meta.sha256 !== sourceHash) {
+      throw new Error(`Attachment checksum mismatch: ${meta.filename || meta.id}`);
+    }
+    attachments.set(meta.id, { meta: { ...meta, sha256: sourceHash }, buffer, sourceHash });
+  }
+
+  const notes = new Map<string, SourceNote>();
+  const notesFolder = zip.folder("notes");
+  if (notesFolder) {
+    for (const filename of Object.keys(notesFolder.files)) {
+      if (!filename.endsWith("/meta.json")) continue;
+      const sourceId = filename.split("/")[1];
+      if (!sourceId) continue;
+      const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
+      if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
+      const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
+      if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
+      const content = await contentEntry.async("string");
+      const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
+      notes.set(sourceId, {
+        meta,
+        content,
+        sourceHash: sourceNoteHash(meta, content, noteAttachments),
+      });
+    }
+  }
+
+  return {
+    manifest,
+    notebooks,
+    notes,
+    tags: (await readJson<TagMeta[]>(zip, "tags.json")) || [],
+    noteTags: (await readJson<Array<{ noteId: string; tagId: string }>>(zip, "note_tags.json")) || [],
+    attachments,
+  };
+}
+
+function scopeWhere(workspaceId: string | null): { sql: string; params: unknown[] } {
+  return workspaceId
+    ? { sql: "workspaceId = ?", params: [workspaceId] }
+    : { sql: "workspaceId IS NULL", params: [] };
+}
+
+export function captureRoundTripImportSnapshot(
+  userId: string,
+  workspaceId: string | null,
+): ImportTargetSnapshot {
+  const db = getDb();
+  const scope = scopeWhere(workspaceId);
+  const notebooks = db.prepare(`SELECT id FROM notebooks WHERE userId = ? AND ${scope.sql}`).all(userId, ...scope.params) as Array<{ id: string }>;
+  const notes = db.prepare(`SELECT id FROM notes WHERE userId = ? AND ${scope.sql}`).all(userId, ...scope.params) as Array<{ id: string }>;
+  const attachments = db.prepare(`
+    SELECT a.id
+      FROM attachments a
+      JOIN notes n ON n.id = a.noteId
+     WHERE n.userId = ? AND n.${scope.sql}
+  `).all(userId, ...scope.params) as Array<{ id: string }>;
+  return {
+    notebookIds: new Set(notebooks.map((item) => item.id)),
+    noteIds: new Set(notes.map((item) => item.id)),
+    attachmentIds: new Set(attachments.map((item) => item.id)),
+  };
+}
+
+function loadLinks(
+  db: ReturnType<typeof getDb>,
+  userId: string,
+  workspaceId: string | null,
+  sourceInstanceId: string,
+): LinkRow[] {
+  ensureRoundTripImportLinksSchema(db);
+  return db.prepare(`
+    SELECT * FROM roundtrip_import_links
+     WHERE userId = ? AND workspaceScope = ? AND sourceInstanceId = ?
+  `).all(userId, workspaceScope(workspaceId), sourceInstanceId) as LinkRow[];
+}
+
+function linkKey(resourceType: LinkRow["resourceType"], sourceResourceId: string): string {
+  return `${resourceType}:${sourceResourceId}`;
+}
+
+function linkMap(rows: LinkRow[]): Map<string, LinkRow> {
+  return new Map(rows.map((row) => [linkKey(row.resourceType, row.sourceResourceId), row]));
+}
+
+function upsertLink(db: ReturnType<typeof getDb>, args: {
+  userId: string;
+  workspaceId: string | null;
+  sourceInstanceId: string;
+  resourceType: LinkRow["resourceType"];
+  sourceResourceId: string;
+  targetResourceId: string;
+  sourceHash: string;
+  targetHash: string;
+  exportBatchId?: string;
+  metadata?: Record<string, unknown>;
+}): void {
+  db.prepare(`
+    INSERT INTO roundtrip_import_links (
+      id, userId, workspaceId, workspaceScope, sourceInstanceId, resourceType,
+      sourceResourceId, targetResourceId, sourceHash, targetHash,
+      lastExportBatchId, importedAt, updatedAt, metadata
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?)
+    ON CONFLICT(userId, workspaceScope, sourceInstanceId, resourceType, sourceResourceId)
+    DO UPDATE SET
+      workspaceId = excluded.workspaceId,
+      targetResourceId = excluded.targetResourceId,
+      sourceHash = excluded.sourceHash,
+      targetHash = excluded.targetHash,
+      lastExportBatchId = excluded.lastExportBatchId,
+      updatedAt = datetime('now'),
+      metadata = excluded.metadata
+  `).run(
+    uuid(), args.userId, args.workspaceId, workspaceScope(args.workspaceId),
+    args.sourceInstanceId, args.resourceType, args.sourceResourceId, args.targetResourceId,
+    args.sourceHash, args.targetHash, args.exportBatchId || null,
+    JSON.stringify(args.metadata || {}),
+  );
+}
+
+function touchLinkBatch(db: ReturnType<typeof getDb>, link: LinkRow, exportBatchId?: string): void {
+  db.prepare(`
+    UPDATE roundtrip_import_links
+       SET lastExportBatchId = ?, updatedAt = datetime('now')
+     WHERE id = ?
+  `).run(exportBatchId || null, link.id);
+}
+
+function notebookRowsForScope(userId: string, workspaceId: string | null): NotebookRow[] {
+  const scope = scopeWhere(workspaceId);
+  return getDb().prepare(`
+    SELECT id, parentId, name, description, icon, color, sortOrder, isExpanded, createdAt, updatedAt
+      FROM notebooks
+     WHERE userId = ? AND ${scope.sql} AND (isDeleted IS NULL OR isDeleted = 0)
+  `).all(userId, ...scope.params) as NotebookRow[];
+}
+
+function noteRowsForScope(userId: string, workspaceId: string | null): NoteRow[] {
+  const scope = scopeWhere(workspaceId);
+  return getDb().prepare(`
+    SELECT rowid, id, notebookId, title, content, contentText, contentFormat,
+           isPinned, isFavorite, isLocked, isArchived, version, sortOrder, createdAt, updatedAt
+      FROM notes
+     WHERE userId = ? AND ${scope.sql} AND (isTrashed IS NULL OR isTrashed = 0)
+     ORDER BY rowid
+  `).all(userId, ...scope.params) as NoteRow[];
+}
+
+function attachmentRowsForScope(userId: string, workspaceId: string | null): AttachmentRow[] {
+  const scope = scopeWhere(workspaceId);
+  return getDb().prepare(`
+    SELECT a.rowid, a.id, a.noteId, a.filename, a.mimeType, a.size, a.path, a.hash, a.createdAt
+      FROM attachments a
+      JOIN notes n ON n.id = a.noteId
+     WHERE n.userId = ? AND n.${scope.sql}
+     ORDER BY a.rowid
+  `).all(userId, ...scope.params) as AttachmentRow[];
+}
+
+function withSyncAvailability(result: any, model: PackageModel, userId: string, workspaceId: string | null): any {
+  const sourceInstanceId = String(model.manifest.sourceInstanceId || "").trim();
+  const validIdentity = SOURCE_INSTANCE_PATTERN.test(sourceInstanceId);
+  const linkedResources = validIdentity
+    ? loadLinks(getDb(), userId, workspaceId, sourceInstanceId).length
+    : 0;
+  const packageKind = model.manifest.packageKind || "nowen";
+  const available = packageKind !== "markdown" && validIdentity && linkedResources > 0;
+  result.package = {
+    ...(result.package || {}),
+    sourceInstanceId: validIdentity ? sourceInstanceId : null,
+    exportBatchId: model.manifest.exportBatchId || null,
+    sync: {
+      available,
+      linkedResources,
+      reason: packageKind === "markdown"
+        ? "Markdown 往返包发生过格式转换，不支持覆盖同步"
+        : !validIdentity
+          ? "数据包没有稳定的 sourceInstanceId，请重新导出"
+          : linkedResources === 0
+            ? "当前空间尚未导入过该来源，请先创建副本或合并导入"
+            : null,
+    },
+  };
+  return result;
+}
+
+function rootsOf(model: PackageModel): NotebookMeta[] {
+  const ids = new Set(model.notebooks.map((item) => item.id));
+  return model.notebooks.filter((item) => !item.parentId || !ids.has(item.parentId));
+}
+
+export async function recordRoundTripLinksAfterImport(args: {
+  zipBuffer: Buffer;
+  userId: string;
+  workspaceId: string | null;
+  snapshot: ImportTargetSnapshot;
+  result: any;
+}): Promise<void> {
+  const model = await parsePackage(args.zipBuffer);
+  const sourceInstanceId = String(model.manifest.sourceInstanceId || "").trim();
+  if (model.manifest.packageKind === "markdown" || !SOURCE_INSTANCE_PATTERN.test(sourceInstanceId)) return;
+
+  const db = getDb();
+  ensureRoundTripImportLinksSchema(db);
+  const conflicts = (args.result.conflicts || []) as ImportConflict[];
+  const mergedBySource = new Map(conflicts
+    .filter((item) => item.action === "merge-directory" && item.targetId)
+    .map((item) => [item.sourceId, item.targetId!]));
+  const renamedNoteBySource = new Map(conflicts
+    .filter((item) => item.action === "rename-note")
+    .map((item) => [item.sourceId, item.importedName]));
+
+  const allNotebooks = notebookRowsForScope(args.userId, args.workspaceId);
+  const newNotebookIds = new Set(allNotebooks.filter((item) => !args.snapshot.notebookIds.has(item.id)).map((item) => item.id));
+  const targetNotebookById = new Map(allNotebooks.map((item) => [item.id, item]));
+  const notebookMap = new Map<string, string>();
+  const usedNotebookTargets = new Set<string>();
+  const roots = rootsOf(model);
+  const importedRoots = (args.result.rootNotebookIds || []) as string[];
+  roots.forEach((source, index) => {
+    const targetId = mergedBySource.get(source.id) || importedRoots[index];
+    if (targetId) {
+      notebookMap.set(source.id, targetId);
+      usedNotebookTargets.add(targetId);
+    }
+  });
+
+  for (const source of model.notebooks) {
+    if (notebookMap.has(source.id)) continue;
+    const explicit = mergedBySource.get(source.id);
+    if (explicit) {
+      notebookMap.set(source.id, explicit);
+      usedNotebookTargets.add(explicit);
+      continue;
+    }
+    const parentId = source.parentId ? notebookMap.get(source.parentId) : null;
+    const candidates = allNotebooks.filter((item) =>
+      !usedNotebookTargets.has(item.id)
+      && newNotebookIds.has(item.id)
+      && item.parentId === (parentId || null)
+      && item.name === source.name,
+    ).sort((a, b) =>
+      Number(a.sortOrder === source.sortOrder ? -1 : 0)
+      || a.createdAt.localeCompare(b.createdAt)
+      || a.id.localeCompare(b.id),
+    );
+    const target = candidates[0];
+    if (target) {
+      notebookMap.set(source.id, target.id);
+      usedNotebookTargets.add(target.id);
+    }
+  }
+
+  const allNotes = noteRowsForScope(args.userId, args.workspaceId);
+  const newNotes = allNotes.filter((item) => !args.snapshot.noteIds.has(item.id));
+  const usedNotes = new Set<string>();
+  const noteMap = new Map<string, string>();
+  for (const [sourceId, source] of model.notes) {
+    const notebookId = notebookMap.get(source.meta.notebookId);
+    if (!notebookId) continue;
+    const title = renamedNoteBySource.get(sourceId) || source.meta.title;
+    const candidate = newNotes.find((item) =>
+      !usedNotes.has(item.id)
+      && item.notebookId === notebookId
+      && item.title === title
+      && item.contentFormat === (KNOWN_CONTENT_FORMATS.has(source.meta.contentFormat) ? source.meta.contentFormat : "tiptap-json")
+      && item.sortOrder === (source.meta.sortOrder || 0),
+    ) || newNotes.find((item) => !usedNotes.has(item.id) && item.notebookId === notebookId && item.title === title);
+    if (candidate) {
+      noteMap.set(sourceId, candidate.id);
+      usedNotes.add(candidate.id);
+    }
+  }
+
+  const allAttachments = attachmentRowsForScope(args.userId, args.workspaceId);
+  const newAttachments = allAttachments.filter((item) => !args.snapshot.attachmentIds.has(item.id));
+  const usedAttachments = new Set<string>();
+  const attachmentMap = new Map<string, string>();
+  for (const [sourceId, source] of model.attachments) {
+    const noteId = noteMap.get(source.meta.noteId);
+    if (!noteId) continue;
+    const candidate = newAttachments.find((item) =>
+      !usedAttachments.has(item.id)
+      && item.noteId === noteId
+      && item.filename === source.meta.filename
+      && Number(item.size) === source.buffer.length
+      && item.mimeType === (source.meta.mimeType || "application/octet-stream"),
+    );
+    if (candidate) {
+      attachmentMap.set(sourceId, candidate.id);
+      usedAttachments.add(candidate.id);
+    }
+  }
+
+  const transaction = db.transaction(() => {
+    for (const source of model.notebooks) {
+      const targetId = notebookMap.get(source.id);
+      const target = targetId ? targetNotebookById.get(targetId) : undefined;
+      if (!targetId || !target) continue;
+      upsertLink(db, {
+        userId: args.userId,
+        workspaceId: args.workspaceId,
+        sourceInstanceId,
+        resourceType: "notebook",
+        sourceResourceId: source.id,
+        targetResourceId: targetId,
+        sourceHash: sourceNotebookHash(source),
+        targetHash: targetNotebookHash(target),
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { name: source.name },
+      });
+    }
+    for (const [sourceId, source] of model.notes) {
+      const targetId = noteMap.get(sourceId);
+      const targetHash = targetId ? targetNoteHash(db, targetId) : null;
+      if (!targetId || !targetHash) continue;
+      upsertLink(db, {
+        userId: args.userId,
+        workspaceId: args.workspaceId,
+        sourceInstanceId,
+        resourceType: "note",
+        sourceResourceId: sourceId,
+        targetResourceId: targetId,
+        sourceHash: source.sourceHash,
+        targetHash,
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { title: source.meta.title, sourceNotebookId: source.meta.notebookId },
+      });
+    }
+    for (const [sourceId, source] of model.attachments) {
+      const targetId = attachmentMap.get(sourceId);
+      if (!targetId) continue;
+      upsertLink(db, {
+        userId: args.userId,
+        workspaceId: args.workspaceId,
+        sourceInstanceId,
+        resourceType: "attachment",
+        sourceResourceId: sourceId,
+        targetResourceId: targetId,
+        sourceHash: source.sourceHash,
+        targetHash: source.sourceHash,
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { filename: source.meta.filename, sourceNoteId: source.meta.noteId },
+      });
+    }
+  });
+  transaction();
+}
+
+function uniqueName(desired: string, used: Set<string>): string {
+  if (!used.has(desired)) {
+    used.add(desired);
+    return desired;
+  }
+  let index = 2;
+  while (used.has(`${desired} (${index})`)) index += 1;
+  const result = `${desired} (${index})`;
+  used.add(result);
+  return result;
+}
+
+function parseLinkMetadata(link: LinkRow): Record<string, unknown> {
+  try { return link.metadata ? JSON.parse(link.metadata) as Record<string, unknown> : {}; }
+  catch { return {}; }
+}
+
+async function removeAttachmentObjects(rows: AttachmentRow[], warnings: any[]): Promise<void> {
+  const db = getDb();
+  for (const row of rows) {
+    try {
+      const other = db.prepare("SELECT COUNT(*) AS count FROM attachments WHERE path = ?").get(row.path) as { count: number };
+      if (!other.count) await deleteAttachmentObject(row.path);
+    } catch (error) {
+      warnings.push({
+        type: "attachment_cleanup_failed",
+        id: row.id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+export async function importRoundTripPackageSync(
+  zipBuffer: Buffer,
+  params: RoundTripImportParams,
+): Promise<any> {
+  const validation = await importNowenPackageV2(zipBuffer, {
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    targetNotebookId: undefined,
+    importMode: "new-root",
+    dryRun: true,
+  });
+  if (!validation.success) return { ...validation, strategy: "sync" };
+
+  const model = await parsePackage(zipBuffer);
+  const workspaceId = params.workspaceId || null;
+  const sourceInstanceId = String(model.manifest.sourceInstanceId || "").trim();
+  const errors: string[] = [];
+  const warnings: Array<{ type: string; message: string; id?: string }> = [];
+  const conflicts: Array<ImportConflict | {
+    action: "sync-create-directory" | "sync-update-directory" | "sync-create-note" | "sync-update-note" | "sync-local-conflict" | "sync-replace-attachment";
+    resourceType: "notebook" | "note" | "attachment";
+    sourceId: string;
+    originalName: string;
+    importedName: string;
+    parentId: string | null;
+    targetId?: string;
+  }> = [];
+
+  if (model.manifest.packageKind === "markdown") {
+    errors.push("Markdown 往返包发生过格式转换，不能使用增量同步");
+  }
+  if (!SOURCE_INSTANCE_PATTERN.test(sourceInstanceId)) {
+    errors.push("数据包缺少稳定 sourceInstanceId，请在来源实例重新导出 Nowen 无损包");
+  }
+  if (params.targetNotebookId) {
+    errors.push("增量同步使用首次导入时记录的位置，不能重新指定目标笔记本");
+  }
+
+  const db = getDb();
+  ensureRoundTripImportLinksSchema(db);
+  const links = SOURCE_INSTANCE_PATTERN.test(sourceInstanceId)
+    ? loadLinks(db, params.userId, workspaceId, sourceInstanceId)
+    : [];
+  if (!links.length) errors.push("当前空间没有该来源的导入映射，请先使用“创建独立副本”或“合并导入”完成首次导入");
+  const linksByKey = linkMap(links);
+
+  const targetNotebooks = notebookRowsForScope(params.userId, workspaceId);
+  const targetNotebookById = new Map(targetNotebooks.map((item) => [item.id, item]));
+  const namesByParent = new Map<string, Set<string>>();
+  const nameSet = (parentId: string | null): Set<string> => {
+    const key = parentId || "__root__";
+    let set = namesByParent.get(key);
+    if (!set) {
+      set = new Set(targetNotebooks.filter((item) => item.parentId === parentId).map((item) => item.name));
+      namesByParent.set(key, set);
+    }
+    return set;
+  };
+
+  const notebookPlans: SyncNotebookPlan[] = [];
+  const notebookIdMap = new Map<string, string>();
+  for (const source of model.notebooks) {
+    const parentTargetId = source.parentId ? notebookIdMap.get(source.parentId) || null : null;
+    const sourceHash = sourceNotebookHash(source);
+    const link = linksByKey.get(linkKey("notebook", source.id));
+    const target = link ? targetNotebookById.get(link.targetResourceId) : undefined;
+    if (!target) {
+      const targetId = uuid();
+      const importedName = uniqueName(source.name, nameSet(parentTargetId));
+      notebookIdMap.set(source.id, targetId);
+      const action = link ? "recreate" : "create";
+      notebookPlans.push({ source, sourceHash, targetId, parentTargetId, importedName, action, link });
+      conflicts.push({
+        action: "sync-create-directory",
+        resourceType: "notebook",
+        sourceId: source.id,
+        originalName: source.name,
+        importedName,
+        parentId: parentTargetId,
+        targetId,
+      });
+      continue;
+    }
+
+    notebookIdMap.set(source.id, target.id);
+    const sourceChanged = sourceHash !== (link?.sourceHash || "");
+    const currentHash = targetNotebookHash(target);
+    if (!sourceChanged) {
+      notebookPlans.push({ source, sourceHash, targetId: target.id, parentTargetId, importedName: target.name, action: "unchanged", link });
+      continue;
+    }
+    if (!link?.targetHash || currentHash !== link.targetHash) {
+      notebookPlans.push({ source, sourceHash, targetId: target.id, parentTargetId: target.parentId, importedName: target.name, action: "local-conflict", link });
+      conflicts.push({
+        action: "sync-local-conflict",
+        resourceType: "notebook",
+        sourceId: source.id,
+        originalName: source.name,
+        importedName: target.name,
+        parentId: target.parentId,
+        targetId: target.id,
+      });
+      continue;
+    }
+    const used = nameSet(parentTargetId);
+    used.delete(target.name);
+    const importedName = uniqueName(source.name, used);
+    notebookPlans.push({ source, sourceHash, targetId: target.id, parentTargetId, importedName, action: "update", link });
+    conflicts.push({
+      action: "sync-update-directory",
+      resourceType: "notebook",
+      sourceId: source.id,
+      originalName: target.name,
+      importedName,
+      parentId: parentTargetId,
+      targetId: target.id,
+    });
+  }
+
+  const targetNotes = noteRowsForScope(params.userId, workspaceId);
+  const targetNoteById = new Map(targetNotes.map((item) => [item.id, item]));
+  const titlesByNotebook = new Map<string, Set<string>>();
+  const titleSet = (notebookId: string): Set<string> => {
+    let set = titlesByNotebook.get(notebookId);
+    if (!set) {
+      set = new Set(targetNotes.filter((item) => item.notebookId === notebookId).map((item) => item.title));
+      titlesByNotebook.set(notebookId, set);
+    }
+    return set;
+  };
+
+  const notePlans: SyncNotePlan[] = [];
+  const noteIdMap = new Map<string, string>();
+  for (const [sourceId, source] of model.notes) {
+    const notebookId = notebookIdMap.get(source.meta.notebookId);
+    if (!notebookId) {
+      errors.push(`无法确定笔记目标目录：${source.meta.title}`);
+      continue;
+    }
+    const link = linksByKey.get(linkKey("note", sourceId));
+    const target = link ? targetNoteById.get(link.targetResourceId) : undefined;
+    if (!target) {
+      const targetId = uuid();
+      const importedTitle = uniqueName(source.meta.title, titleSet(notebookId));
+      noteIdMap.set(sourceId, targetId);
+      const action = link ? "recreate" : "create";
+      notePlans.push({ source, targetId, notebookId, importedTitle, action, link });
+      conflicts.push({
+        action: "sync-create-note",
+        resourceType: "note",
+        sourceId,
+        originalName: source.meta.title,
+        importedName: importedTitle,
+        parentId: notebookId,
+        targetId,
+      });
+      continue;
+    }
+
+    noteIdMap.set(sourceId, target.id);
+    const sourceChanged = source.sourceHash !== (link?.sourceHash || "");
+    if (!sourceChanged) {
+      notePlans.push({ source, targetId: target.id, notebookId: target.notebookId, importedTitle: target.title, action: "unchanged", link });
+      continue;
+    }
+    const currentHash = targetNoteHash(db, target.id);
+    if (!link?.targetHash || currentHash !== link.targetHash) {
+      notePlans.push({ source, targetId: target.id, notebookId: target.notebookId, importedTitle: target.title, action: "local-conflict", link });
+      conflicts.push({
+        action: "sync-local-conflict",
+        resourceType: "note",
+        sourceId,
+        originalName: source.meta.title,
+        importedName: target.title,
+        parentId: target.notebookId,
+        targetId: target.id,
+      });
+      continue;
+    }
+    notePlans.push({ source, targetId: target.id, notebookId, importedTitle: source.meta.title, action: "update", link });
+    conflicts.push({
+      action: "sync-update-note",
+      resourceType: "note",
+      sourceId,
+      originalName: target.title,
+      importedName: source.meta.title,
+      parentId: notebookId,
+      targetId: target.id,
+    });
+  }
+
+  const targetAttachments = attachmentRowsForScope(params.userId, workspaceId);
+  const targetAttachmentById = new Map(targetAttachments.map((item) => [item.id, item]));
+  const notePlanBySource = new Map(notePlans.map((plan) => [plan.source.meta.id, plan]));
+  const attachmentPlans: SyncAttachmentPlan[] = [];
+  const attachmentIdMap = new Map<string, string>();
+  for (const [sourceId, source] of model.attachments) {
+    const notePlan = notePlanBySource.get(source.meta.noteId);
+    const link = linksByKey.get(linkKey("attachment", sourceId));
+    const target = link ? targetAttachmentById.get(link.targetResourceId) : undefined;
+    if (!notePlan || notePlan.action === "unchanged" || notePlan.action === "local-conflict") {
+      if (target) attachmentIdMap.set(sourceId, target.id);
+      attachmentPlans.push({ source, targetId: target?.id || "", targetNoteId: notePlan?.targetId || "", action: "ignore", link });
+      continue;
+    }
+    if (target && link?.sourceHash === source.sourceHash && target.noteId === notePlan.targetId) {
+      attachmentIdMap.set(sourceId, target.id);
+      attachmentPlans.push({ source, targetId: target.id, targetNoteId: notePlan.targetId, action: "reuse", link });
+      continue;
+    }
+    const targetId = uuid();
+    attachmentIdMap.set(sourceId, targetId);
+    attachmentPlans.push({
+      source,
+      targetId,
+      targetNoteId: notePlan.targetId,
+      action: target ? "replace" : "create",
+      oldTargetId: target?.id,
+      link,
+    });
+    if (target) {
+      conflicts.push({
+        action: "sync-replace-attachment",
+        resourceType: "attachment",
+        sourceId,
+        originalName: target.filename,
+        importedName: source.meta.filename,
+        parentId: notePlan.targetId,
+        targetId,
+      });
+    }
+  }
+
+  const sourceAttachmentIdsByNote = new Map<string, Set<string>>();
+  for (const [sourceId, source] of model.attachments) {
+    const set = sourceAttachmentIdsByNote.get(source.meta.noteId) || new Set<string>();
+    set.add(sourceId);
+    sourceAttachmentIdsByNote.set(source.meta.noteId, set);
+  }
+  const staleAttachmentRows: AttachmentRow[] = [];
+  for (const plan of notePlans) {
+    if (plan.action !== "update") continue;
+    const currentIds = sourceAttachmentIdsByNote.get(plan.source.meta.id) || new Set<string>();
+    for (const link of links.filter((item) => item.resourceType === "attachment")) {
+      const metadata = parseLinkMetadata(link);
+      if (metadata.sourceNoteId !== plan.source.meta.id) continue;
+      const replacement = attachmentPlans.find((item) => item.source.meta.id === link.sourceResourceId);
+      if (!currentIds.has(link.sourceResourceId) || (replacement && replacement.targetId !== link.targetResourceId)) {
+        const row = targetAttachmentById.get(link.targetResourceId);
+        if (row && row.noteId === plan.targetId) staleAttachmentRows.push(row);
+      }
+    }
+  }
+
+  const counts = {
+    notebooks: notebookPlans.filter((item) => item.action === "create" || item.action === "recreate").length,
+    notes: notePlans.filter((item) => item.action === "create" || item.action === "recreate").length,
+    tags: model.tags.length,
+    noteTags: model.noteTags.length,
+    attachments: attachmentPlans.filter((item) => item.action === "create" || item.action === "replace").length,
+    updatedNotebooks: notebookPlans.filter((item) => item.action === "update").length,
+    updatedNotes: notePlans.filter((item) => item.action === "update").length,
+    unchangedNotes: notePlans.filter((item) => item.action === "unchanged").length,
+    localConflicts: notebookPlans.filter((item) => item.action === "local-conflict").length
+      + notePlans.filter((item) => item.action === "local-conflict").length,
+    recreatedResources: notebookPlans.filter((item) => item.action === "recreate").length
+      + notePlans.filter((item) => item.action === "recreate").length,
+    reusedAttachments: attachmentPlans.filter((item) => item.action === "reuse").length,
+    removedAttachments: staleAttachmentRows.length,
+  };
+
+  const packagePreview = {
+    format: model.manifest.format,
+    formatVersion: model.manifest.formatVersion,
+    schemaVersion: model.manifest.schemaVersion,
+    exportedAt: model.manifest.exportedAt,
+    packageKind: model.manifest.packageKind,
+    sourceInstanceId,
+    exportBatchId: model.manifest.exportBatchId || null,
+    counts: {
+      notebooks: model.notebooks.length,
+      notes: model.notes.size,
+      tags: model.tags.length,
+      attachments: model.attachments.size,
+    },
+    formatStats: model.manifest.formatStats || { markdown: 0, richText: 0, html: 0 },
+    sync: { available: errors.length === 0, linkedResources: links.length, reason: errors[0] || null },
+  };
+
+  warnings.push({
+    type: "sync_non_destructive",
+    message: "本次采用非破坏性增量同步：不会删除目标中已存在但本数据包未包含的笔记或目录",
+  });
+  if (counts.localConflicts > 0) {
+    warnings.push({
+      type: "sync_local_conflicts",
+      message: `检测到 ${counts.localConflicts} 项本地修改冲突，已保留本地版本并跳过覆盖`,
+    });
+  }
+
+  if (params.dryRun || errors.length) {
+    return {
+      success: errors.length === 0,
+      dryRun: params.dryRun === true,
+      strategy: "sync",
+      package: packagePreview,
+      counts,
+      conflicts,
+      warnings,
+      errors,
+    };
+  }
+
+  const writtenPaths: string[] = [];
+  try {
+    for (const plan of attachmentPlans) {
+      if (plan.action !== "create" && plan.action !== "replace") continue;
+      plan.storagePath = `${getUploadMonthPath()}/${plan.targetId}${safeExtension(plan.source.meta.filename)}`;
+      await writeAttachmentObject(
+        plan.storagePath,
+        plan.source.buffer,
+        plan.source.meta.mimeType || "application/octet-stream",
+      );
+      writtenPaths.push(plan.storagePath);
+    }
+  } catch (error) {
+    await Promise.all(writtenPaths.map((item) => deleteAttachmentObject(item).catch(() => undefined)));
+    return {
+      success: false,
+      dryRun: false,
+      strategy: "sync",
+      package: packagePreview,
+      counts,
+      conflicts,
+      warnings,
+      errors: [`Attachment restore failed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  const tagIdMap = new Map<string, string>();
+  const rewrittenByNote = new Map<string, string>();
+  try {
+    db.exec("BEGIN TRANSACTION");
+
+    for (const plan of notebookPlans) {
+      if (plan.action === "create" || plan.action === "recreate") {
+        db.prepare(`
+          INSERT INTO notebooks (
+            id, userId, workspaceId, parentId, name, description, icon, color,
+            sortOrder, isExpanded, isDeleted, createdAt, updatedAt
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+        `).run(
+          plan.targetId, params.userId, workspaceId, plan.parentTargetId, plan.importedName,
+          plan.source.description, plan.source.icon, plan.source.color, plan.source.sortOrder,
+          plan.source.isExpanded, plan.source.createdAt, plan.source.updatedAt,
+        );
+      } else if (plan.action === "update") {
+        db.prepare(`
+          UPDATE notebooks
+             SET parentId = ?, name = ?, description = ?, icon = ?, color = ?,
+                 sortOrder = ?, isExpanded = ?, createdAt = ?, updatedAt = ?
+           WHERE id = ?
+        `).run(
+          plan.parentTargetId, plan.importedName, plan.source.description, plan.source.icon,
+          plan.source.color, plan.source.sortOrder, plan.source.isExpanded,
+          plan.source.createdAt, plan.source.updatedAt, plan.targetId,
+        );
+      }
+    }
+
+    for (const tag of model.tags) {
+      const existing = db.prepare(`
+        SELECT id FROM tags
+         WHERE userId = ? AND name = ? AND workspaceId ${workspaceId ? "= ?" : "IS NULL"}
+         LIMIT 1
+      `).get(...(workspaceId ? [params.userId, tag.name, workspaceId] : [params.userId, tag.name])) as { id: string } | undefined;
+      if (existing) tagIdMap.set(tag.id, existing.id);
+      else {
+        const targetId = uuid();
+        db.prepare("INSERT INTO tags (id, userId, workspaceId, name, color, createdAt) VALUES (?, ?, ?, ?, ?, ?)")
+          .run(targetId, params.userId, workspaceId, tag.name, tag.color, tag.createdAt);
+        tagIdMap.set(tag.id, targetId);
+      }
+    }
+
+    for (const plan of notePlans) {
+      if (plan.action !== "create" && plan.action !== "recreate" && plan.action !== "update") continue;
+      const rewritten = rewriteIdReferences(plan.source.content, attachmentIdMap, noteIdMap);
+      for (const sourceId of rewritten.unmappedAttachmentIds) {
+        warnings.push({ type: "attachment_ref_unmapped", id: sourceId, message: `附件 ${sourceId} 未能恢复` });
+      }
+      const meta = plan.source.meta;
+      const contentFormat = KNOWN_CONTENT_FORMATS.has(meta.contentFormat) ? meta.contentFormat : "tiptap-json";
+      if (plan.action === "create" || plan.action === "recreate") {
+        db.prepare(`
+          INSERT INTO notes (
+            id, userId, workspaceId, notebookId, title, content, contentText, contentFormat,
+            isPinned, isFavorite, isLocked, isArchived, isTrashed, version, sortOrder,
+            createdAt, updatedAt
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+        `).run(
+          plan.targetId, params.userId, workspaceId, plan.notebookId, plan.importedTitle,
+          rewritten.content, meta.contentText || "", contentFormat, meta.isPinned || 0,
+          meta.isFavorite || 0, meta.isLocked || 0, meta.isArchived || 0,
+          meta.version || 1, meta.sortOrder || 0, meta.createdAt, meta.updatedAt,
+        );
+      } else {
+        db.prepare(`
+          UPDATE notes
+             SET notebookId = ?, title = ?, content = ?, contentText = ?, contentFormat = ?,
+                 isPinned = ?, isFavorite = ?, isLocked = ?, isArchived = ?,
+                 sortOrder = ?, createdAt = ?, updatedAt = ?, version = version + 1
+           WHERE id = ?
+        `).run(
+          plan.notebookId, plan.importedTitle, rewritten.content, meta.contentText || "",
+          contentFormat, meta.isPinned || 0, meta.isFavorite || 0, meta.isLocked || 0,
+          meta.isArchived || 0, meta.sortOrder || 0, meta.createdAt, meta.updatedAt, plan.targetId,
+        );
+      }
+      rewrittenByNote.set(plan.targetId, rewritten.content);
+    }
+
+    for (const plan of attachmentPlans) {
+      if (plan.action !== "create" && plan.action !== "replace") continue;
+      db.prepare(`
+        INSERT INTO attachments (
+          id, userId, workspaceId, noteId, filename, mimeType, size, path, hash, uploadSource, createdAt
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        plan.targetId, params.userId, workspaceId, plan.targetNoteId,
+        plan.source.meta.filename, plan.source.meta.mimeType || "application/octet-stream",
+        plan.source.buffer.length, plan.storagePath, plan.source.sourceHash,
+        "nowen-roundtrip-sync", plan.source.meta.createdAt,
+      );
+    }
+
+    for (const row of staleAttachmentRows) {
+      db.prepare("DELETE FROM attachments WHERE id = ?").run(row.id);
+    }
+
+    for (const relation of model.noteTags) {
+      const notePlan = notePlanBySource.get(relation.noteId);
+      const tagId = tagIdMap.get(relation.tagId);
+      if (!notePlan || !tagId || (notePlan.action !== "create" && notePlan.action !== "recreate" && notePlan.action !== "update")) continue;
+      db.prepare("INSERT OR IGNORE INTO note_tags (noteId, tagId) VALUES (?, ?)").run(notePlan.targetId, tagId);
+    }
+
+    for (const [noteId, content] of rewrittenByNote) {
+      if (content.includes("/api/attachments/")) syncAttachmentReferences(db, noteId, content);
+    }
+
+    for (const plan of notebookPlans) {
+      if (plan.action === "local-conflict") continue;
+      if (plan.action === "unchanged" && plan.link) {
+        touchLinkBatch(db, plan.link, model.manifest.exportBatchId);
+        continue;
+      }
+      const target = db.prepare(`
+        SELECT id, parentId, name, description, icon, color, sortOrder, isExpanded, createdAt, updatedAt
+          FROM notebooks WHERE id = ?
+      `).get(plan.targetId) as NotebookRow;
+      upsertLink(db, {
+        userId: params.userId,
+        workspaceId,
+        sourceInstanceId,
+        resourceType: "notebook",
+        sourceResourceId: plan.source.id,
+        targetResourceId: plan.targetId,
+        sourceHash: plan.sourceHash,
+        targetHash: targetNotebookHash(target),
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { name: plan.source.name },
+      });
+    }
+
+    for (const plan of notePlans) {
+      if (plan.action === "local-conflict") continue;
+      if (plan.action === "unchanged" && plan.link) {
+        touchLinkBatch(db, plan.link, model.manifest.exportBatchId);
+        continue;
+      }
+      const currentTargetHash = targetNoteHash(db, plan.targetId);
+      if (!currentTargetHash) continue;
+      upsertLink(db, {
+        userId: params.userId,
+        workspaceId,
+        sourceInstanceId,
+        resourceType: "note",
+        sourceResourceId: plan.source.meta.id,
+        targetResourceId: plan.targetId,
+        sourceHash: plan.source.sourceHash,
+        targetHash: currentTargetHash,
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { title: plan.source.meta.title, sourceNotebookId: plan.source.meta.notebookId },
+      });
+    }
+
+    for (const plan of attachmentPlans) {
+      if (plan.action === "ignore" || !plan.targetId) continue;
+      upsertLink(db, {
+        userId: params.userId,
+        workspaceId,
+        sourceInstanceId,
+        resourceType: "attachment",
+        sourceResourceId: plan.source.meta.id,
+        targetResourceId: plan.targetId,
+        sourceHash: plan.source.sourceHash,
+        targetHash: plan.source.sourceHash,
+        exportBatchId: model.manifest.exportBatchId,
+        metadata: { filename: plan.source.meta.filename, sourceNoteId: plan.source.meta.noteId },
+      });
+    }
+
+    db.exec("COMMIT");
+  } catch (error) {
+    try { db.exec("ROLLBACK"); } catch { /* ignore */ }
+    await Promise.all(writtenPaths.map((item) => deleteAttachmentObject(item).catch(() => undefined)));
+    return {
+      success: false,
+      dryRun: false,
+      strategy: "sync",
+      package: packagePreview,
+      counts,
+      conflicts,
+      warnings,
+      errors: [`Sync failed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  await removeAttachmentObjects(staleAttachmentRows, warnings);
+  return {
+    success: true,
+    dryRun: false,
+    strategy: "sync",
+    rootNotebookId: notebookPlans.find((item) => !item.source.parentId)?.targetId,
+    rootNotebookIds: notebookPlans.filter((item) => !item.source.parentId).map((item) => item.targetId),
+    package: packagePreview,
+    counts,
+    conflicts,
+    warnings,
+    errors: [],
+  };
+}
+
+export async function importNowenPackageWithSync(
+  zipBuffer: Buffer,
+  params: RoundTripImportParams,
+): Promise<any> {
+  if (params.importMode === "sync") return importRoundTripPackageSync(zipBuffer, params);
+
+  const workspaceId = params.workspaceId || null;
+  const snapshot = params.dryRun ? null : captureRoundTripImportSnapshot(params.userId, workspaceId);
+  const result = await importNowenPackageV2(zipBuffer, {
+    ...params,
+    importMode: params.importMode === "merge"
+      ? "merge"
+      : params.importMode === "into-target"
+        ? "into-target"
+        : "new-root",
+  });
+
+  let model: PackageModel | null = null;
+  try {
+    model = await parsePackage(zipBuffer);
+    withSyncAvailability(result, model, params.userId, workspaceId);
+  } catch (error) {
+    result.warnings = [...(result.warnings || []), {
+      type: "sync_manifest_unavailable",
+      message: error instanceof Error ? error.message : String(error),
+    }];
+  }
+
+  if (result.success && !params.dryRun && snapshot && model?.manifest.packageKind !== "markdown") {
+    try {
+      await recordRoundTripLinksAfterImport({
+        zipBuffer,
+        userId: params.userId,
+        workspaceId,
+        snapshot,
+        result,
+      });
+      withSyncAvailability(result, model, params.userId, workspaceId);
+    } catch (error) {
+      result.warnings = [...(result.warnings || []), {
+        type: "sync_link_record_failed",
+        message: `数据已导入，但来源映射记录失败：${error instanceof Error ? error.message : String(error)}`,
+      }];
+    }
+  }
+  return result;
+}

--- a/backend/src/services/roundTripMarkdownExportJobs.ts
+++ b/backend/src/services/roundTripMarkdownExportJobs.ts
@@ -11,7 +11,12 @@ import {
   type PreparedMarkdownNote,
   type ReliableExportJobSnapshot,
 } from "./reliableExportJobs";
-import { createNowenPackageExport } from "./nowenPackageExport";
+import { createStableNowenPackageExport } from "./nowenPackageExportStable";
+import { ensureNowenInstanceEnvironment } from "./nowenInstanceIdentity";
+
+// export.ts imports this service at router startup. Pin the instance identity once so the native
+// Nowen-package endpoint and Markdown jobs both write the same stable sourceInstanceId.
+ensureNowenInstanceEnvironment();
 
 const TMP_PREFIX = "nowen-roundtrip-markdown-";
 const TTL_MS = 30 * 60 * 1000;
@@ -104,7 +109,7 @@ async function buildJob(
     job.message = "正在生成完整目录与附件清单";
     const noteIds = notes.map((note) => note.id);
     const workspaceId = inferWorkspaceId(job.userId, noteIds);
-    const result = await createNowenPackageExport({
+    const result = await createStableNowenPackageExport({
       userId: job.userId,
       workspaceId,
       noteIds,

--- a/backend/tests/nowen-package-roundtrip.test.ts
+++ b/backend/tests/nowen-package-roundtrip.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-package-roundtrip-test-"));
 process.env.DB_PATH = path.join(tmpDir, "test.db");
 process.env.ELECTRON_USER_DATA = tmpDir;
+process.env.NOWEN_INSTANCE_ID = "roundtrip-source-instance-test";
 
 let closeDb: typeof import("../src/db/schema").closeDb;
 
@@ -15,7 +16,7 @@ test.after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-test("Nowen package supports independent-copy and explicit safe-merge round trips", async () => {
+test("Nowen package supports copy, merge and conflict-safe incremental sync round trips", async () => {
   const schema = await import("../src/db/schema");
   const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
   const { importNowenPackage } = await import("../src/services/nowenPackageImport");
@@ -67,11 +68,15 @@ test("Nowen package supports independent-copy and explicit safe-merge round trip
     "2026-07-22 10:30:00",
   );
 
-  const exported = await createNowenPackageExport({
+  const exportSource = () => createNowenPackageExport({
     userId: "roundtrip-user",
     workspaceId: null,
+    notebookId: "root-source",
+    includeSubNotebooks: true,
     packageKind: "nowen",
   });
+
+  const exported = await exportSource();
   assert.equal(exported.stats.notebooks, 2);
   assert.equal(exported.stats.notes, 1);
   assert.equal(exported.stats.attachments, 1);
@@ -87,6 +92,7 @@ test("Nowen package supports independent-copy and explicit safe-merge round trip
   assert.equal(preview.conflicts?.length, 1);
   assert.equal(preview.conflicts?.[0].action, "rename-root");
   assert.equal(preview.conflicts?.[0].importedName, "产品资料 (2)");
+  assert.equal(preview.package?.sync?.available, false);
 
   const imported = await importNowenPackage(exported.buffer, {
     userId: "roundtrip-user",
@@ -98,6 +104,7 @@ test("Nowen package supports independent-copy and explicit safe-merge round trip
   assert.equal(imported.counts?.notebooks, 2);
   assert.equal(imported.counts?.notes, 1);
   assert.equal(imported.counts?.attachments, 1);
+  assert.equal(imported.package?.sync?.available, true);
 
   const importedRoot = db.prepare(`
     SELECT id, name, sortOrder FROM notebooks
@@ -149,6 +156,83 @@ test("Nowen package supports independent-copy and explicit safe-merge round trip
   assert.equal(importedAttachment!.size, 9);
   assert.equal(fs.readFileSync(path.join(attachmentDir, importedAttachment!.path), "utf8"), "pdf bytes");
 
+  const linkCounts = db.prepare(`
+    SELECT resourceType, COUNT(*) AS count
+      FROM roundtrip_import_links
+     WHERE sourceInstanceId = ?
+     GROUP BY resourceType
+  `).all("roundtrip-source-instance-test") as Array<{ resourceType: string; count: number }>;
+  assert.deepEqual(Object.fromEntries(linkCounts.map((item) => [item.resourceType, item.count])), {
+    attachment: 1,
+    note: 1,
+    notebook: 2,
+  });
+
+  // Source changed, target copy untouched: sync updates the mapped target in place.
+  db.prepare(`
+    UPDATE notes SET title = ?, content = ?, contentText = ?, updatedAt = ? WHERE id = ?
+  `).run(
+    "生产记录（来源更新）",
+    "来源第二版 [检测报告](/api/attachments/att-source)",
+    "来源第二版",
+    "2026-07-22 12:00:00",
+    "note-source",
+  );
+  const secondPackage = await exportSource();
+  const syncPreview = await importNowenPackage(secondPackage.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "sync",
+    dryRun: true,
+  });
+  assert.equal(syncPreview.success, true, syncPreview.errors.join("; "));
+  assert.equal(syncPreview.strategy, "sync");
+  assert.equal(syncPreview.counts?.updatedNotes, 1);
+  assert.equal(syncPreview.counts?.localConflicts, 0);
+
+  const synced = await importNowenPackage(secondPackage.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "sync",
+  });
+  assert.equal(synced.success, true, synced.errors.join("; "));
+  assert.equal(synced.counts?.updatedNotes, 1);
+  const afterSync = db.prepare("SELECT title, content FROM notes WHERE id = ?").get(importedNote!.id) as { title: string; content: string };
+  assert.equal(afterSync.title, "生产记录（来源更新）");
+  assert.match(afterSync.content, /来源第二版/);
+  assert.match(afterSync.content, new RegExp(`/api/attachments/${importedAttachment!.id}`));
+
+  // Both source and target changed: keep local content and report a conflict.
+  db.prepare("UPDATE notes SET title = ?, content = ?, contentText = ?, updatedAt = ? WHERE id = ?")
+    .run("本地人工修改", "本地必须保留", "本地必须保留", "2026-07-22 12:30:00", importedNote!.id);
+  db.prepare("UPDATE notes SET title = ?, content = ?, contentText = ?, updatedAt = ? WHERE id = ?")
+    .run("来源第三版", "来源第三版", "来源第三版", "2026-07-22 13:00:00", "note-source");
+  const thirdPackage = await exportSource();
+  const conflictPreview = await importNowenPackage(thirdPackage.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "sync",
+    dryRun: true,
+  });
+  assert.equal(conflictPreview.success, true, conflictPreview.errors.join("; "));
+  assert.equal(conflictPreview.counts?.localConflicts, 1);
+  assert.ok(conflictPreview.conflicts?.some((item: any) => item.action === "sync-local-conflict" && item.resourceType === "note"));
+
+  const conflictSync = await importNowenPackage(thirdPackage.buffer, {
+    userId: "roundtrip-user",
+    workspaceId: null,
+    importMode: "sync",
+  });
+  assert.equal(conflictSync.success, true, conflictSync.errors.join("; "));
+  assert.equal(conflictSync.counts?.localConflicts, 1);
+  const preserved = db.prepare("SELECT title, content FROM notes WHERE id = ?").get(importedNote!.id) as { title: string; content: string };
+  assert.equal(preserved.title, "本地人工修改");
+  assert.equal(preserved.content, "本地必须保留");
+
+  // Restore the original source title before exercising explicit merge behavior with the first package.
+  db.prepare("UPDATE notes SET title = ?, content = ?, contentText = ?, updatedAt = ? WHERE id = ?")
+    .run("生产记录", "[检测报告](/api/attachments/att-source)", "生产记录", "2026-07-22 11:00:00", "note-source");
+
   const mergePreview = await importNowenPackage(exported.buffer, {
     userId: "roundtrip-user",
     workspaceId: null,
@@ -160,8 +244,8 @@ test("Nowen package supports independent-copy and explicit safe-merge round trip
   assert.equal(mergePreview.counts?.notebooks, 0, "all package folders already exist in the matching root");
   assert.equal(mergePreview.counts?.mergedNotebooks, 2);
   assert.equal(mergePreview.counts?.renamedNotes, 1);
-  assert.ok(mergePreview.conflicts?.some((item) => item.action === "merge-directory" && item.originalName === "产品资料"));
-  assert.ok(mergePreview.conflicts?.some((item) => item.action === "rename-note" && item.importedName === "生产记录 (2)"));
+  assert.ok(mergePreview.conflicts?.some((item: any) => item.action === "merge-directory" && item.originalName === "产品资料"));
+  assert.ok(mergePreview.conflicts?.some((item: any) => item.action === "rename-note" && item.importedName === "生产记录 (2)"));
 
   const merged = await importNowenPackage(exported.buffer, {
     userId: "roundtrip-user",

--- a/frontend/src/components/RoundTripImportReviewCenter.tsx
+++ b/frontend/src/components/RoundTripImportReviewCenter.tsx
@@ -7,11 +7,15 @@ import {
   FileArchive,
   FileText,
   FolderInput,
+  FolderPlus,
   FolderTree,
   Hash,
   Loader2,
   PackageCheck,
   Paperclip,
+  PencilLine,
+  RefreshCw,
+  ShieldAlert,
   ShieldCheck,
   Tags,
   X,
@@ -19,6 +23,7 @@ import {
 import {
   resolveRoundTripImportReview,
   subscribeRoundTripImportReviews,
+  type RoundTripImportConflictAction,
   type RoundTripImportReviewRequest,
   type RoundTripImportStrategy,
   type RoundTripPackagePreview,
@@ -51,6 +56,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
   const [loadingStrategy, setLoadingStrategy] = useState<RoundTripImportStrategy | null>(null);
   const [loadError, setLoadError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
   const preview = previews[strategy] || request.preview;
   const pkg = preview.package || {};
   const counts = pkg.counts || preview.counts || {};
@@ -60,14 +66,17 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
   const warnings = preview.warnings || [];
   const errors = [...(preview.errors || []), ...(loadError ? [loadError] : [])];
   const canChooseStrategy = typeof request.loadPreview === "function";
+  const syncAvailability = request.preview.package?.sync;
+  const syncEnabled = syncAvailability?.available === true;
 
   const copy = zh ? {
     title: "导入预检报告",
-    subtitle: "选择冲突处理方式，并核对目录、附件和重名结果",
+    subtitle: "选择导入方式，并核对目录、附件和冲突处理结果",
     packageFile: "数据包",
     target: "导入目标",
     exportedAt: "导出时间",
     protocol: "协议",
+    sourceInstance: "来源实例",
     notebooks: "目录",
     notes: "笔记",
     tags: "标签",
@@ -76,32 +85,51 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     markdown: "Markdown",
     richText: "富文本",
     html: "HTML",
-    strategyTitle: "遇到同名目录时",
+    strategyTitle: "选择导入方式",
     copyTitle: "创建独立副本",
     copyBadge: "推荐",
     copyDesc: "不接触已有内容；冲突根目录自动命名为“名称 (2)”。",
     mergeTitle: "合并到现有目录",
-    mergeDesc: "按同级同名目录逐层合并；现有笔记不会覆盖，同名笔记增加编号。",
-    planTitle: strategy === "merge" ? "合并与重命名计划" : "目录重命名计划",
+    mergeDesc: "按同级同名目录逐层合并；已有笔记不覆盖，同名笔记增加编号。",
+    syncTitle: "安全增量同步",
+    syncDesc: "根据首次导入留下的稳定来源映射，只更新来源有变化且本地未修改的内容。",
+    syncUnavailable: syncAvailability?.reason || "当前数据包或目标空间尚不满足同步条件",
+    linkedResources: "已关联资源",
+    planTitle: strategy === "sync" ? "增量同步计划" : strategy === "merge" ? "合并与重命名计划" : "目录重命名计划",
     copyPlanDesc: "只重命名冲突树的最高层目录，内部结构和名称保持不变。",
     mergePlanDesc: "同名目录会复用；导入的同名笔记改为“名称 (2)”，不会覆盖正文。",
-    noPlan: strategy === "merge" ? "没有需要合并或重命名的内容。" : "目标中未发现同名根目录。",
+    syncPlanDesc: "来源和本地同时变化时保留本地版本；来源包中缺少的目录和笔记不会从本地删除。",
+    noPlan: strategy === "sync" ? "没有需要新增、更新或处理冲突的资源。" : strategy === "merge" ? "没有需要合并或重命名的内容。" : "目标中未发现同名根目录。",
     mergeDirectory: "复用目录",
     renameRoot: "根目录改名",
     renameNote: "笔记改名",
+    syncCreateDirectory: "新增目录",
+    syncUpdateDirectory: "更新目录",
+    syncCreateNote: "新增笔记",
+    syncUpdateNote: "更新笔记",
+    syncLocalConflict: "保留本地",
+    syncReplaceAttachment: "替换附件",
     actionSummary: "执行摘要",
     createdDirectories: "新建目录",
     mergedDirectories: "复用目录",
     renamedNotes: "改名笔记",
+    createdNotes: "新增笔记",
+    updatedDirectories: "更新目录",
+    updatedNotes: "更新笔记",
+    unchangedNotes: "无需变更",
+    localConflicts: "本地冲突",
+    recreatedResources: "重建资源",
     warningsTitle: "需要检查",
     noWarnings: "未发现附件缺失、校验失败或结构异常。",
     safetyTitle: "本次导入的安全策略",
     copySafety: "创建独立副本，不覆盖或静默合并已有目录和笔记。",
     mergeSafety: "仅复用同级同名目录；所有导入笔记仍会创建为新笔记。",
-    safetyB: "附件会生成新的 ID，并重写正文中的附件地址。",
-    safetyC: "任一步骤失败都会回滚数据库并清理已写入文件。",
+    syncSafety: "只有稳定来源映射、来源已变化且目标未被本地修改的资源才会更新。",
+    safetyB: strategy === "sync" ? "本地和来源同时变化时保留本地版本，并在报告中标为冲突。" : "附件会生成新的 ID，并重写正文中的附件地址。",
+    safetyC: strategy === "sync" ? "同步不会删除目标中已有但本次数据包未包含的目录或笔记。" : "任一步骤失败都会回滚数据库并清理已写入文件。",
+    safetyD: "任一步骤失败都会回滚数据库并清理已写入文件。",
     cancel: "取消导入",
-    confirm: strategy === "merge" ? "确认合并导入" : "确认创建副本",
+    confirm: strategy === "sync" ? "确认安全同步" : strategy === "merge" ? "确认合并导入" : "确认创建副本",
     currentSpace: "当前导入空间",
     packageKindMarkdown: "Markdown 往返包",
     packageKindNowen: "Nowen 无损包",
@@ -109,11 +137,12 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     loadFailed: "无法生成该策略的预检结果",
   } : {
     title: "Import preflight report",
-    subtitle: "Choose a conflict policy and review the tree, attachments and rename plan",
+    subtitle: "Choose an import mode and review the tree, attachments and conflict plan",
     packageFile: "Package",
     target: "Target",
     exportedAt: "Exported",
     protocol: "Protocol",
+    sourceInstance: "Source instance",
     notebooks: "Folders",
     notes: "Notes",
     tags: "Tags",
@@ -122,32 +151,51 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     markdown: "Markdown",
     richText: "Rich text",
     html: "HTML",
-    strategyTitle: "When matching folders exist",
+    strategyTitle: "Import mode",
     copyTitle: "Create an independent copy",
     copyBadge: "Recommended",
     copyDesc: "Leaves existing content untouched and renames a conflicting root to “Name (2)”.",
     mergeTitle: "Merge into existing folders",
-    mergeDesc: "Reuses exact sibling folder names. Existing notes are never overwritten; duplicates are numbered.",
-    planTitle: strategy === "merge" ? "Merge and rename plan" : "Folder rename plan",
+    mergeDesc: "Reuses exact sibling folders. Existing notes are never overwritten; duplicates are numbered.",
+    syncTitle: "Safe incremental sync",
+    syncDesc: "Uses stable mappings from the first import and only updates changed source resources without local edits.",
+    syncUnavailable: syncAvailability?.reason || "This package or target does not meet sync requirements",
+    linkedResources: "Linked resources",
+    planTitle: strategy === "sync" ? "Incremental sync plan" : strategy === "merge" ? "Merge and rename plan" : "Folder rename plan",
     copyPlanDesc: "Only the highest conflicting root is renamed; its subtree remains unchanged.",
     mergePlanDesc: "Matching folders are reused and duplicate imported notes become “Name (2)”.",
-    noPlan: strategy === "merge" ? "Nothing needs to be merged or renamed." : "No conflicting root folders were found.",
+    syncPlanDesc: "Local edits win when both sides changed. Missing source items are not deleted from the target.",
+    noPlan: strategy === "sync" ? "No resources need to be created, updated or resolved." : strategy === "merge" ? "Nothing needs to be merged or renamed." : "No conflicting root folders were found.",
     mergeDirectory: "Reuse folder",
     renameRoot: "Rename root",
     renameNote: "Rename note",
+    syncCreateDirectory: "Create folder",
+    syncUpdateDirectory: "Update folder",
+    syncCreateNote: "Create note",
+    syncUpdateNote: "Update note",
+    syncLocalConflict: "Keep local",
+    syncReplaceAttachment: "Replace attachment",
     actionSummary: "Action summary",
     createdDirectories: "New folders",
     mergedDirectories: "Reused folders",
     renamedNotes: "Renamed notes",
+    createdNotes: "New notes",
+    updatedDirectories: "Updated folders",
+    updatedNotes: "Updated notes",
+    unchangedNotes: "Unchanged",
+    localConflicts: "Local conflicts",
+    recreatedResources: "Recreated",
     warningsTitle: "Needs attention",
     noWarnings: "No missing attachments, checksum failures or structural errors were found.",
     safetyTitle: "Import safety policy",
     copySafety: "Creates an independent copy without overwriting or silently merging existing content.",
     mergeSafety: "Only exact sibling folders are reused; every imported note is still created as a new note.",
-    safetyB: "Attachments receive new IDs and content references are rewritten.",
-    safetyC: "Any failure rolls back the database and removes files already written.",
+    syncSafety: "Only stable mapped resources changed at the source and untouched locally are updated.",
+    safetyB: strategy === "sync" ? "When source and local content both changed, the local version is preserved and reported." : "Attachments receive new IDs and content references are rewritten.",
+    safetyC: strategy === "sync" ? "Sync never deletes target folders or notes missing from this package." : "Any failure rolls back the database and removes files already written.",
+    safetyD: "Any failure rolls back the database and removes files already written.",
     cancel: "Cancel import",
-    confirm: strategy === "merge" ? "Confirm merge import" : "Confirm independent copy",
+    confirm: strategy === "sync" ? "Confirm safe sync" : strategy === "merge" ? "Confirm merge import" : "Confirm independent copy",
     currentSpace: "Current import space",
     packageKindMarkdown: "Markdown round-trip package",
     packageKindNowen: "Nowen lossless package",
@@ -168,6 +216,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
   }, [loadingStrategy, request.id, submitting]);
 
   const chooseStrategy = async (next: RoundTripImportStrategy) => {
+    if (next === "sync" && !syncEnabled) return;
     if (next === strategy || submitting || loadingStrategy) return;
     setStrategy(next);
     setLoadError("");
@@ -192,9 +241,15 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     );
   };
 
-  const actionLabel = (action?: string): string => {
+  const actionLabel = (action?: RoundTripImportConflictAction): string => {
     if (action === "merge-directory") return copy.mergeDirectory;
     if (action === "rename-note") return copy.renameNote;
+    if (action === "sync-create-directory") return copy.syncCreateDirectory;
+    if (action === "sync-update-directory") return copy.syncUpdateDirectory;
+    if (action === "sync-create-note") return copy.syncCreateNote;
+    if (action === "sync-update-note") return copy.syncUpdateNote;
+    if (action === "sync-local-conflict") return copy.syncLocalConflict;
+    if (action === "sync-replace-attachment") return copy.syncReplaceAttachment;
     return copy.renameRoot;
   };
 
@@ -205,9 +260,15 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     { label: copy.attachments, value: count(counts.attachments), icon: Paperclip },
   ];
 
+  const strategyClass = strategy === "sync"
+    ? "bg-blue-600 hover:bg-blue-700"
+    : strategy === "merge"
+      ? "bg-violet-600 hover:bg-violet-700"
+      : "bg-emerald-600 hover:bg-emerald-700";
+
   return createPortal(
     <div className="fixed inset-0 z-[12000] flex items-end justify-center bg-black/45 backdrop-blur-[1px] sm:items-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="round-trip-import-review-title">
-      <div className="flex max-h-[calc(100dvh-0.75rem)] w-full max-w-3xl flex-col overflow-hidden rounded-t-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900 sm:max-h-[min(90dvh,820px)] sm:rounded-2xl">
+      <div className="flex max-h-[calc(100dvh-0.75rem)] w-full max-w-4xl flex-col overflow-hidden rounded-t-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900 sm:max-h-[min(92dvh,880px)] sm:rounded-2xl">
         <header className="flex items-start gap-3 border-b border-zinc-200 px-4 py-4 dark:border-zinc-800 sm:px-5">
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400"><PackageCheck size={21} /></span>
           <div className="min-w-0 flex-1">
@@ -224,13 +285,14 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
               <div className="flex min-w-0 items-center gap-2"><ShieldCheck size={14} className="shrink-0 text-zinc-400" /><span className="shrink-0 text-zinc-500 dark:text-zinc-400">{copy.target}</span><span className="truncate font-medium text-zinc-800 dark:text-zinc-200">{request.targetLabel || copy.currentSpace}</span></div>
               <div className="flex min-w-0 items-center gap-2"><Hash size={14} className="shrink-0 text-zinc-400" /><span className="shrink-0 text-zinc-500 dark:text-zinc-400">{copy.protocol}</span><span className="font-medium text-zinc-800 dark:text-zinc-200">{packageKind} · v{pkg.formatVersion || "?"}{pkg.schemaVersion ? ` · schema ${pkg.schemaVersion}` : ""}</span></div>
               <div className="flex min-w-0 items-center gap-2"><span className="shrink-0 text-zinc-500 dark:text-zinc-400">{copy.exportedAt}</span><span className="truncate font-medium text-zinc-800 dark:text-zinc-200">{formatDate(pkg.exportedAt)}</span></div>
+              {pkg.sourceInstanceId && <div className="flex min-w-0 items-center gap-2 sm:col-span-2"><RefreshCw size={14} className="shrink-0 text-zinc-400" /><span className="shrink-0 text-zinc-500 dark:text-zinc-400">{copy.sourceInstance}</span><code className="truncate text-[11px] text-zinc-700 dark:text-zinc-300">{pkg.sourceInstanceId}</code></div>}
             </div>
           </section>
 
           {canChooseStrategy && (
             <section>
               <h3 className="mb-2 text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.strategyTitle}</h3>
-              <div className="grid gap-2 sm:grid-cols-2">
+              <div className="grid gap-2 lg:grid-cols-3">
                 <button type="button" onClick={() => void chooseStrategy("copy")} disabled={submitting || !!loadingStrategy} className={`rounded-xl border p-3 text-left transition-colors ${strategy === "copy" ? "border-emerald-400 bg-emerald-50/70 ring-2 ring-emerald-500/10 dark:border-emerald-700 dark:bg-emerald-500/10" : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"}`}>
                   <div className="flex items-center gap-2"><Copy size={17} className="text-emerald-600 dark:text-emerald-400" /><span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{copy.copyTitle}</span><span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">{copy.copyBadge}</span></div>
                   <p className="mt-1.5 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{copy.copyDesc}</p>
@@ -238,6 +300,11 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
                 <button type="button" onClick={() => void chooseStrategy("merge")} disabled={submitting || !!loadingStrategy} className={`rounded-xl border p-3 text-left transition-colors ${strategy === "merge" ? "border-violet-400 bg-violet-50/70 ring-2 ring-violet-500/10 dark:border-violet-700 dark:bg-violet-500/10" : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"}`}>
                   <div className="flex items-center gap-2"><FolderInput size={17} className="text-violet-600 dark:text-violet-400" /><span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{copy.mergeTitle}</span>{loadingStrategy === "merge" && <Loader2 size={14} className="animate-spin text-violet-500" />}</div>
                   <p className="mt-1.5 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{copy.mergeDesc}</p>
+                </button>
+                <button type="button" onClick={() => void chooseStrategy("sync")} disabled={submitting || !!loadingStrategy || !syncEnabled} className={`rounded-xl border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${strategy === "sync" ? "border-blue-400 bg-blue-50/70 ring-2 ring-blue-500/10 dark:border-blue-700 dark:bg-blue-500/10" : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"}`}>
+                  <div className="flex items-center gap-2"><RefreshCw size={17} className="text-blue-600 dark:text-blue-400" /><span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{copy.syncTitle}</span>{loadingStrategy === "sync" && <Loader2 size={14} className="animate-spin text-blue-500" />}</div>
+                  <p className="mt-1.5 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{copy.syncDesc}</p>
+                  {syncEnabled ? <p className="mt-1 text-[10px] font-medium text-blue-600 dark:text-blue-300">{copy.linkedResources}：{count(syncAvailability?.linkedResources)}</p> : <p className="mt-1 text-[10px] leading-4 text-amber-600 dark:text-amber-300">{copy.syncUnavailable}</p>}
                 </button>
               </div>
             </section>
@@ -259,18 +326,38 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
             </section>
           )}
 
+          {strategy === "sync" && (
+            <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5">
+              <h3 className="text-xs font-semibold text-blue-800 dark:text-blue-200">{copy.actionSummary}</h3>
+              <div className="mt-2 grid grid-cols-2 gap-2 text-center text-[11px] sm:grid-cols-3 lg:grid-cols-6">
+                {[
+                  [copy.createdDirectories, actionCounts.notebooks, FolderPlus],
+                  [copy.createdNotes, actionCounts.notes, FileText],
+                  [copy.updatedDirectories, actionCounts.updatedNotebooks, FolderTree],
+                  [copy.updatedNotes, actionCounts.updatedNotes, PencilLine],
+                  [copy.unchangedNotes, actionCounts.unchangedNotes, ShieldCheck],
+                  [copy.localConflicts, actionCounts.localConflicts, ShieldAlert],
+                ].map(([label, value, Icon]) => {
+                  const SummaryIcon = Icon as React.ComponentType<{ size?: number; className?: string }>;
+                  return <div key={String(label)} className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><SummaryIcon size={14} className="mx-auto mb-1 text-blue-500" /><div className="text-lg font-bold text-zinc-900 dark:text-zinc-100">{count(value)}</div><div className="text-zinc-500">{String(label)}</div></div>;
+                })}
+              </div>
+              {count(actionCounts.recreatedResources) > 0 && <p className="mt-2 text-[11px] text-blue-700 dark:text-blue-300">{copy.recreatedResources}：{count(actionCounts.recreatedResources)}</p>}
+            </section>
+          )}
+
           <section className={`rounded-xl border p-3 ${conflicts.length > 0 ? "border-amber-200 bg-amber-50/45 dark:border-amber-900/50 dark:bg-amber-500/5" : "border-emerald-200 bg-emerald-50/45 dark:border-emerald-900/50 dark:bg-emerald-500/5"}`}>
-            <div className="flex items-start gap-2">{conflicts.length > 0 ? <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" /> : <ShieldCheck size={16} className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" />}<div className="min-w-0 flex-1"><h3 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.planTitle} · {conflicts.length}</h3><p className="mt-1 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{conflicts.length > 0 ? (strategy === "merge" ? copy.mergePlanDesc : copy.copyPlanDesc) : copy.noPlan}</p>{conflicts.length > 0 && <div className="mt-2 max-h-44 space-y-1.5 overflow-y-auto pr-1">{conflicts.map((conflict, index) => <div key={`${conflict.sourceId || index}-${index}`} className="flex min-w-0 items-center gap-2 rounded-lg border border-amber-200/70 bg-white/75 px-2.5 py-2 text-xs dark:border-amber-900/45 dark:bg-zinc-900/60"><span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">{actionLabel(conflict.action)}</span><span className="min-w-0 flex-1 truncate text-zinc-700 dark:text-zinc-300" title={conflict.originalName || ""}>{conflict.originalName || "—"}</span>{conflict.importedName !== conflict.originalName && <><ArrowRight size={13} className="shrink-0 text-amber-500" /><span className="min-w-0 flex-1 truncate font-semibold text-amber-700 dark:text-amber-300" title={conflict.importedName || ""}>{conflict.importedName || "—"}</span></>}</div>)}</div>}</div></div>
+            <div className="flex items-start gap-2">{conflicts.length > 0 ? <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" /> : <ShieldCheck size={16} className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" />}<div className="min-w-0 flex-1"><h3 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.planTitle} · {conflicts.length}</h3><p className="mt-1 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{conflicts.length > 0 ? (strategy === "sync" ? copy.syncPlanDesc : strategy === "merge" ? copy.mergePlanDesc : copy.copyPlanDesc) : copy.noPlan}</p>{conflicts.length > 0 && <div className="mt-2 max-h-52 space-y-1.5 overflow-y-auto pr-1">{conflicts.map((conflict, index) => <div key={`${conflict.sourceId || index}-${index}`} className="flex min-w-0 items-center gap-2 rounded-lg border border-amber-200/70 bg-white/75 px-2.5 py-2 text-xs dark:border-amber-900/45 dark:bg-zinc-900/60"><span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">{actionLabel(conflict.action)}</span><span className="min-w-0 flex-1 truncate text-zinc-700 dark:text-zinc-300" title={conflict.originalName || ""}>{conflict.originalName || "—"}</span>{conflict.importedName !== conflict.originalName && <><ArrowRight size={13} className="shrink-0 text-amber-500" /><span className="min-w-0 flex-1 truncate font-semibold text-amber-700 dark:text-amber-300" title={conflict.importedName || ""}>{conflict.importedName || "—"}</span></>}</div>)}</div>}</div></div>
           </section>
 
           <section className={`rounded-xl border p-3 ${warnings.length || errors.length ? "border-red-200 bg-red-50/40 dark:border-red-900/50 dark:bg-red-500/5" : "border-zinc-200 dark:border-zinc-800"}`}><h3 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.warningsTitle} · {warnings.length + errors.length}</h3>{warnings.length || errors.length ? <div className="mt-2 max-h-36 space-y-1 overflow-y-auto text-[11px] leading-5 text-red-700 dark:text-red-300">{errors.map((message, index) => <p key={`error-${index}`}>• {message}</p>)}{warnings.map((warning, index) => <p key={`${warning.type || "warning"}-${index}`}>• {warning.message || warning.type || "warning"}</p>)}</div> : <p className="mt-1 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{copy.noWarnings}</p>}</section>
 
-          <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5"><h3 className="flex items-center gap-1.5 text-xs font-semibold text-blue-800 dark:text-blue-200"><ShieldCheck size={15} />{copy.safetyTitle}</h3><div className="mt-2 space-y-1 text-[11px] leading-5 text-blue-700/90 dark:text-blue-300/90"><p>• {strategy === "merge" ? copy.mergeSafety : copy.copySafety}</p><p>• {copy.safetyB}</p><p>• {copy.safetyC}</p></div></section>
+          <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5"><h3 className="flex items-center gap-1.5 text-xs font-semibold text-blue-800 dark:text-blue-200"><ShieldCheck size={15} />{copy.safetyTitle}</h3><div className="mt-2 space-y-1 text-[11px] leading-5 text-blue-700/90 dark:text-blue-300/90"><p>• {strategy === "sync" ? copy.syncSafety : strategy === "merge" ? copy.mergeSafety : copy.copySafety}</p><p>• {copy.safetyB}</p><p>• {copy.safetyC}</p>{strategy === "sync" && <p>• {copy.safetyD}</p>}</div></section>
         </div>
 
         <footer className="flex shrink-0 gap-2 border-t border-zinc-200 px-4 pt-3 pb-[max(0.9rem,env(safe-area-inset-bottom))] dark:border-zinc-800 sm:justify-end sm:px-5 sm:pb-4">
           <button type="button" onClick={() => decide(false)} disabled={submitting || !!loadingStrategy} className="flex-1 rounded-lg border border-zinc-300 px-4 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 sm:flex-none">{copy.cancel}</button>
-          <button type="button" onClick={() => decide(true)} disabled={submitting || !!loadingStrategy || errors.length > 0} className={`flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none ${strategy === "merge" ? "bg-violet-600 hover:bg-violet-700" : "bg-emerald-600 hover:bg-emerald-700"}`}>{submitting || loadingStrategy ? <Loader2 size={16} className="mr-2 animate-spin" /> : strategy === "merge" ? <FolderInput size={16} className="mr-2" /> : <PackageCheck size={16} className="mr-2" />}{loadingStrategy ? copy.loadingPlan : copy.confirm}</button>
+          <button type="button" onClick={() => decide(true)} disabled={submitting || !!loadingStrategy || errors.length > 0} className={`flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none ${strategyClass}`}>{submitting || loadingStrategy ? <Loader2 size={16} className="mr-2 animate-spin" /> : strategy === "sync" ? <RefreshCw size={16} className="mr-2" /> : strategy === "merge" ? <FolderInput size={16} className="mr-2" /> : <PackageCheck size={16} className="mr-2" />}{loadingStrategy ? copy.loadingPlan : copy.confirm}</button>
         </footer>
       </div>
     </div>,

--- a/frontend/src/lib/__tests__/roundTripImportReview.test.ts
+++ b/frontend/src/lib/__tests__/roundTripImportReview.test.ts
@@ -26,6 +26,7 @@ describe("round-trip import review queue", () => {
         packageKind: "markdown",
         counts: { notebooks: 4, notes: 8, tags: 2, attachments: 3 },
         formatStats: { markdown: 8, richText: 0, html: 0 },
+        sync: { available: false, linkedResources: 0, reason: "Markdown 往返包不支持同步" },
       },
       conflicts: [{
         action: "rename-root",
@@ -46,6 +47,7 @@ describe("round-trip import review queue", () => {
     const request = snapshots.at(-1)?.[0];
     expect(request?.fileName).toBe("产品资料.zip");
     expect(request?.preview.package?.counts?.notes).toBe(8);
+    expect(request?.preview.package?.sync?.available).toBe(false);
     expect(request?.preview.conflicts?.[0]?.importedName).toBe("产品资料 (2)");
 
     resolveRoundTripImportReview(request!.id, { accepted: true, strategy: "copy" });
@@ -82,6 +84,63 @@ describe("round-trip import review queue", () => {
 
     resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "merge" });
     await expect(decision).resolves.toEqual({ accepted: true, strategy: "merge" });
+    unsubscribe();
+  });
+
+  it("loads a source-linked sync plan and returns an explicit safe-sync decision", async () => {
+    let current: RoundTripImportReviewRequest[] = [];
+    const loadPreview = vi.fn(async (strategy: "copy" | "merge" | "sync") => ({
+      success: true,
+      dryRun: true,
+      strategy,
+      package: {
+        format: "nowen-package",
+        formatVersion: 2,
+        packageKind: "nowen",
+        sourceInstanceId: "source-instance-1",
+        sync: { available: true, linkedResources: 12, reason: null },
+      },
+      counts: {
+        notes: 1,
+        updatedNotes: 3,
+        unchangedNotes: 8,
+        localConflicts: 1,
+      },
+      conflicts: [{
+        action: "sync-local-conflict" as const,
+        resourceType: "note" as const,
+        sourceId: "source-note",
+        targetId: "target-note",
+        originalName: "来源第三版",
+        importedName: "本地人工修改",
+      }],
+      warnings: [{ type: "sync_local_conflicts", message: "本地修改已保留" }],
+      errors: [],
+    }));
+    const unsubscribe = subscribeRoundTripImportReviews((items) => { current = items; });
+    const decision = requestRoundTripImportReview({
+      success: true,
+      strategy: "copy",
+      package: {
+        format: "nowen-package",
+        packageKind: "nowen",
+        sourceInstanceId: "source-instance-1",
+        sync: { available: true, linkedResources: 12, reason: null },
+      },
+    }, {
+      fileName: "incremental.nowen.zip",
+      loadPreview,
+    });
+
+    const syncPreview = await current[0].loadPreview?.("sync");
+    expect(loadPreview).toHaveBeenCalledWith("sync");
+    expect(syncPreview?.strategy).toBe("sync");
+    expect(syncPreview?.counts?.updatedNotes).toBe(3);
+    expect(syncPreview?.counts?.localConflicts).toBe(1);
+    expect(syncPreview?.conflicts?.[0]?.action).toBe("sync-local-conflict");
+
+    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "sync" });
+    await expect(decision).resolves.toEqual({ accepted: true, strategy: "sync" });
     unsubscribe();
   });
 

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -11,6 +11,7 @@ import type {
 import {
   requestRoundTripImportReview,
   submitRoundTripPackage,
+  type RoundTripImportStrategy,
 } from "./roundTripImportReview";
 
 export {
@@ -131,14 +132,16 @@ export async function importNotes(
   }
 
   const file = packageItems[0].__nowenRoundTripPackage!;
-  const submitOptions = {
+  const submitOptionsFor = (strategy: RoundTripImportStrategy) => ({
     workspaceId: options?.workspaceId,
-    targetNotebookId: notebookId || undefined,
-  };
+    // Sync always follows the source→target mappings recorded by the first import. A folder
+    // currently selected in the import UI must not relocate mapped resources accidentally.
+    targetNotebookId: strategy === "sync" ? undefined : notebookId || undefined,
+  });
   try {
     onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件和来源映射…" });
     const copyPreview = await submitRoundTripPackage(file, {
-      ...submitOptions,
+      ...submitOptionsFor("copy"),
       dryRun: true,
       strategy: "copy",
     });
@@ -148,7 +151,7 @@ export async function importNotes(
       source: "shared-import",
       initialStrategy: "copy",
       loadPreview: (strategy) => submitRoundTripPackage(file, {
-        ...submitOptions,
+        ...submitOptionsFor(strategy),
         dryRun: true,
         strategy,
       }),
@@ -161,7 +164,7 @@ export async function importNotes(
     const selectedPreview = decision.strategy === "copy"
       ? copyPreview
       : await submitRoundTripPackage(file, {
-        ...submitOptions,
+        ...submitOptionsFor(decision.strategy),
         dryRun: true,
         strategy: decision.strategy,
       });
@@ -179,7 +182,7 @@ export async function importNotes(
             : "预检已确认，正在原样恢复目录和附件…",
     });
     const result = await submitRoundTripPackage(file, {
-      ...submitOptions,
+      ...submitOptionsFor(decision.strategy),
       dryRun: false,
       strategy: decision.strategy,
     });

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -113,8 +113,8 @@ function targetLabel(workspaceId?: string): string {
 }
 
 /**
- * Round-trip package import is atomic. The review dialog defaults to an independent copy, while
- * explicit merge mode only reuses exact sibling folder names and never overwrites an existing note.
+ * Round-trip package import is atomic. Copy remains the safe default; merge reuses exact sibling
+ * folders; sync only updates stable source mappings that have no local edits.
  */
 export async function importNotes(
   fileInfos: ImportFileInfo[],
@@ -136,7 +136,7 @@ export async function importNotes(
     targetNotebookId: notebookId || undefined,
   };
   try {
-    onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件和冲突…" });
+    onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件和来源映射…" });
     const copyPreview = await submitRoundTripPackage(file, {
       ...submitOptions,
       dryRun: true,
@@ -170,32 +170,42 @@ export async function importNotes(
       phase: "uploading",
       current: 0,
       total: 1,
-      message: decision.strategy === "merge"
-        ? `正在按合并计划导入${conflicts ? `（${conflicts} 项处理）` : ""}…`
-        : conflicts > 0
-          ? `已确认 ${conflicts} 个重名处理方案，正在创建独立副本`
-          : "预检已确认，正在原样恢复目录和附件…",
+      message: decision.strategy === "sync"
+        ? `正在执行安全增量同步${conflicts ? `（${conflicts} 项变更或冲突）` : ""}…`
+        : decision.strategy === "merge"
+          ? `正在按合并计划导入${conflicts ? `（${conflicts} 项处理）` : ""}…`
+          : conflicts > 0
+            ? `已确认 ${conflicts} 个重名处理方案，正在创建独立副本`
+            : "预检已确认，正在原样恢复目录和附件…",
     });
     const result = await submitRoundTripPackage(file, {
       ...submitOptions,
       dryRun: false,
       strategy: decision.strategy,
     });
-    const importedCount = Number(result?.counts?.notes || 0);
+
+    const createdNotes = Number(result?.counts?.notes || 0);
+    const updatedNotes = Number(result?.counts?.updatedNotes || 0);
+    const affectedCount = createdNotes + updatedNotes;
     const warningCount = Array.isArray(result?.warnings) ? result.warnings.length : 0;
     const mergedCount = Number(result?.counts?.mergedNotebooks || 0);
     const renamedCount = Number(result?.counts?.renamedNotes || 0);
+    const unchangedCount = Number(result?.counts?.unchangedNotes || 0);
+    const localConflictCount = Number(result?.counts?.localConflicts || 0);
+
     onProgress?.({
       phase: "done",
-      current: importedCount,
-      total: importedCount,
-      message: decision.strategy === "merge"
-        ? `导入完成，共 ${importedCount} 篇笔记，复用 ${mergedCount} 个目录${renamedCount ? `，${renamedCount} 篇同名笔记已编号` : ""}`
-        : warningCount > 0
-          ? `导入完成，共 ${importedCount} 篇笔记，${warningCount} 项需要检查`
-          : `导入完成，共 ${importedCount} 篇笔记`,
+      current: affectedCount,
+      total: affectedCount,
+      message: decision.strategy === "sync"
+        ? `同步完成，新增 ${createdNotes} 篇、更新 ${updatedNotes} 篇、无需变更 ${unchangedCount} 篇${localConflictCount ? `，${localConflictCount} 项本地修改已保留` : ""}`
+        : decision.strategy === "merge"
+          ? `导入完成，共 ${createdNotes} 篇笔记，复用 ${mergedCount} 个目录${renamedCount ? `，${renamedCount} 篇同名笔记已编号` : ""}`
+          : warningCount > 0
+            ? `导入完成，共 ${createdNotes} 篇笔记，${warningCount} 项需要检查`
+            : `导入完成，共 ${createdNotes} 篇笔记`,
     });
-    return { success: true, count: importedCount };
+    return { success: true, count: decision.strategy === "sync" ? affectedCount : createdNotes };
   } catch (error) {
     onProgress?.({
       phase: "error",

--- a/frontend/src/lib/roundTripImportReview.ts
+++ b/frontend/src/lib/roundTripImportReview.ts
@@ -1,6 +1,6 @@
-import { api, getBaseUrl } from "./api";
+import { api, getBaseUrl, getCurrentWorkspace } from "./api";
 
-export type RoundTripImportStrategy = "copy" | "merge";
+export type RoundTripImportStrategy = "copy" | "merge" | "sync";
 
 export interface RoundTripPackageCounts {
   notebooks?: number;
@@ -11,6 +11,13 @@ export interface RoundTripPackageCounts {
   renamedRoots?: number;
   mergedNotebooks?: number;
   renamedNotes?: number;
+  updatedNotebooks?: number;
+  updatedNotes?: number;
+  unchangedNotes?: number;
+  localConflicts?: number;
+  recreatedResources?: number;
+  reusedAttachments?: number;
+  removedAttachments?: number;
 }
 
 export interface RoundTripPackageFormatStats {
@@ -19,14 +26,31 @@ export interface RoundTripPackageFormatStats {
   html?: number;
 }
 
+export type RoundTripImportConflictAction =
+  | "rename-root"
+  | "merge-directory"
+  | "rename-note"
+  | "sync-create-directory"
+  | "sync-update-directory"
+  | "sync-create-note"
+  | "sync-update-note"
+  | "sync-local-conflict"
+  | "sync-replace-attachment";
+
 export interface RoundTripImportConflict {
-  action?: "rename-root" | "merge-directory" | "rename-note";
-  resourceType?: "notebook" | "note";
+  action?: RoundTripImportConflictAction;
+  resourceType?: "notebook" | "note" | "attachment";
   sourceId?: string;
   originalName?: string;
   importedName?: string;
   parentId?: string | null;
   targetId?: string;
+}
+
+export interface RoundTripSyncAvailability {
+  available?: boolean;
+  linkedResources?: number;
+  reason?: string | null;
 }
 
 export interface RoundTripPackagePreview {
@@ -39,6 +63,9 @@ export interface RoundTripPackagePreview {
     schemaVersion?: number;
     exportedAt?: string;
     packageKind?: string;
+    sourceInstanceId?: string | null;
+    exportBatchId?: string | null;
+    sync?: RoundTripSyncAvailability;
     counts?: RoundTripPackageCounts;
     formatStats?: RoundTripPackageFormatStats;
   };
@@ -74,13 +101,18 @@ interface SubmitRoundTripPackageOptions {
   targetNotebookId?: string;
 }
 
+interface RememberedImportDecision {
+  strategy: RoundTripImportStrategy;
+  workspaceId?: string;
+}
+
 type Listener = (requests: RoundTripImportReviewRequest[]) => void;
 
 let sequence = 1;
 let requests: RoundTripImportReviewRequest[] = [];
 const listeners = new Set<Listener>();
 const resolvers = new Map<number, (decision: RoundTripImportReviewDecision) => void>();
-const selectedStrategyByFile = new WeakMap<File, RoundTripImportStrategy>();
+const selectedDecisionByFile = new WeakMap<File, RememberedImportDecision>();
 let bridgeInstalled = false;
 
 function emit(): void {
@@ -107,11 +139,13 @@ export async function submitRoundTripPackage(
   if (options.targetNotebookId) params.set("targetNotebookId", options.targetNotebookId);
   params.set(
     "importMode",
-    options.strategy === "merge"
-      ? "merge"
-      : options.targetNotebookId
-        ? "into-target"
-        : "new-root",
+    options.strategy === "sync"
+      ? "sync"
+      : options.strategy === "merge"
+        ? "merge"
+        : options.targetNotebookId
+          ? "into-target"
+          : "new-root",
   );
   if (options.dryRun) params.set("dryRun", "1");
 
@@ -197,44 +231,61 @@ function armLegacyConfirmResult(result: boolean): void {
   timer = window.setTimeout(restore, 2_000);
 }
 
+function currentWorkspaceId(): string | undefined {
+  const value = getCurrentWorkspace();
+  return value && value !== "personal" ? value : undefined;
+}
+
 /**
- * Enhances the legacy Nowen-package panel without coupling the dialog to DataManager. The selected
- * strategy is remembered for the exact File object and applied to the formal import call.
+ * Enhance the legacy Nowen-package panel without coupling it to the review dialog.
+ *
+ * All three strategies use the same explicit workspace-aware endpoint. This avoids the historical
+ * dry-run/import mismatch where the preview was calculated in personal scope while the UI showed a
+ * workspace. Sync is only offered when the server confirms that stable source mappings exist.
  */
 export function installRoundTripImportReviewBridge(): void {
   if (bridgeInstalled) return;
   bridgeInstalled = true;
 
-  const nativeDryRun = api.dryRunNowenPackage.bind(api);
   const nativeImport = api.importNowenPackage.bind(api);
 
   api.dryRunNowenPackage = (async (file: File) => {
-    const preview = await nativeDryRun(file) as RoundTripPackagePreview;
+    const workspaceId = currentWorkspaceId();
+    const preview = await submitRoundTripPackage(file, {
+      dryRun: true,
+      strategy: "copy",
+      workspaceId,
+    });
     if (!preview?.success) return preview;
     const decision = await requestRoundTripImportReview(preview, {
       fileName: file.name,
-      targetLabel: "当前导入空间",
+      targetLabel: workspaceId ? "所选工作区" : "个人空间",
       source: "nowen-panel",
       initialStrategy: "copy",
-      loadPreview: (strategy) => strategy === "copy"
-        ? Promise.resolve(preview)
-        : submitRoundTripPackage(file, { dryRun: true, strategy }),
+      loadPreview: (strategy) => submitRoundTripPackage(file, {
+        dryRun: true,
+        strategy,
+        workspaceId,
+      }),
     });
-    if (decision.accepted) selectedStrategyByFile.set(file, decision.strategy);
-    else selectedStrategyByFile.delete(file);
+    if (decision.accepted) {
+      selectedDecisionByFile.set(file, { strategy: decision.strategy, workspaceId });
+    } else {
+      selectedDecisionByFile.delete(file);
+    }
     armLegacyConfirmResult(decision.accepted);
     return preview;
   }) as typeof api.dryRunNowenPackage;
 
   api.importNowenPackage = (async (file: File, opts?: any) => {
-    const strategy = selectedStrategyByFile.get(file) || "copy";
-    selectedStrategyByFile.delete(file);
-    if (strategy === "copy") return nativeImport(file, opts);
+    const remembered = selectedDecisionByFile.get(file);
+    selectedDecisionByFile.delete(file);
+    if (!remembered) return nativeImport(file, opts);
     return submitRoundTripPackage(file, {
       dryRun: false,
-      strategy,
+      strategy: remembered.strategy,
+      workspaceId: opts?.workspaceId ?? remembered.workspaceId,
       targetNotebookId: opts?.targetNotebookId,
-      workspaceId: opts?.workspaceId,
     });
   }) as typeof api.importNowenPackage;
 }


### PR DESCRIPTION
Continues #371 and closes #376.

实现 Nowen 无损包的稳定来源映射与安全增量同步：

- 为实例生成并持久化稳定 `sourceInstanceId`；
- 新增 SQLite v53 与 PostgreSQL 对等来源映射表；
- 首次创建副本或合并导入后记录目录、笔记、附件的 source→target 映射；
- 后续预检可选择“安全增量同步”；
- 仅更新“来源已变化且目标自上次同步后未被本地修改”的资源；
- 来源与本地同时变化时保留本地版本并报告冲突；
- 支持新增、移动、重命名、正文更新和附件替换；
- 不删除本次包中缺少的本地目录或笔记；
- Markdown 往返包明确禁止覆盖同步；
- 同步仍使用附件校验、ID 重映射、数据库事务和失败清理；
- 增加 copy→sync→local-conflict→merge 后端往返测试及前端同步策略测试。

默认导入策略仍是“创建独立副本”，同步必须由用户在预检界面主动选择。