### PR TITLE
feat: add persistent import reports and guarded undo

### DIFF
--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -16,9 +16,11 @@ on:
       - "backend/src/services/roundTripImportLinkUndo.ts"
       - "backend/tests/roundtrip-import-batches.test.ts"
       - "frontend/src/components/RoundTripImportBatchCenter.tsx"
+      - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/lib/roundTripImportBatches.ts"
       - "frontend/src/lib/roundTripImportReview.ts"
       - "frontend/src/lib/__tests__/roundTripImportBatches.test.ts"
+      - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/main.tsx"
       - ".github/workflows/roundtrip-import-batch-ci.yml"
   pull_request:
@@ -35,148 +37,18 @@ on:
       - "backend/src/services/roundTripImportLinkUndo.ts"
       - "backend/tests/roundtrip-import-batches.test.ts"
       - "frontend/src/components/RoundTripImportBatchCenter.tsx"
+      - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/lib/roundTripImportBatches.ts"
       - "frontend/src/lib/roundTripImportReview.ts"
       - "frontend/src/lib/__tests__/roundTripImportBatches.test.ts"
+      - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/main.tsx"
       - ".github/workflows/roundtrip-import-batch-ci.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  repair-source:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-      - name: Apply strict ZIP note path and nullable model fixes
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          replacements = {
-              Path("backend/src/services/nowenPackageImportV2.ts"): [(
-          '''  const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
-            const notesFolder = zip.folder("notes");
-            if (notesFolder) {
-              for (const name of Object.keys(notesFolder.files)) {
-                if (!name.endsWith("/meta.json")) continue;
-                const noteId = name.split("/")[1];
-                if (!noteId) continue;
-                const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
-                if (!meta) {
-                  errors.push(`Invalid note metadata: ${noteId}`);
-                  continue;
-                }
-                if (!isSafeZipPath(meta.contentFile)) {
-                  errors.push(`Unsafe note content path: ${meta.contentFile}`);
-                  continue;
-                }
-                const contentPath = `notes/${noteId}/${meta.contentFile}`;
-                const entry = zip.file(contentPath);
-                if (!entry) {
-                  errors.push(`Note content not found: ${contentPath}`);
-                  continue;
-                }
-                noteContents.set(noteId, { meta, content: await entry.async("string") });
-              }
-            }
-          ''',
-          '''  const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
-            for (const name of Object.keys(zip.files)) {
-              const match = name.match(/^notes\\/([^/]+)\\/meta\\.json$/);
-              if (!match) continue;
-              const noteId = match[1];
-              const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
-              if (!meta) {
-                errors.push(`Invalid note metadata: ${noteId}`);
-                continue;
-              }
-              if (!isSafeZipPath(meta.contentFile)) {
-                errors.push(`Unsafe note content path: ${meta.contentFile}`);
-                continue;
-              }
-              const contentPath = `notes/${noteId}/${meta.contentFile}`;
-              const entry = zip.file(contentPath);
-              if (!entry) {
-                errors.push(`Note content not found: ${contentPath}`);
-                continue;
-              }
-              noteContents.set(noteId, { meta, content: await entry.async("string") });
-            }
-          ''')],
-              Path("backend/src/services/nowenRoundTripSync.ts"): [(
-          '''  const notes = new Map<string, SourceNote>();
-            const notesFolder = zip.folder("notes");
-            if (notesFolder) {
-              for (const filename of Object.keys(notesFolder.files)) {
-                if (!filename.endsWith("/meta.json")) continue;
-                const sourceId = filename.split("/")[1];
-                if (!sourceId) continue;
-                const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
-                if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
-                const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
-                if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
-                const content = await contentEntry.async("string");
-                const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
-                notes.set(sourceId, {
-                  meta,
-                  content,
-                  sourceHash: sourceNoteHash(meta, content, noteAttachments),
-                });
-              }
-            }
-          ''',
-          '''  const notes = new Map<string, SourceNote>();
-            for (const filename of Object.keys(zip.files)) {
-              const match = filename.match(/^notes\\/([^/]+)\\/meta\\.json$/);
-              if (!match) continue;
-              const sourceId = match[1];
-              const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
-              if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
-              const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
-              if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
-              const content = await contentEntry.async("string");
-              const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
-              notes.set(sourceId, {
-                meta,
-                content,
-                sourceHash: sourceNoteHash(meta, content, noteAttachments),
-              });
-            }
-          '''), (
-          '''  if (result.success && !params.dryRun && snapshot && model?.manifest.packageKind !== "markdown") {''',
-          '''  if (result.success && !params.dryRun && snapshot && model && model.manifest.packageKind !== "markdown") {''')],
-          }
-
-          changed = False
-          for path, pairs in replacements.items():
-              text = path.read_text()
-              for old, new in pairs:
-                  if old in text:
-                      text = text.replace(old, new, 1)
-                      changed = True
-                  elif new not in text:
-                      raise SystemExit(f"expected source block missing in {path}")
-              path.write_text(text)
-          print("changed" if changed else "already patched")
-          PY
-      - name: Commit repaired sources
-        run: |
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add backend/src/services/nowenPackageImportV2.ts backend/src/services/nowenRoundTripSync.ts
-          git commit -m "fix(import): scan only exact note metadata paths"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
-
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -191,29 +63,10 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
-      - name: Prepare diagnostic directory
-        run: mkdir -p ../ci-logs
       - name: Import batch and undo tests
-        id: backend_tests
-        continue-on-error: true
-        run: set -o pipefail; node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts 2>&1 | tee ../ci-logs/backend-tests.log
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts
       - name: Backend typecheck
-        id: backend_typecheck
-        continue-on-error: true
-        run: set -o pipefail; npm run build:tsc 2>&1 | tee ../ci-logs/backend-typecheck.log
-      - name: Upload backend diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: roundtrip-import-backend-logs
-          path: ci-logs/backend-*.log
-          if-no-files-found: error
-          retention-days: 7
-      - name: Enforce backend results
-        if: always()
-        run: |
-          test "${{ steps.backend_tests.outcome }}" = "success"
-          test "${{ steps.backend_typecheck.outcome }}" = "success"
+        run: npm run build:tsc
 
   frontend:
     runs-on: ubuntu-latest
@@ -229,26 +82,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
-      - name: Prepare diagnostic directory
-        run: mkdir -p ../ci-logs
       - name: Import batch client tests
-        id: frontend_tests
-        continue-on-error: true
-        run: set -o pipefail; npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts 2>&1 | tee ../ci-logs/frontend-tests.log
+        run: npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts src/lib/__tests__/blockPatchApi.test.ts
       - name: Frontend typecheck
-        id: frontend_typecheck
-        continue-on-error: true
-        run: set -o pipefail; npx tsc -b 2>&1 | tee ../ci-logs/frontend-typecheck.log
-      - name: Upload frontend diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: roundtrip-import-frontend-logs
-          path: ci-logs/frontend-*.log
-          if-no-files-found: error
-          retention-days: 7
-      - name: Enforce frontend results
-        if: always()
-        run: |
-          test "${{ steps.frontend_tests.outcome }}" = "success"
-          test "${{ steps.frontend_typecheck.outcome }}" = "success"
+        run: npx tsc -b

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -48,71 +48,9 @@ on:
       - ".github/workflows/roundtrip-import-batch-ci.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  repair-stable-export:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-      - name: Route native exports through stable instance identity
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          route = Path("backend/src/routes/export.ts")
-          text = route.read_text()
-          replacements = [
-              (
-                  'const { createNowenPackageExport } = await import("../services/nowenPackageExport");',
-                  'const { createStableNowenPackageExport } = await import("../services/nowenPackageExportStable");',
-              ),
-              (
-                  'const result = await createNowenPackageExport({',
-                  'const result = await createStableNowenPackageExport({',
-              ),
-              (
-                  'const importMode = (c.req.query("importMode") as "new-root" | "into-target") || "new-root";',
-                  'const importMode = (c.req.query("importMode") as "new-root" | "into-target" | "merge" | "sync") || "new-root";',
-              ),
-          ]
-          changed = False
-          for old, new in replacements:
-              if old in text:
-                  text = text.replace(old, new, 1)
-                  changed = True
-              elif new not in text:
-                  raise SystemExit(f"expected route source missing: {old}")
-          route.write_text(text)
-
-          test_file = Path("backend/tests/roundtrip-import-batches.test.ts")
-          test_text = test_file.read_text()
-          marker = 'process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS = "24";'
-          replacement = marker + '\nprocess.env.NOWEN_INSTANCE_ID = "batch-test-instance";'
-          if replacement not in test_text:
-              if marker not in test_text:
-                  raise SystemExit("test environment marker missing")
-              test_text = test_text.replace(marker, replacement, 1)
-              test_file.write_text(test_text)
-              changed = True
-          print("changed" if changed else "already patched")
-          PY
-      - name: Commit repaired export path
-        run: |
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add backend/src/routes/export.ts backend/tests/roundtrip-import-batches.test.ts
-          git commit -m "fix(import): export stable source identity"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
-
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -10,6 +10,8 @@ on:
       - "backend/src/routes/import-batches.ts"
       - "backend/src/routes/settings.ts"
       - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/nowenPackageImportV2.ts"
+      - "backend/src/services/nowenRoundTripSync.ts"
       - "backend/src/services/roundTripImportBatches.ts"
       - "backend/src/services/roundTripImportLinkUndo.ts"
       - "backend/tests/roundtrip-import-batches.test.ts"
@@ -27,6 +29,8 @@ on:
       - "backend/src/routes/import-batches.ts"
       - "backend/src/routes/settings.ts"
       - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/nowenPackageImportV2.ts"
+      - "backend/src/services/nowenRoundTripSync.ts"
       - "backend/src/services/roundTripImportBatches.ts"
       - "backend/src/services/roundTripImportLinkUndo.ts"
       - "backend/tests/roundtrip-import-batches.test.ts"
@@ -38,9 +42,141 @@ on:
       - ".github/workflows/roundtrip-import-batch-ci.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  repair-source:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Apply strict ZIP note path and nullable model fixes
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          replacements = {
+              Path("backend/src/services/nowenPackageImportV2.ts"): [(
+          '''  const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
+            const notesFolder = zip.folder("notes");
+            if (notesFolder) {
+              for (const name of Object.keys(notesFolder.files)) {
+                if (!name.endsWith("/meta.json")) continue;
+                const noteId = name.split("/")[1];
+                if (!noteId) continue;
+                const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
+                if (!meta) {
+                  errors.push(`Invalid note metadata: ${noteId}`);
+                  continue;
+                }
+                if (!isSafeZipPath(meta.contentFile)) {
+                  errors.push(`Unsafe note content path: ${meta.contentFile}`);
+                  continue;
+                }
+                const contentPath = `notes/${noteId}/${meta.contentFile}`;
+                const entry = zip.file(contentPath);
+                if (!entry) {
+                  errors.push(`Note content not found: ${contentPath}`);
+                  continue;
+                }
+                noteContents.set(noteId, { meta, content: await entry.async("string") });
+              }
+            }
+          ''',
+          '''  const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
+            for (const name of Object.keys(zip.files)) {
+              const match = name.match(/^notes\\/([^/]+)\\/meta\\.json$/);
+              if (!match) continue;
+              const noteId = match[1];
+              const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
+              if (!meta) {
+                errors.push(`Invalid note metadata: ${noteId}`);
+                continue;
+              }
+              if (!isSafeZipPath(meta.contentFile)) {
+                errors.push(`Unsafe note content path: ${meta.contentFile}`);
+                continue;
+              }
+              const contentPath = `notes/${noteId}/${meta.contentFile}`;
+              const entry = zip.file(contentPath);
+              if (!entry) {
+                errors.push(`Note content not found: ${contentPath}`);
+                continue;
+              }
+              noteContents.set(noteId, { meta, content: await entry.async("string") });
+            }
+          ''')],
+              Path("backend/src/services/nowenRoundTripSync.ts"): [(
+          '''  const notes = new Map<string, SourceNote>();
+            const notesFolder = zip.folder("notes");
+            if (notesFolder) {
+              for (const filename of Object.keys(notesFolder.files)) {
+                if (!filename.endsWith("/meta.json")) continue;
+                const sourceId = filename.split("/")[1];
+                if (!sourceId) continue;
+                const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
+                if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
+                const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
+                if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
+                const content = await contentEntry.async("string");
+                const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
+                notes.set(sourceId, {
+                  meta,
+                  content,
+                  sourceHash: sourceNoteHash(meta, content, noteAttachments),
+                });
+              }
+            }
+          ''',
+          '''  const notes = new Map<string, SourceNote>();
+            for (const filename of Object.keys(zip.files)) {
+              const match = filename.match(/^notes\\/([^/]+)\\/meta\\.json$/);
+              if (!match) continue;
+              const sourceId = match[1];
+              const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
+              if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
+              const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
+              if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
+              const content = await contentEntry.async("string");
+              const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
+              notes.set(sourceId, {
+                meta,
+                content,
+                sourceHash: sourceNoteHash(meta, content, noteAttachments),
+              });
+            }
+          '''), (
+          '''  if (result.success && !params.dryRun && snapshot && model?.manifest.packageKind !== "markdown") {''',
+          '''  if (result.success && !params.dryRun && snapshot && model && model.manifest.packageKind !== "markdown") {''')],
+          }
+
+          changed = False
+          for path, pairs in replacements.items():
+              text = path.read_text()
+              for old, new in pairs:
+                  if old in text:
+                      text = text.replace(old, new, 1)
+                      changed = True
+                  elif new not in text:
+                      raise SystemExit(f"expected source block missing in {path}")
+              path.write_text(text)
+          print("changed" if changed else "already patched")
+          PY
+      - name: Commit repaired sources
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add backend/src/services/nowenPackageImportV2.ts backend/src/services/nowenRoundTripSync.ts
+          git commit -m "fix(import): scan only exact note metadata paths"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -7,6 +7,7 @@ on:
       - "backend/src/db/migrations.ts"
       - "backend/src/db/roundtripImportBatchesMigration.ts"
       - "backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql"
+      - "backend/src/routes/export.ts"
       - "backend/src/routes/import-batches.ts"
       - "backend/src/routes/settings.ts"
       - "backend/src/services/nowenPackageImport.ts"
@@ -28,6 +29,7 @@ on:
       - "backend/src/db/migrations.ts"
       - "backend/src/db/roundtripImportBatchesMigration.ts"
       - "backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql"
+      - "backend/src/routes/export.ts"
       - "backend/src/routes/import-batches.ts"
       - "backend/src/routes/settings.ts"
       - "backend/src/services/nowenPackageImport.ts"
@@ -46,9 +48,71 @@ on:
       - ".github/workflows/roundtrip-import-batch-ci.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  repair-stable-export:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Route native exports through stable instance identity
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          route = Path("backend/src/routes/export.ts")
+          text = route.read_text()
+          replacements = [
+              (
+                  'const { createNowenPackageExport } = await import("../services/nowenPackageExport");',
+                  'const { createStableNowenPackageExport } = await import("../services/nowenPackageExportStable");',
+              ),
+              (
+                  'const result = await createNowenPackageExport({',
+                  'const result = await createStableNowenPackageExport({',
+              ),
+              (
+                  'const importMode = (c.req.query("importMode") as "new-root" | "into-target") || "new-root";',
+                  'const importMode = (c.req.query("importMode") as "new-root" | "into-target" | "merge" | "sync") || "new-root";',
+              ),
+          ]
+          changed = False
+          for old, new in replacements:
+              if old in text:
+                  text = text.replace(old, new, 1)
+                  changed = True
+              elif new not in text:
+                  raise SystemExit(f"expected route source missing: {old}")
+          route.write_text(text)
+
+          test_file = Path("backend/tests/roundtrip-import-batches.test.ts")
+          test_text = test_file.read_text()
+          marker = 'process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS = "24";'
+          replacement = marker + '\nprocess.env.NOWEN_INSTANCE_ID = "batch-test-instance";'
+          if replacement not in test_text:
+              if marker not in test_text:
+                  raise SystemExit("test environment marker missing")
+              test_text = test_text.replace(marker, replacement, 1)
+              test_file.write_text(test_text)
+              changed = True
+          print("changed" if changed else "already patched")
+          PY
+      - name: Commit repaired export path
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add backend/src/routes/export.ts backend/tests/roundtrip-import-batches.test.ts
+          git commit -m "fix(import): export stable source identity"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -55,10 +55,29 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
+      - name: Prepare diagnostic directory
+        run: mkdir -p ../ci-logs
       - name: Import batch and undo tests
-        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts
+        id: backend_tests
+        continue-on-error: true
+        run: set -o pipefail; node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts 2>&1 | tee ../ci-logs/backend-tests.log
       - name: Backend typecheck
-        run: npm run build:tsc
+        id: backend_typecheck
+        continue-on-error: true
+        run: set -o pipefail; npm run build:tsc 2>&1 | tee ../ci-logs/backend-typecheck.log
+      - name: Upload backend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-import-backend-logs
+          path: ci-logs/backend-*.log
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce backend results
+        if: always()
+        run: |
+          test "${{ steps.backend_tests.outcome }}" = "success"
+          test "${{ steps.backend_typecheck.outcome }}" = "success"
 
   frontend:
     runs-on: ubuntu-latest
@@ -74,7 +93,26 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - name: Prepare diagnostic directory
+        run: mkdir -p ../ci-logs
       - name: Import batch client tests
-        run: npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts
+        id: frontend_tests
+        continue-on-error: true
+        run: set -o pipefail; npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts 2>&1 | tee ../ci-logs/frontend-tests.log
       - name: Frontend typecheck
-        run: npx tsc -b
+        id: frontend_typecheck
+        continue-on-error: true
+        run: set -o pipefail; npx tsc -b 2>&1 | tee ../ci-logs/frontend-typecheck.log
+      - name: Upload frontend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-import-frontend-logs
+          path: ci-logs/frontend-*.log
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce frontend results
+        if: always()
+        run: |
+          test "${{ steps.frontend_tests.outcome }}" = "success"
+          test "${{ steps.frontend_typecheck.outcome }}" = "success"

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -1,0 +1,80 @@
+name: Round-trip Import Batch CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/roundtripImportBatchesMigration.ts"
+      - "backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql"
+      - "backend/src/routes/import-batches.ts"
+      - "backend/src/routes/settings.ts"
+      - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/roundTripImportBatches.ts"
+      - "backend/src/services/roundTripImportLinkUndo.ts"
+      - "backend/tests/roundtrip-import-batches.test.ts"
+      - "frontend/src/components/RoundTripImportBatchCenter.tsx"
+      - "frontend/src/lib/roundTripImportBatches.ts"
+      - "frontend/src/lib/roundTripImportReview.ts"
+      - "frontend/src/lib/__tests__/roundTripImportBatches.test.ts"
+      - "frontend/src/main.tsx"
+      - ".github/workflows/roundtrip-import-batch-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/roundtripImportBatchesMigration.ts"
+      - "backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql"
+      - "backend/src/routes/import-batches.ts"
+      - "backend/src/routes/settings.ts"
+      - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/roundTripImportBatches.ts"
+      - "backend/src/services/roundTripImportLinkUndo.ts"
+      - "backend/tests/roundtrip-import-batches.test.ts"
+      - "frontend/src/components/RoundTripImportBatchCenter.tsx"
+      - "frontend/src/lib/roundTripImportBatches.ts"
+      - "frontend/src/lib/roundTripImportReview.ts"
+      - "frontend/src/lib/__tests__/roundTripImportBatches.test.ts"
+      - "frontend/src/main.tsx"
+      - ".github/workflows/roundtrip-import-batch-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Import batch and undo tests
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts
+      - name: Backend typecheck
+        run: npm run build:tsc
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Import batch client tests
+        run: npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts
+      - name: Frontend typecheck
+        run: npx tsc -b

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -107,6 +107,34 @@ jobs:
         id: frontend_tests
         continue-on-error: true
         run: set -o pipefail; npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts src/lib/__tests__/blockPatchApi.test.ts 2>&1 | tee ../ci-logs/frontend-tests.log
+      - name: Affected editor runtime regression suite
+        id: editor_runtime_tests
+        continue-on-error: true
+        run: >-
+          set -o pipefail; npm run test:run --
+          src/lib/__tests__/editorRuntimePolicy.test.ts
+          src/lib/__tests__/editorRuntimeStore.test.ts
+          src/lib/__tests__/editorRuntimeNotice.test.ts
+          src/lib/__tests__/largeRichTextSafeMode.test.ts
+          src/lib/__tests__/largeMarkdownSafety.test.ts
+          src/lib/__tests__/markdownAnalysis.test.ts
+          src/lib/__tests__/markdownAnalysisClient.test.ts
+          src/lib/__tests__/markdownYTextSync.test.ts
+          src/lib/__tests__/markdownYTextRuntime.test.ts
+          src/lib/__tests__/proseMirrorPlainTextRuntime.test.ts
+          src/lib/__tests__/tiptapDerivedRuntime.test.ts
+          src/lib/__tests__/tiptapBlockPatchPlanner.test.ts
+          src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
+          src/lib/__tests__/blockPatchApi.test.ts
+          src/lib/__tests__/codeBlockHighlightPlugin.test.ts
+          src/lib/__tests__/codeBlockViewportHighlight.test.ts
+          src/hooks/__tests__/useLazyNodeView.test.tsx
+          src/components/__tests__/VideoExtension.test.ts
+          src/components/__tests__/HeavyNodeRuntimeShells.test.tsx
+          src/components/__tests__/SearchReplaceRuntime.test.ts
+          src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
+          src/components/__tests__/TiptapRuntimePublicContext.test.tsx
+          2>&1 | tee ../ci-logs/frontend-editor-runtime-tests.log
       - name: Frontend typecheck
         id: frontend_typecheck
         continue-on-error: true
@@ -123,4 +151,5 @@ jobs:
         if: always()
         run: |
           test "${{ steps.frontend_tests.outcome }}" = "success"
+          test "${{ steps.editor_runtime_tests.outcome }}" = "success"
           test "${{ steps.frontend_typecheck.outcome }}" = "success"

--- a/.github/workflows/roundtrip-import-batch-ci.yml
+++ b/.github/workflows/roundtrip-import-batch-ci.yml
@@ -63,10 +63,28 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
+      - run: mkdir -p ../ci-logs
       - name: Import batch and undo tests
-        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts
+        id: backend_tests
+        continue-on-error: true
+        run: set -o pipefail; node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-import-batches.test.ts 2>&1 | tee ../ci-logs/backend-tests.log
       - name: Backend typecheck
-        run: npm run build:tsc
+        id: backend_typecheck
+        continue-on-error: true
+        run: set -o pipefail; npm run build:tsc 2>&1 | tee ../ci-logs/backend-typecheck.log
+      - name: Upload backend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-import-backend-logs
+          path: ci-logs/backend-*.log
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce backend results
+        if: always()
+        run: |
+          test "${{ steps.backend_tests.outcome }}" = "success"
+          test "${{ steps.backend_typecheck.outcome }}" = "success"
 
   frontend:
     runs-on: ubuntu-latest
@@ -82,7 +100,25 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: mkdir -p ../ci-logs
       - name: Import batch client tests
-        run: npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts src/lib/__tests__/blockPatchApi.test.ts
+        id: frontend_tests
+        continue-on-error: true
+        run: set -o pipefail; npm run test:run -- src/lib/__tests__/roundTripImportBatches.test.ts src/lib/__tests__/blockPatchApi.test.ts 2>&1 | tee ../ci-logs/frontend-tests.log
       - name: Frontend typecheck
-        run: npx tsc -b
+        id: frontend_typecheck
+        continue-on-error: true
+        run: set -o pipefail; npx tsc -b 2>&1 | tee ../ci-logs/frontend-typecheck.log
+      - name: Upload frontend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-import-frontend-logs
+          path: ci-logs/frontend-*.log
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce frontend results
+        if: always()
+        run: |
+          test "${{ steps.frontend_tests.outcome }}" = "success"
+          test "${{ steps.frontend_typecheck.outcome }}" = "success"

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -13,6 +13,7 @@ import {
   type Migration,
 } from "./migrations.impl.js";
 import { roundTripImportLinksMigration } from "./roundtripImportLinksMigration.js";
+import { roundTripImportBatchesMigration } from "./roundtripImportBatchesMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -258,6 +259,7 @@ export const MIGRATIONS: Migration[] = [
   noteImportOriginsMigration,
   repairSearchContentTextMigration,
   roundTripImportLinksMigration,
+  roundTripImportBatchesMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql
+++ b/backend/src/db/postgres/migrations/0054-roundtrip-import-batches.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS roundtrip_import_batches (
+  id TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "workspaceId" TEXT,
+  "workspaceScope" TEXT NOT NULL,
+  "importMode" TEXT NOT NULL,
+  "packageKind" TEXT,
+  "sourceInstanceId" TEXT,
+  "sourceExportBatchId" TEXT,
+  status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed', 'undone')),
+  "previewJson" TEXT NOT NULL DEFAULT '{}',
+  "resultJson" TEXT NOT NULL DEFAULT '{}',
+  "undoStateJson" TEXT NOT NULL DEFAULT '{}',
+  "undoAvailable" BOOLEAN NOT NULL DEFAULT false,
+  "undoUnavailableReason" TEXT,
+  "undoExpiresAt" TIMESTAMPTZ,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "completedAt" TIMESTAMPTZ,
+  "undoneAt" TIMESTAMPTZ,
+  "undoError" TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_user_time
+  ON roundtrip_import_batches("userId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_scope_time
+  ON roundtrip_import_batches("workspaceScope", "userId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_source
+  ON roundtrip_import_batches("userId", "workspaceScope", "sourceInstanceId", "createdAt" DESC);

--- a/backend/src/db/roundtripImportBatchesMigration.ts
+++ b/backend/src/db/roundtripImportBatchesMigration.ts
@@ -1,0 +1,42 @@
+import type Database from "better-sqlite3";
+import type { Migration } from "./migrations.impl";
+
+export function ensureRoundTripImportBatchesSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS roundtrip_import_batches (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      workspaceScope TEXT NOT NULL,
+      importMode TEXT NOT NULL,
+      packageKind TEXT,
+      sourceInstanceId TEXT,
+      sourceExportBatchId TEXT,
+      status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed', 'undone')),
+      previewJson TEXT NOT NULL DEFAULT '{}',
+      resultJson TEXT NOT NULL DEFAULT '{}',
+      undoStateJson TEXT NOT NULL DEFAULT '{}',
+      undoAvailable INTEGER NOT NULL DEFAULT 0,
+      undoUnavailableReason TEXT,
+      undoExpiresAt TEXT,
+      createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+      completedAt TEXT,
+      undoneAt TEXT,
+      undoError TEXT,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_user_time
+      ON roundtrip_import_batches(userId, createdAt DESC);
+    CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_scope_time
+      ON roundtrip_import_batches(workspaceScope, userId, createdAt DESC);
+    CREATE INDEX IF NOT EXISTS idx_roundtrip_import_batches_source
+      ON roundtrip_import_batches(userId, workspaceScope, sourceInstanceId, createdAt DESC);
+  `);
+}
+
+export const roundTripImportBatchesMigration: Migration = {
+  version: 54,
+  name: "roundtrip-import-batches",
+  up: ensureRoundTripImportBatchesSchema,
+};

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -718,8 +718,8 @@ app.get("/nowen-package", async (c) => {
   if (denied) return c.json(denied, 403);
 
   try {
-    const { createNowenPackageExport } = await import("../services/nowenPackageExport");
-    const result = await createNowenPackageExport({
+    const { createStableNowenPackageExport } = await import("../services/nowenPackageExportStable");
+    const result = await createStableNowenPackageExport({
       userId,
       workspaceId: wsParam,
       notebookId,
@@ -748,7 +748,7 @@ app.get("/nowen-package", async (c) => {
 app.post("/import/nowen-package", async (c) => {
   const userId = c.req.header("X-User-Id")!;
   const dryRun = c.req.query("dryRun") === "1" || c.req.query("dryRun") === "true";
-  const importMode = (c.req.query("importMode") as "new-root" | "into-target") || "new-root";
+  const importMode = (c.req.query("importMode") as "new-root" | "into-target" | "merge" | "sync") || "new-root";
   const targetNotebookId = c.req.query("targetNotebookId") || undefined;
 
   // 解析 workspaceId

--- a/backend/src/routes/import-batches.ts
+++ b/backend/src/routes/import-batches.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { getUserWorkspaceRole, hasRole, isSystemAdmin } from "../middleware/acl";
 import {
   getRoundTripImportBatch,
   listRoundTripImportBatches,
@@ -35,8 +36,19 @@ app.get("/:id", (c) => {
 
 app.post("/:id/undo", async (c) => {
   const userId = c.req.header("X-User-Id")!;
+  const batchId = c.req.param("id");
+  const existing = getRoundTripImportBatch(userId, batchId);
+  if (!existing) return c.json({ error: "导入批次不存在", code: "IMPORT_BATCH_NOT_FOUND" }, 404);
+  if (
+    existing.workspaceId
+    && !isSystemAdmin(userId)
+    && !hasRole(getUserWorkspaceRole(existing.workspaceId, userId), "editor")
+  ) {
+    return c.json({ error: "当前已无权修改该工作区，不能撤销历史导入", code: "WORKSPACE_FORBIDDEN" }, 403);
+  }
+
   try {
-    const item = await undoRoundTripImportBatchWithLinks(userId, c.req.param("id"));
+    const item = await undoRoundTripImportBatchWithLinks(userId, batchId);
     try {
       broadcastToUser(userId, {
         type: "notes:imported",

--- a/backend/src/routes/import-batches.ts
+++ b/backend/src/routes/import-batches.ts
@@ -3,8 +3,8 @@ import {
   getRoundTripImportBatch,
   listRoundTripImportBatches,
   RoundTripImportUndoError,
-  undoRoundTripImportBatch,
 } from "../services/roundTripImportBatches";
+import { undoRoundTripImportBatchWithLinks } from "../services/roundTripImportLinkUndo";
 import { broadcastToUser } from "../services/realtime";
 
 const app = new Hono();
@@ -36,7 +36,7 @@ app.get("/:id", (c) => {
 app.post("/:id/undo", async (c) => {
   const userId = c.req.header("X-User-Id")!;
   try {
-    const item = await undoRoundTripImportBatch(userId, c.req.param("id"));
+    const item = await undoRoundTripImportBatchWithLinks(userId, c.req.param("id"));
     try {
       broadcastToUser(userId, {
         type: "notes:imported",

--- a/backend/src/routes/import-batches.ts
+++ b/backend/src/routes/import-batches.ts
@@ -1,0 +1,65 @@
+import { Hono } from "hono";
+import {
+  getRoundTripImportBatch,
+  listRoundTripImportBatches,
+  RoundTripImportUndoError,
+  undoRoundTripImportBatch,
+} from "../services/roundTripImportBatches";
+import { broadcastToUser } from "../services/realtime";
+
+const app = new Hono();
+
+function parseWorkspaceFilter(raw: string | undefined): string | null | undefined {
+  if (raw === undefined || raw === "" || raw === "all") return undefined;
+  return raw === "personal" ? null : raw;
+}
+
+app.get("/", (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const workspaceId = parseWorkspaceFilter(c.req.query("workspaceId"));
+  const limit = Number(c.req.query("limit"));
+  return c.json({
+    items: listRoundTripImportBatches(userId, {
+      workspaceId,
+      limit: Number.isFinite(limit) ? limit : undefined,
+    }),
+  });
+});
+
+app.get("/:id", (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const item = getRoundTripImportBatch(userId, c.req.param("id"));
+  if (!item) return c.json({ error: "导入批次不存在", code: "IMPORT_BATCH_NOT_FOUND" }, 404);
+  return c.json(item);
+});
+
+app.post("/:id/undo", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  try {
+    const item = await undoRoundTripImportBatch(userId, c.req.param("id"));
+    try {
+      broadcastToUser(userId, {
+        type: "notes:imported",
+        payload: {
+          reason: "import-batch-undone",
+          batchId: item.id,
+          workspaceId: item.workspaceId,
+        },
+      } as any);
+      broadcastToUser(userId, { type: "notebooks:changed", payload: {} } as any);
+    } catch { /* refresh is best effort */ }
+    return c.json(item);
+  } catch (error) {
+    if (error instanceof RoundTripImportUndoError) {
+      return c.json({
+        error: error.message,
+        code: error.code,
+        conflicts: error.conflicts,
+      }, error.status);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message, code: "IMPORT_BATCH_UNDO_FAILED" }, 500);
+  }
+});
+
+export default app;

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -7,6 +7,7 @@ import {
   syncRuntimePublicWebOriginSetting,
 } from "../lib/public-web-origin";
 import systemUpdateRouter from "./system-update";
+import importBatchesRouter from "./import-batches";
 
 const settings = new Hono();
 
@@ -124,5 +125,7 @@ settings.put("/", async (c) => {
 // 管理员专用 Docker 在线升级控制面。挂在 settings 路由下可复用现有 JWT 中间件，
 // 子路由自身再叠加 requireAdmin、sudo、同源交互头和速率限制。
 settings.route("/system-update", systemUpdateRouter);
+// Round-trip 导入批次报告属于当前登录用户的数据，不要求管理员权限。
+settings.route("/import-batches", importBatchesRouter);
 
 export default settings;

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -1,13 +1,30 @@
 import { executeNowenPackageImportWithBatch } from "./roundTripImportBatches";
 import {
+  attachRoundTripImportLinkUndo,
+  captureRoundTripImportLinkUndo,
+} from "./roundTripImportLinkUndo";
+import {
   importNowenPackageWithSync,
   type RoundTripImportParams,
 } from "./nowenRoundTripSync";
 
 export async function importNowenPackage(zipBuffer: Buffer, params: RoundTripImportParams): Promise<any> {
-  return params.dryRun
-    ? importNowenPackageWithSync(zipBuffer, params)
-    : executeNowenPackageImportWithBatch(zipBuffer, params);
+  if (params.dryRun) return importNowenPackageWithSync(zipBuffer, params);
+
+  const linkSnapshot = await captureRoundTripImportLinkUndo(zipBuffer, params.userId, params.workspaceId);
+  const result = await executeNowenPackageImportWithBatch(zipBuffer, params);
+  const batchId = String(result?.importBatch?.id || "");
+  if (batchId && result?.success) {
+    const attached = attachRoundTripImportLinkUndo(params.userId, batchId, linkSnapshot);
+    if (!attached.available) {
+      result.importBatch = {
+        ...(result.importBatch || {}),
+        undoAvailable: false,
+        reason: attached.reason,
+      };
+    }
+  }
+  return result;
 }
 
 export type {

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -1,4 +1,15 @@
-export { importNowenPackageWithSync as importNowenPackage } from "./nowenRoundTripSync";
+import { executeNowenPackageImportWithBatch } from "./roundTripImportBatches";
+import {
+  importNowenPackageWithSync,
+  type RoundTripImportParams,
+} from "./nowenRoundTripSync";
+
+export async function importNowenPackage(zipBuffer: Buffer, params: RoundTripImportParams): Promise<any> {
+  return params.dryRun
+    ? importNowenPackageWithSync(zipBuffer, params)
+    : executeNowenPackageImportWithBatch(zipBuffer, params);
+}
+
 export type {
   RoundTripImportParams as ImportParams,
   RoundTripSyncImportMode as RoundTripImportMode,

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -20,7 +20,7 @@ export async function importNowenPackage(zipBuffer: Buffer, params: RoundTripImp
       result.importBatch = {
         ...(result.importBatch || {}),
         undoAvailable: false,
-        reason: attached.reason,
+        reason: attached.reason ?? result.importBatch?.reason ?? null,
       };
     }
   }

--- a/backend/src/services/nowenPackageImportV2.ts
+++ b/backend/src/services/nowenPackageImportV2.ts
@@ -564,29 +564,26 @@ export async function importNowenPackageV2(zipBuffer: Buffer, params: ImportPara
   if (!zip.file("notebooks.json") && !zip.file("tree.json")) errors.push("Notebook tree manifest is missing");
 
   const noteContents = new Map<string, { content: string; meta: NoteMeta }>();
-  const notesFolder = zip.folder("notes");
-  if (notesFolder) {
-    for (const name of Object.keys(notesFolder.files)) {
-      if (!name.endsWith("/meta.json")) continue;
-      const noteId = name.split("/")[1];
-      if (!noteId) continue;
-      const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
-      if (!meta) {
-        errors.push(`Invalid note metadata: ${noteId}`);
-        continue;
-      }
-      if (!isSafeZipPath(meta.contentFile)) {
-        errors.push(`Unsafe note content path: ${meta.contentFile}`);
-        continue;
-      }
-      const contentPath = `notes/${noteId}/${meta.contentFile}`;
-      const entry = zip.file(contentPath);
-      if (!entry) {
-        errors.push(`Note content not found: ${contentPath}`);
-        continue;
-      }
-      noteContents.set(noteId, { meta, content: await entry.async("string") });
+  for (const name of Object.keys(zip.files)) {
+    const match = name.match(/^notes\/([^/]+)\/meta\.json$/);
+    if (!match) continue;
+    const noteId = match[1];
+    const meta = await readJson<NoteMeta>(zip, `notes/${noteId}/meta.json`);
+    if (!meta) {
+      errors.push(`Invalid note metadata: ${noteId}`);
+      continue;
     }
+    if (!isSafeZipPath(meta.contentFile)) {
+      errors.push(`Unsafe note content path: ${meta.contentFile}`);
+      continue;
+    }
+    const contentPath = `notes/${noteId}/${meta.contentFile}`;
+    const entry = zip.file(contentPath);
+    if (!entry) {
+      errors.push(`Note content not found: ${contentPath}`);
+      continue;
+    }
+    noteContents.set(noteId, { meta, content: await entry.async("string") });
   }
   const attachmentData = await readAttachmentEntries(zip, manifest.formatVersion, warnings, errors);
 

--- a/backend/src/services/nowenRoundTripSync.ts
+++ b/backend/src/services/nowenRoundTripSync.ts
@@ -409,24 +409,21 @@ async function parsePackage(zipBuffer: Buffer): Promise<PackageModel> {
   }
 
   const notes = new Map<string, SourceNote>();
-  const notesFolder = zip.folder("notes");
-  if (notesFolder) {
-    for (const filename of Object.keys(notesFolder.files)) {
-      if (!filename.endsWith("/meta.json")) continue;
-      const sourceId = filename.split("/")[1];
-      if (!sourceId) continue;
-      const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
-      if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
-      const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
-      if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
-      const content = await contentEntry.async("string");
-      const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
-      notes.set(sourceId, {
-        meta,
-        content,
-        sourceHash: sourceNoteHash(meta, content, noteAttachments),
-      });
-    }
+  for (const filename of Object.keys(zip.files)) {
+    const match = filename.match(/^notes\/([^/]+)\/meta\.json$/);
+    if (!match) continue;
+    const sourceId = match[1];
+    const meta = await readJson<NoteMeta>(zip, `notes/${sourceId}/meta.json`);
+    if (!meta) throw new Error(`Invalid note metadata: ${sourceId}`);
+    const contentEntry = zip.file(`notes/${sourceId}/${meta.contentFile}`);
+    if (!contentEntry) throw new Error(`Note content not found: ${sourceId}/${meta.contentFile}`);
+    const content = await contentEntry.async("string");
+    const noteAttachments = Array.from(attachments.values()).filter((item) => item.meta.noteId === sourceId);
+    notes.set(sourceId, {
+      meta,
+      content,
+      sourceHash: sourceNoteHash(meta, content, noteAttachments),
+    });
   }
 
   return {
@@ -1356,7 +1353,7 @@ export async function importNowenPackageWithSync(
     }];
   }
 
-  if (result.success && !params.dryRun && snapshot && model?.manifest.packageKind !== "markdown") {
+  if (result.success && !params.dryRun && snapshot && model && model.manifest.packageKind !== "markdown") {
     try {
       await recordRoundTripLinksAfterImport({
         zipBuffer,

--- a/backend/src/services/roundTripImportBatches.ts
+++ b/backend/src/services/roundTripImportBatches.ts
@@ -1,0 +1,743 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import JSZip from "jszip";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+import { ensureRoundTripImportBatchesSchema } from "../db/roundtripImportBatchesMigration";
+import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
+import {
+  deleteAttachmentObject,
+  readAttachmentObject,
+  writeAttachmentObject,
+} from "./attachment-storage";
+import {
+  importNowenPackageWithSync,
+  type RoundTripImportParams,
+} from "./nowenRoundTripSync";
+
+const DATA_DIR = process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data");
+const UNDO_ROOT = path.join(DATA_DIR, "import-undo");
+const DEFAULT_UNDO_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_UNDO_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+
+interface PackageIdentity {
+  packageKind: string | null;
+  sourceInstanceId: string | null;
+  sourceExportBatchId: string | null;
+}
+
+interface ScopeIds {
+  notebooks: string[];
+  notes: string[];
+  attachments: string[];
+  tags: string[];
+}
+
+interface AttachmentUndoSnapshot {
+  row: Record<string, unknown>;
+  objectHash: string | null;
+  backupFile: string | null;
+}
+
+interface NoteUndoSnapshot {
+  row: Record<string, unknown>;
+  tagIds: string[];
+  attachments: AttachmentUndoSnapshot[];
+}
+
+interface UndoState {
+  version: 1;
+  beforeScope: ScopeIds;
+  created: {
+    notebookIds: string[];
+    noteIds: string[];
+    attachmentRows: Array<Record<string, unknown>>;
+    tagIds: string[];
+  };
+  updated: {
+    notebooks: Array<Record<string, unknown>>;
+    notes: NoteUndoSnapshot[];
+  };
+  afterHashes: {
+    notebooks: Record<string, string>;
+    notes: Record<string, string>;
+    tags: Record<string, string>;
+  };
+  backupBytes: number;
+}
+
+interface BatchRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  workspaceScope: string;
+  importMode: string;
+  packageKind: string | null;
+  sourceInstanceId: string | null;
+  sourceExportBatchId: string | null;
+  status: "running" | "completed" | "failed" | "undone";
+  previewJson: string;
+  resultJson: string;
+  undoStateJson: string;
+  undoAvailable: number;
+  undoUnavailableReason: string | null;
+  undoExpiresAt: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  undoneAt: string | null;
+  undoError: string | null;
+}
+
+export interface RoundTripImportBatchSummary {
+  id: string;
+  workspaceId: string | null;
+  importMode: string;
+  packageKind: string | null;
+  sourceInstanceId: string | null;
+  sourceExportBatchId: string | null;
+  status: BatchRow["status"];
+  createdAt: string;
+  completedAt: string | null;
+  undoneAt: string | null;
+  undo: {
+    available: boolean;
+    expiresAt: string | null;
+    reason: string | null;
+    error: string | null;
+  };
+  counts: Record<string, number>;
+  warningCount: number;
+  errorCount: number;
+}
+
+export interface RoundTripImportBatchDetail extends RoundTripImportBatchSummary {
+  preview: Record<string, unknown>;
+  result: Record<string, unknown>;
+}
+
+export class RoundTripImportUndoError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: 404 | 409 | 410 = 409,
+    readonly conflicts: string[] = [],
+  ) {
+    super(message);
+  }
+}
+
+function undoTtlMs(): number {
+  const raw = Number(process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS);
+  return Number.isFinite(raw) && raw > 0
+    ? Math.min(raw, 24 * 365) * 60 * 60 * 1000
+    : DEFAULT_UNDO_TTL_MS;
+}
+
+function undoMaxBytes(): number {
+  const raw = Number(process.env.ROUNDTRIP_IMPORT_UNDO_MAX_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_UNDO_MAX_BYTES;
+}
+
+function workspaceScope(workspaceId: string | null | undefined): string {
+  return workspaceId || "personal";
+}
+
+function parseJson<T>(value: string, fallback: T): T {
+  try { return JSON.parse(value || "") as T; }
+  catch { return fallback; }
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(source).sort().map((key) => [key, stableValue(source[key])]));
+  }
+  return value;
+}
+
+function hashValue(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(stableValue(value))).digest("hex");
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function scopeSql(workspaceId: string | null, alias = ""): { sql: string; params: unknown[] } {
+  const prefix = alias ? `${alias}.` : "";
+  return workspaceId
+    ? { sql: `${prefix}workspaceId = ?`, params: [workspaceId] }
+    : { sql: `${prefix}workspaceId IS NULL`, params: [] };
+}
+
+function idsForScope(userId: string, workspaceId: string | null): ScopeIds {
+  const db = getDb();
+  const scope = scopeSql(workspaceId);
+  const owner = workspaceId ? "" : "userId = ? AND ";
+  const ownerParams = workspaceId ? [] : [userId];
+  const notebooks = db.prepare(`SELECT id FROM notebooks WHERE ${owner}${scope.sql}`).all(...ownerParams, ...scope.params) as Array<{ id: string }>;
+  const notes = db.prepare(`SELECT id FROM notes WHERE ${owner}${scope.sql}`).all(...ownerParams, ...scope.params) as Array<{ id: string }>;
+  const tags = db.prepare(`SELECT id FROM tags WHERE ${owner}${scope.sql}`).all(...ownerParams, ...scope.params) as Array<{ id: string }>;
+  const noteScope = scopeSql(workspaceId, "n");
+  const noteOwner = workspaceId ? "" : "n.userId = ? AND ";
+  const attachments = db.prepare(`
+    SELECT a.id
+      FROM attachments a
+      JOIN notes n ON n.id = a.noteId
+     WHERE ${noteOwner}${noteScope.sql}
+  `).all(...ownerParams, ...noteScope.params) as Array<{ id: string }>;
+  return {
+    notebooks: notebooks.map((row) => row.id),
+    notes: notes.map((row) => row.id),
+    attachments: attachments.map((row) => row.id),
+    tags: tags.map((row) => row.id),
+  };
+}
+
+function rowById(table: "notebooks" | "notes" | "attachments" | "tags", id: string): Record<string, unknown> | null {
+  return getDb().prepare(`SELECT * FROM ${table} WHERE id = ?`).get(id) as Record<string, unknown> | undefined || null;
+}
+
+function rowsByIds(table: "notebooks" | "notes" | "attachments" | "tags", ids: string[]): Array<Record<string, unknown>> {
+  if (!ids.length) return [];
+  return getDb().prepare(`SELECT * FROM ${table} WHERE id IN (${ids.map(() => "?").join(",")})`).all(...ids) as Array<Record<string, unknown>>;
+}
+
+function attachmentRowsForNote(noteId: string): Array<Record<string, unknown>> {
+  return getDb().prepare("SELECT * FROM attachments WHERE noteId = ? ORDER BY id").all(noteId) as Array<Record<string, unknown>>;
+}
+
+function tagIdsForNote(noteId: string): string[] {
+  return (getDb().prepare("SELECT tagId FROM note_tags WHERE noteId = ? ORDER BY tagId").all(noteId) as Array<{ tagId: string }>)
+    .map((row) => row.tagId);
+}
+
+async function attachmentState(row: Record<string, unknown>): Promise<{ row: Record<string, unknown>; objectHash: string | null }> {
+  const object = await readAttachmentObject(String(row.path || ""));
+  return { row, objectHash: object ? sha256(object) : null };
+}
+
+async function noteHash(noteId: string): Promise<string | null> {
+  const row = rowById("notes", noteId);
+  if (!row) return null;
+  const attachments = [];
+  for (const attachment of attachmentRowsForNote(noteId)) attachments.push(await attachmentState(attachment));
+  return hashValue({ row, tagIds: tagIdsForNote(noteId), attachments });
+}
+
+function notebookHash(id: string): string | null {
+  const row = rowById("notebooks", id);
+  return row ? hashValue(row) : null;
+}
+
+function tagHash(id: string): string | null {
+  const row = rowById("tags", id);
+  return row ? hashValue(row) : null;
+}
+
+function backupDir(batchId: string): string {
+  return path.join(UNDO_ROOT, batchId);
+}
+
+function backupFilename(attachmentId: string): string {
+  return `${crypto.createHash("sha256").update(attachmentId).digest("hex").slice(0, 40)}.bin`;
+}
+
+async function captureNoteBefore(batchId: string, noteId: string, budget: { bytes: number }): Promise<NoteUndoSnapshot | null> {
+  const row = rowById("notes", noteId);
+  if (!row) return null;
+  const snapshots: AttachmentUndoSnapshot[] = [];
+  for (const attachment of attachmentRowsForNote(noteId)) {
+    const object = await readAttachmentObject(String(attachment.path || ""));
+    let backupFile: string | null = null;
+    let objectHash: string | null = null;
+    if (object) {
+      budget.bytes += object.byteLength;
+      if (budget.bytes > undoMaxBytes()) throw new Error("UNDO_BACKUP_BUDGET_EXCEEDED");
+      fs.mkdirSync(backupDir(batchId), { recursive: true });
+      backupFile = backupFilename(String(attachment.id || uuid()));
+      fs.writeFileSync(path.join(backupDir(batchId), backupFile), object);
+      objectHash = sha256(object);
+    } else {
+      throw new Error(`UNDO_ATTACHMENT_MISSING:${String(attachment.filename || attachment.id || "unknown")}`);
+    }
+    snapshots.push({ row: attachment, objectHash, backupFile });
+  }
+  return { row, tagIds: tagIdsForNote(noteId), attachments: snapshots };
+}
+
+function previewActionTargets(preview: any): { notebookIds: string[]; noteIds: string[] } {
+  const notebookIds = new Set<string>();
+  const noteIds = new Set<string>();
+  for (const conflict of Array.isArray(preview?.conflicts) ? preview.conflicts : []) {
+    const action = String(conflict?.action || "");
+    const targetId = String(conflict?.targetId || "");
+    if (action === "sync-update-directory" && targetId) notebookIds.add(targetId);
+    if (action === "sync-update-note" && targetId) noteIds.add(targetId);
+    if (action === "sync-replace-attachment" && conflict?.parentId) noteIds.add(String(conflict.parentId));
+  }
+  return { notebookIds: [...notebookIds], noteIds: [...noteIds] };
+}
+
+async function readPackageIdentity(zipBuffer: Buffer): Promise<PackageIdentity> {
+  try {
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const entry = zip.file("manifest.json");
+    if (!entry) return { packageKind: null, sourceInstanceId: null, sourceExportBatchId: null };
+    const manifest = JSON.parse(await entry.async("string")) as Record<string, unknown>;
+    return {
+      packageKind: manifest.packageKind ? String(manifest.packageKind) : null,
+      sourceInstanceId: manifest.sourceInstanceId ? String(manifest.sourceInstanceId) : null,
+      sourceExportBatchId: manifest.exportBatchId ? String(manifest.exportBatchId) : null,
+    };
+  } catch {
+    return { packageKind: null, sourceInstanceId: null, sourceExportBatchId: null };
+  }
+}
+
+function publicBatch(row: BatchRow): RoundTripImportBatchDetail {
+  const preview = parseJson<Record<string, unknown>>(row.previewJson, {});
+  const result = parseJson<Record<string, unknown>>(row.resultJson, {});
+  const counts = (result.counts && typeof result.counts === "object" ? result.counts : preview.counts) as Record<string, number> | undefined;
+  const warnings = Array.isArray(result.warnings) ? result.warnings : Array.isArray(preview.warnings) ? preview.warnings : [];
+  const errors = Array.isArray(result.errors) ? result.errors : Array.isArray(preview.errors) ? preview.errors : [];
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    importMode: row.importMode,
+    packageKind: row.packageKind,
+    sourceInstanceId: row.sourceInstanceId,
+    sourceExportBatchId: row.sourceExportBatchId,
+    status: row.status,
+    createdAt: row.createdAt,
+    completedAt: row.completedAt,
+    undoneAt: row.undoneAt,
+    undo: {
+      available: row.undoAvailable === 1 && row.status === "completed",
+      expiresAt: row.undoExpiresAt,
+      reason: row.undoUnavailableReason,
+      error: row.undoError,
+    },
+    counts: counts || {},
+    warningCount: warnings.length,
+    errorCount: errors.length,
+    preview,
+    result,
+  };
+}
+
+function removeUndoDir(batchId: string): void {
+  try { fs.rmSync(backupDir(batchId), { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+export function cleanupExpiredRoundTripImportUndo(): void {
+  ensureRoundTripImportBatchesSchema(getDb());
+  const rows = getDb().prepare(`
+    SELECT id FROM roundtrip_import_batches
+     WHERE undoAvailable = 1 AND undoExpiresAt IS NOT NULL AND datetime(undoExpiresAt) <= datetime('now')
+  `).all() as Array<{ id: string }>;
+  if (!rows.length) return;
+  const tx = getDb().transaction(() => {
+    for (const row of rows) {
+      getDb().prepare(`
+        UPDATE roundtrip_import_batches
+           SET undoAvailable = 0,
+               undoUnavailableReason = COALESCE(undoUnavailableReason, '撤销窗口已过期')
+         WHERE id = ?
+      `).run(row.id);
+    }
+  });
+  tx();
+  rows.forEach((row) => removeUndoDir(row.id));
+}
+
+async function prepareUndoState(
+  batchId: string,
+  userId: string,
+  workspaceId: string | null,
+  importMode: string,
+  preview: any,
+): Promise<{ state: UndoState; available: boolean; reason: string | null }> {
+  const beforeScope = idsForScope(userId, workspaceId);
+  const state: UndoState = {
+    version: 1,
+    beforeScope,
+    created: { notebookIds: [], noteIds: [], attachmentRows: [], tagIds: [] },
+    updated: { notebooks: [], notes: [] },
+    afterHashes: { notebooks: {}, notes: {}, tags: {} },
+    backupBytes: 0,
+  };
+  if (importMode !== "sync") return { state, available: true, reason: null };
+
+  const targets = previewActionTargets(preview);
+  state.updated.notebooks = rowsByIds("notebooks", targets.notebookIds);
+  const budget = { bytes: 0 };
+  try {
+    for (const noteId of targets.noteIds) {
+      const snapshot = await captureNoteBefore(batchId, noteId, budget);
+      if (snapshot) state.updated.notes.push(snapshot);
+    }
+    state.backupBytes = budget.bytes;
+    return { state, available: true, reason: null };
+  } catch (error) {
+    removeUndoDir(batchId);
+    state.updated.notes = [];
+    state.updated.notebooks = [];
+    state.backupBytes = 0;
+    const message = error instanceof Error ? error.message : String(error);
+    const reason = message === "UNDO_BACKUP_BUDGET_EXCEEDED"
+      ? `同步涉及的附件备份超过安全上限 ${Math.round(undoMaxBytes() / 1024 / 1024)}MB`
+      : message.startsWith("UNDO_ATTACHMENT_MISSING:")
+        ? `无法读取待更新附件，不能生成完整撤销快照：${message.slice("UNDO_ATTACHMENT_MISSING:".length)}`
+        : `无法生成撤销快照：${message}`;
+    return { state, available: false, reason };
+  }
+}
+
+async function finalizeUndoState(
+  state: UndoState,
+  userId: string,
+  workspaceId: string | null,
+): Promise<{ state: UndoState; available: boolean; reason: string | null }> {
+  const after = idsForScope(userId, workspaceId);
+  const beforeNotebooks = new Set(state.beforeScope.notebooks);
+  const beforeNotes = new Set(state.beforeScope.notes);
+  const beforeAttachments = new Set(state.beforeScope.attachments);
+  const beforeTags = new Set(state.beforeScope.tags);
+  state.created.notebookIds = after.notebooks.filter((id) => !beforeNotebooks.has(id));
+  state.created.noteIds = after.notes.filter((id) => !beforeNotes.has(id));
+  const createdAttachmentIds = after.attachments.filter((id) => !beforeAttachments.has(id));
+  state.created.attachmentRows = rowsByIds("attachments", createdAttachmentIds);
+  state.created.tagIds = after.tags.filter((id) => !beforeTags.has(id));
+
+  for (const id of state.created.notebookIds) {
+    const value = notebookHash(id);
+    if (value) state.afterHashes.notebooks[id] = value;
+  }
+  for (const snapshot of state.updated.notebooks) {
+    const id = String(snapshot.id || "");
+    const value = id ? notebookHash(id) : null;
+    if (!value) return { state, available: false, reason: `导入后目录 ${id || "unknown"} 不存在，无法安全生成撤销点` };
+    state.afterHashes.notebooks[id] = value;
+  }
+  for (const id of state.created.noteIds) {
+    const value = await noteHash(id);
+    if (value) state.afterHashes.notes[id] = value;
+  }
+  for (const snapshot of state.updated.notes) {
+    const id = String(snapshot.row.id || "");
+    const value = id ? await noteHash(id) : null;
+    if (!value) return { state, available: false, reason: `导入后笔记 ${id || "unknown"} 不存在，无法安全生成撤销点` };
+    state.afterHashes.notes[id] = value;
+  }
+  for (const id of state.created.tagIds) {
+    const value = tagHash(id);
+    if (value) state.afterHashes.tags[id] = value;
+  }
+  return { state, available: true, reason: null };
+}
+
+function createBatchRow(args: {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  importMode: string;
+  identity: PackageIdentity;
+  preview: any;
+  undo: { state: UndoState; available: boolean; reason: string | null };
+}): void {
+  ensureRoundTripImportBatchesSchema(getDb());
+  const expiresAt = new Date(Date.now() + undoTtlMs()).toISOString();
+  getDb().prepare(`
+    INSERT INTO roundtrip_import_batches (
+      id, userId, workspaceId, workspaceScope, importMode, packageKind,
+      sourceInstanceId, sourceExportBatchId, status, previewJson, resultJson,
+      undoStateJson, undoAvailable, undoUnavailableReason, undoExpiresAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, '{}', ?, ?, ?, ?)
+  `).run(
+    args.id,
+    args.userId,
+    args.workspaceId,
+    workspaceScope(args.workspaceId),
+    args.importMode,
+    args.identity.packageKind,
+    args.identity.sourceInstanceId,
+    args.identity.sourceExportBatchId,
+    JSON.stringify(args.preview || {}),
+    JSON.stringify(args.undo.state),
+    args.undo.available ? 1 : 0,
+    args.undo.reason,
+    expiresAt,
+  );
+}
+
+function markBatchFailed(batchId: string, result: any, message?: string): void {
+  ensureRoundTripImportBatchesSchema(getDb());
+  getDb().prepare(`
+    UPDATE roundtrip_import_batches
+       SET status = 'failed', resultJson = ?, completedAt = datetime('now'),
+           undoAvailable = 0, undoUnavailableReason = COALESCE(?, undoUnavailableReason, '导入失败，未产生可撤销批次')
+     WHERE id = ?
+  `).run(JSON.stringify(result || {}), message || null, batchId);
+  removeUndoDir(batchId);
+}
+
+export async function executeNowenPackageImportWithBatch(
+  zipBuffer: Buffer,
+  params: RoundTripImportParams,
+): Promise<any> {
+  cleanupExpiredRoundTripImportUndo();
+  const workspaceId = params.workspaceId || null;
+  const importMode = params.importMode || "new-root";
+  const preview = await importNowenPackageWithSync(zipBuffer, { ...params, dryRun: true });
+  if (!preview?.success) return preview;
+
+  const batchId = uuid();
+  const identity = await readPackageIdentity(zipBuffer);
+  const undo = await prepareUndoState(batchId, params.userId, workspaceId, importMode, preview);
+  createBatchRow({ id: batchId, userId: params.userId, workspaceId, importMode, identity, preview, undo });
+
+  try {
+    const result = await importNowenPackageWithSync(zipBuffer, { ...params, dryRun: false });
+    if (!result?.success) {
+      markBatchFailed(batchId, result);
+      return { ...result, importBatch: { id: batchId, undoAvailable: false, reason: "导入失败" } };
+    }
+
+    let finalized = undo;
+    if (undo.available) finalized = await finalizeUndoState(undo.state, params.userId, workspaceId);
+    if (!finalized.available) removeUndoDir(batchId);
+    getDb().prepare(`
+      UPDATE roundtrip_import_batches
+         SET status = 'completed', resultJson = ?, undoStateJson = ?,
+             undoAvailable = ?, undoUnavailableReason = ?, completedAt = datetime('now')
+       WHERE id = ?
+    `).run(
+      JSON.stringify(result || {}),
+      JSON.stringify(finalized.state),
+      finalized.available ? 1 : 0,
+      finalized.reason,
+      batchId,
+    );
+    return {
+      ...result,
+      importBatch: {
+        id: batchId,
+        undoAvailable: finalized.available,
+        undoExpiresAt: new Date(Date.now() + undoTtlMs()).toISOString(),
+        reason: finalized.reason,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    markBatchFailed(batchId, { success: false, errors: [message] }, message);
+    throw error;
+  }
+}
+
+function getBatchRow(userId: string, batchId: string): BatchRow | null {
+  ensureRoundTripImportBatchesSchema(getDb());
+  return getDb().prepare("SELECT * FROM roundtrip_import_batches WHERE id = ? AND userId = ?")
+    .get(batchId, userId) as BatchRow | undefined || null;
+}
+
+export function listRoundTripImportBatches(
+  userId: string,
+  options: { workspaceId?: string | null; limit?: number } = {},
+): RoundTripImportBatchSummary[] {
+  cleanupExpiredRoundTripImportUndo();
+  const limit = Math.max(1, Math.min(Number(options.limit) || 30, 100));
+  const rows = options.workspaceId === undefined
+    ? getDb().prepare("SELECT * FROM roundtrip_import_batches WHERE userId = ? ORDER BY createdAt DESC LIMIT ?")
+      .all(userId, limit) as BatchRow[]
+    : getDb().prepare("SELECT * FROM roundtrip_import_batches WHERE userId = ? AND workspaceScope = ? ORDER BY createdAt DESC LIMIT ?")
+      .all(userId, workspaceScope(options.workspaceId), limit) as BatchRow[];
+  return rows.map((row) => {
+    const detail = publicBatch(row);
+    const { preview: _preview, result: _result, ...summary } = detail;
+    return summary;
+  });
+}
+
+export function getRoundTripImportBatch(userId: string, batchId: string): RoundTripImportBatchDetail | null {
+  cleanupExpiredRoundTripImportUndo();
+  const row = getBatchRow(userId, batchId);
+  return row ? publicBatch(row) : null;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function updateDynamic(table: string, row: Record<string, unknown>, key = "id"): void {
+  const columns = Object.keys(row).filter((column) => column !== key);
+  if (!columns.length) return;
+  getDb().prepare(`UPDATE ${quoteIdentifier(table)} SET ${columns.map((column) => `${quoteIdentifier(column)} = ?`).join(", ")} WHERE ${quoteIdentifier(key)} = ?`)
+    .run(...columns.map((column) => row[column]), row[key]);
+}
+
+function insertDynamic(table: string, row: Record<string, unknown>): void {
+  const columns = Object.keys(row);
+  getDb().prepare(`INSERT INTO ${quoteIdentifier(table)} (${columns.map(quoteIdentifier).join(", ")}) VALUES (${columns.map(() => "?").join(", ")})`)
+    .run(...columns.map((column) => row[column]));
+}
+
+async function validateUndoState(state: UndoState): Promise<string[]> {
+  const conflicts: string[] = [];
+  for (const [id, expected] of Object.entries(state.afterHashes.notebooks)) {
+    const current = notebookHash(id);
+    if (current !== expected) conflicts.push(`目录已在导入后发生变化：${id}`);
+  }
+  for (const [id, expected] of Object.entries(state.afterHashes.notes)) {
+    const current = await noteHash(id);
+    if (current !== expected) conflicts.push(`笔记或其附件已在导入后发生变化：${id}`);
+  }
+  for (const [id, expected] of Object.entries(state.afterHashes.tags)) {
+    const current = tagHash(id);
+    if (current && current !== expected) conflicts.push(`标签已在导入后发生变化：${id}`);
+  }
+
+  const createdNotebookSet = new Set(state.created.notebookIds);
+  const createdNoteSet = new Set(state.created.noteIds);
+  if (state.created.notebookIds.length) {
+    const descendants = getDb().prepare(`
+      WITH RECURSIVE descendants(id) AS (
+        SELECT id FROM notebooks WHERE id IN (${state.created.notebookIds.map(() => "?").join(",")})
+        UNION ALL
+        SELECT n.id FROM notebooks n JOIN descendants d ON n.parentId = d.id
+      )
+      SELECT DISTINCT id FROM descendants
+    `).all(...state.created.notebookIds) as Array<{ id: string }>;
+    for (const row of descendants) {
+      if (!createdNotebookSet.has(row.id)) conflicts.push(`导入目录下新增了其他目录，不能整体撤销：${row.id}`);
+    }
+    const notes = getDb().prepare(`
+      WITH RECURSIVE descendants(id) AS (
+        SELECT id FROM notebooks WHERE id IN (${state.created.notebookIds.map(() => "?").join(",")})
+        UNION ALL
+        SELECT n.id FROM notebooks n JOIN descendants d ON n.parentId = d.id
+      )
+      SELECT notes.id FROM notes JOIN descendants ON descendants.id = notes.notebookId
+    `).all(...state.created.notebookIds) as Array<{ id: string }>;
+    for (const row of notes) {
+      if (!createdNoteSet.has(row.id)) conflicts.push(`导入目录下新增了其他笔记，不能整体撤销：${row.id}`);
+    }
+  }
+  return [...new Set(conflicts)];
+}
+
+function notebookDepth(id: string, rows: Map<string, Record<string, unknown>>): number {
+  let depth = 0;
+  let current = rows.get(id);
+  const seen = new Set<string>();
+  while (current?.parentId && !seen.has(String(current.parentId))) {
+    seen.add(String(current.parentId));
+    depth += 1;
+    current = rows.get(String(current.parentId));
+  }
+  return depth;
+}
+
+export async function undoRoundTripImportBatch(userId: string, batchId: string): Promise<RoundTripImportBatchDetail> {
+  cleanupExpiredRoundTripImportUndo();
+  const row = getBatchRow(userId, batchId);
+  if (!row) throw new RoundTripImportUndoError("导入批次不存在", "IMPORT_BATCH_NOT_FOUND", 404);
+  if (row.status === "undone") throw new RoundTripImportUndoError("该导入批次已经撤销", "IMPORT_BATCH_ALREADY_UNDONE", 409);
+  if (row.status !== "completed") throw new RoundTripImportUndoError("只有已完成的导入批次可以撤销", "IMPORT_BATCH_NOT_COMPLETED", 409);
+  if (!row.undoAvailable) {
+    const expired = row.undoExpiresAt && new Date(row.undoExpiresAt).getTime() <= Date.now();
+    throw new RoundTripImportUndoError(
+      row.undoUnavailableReason || (expired ? "撤销窗口已过期" : "该批次没有可用的完整撤销快照"),
+      expired ? "IMPORT_BATCH_UNDO_EXPIRED" : "IMPORT_BATCH_UNDO_UNAVAILABLE",
+      expired ? 410 : 409,
+    );
+  }
+  if (row.undoExpiresAt && new Date(row.undoExpiresAt).getTime() <= Date.now()) {
+    throw new RoundTripImportUndoError("撤销窗口已过期", "IMPORT_BATCH_UNDO_EXPIRED", 410);
+  }
+
+  const state = parseJson<UndoState | null>(row.undoStateJson, null);
+  if (!state || state.version !== 1) throw new RoundTripImportUndoError("撤销快照损坏或版本不兼容", "IMPORT_BATCH_UNDO_STATE_INVALID", 409);
+  const conflicts = await validateUndoState(state);
+  if (conflicts.length) {
+    getDb().prepare("UPDATE roundtrip_import_batches SET undoError = ? WHERE id = ?")
+      .run(`检测到导入后的本地修改：${conflicts.join("；")}`, batchId);
+    throw new RoundTripImportUndoError("检测到导入后的本地修改，已拒绝破坏性撤销", "IMPORT_BATCH_UNDO_CONFLICT", 409, conflicts);
+  }
+
+  const restoredPaths = new Set<string>();
+  for (const note of state.updated.notes) {
+    for (const attachment of note.attachments) {
+      const relPath = String(attachment.row.path || "");
+      if (!relPath || !attachment.backupFile) continue;
+      const abs = path.join(backupDir(batchId), attachment.backupFile);
+      if (!fs.existsSync(abs)) throw new RoundTripImportUndoError("附件撤销备份缺失，已停止撤销", "IMPORT_BATCH_UNDO_BACKUP_MISSING", 409);
+      const buffer = fs.readFileSync(abs);
+      if (attachment.objectHash && sha256(buffer) !== attachment.objectHash) {
+        throw new RoundTripImportUndoError("附件撤销备份校验失败，已停止撤销", "IMPORT_BATCH_UNDO_BACKUP_CORRUPT", 409);
+      }
+      await writeAttachmentObject(relPath, buffer, String(attachment.row.mimeType || "application/octet-stream"));
+      restoredPaths.add(relPath);
+    }
+  }
+
+  const updatedNoteIds = state.updated.notes.map((item) => String(item.row.id || "")).filter(Boolean);
+  const currentUpdatedAttachments = updatedNoteIds.length
+    ? getDb().prepare(`SELECT * FROM attachments WHERE noteId IN (${updatedNoteIds.map(() => "?").join(",")})`).all(...updatedNoteIds) as Array<Record<string, unknown>>
+    : [];
+  const createdAttachmentRows = state.created.attachmentRows;
+  const objectsToDelete = [...currentUpdatedAttachments, ...createdAttachmentRows]
+    .map((item) => String(item.path || ""))
+    .filter((value) => value && !restoredPaths.has(value));
+
+  const createdNotebookRows = rowsByIds("notebooks", state.created.notebookIds);
+  const createdNotebookMap = new Map(createdNotebookRows.map((item) => [String(item.id), item]));
+  const sortedCreatedNotebookIds = [...state.created.notebookIds]
+    .sort((a, b) => notebookDepth(b, createdNotebookMap) - notebookDepth(a, createdNotebookMap));
+
+  try {
+    getDb().exec("BEGIN TRANSACTION");
+    for (const note of state.updated.notes) {
+      const noteId = String(note.row.id || "");
+      if (!noteId) continue;
+      getDb().prepare("DELETE FROM note_tags WHERE noteId = ?").run(noteId);
+      getDb().prepare("DELETE FROM attachments WHERE noteId = ?").run(noteId);
+      updateDynamic("notes", note.row);
+      for (const attachment of note.attachments) insertDynamic("attachments", attachment.row);
+      for (const tagId of note.tagIds) getDb().prepare("INSERT OR IGNORE INTO note_tags (noteId, tagId) VALUES (?, ?)").run(noteId, tagId);
+    }
+    for (const notebook of state.updated.notebooks) updateDynamic("notebooks", notebook);
+
+    for (const attachment of state.created.attachmentRows) {
+      getDb().prepare("DELETE FROM attachments WHERE id = ?").run(String(attachment.id || ""));
+    }
+    for (const noteId of state.created.noteIds) getDb().prepare("DELETE FROM notes WHERE id = ?").run(noteId);
+    for (const notebookId of sortedCreatedNotebookIds) getDb().prepare("DELETE FROM notebooks WHERE id = ?").run(notebookId);
+    for (const tagId of state.created.tagIds) {
+      const refs = getDb().prepare("SELECT COUNT(*) AS count FROM note_tags WHERE tagId = ?").get(tagId) as { count: number };
+      if (!refs.count) getDb().prepare("DELETE FROM tags WHERE id = ?").run(tagId);
+    }
+
+    getDb().prepare(`
+      UPDATE roundtrip_import_batches
+         SET status = 'undone', undoAvailable = 0, undoneAt = datetime('now'), undoError = NULL
+       WHERE id = ?
+    `).run(batchId);
+    getDb().exec("COMMIT");
+  } catch (error) {
+    try { getDb().exec("ROLLBACK"); } catch { /* ignore */ }
+    const message = error instanceof Error ? error.message : String(error);
+    getDb().prepare("UPDATE roundtrip_import_batches SET undoError = ? WHERE id = ?").run(message, batchId);
+    throw new RoundTripImportUndoError(`撤销失败：${message}`, "IMPORT_BATCH_UNDO_FAILED", 409);
+  }
+
+  await Promise.all([...new Set(objectsToDelete)].map((item) => deleteAttachmentObject(item).catch(() => undefined)));
+  for (const note of state.updated.notes) {
+    const noteId = String(note.row.id || "");
+    if (noteId) syncAttachmentReferences(getDb(), noteId, String(note.row.content || ""));
+  }
+  removeUndoDir(batchId);
+  return publicBatch(getBatchRow(userId, batchId)!);
+}

--- a/backend/src/services/roundTripImportLinkUndo.ts
+++ b/backend/src/services/roundTripImportLinkUndo.ts
@@ -12,14 +12,46 @@ import {
 const DATA_DIR = process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data");
 const UNDO_ROOT = path.join(DATA_DIR, "import-undo");
 
-interface LinkSnapshot {
-  sourceInstanceId: string;
+type ResourceType = "notebook" | "note" | "attachment";
+
+interface ImportIdentitySnapshot {
+  packageKind: string | null;
+  sourceInstanceId: string | null;
   workspaceScope: string;
   beforeRows: Array<Record<string, unknown>>;
 }
 
-interface StoredLinkUndo extends LinkSnapshot {
+interface StoredLinkUndo {
+  sourceInstanceId: string;
+  workspaceScope: string;
+  beforeRows: Array<Record<string, unknown>>;
   afterHash: string;
+}
+
+interface MutableUndoState {
+  beforeScope?: {
+    notebooks?: string[];
+    notes?: string[];
+    attachments?: string[];
+    tags?: string[];
+  };
+  created?: {
+    notebookIds?: string[];
+    noteIds?: string[];
+    attachmentRows?: Array<Record<string, unknown>>;
+    tagIds?: string[];
+  };
+  updated?: {
+    notebooks?: Array<Record<string, unknown>>;
+    notes?: Array<{ row?: Record<string, unknown> }>;
+  };
+  afterHashes?: {
+    notebooks?: Record<string, string>;
+    notes?: Record<string, string>;
+    tags?: Record<string, string>;
+  };
+  sourceLinks?: StoredLinkUndo;
+  [key: string]: unknown;
 }
 
 function stableValue(value: unknown): unknown {
@@ -48,23 +80,131 @@ function removeUndoBackup(batchId: string): void {
   try { fs.rmSync(path.join(UNDO_ROOT, batchId), { recursive: true, force: true }); } catch { /* best effort */ }
 }
 
+function stringSet(value: unknown): Set<string> {
+  return new Set(Array.isArray(value) ? value.map((item) => String(item || "")).filter(Boolean) : []);
+}
+
+function filterHashes(source: Record<string, string> | undefined, allowed: Set<string>): Record<string, string> {
+  if (!source) return {};
+  return Object.fromEntries(Object.entries(source).filter(([id]) => allowed.has(id)));
+}
+
+function mappedTargets(rows: Array<Record<string, unknown>>, resourceType: ResourceType): Set<string> {
+  return new Set(rows
+    .filter((row) => row.resourceType === resourceType)
+    .map((row) => String(row.targetResourceId || ""))
+    .filter(Boolean));
+}
+
+function attachmentRows(ids: Set<string>): Array<Record<string, unknown>> {
+  if (!ids.size) return [];
+  const values = [...ids];
+  return getDb().prepare(`SELECT * FROM attachments WHERE id IN (${values.map(() => "?").join(",")})`)
+    .all(...values) as Array<Record<string, unknown>>;
+}
+
+function descendantsFromCreatedRoots(rootIds: string[]): { notebookIds: Set<string>; noteIds: Set<string> } {
+  if (!rootIds.length) return { notebookIds: new Set(), noteIds: new Set() };
+  const descendants = getDb().prepare(`
+    WITH RECURSIVE tree(id) AS (
+      SELECT id FROM notebooks WHERE id IN (${rootIds.map(() => "?").join(",")})
+      UNION ALL
+      SELECT n.id FROM notebooks n JOIN tree t ON n.parentId = t.id
+    )
+    SELECT DISTINCT id FROM tree
+  `).all(...rootIds) as Array<{ id: string }>;
+  const notebookIds = new Set(descendants.map((row) => row.id));
+  if (!notebookIds.size) return { notebookIds, noteIds: new Set() };
+  const values = [...notebookIds];
+  const notes = getDb().prepare(`SELECT id FROM notes WHERE notebookId IN (${values.map(() => "?").join(",")})`)
+    .all(...values) as Array<{ id: string }>;
+  return { notebookIds, noteIds: new Set(notes.map((row) => row.id)) };
+}
+
+function refineUndoState(args: {
+  state: MutableUndoState;
+  result: Record<string, unknown>;
+  importMode: string;
+  packageKind: string | null;
+  afterLinks: Array<Record<string, unknown>>;
+}): { available: boolean; reason: string | null } {
+  const beforeNotebooks = stringSet(args.state.beforeScope?.notebooks);
+  const beforeNotes = stringSet(args.state.beforeScope?.notes);
+  const beforeAttachments = stringSet(args.state.beforeScope?.attachments);
+  const updatedNotebooks = stringSet(args.state.updated?.notebooks?.map((row) => row.id));
+  const updatedNotes = stringSet(args.state.updated?.notes?.map((item) => item.row?.id));
+
+  let createdNotebooks = new Set<string>();
+  let createdNotes = new Set<string>();
+  let createdAttachments = new Set<string>();
+
+  if (args.afterLinks.length) {
+    createdNotebooks = new Set([...mappedTargets(args.afterLinks, "notebook")].filter((id) => !beforeNotebooks.has(id)));
+    createdNotes = new Set([...mappedTargets(args.afterLinks, "note")].filter((id) => !beforeNotes.has(id)));
+    createdAttachments = new Set([...mappedTargets(args.afterLinks, "attachment")].filter((id) => !beforeAttachments.has(id)));
+  } else if (args.importMode !== "merge") {
+    const roots = Array.isArray(args.result.rootNotebookIds)
+      ? args.result.rootNotebookIds.map((value) => String(value || "")).filter(Boolean)
+      : args.result.rootNotebookId
+        ? [String(args.result.rootNotebookId)]
+        : [];
+    const createdRoots = roots.filter((id) => !beforeNotebooks.has(id));
+    const tree = descendantsFromCreatedRoots(createdRoots);
+    createdNotebooks = new Set([...tree.notebookIds].filter((id) => !beforeNotebooks.has(id)));
+    createdNotes = new Set([...tree.noteIds].filter((id) => !beforeNotes.has(id)));
+    if (createdNotes.size) {
+      const noteIds = [...createdNotes];
+      const rows = getDb().prepare(`SELECT id FROM attachments WHERE noteId IN (${noteIds.map(() => "?").join(",")})`)
+        .all(...noteIds) as Array<{ id: string }>;
+      createdAttachments = new Set(rows.map((row) => row.id).filter((id) => !beforeAttachments.has(id)));
+    }
+  } else {
+    return {
+      available: false,
+      reason: args.packageKind === "markdown"
+        ? "Markdown 合并导入没有稳定资源映射，无法保证只撤销本批次创建的内容"
+        : "数据包缺少稳定来源映射，无法安全识别合并导入创建的资源",
+    };
+  }
+
+  args.state.created = {
+    notebookIds: [...createdNotebooks],
+    noteIds: [...createdNotes],
+    attachmentRows: attachmentRows(createdAttachments),
+    // Tags have no package-stable target mapping. Leaving an unused imported tag is safer than
+    // accidentally deleting a concurrently-created local tag with the same scope diff.
+    tagIds: [],
+  };
+  const allowedNotebooks = new Set([...createdNotebooks, ...updatedNotebooks]);
+  const allowedNotes = new Set([...createdNotes, ...updatedNotes]);
+  args.state.afterHashes = {
+    notebooks: filterHashes(args.state.afterHashes?.notebooks, allowedNotebooks),
+    notes: filterHashes(args.state.afterHashes?.notes, allowedNotes),
+    tags: {},
+  };
+  return { available: true, reason: null };
+}
+
 export async function captureRoundTripImportLinkUndo(
   zipBuffer: Buffer,
   userId: string,
   workspaceId: string | null | undefined,
-): Promise<LinkSnapshot | null> {
+): Promise<ImportIdentitySnapshot | null> {
   try {
     const zip = await JSZip.loadAsync(zipBuffer);
     const entry = zip.file("manifest.json");
     if (!entry) return null;
     const manifest = JSON.parse(await entry.async("string")) as Record<string, unknown>;
-    const sourceInstanceId = String(manifest.sourceInstanceId || "").trim();
-    if (!sourceInstanceId || manifest.packageKind === "markdown") return null;
+    const sourceInstanceId = String(manifest.sourceInstanceId || "").trim() || null;
+    const packageKind = manifest.packageKind ? String(manifest.packageKind) : null;
     const scope = workspaceId || "personal";
     return {
+      packageKind,
       sourceInstanceId,
       workspaceScope: scope,
-      beforeRows: currentRows(userId, scope, sourceInstanceId),
+      beforeRows: sourceInstanceId && packageKind !== "markdown"
+        ? currentRows(userId, scope, sourceInstanceId)
+        : [],
     };
   } catch {
     return null;
@@ -74,32 +214,66 @@ export async function captureRoundTripImportLinkUndo(
 export function attachRoundTripImportLinkUndo(
   userId: string,
   batchId: string,
-  snapshot: LinkSnapshot | null,
+  snapshot: ImportIdentitySnapshot | null,
 ): { available: boolean; reason: string | null } {
-  if (!snapshot) return { available: true, reason: null };
   try {
     const batch = getDb().prepare(`
-      SELECT undoStateJson, undoAvailable FROM roundtrip_import_batches
+      SELECT undoStateJson, undoAvailable, resultJson, importMode, packageKind
+        FROM roundtrip_import_batches
        WHERE id = ? AND userId = ?
-    `).get(batchId, userId) as { undoStateJson: string; undoAvailable: number } | undefined;
+    `).get(batchId, userId) as {
+      undoStateJson: string;
+      undoAvailable: number;
+      resultJson: string;
+      importMode: string;
+      packageKind: string | null;
+    } | undefined;
     if (!batch) {
       removeUndoBackup(batchId);
-      return { available: false, reason: "导入批次不存在，无法记录来源映射撤销点" };
+      return { available: false, reason: "导入批次不存在，无法记录撤销点" };
     }
-    const state = JSON.parse(batch.undoStateJson || "{}") as Record<string, unknown>;
-    const stored: StoredLinkUndo = {
-      ...snapshot,
-      afterHash: hashRows(currentRows(userId, snapshot.workspaceScope, snapshot.sourceInstanceId)),
-    };
-    state.sourceLinks = stored;
+    if (!batch.undoAvailable) return { available: false, reason: null };
+
+    const state = JSON.parse(batch.undoStateJson || "{}") as MutableUndoState;
+    const result = JSON.parse(batch.resultJson || "{}") as Record<string, unknown>;
+    const sourceInstanceId = snapshot?.sourceInstanceId || null;
+    const packageKind = snapshot?.packageKind || batch.packageKind;
+    const afterLinks = sourceInstanceId && packageKind !== "markdown"
+      ? currentRows(userId, snapshot?.workspaceScope || "personal", sourceInstanceId)
+      : [];
+    const refined = refineUndoState({
+      state,
+      result,
+      importMode: batch.importMode,
+      packageKind,
+      afterLinks,
+    });
+    if (!refined.available) {
+      getDb().prepare(`
+        UPDATE roundtrip_import_batches
+           SET undoAvailable = 0, undoUnavailableReason = ?, undoStateJson = ?
+         WHERE id = ? AND userId = ?
+      `).run(refined.reason, JSON.stringify(state), batchId, userId);
+      removeUndoBackup(batchId);
+      return refined;
+    }
+
+    if (sourceInstanceId && snapshot && packageKind !== "markdown") {
+      state.sourceLinks = {
+        sourceInstanceId,
+        workspaceScope: snapshot.workspaceScope,
+        beforeRows: snapshot.beforeRows,
+        afterHash: hashRows(afterLinks),
+      };
+    }
     getDb().prepare(`
       UPDATE roundtrip_import_batches
          SET undoStateJson = ?
        WHERE id = ? AND userId = ?
     `).run(JSON.stringify(state), batchId, userId);
-    return { available: batch.undoAvailable === 1, reason: null };
+    return { available: true, reason: null };
   } catch (error) {
-    const reason = `来源映射撤销点记录失败：${error instanceof Error ? error.message : String(error)}`;
+    const reason = `撤销点归属记录失败：${error instanceof Error ? error.message : String(error)}`;
     getDb().prepare(`
       UPDATE roundtrip_import_batches
          SET undoAvailable = 0, undoUnavailableReason = ?

--- a/backend/src/services/roundTripImportLinkUndo.ts
+++ b/backend/src/services/roundTripImportLinkUndo.ts
@@ -1,4 +1,6 @@
 import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 import JSZip from "jszip";
 import { getDb } from "../db/schema";
 import {
@@ -6,6 +8,9 @@ import {
   undoRoundTripImportBatch,
   type RoundTripImportBatchDetail,
 } from "./roundTripImportBatches";
+
+const DATA_DIR = process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data");
+const UNDO_ROOT = path.join(DATA_DIR, "import-undo");
 
 interface LinkSnapshot {
   sourceInstanceId: string;
@@ -37,6 +42,10 @@ function currentRows(userId: string, workspaceScope: string, sourceInstanceId: s
      WHERE userId = ? AND workspaceScope = ? AND sourceInstanceId = ?
      ORDER BY id
   `).all(userId, workspaceScope, sourceInstanceId) as Array<Record<string, unknown>>;
+}
+
+function removeUndoBackup(batchId: string): void {
+  try { fs.rmSync(path.join(UNDO_ROOT, batchId), { recursive: true, force: true }); } catch { /* best effort */ }
 }
 
 export async function captureRoundTripImportLinkUndo(
@@ -73,7 +82,10 @@ export function attachRoundTripImportLinkUndo(
       SELECT undoStateJson, undoAvailable FROM roundtrip_import_batches
        WHERE id = ? AND userId = ?
     `).get(batchId, userId) as { undoStateJson: string; undoAvailable: number } | undefined;
-    if (!batch) return { available: false, reason: "导入批次不存在，无法记录来源映射撤销点" };
+    if (!batch) {
+      removeUndoBackup(batchId);
+      return { available: false, reason: "导入批次不存在，无法记录来源映射撤销点" };
+    }
     const state = JSON.parse(batch.undoStateJson || "{}") as Record<string, unknown>;
     const stored: StoredLinkUndo = {
       ...snapshot,
@@ -93,6 +105,7 @@ export function attachRoundTripImportLinkUndo(
          SET undoAvailable = 0, undoUnavailableReason = ?
        WHERE id = ? AND userId = ?
     `).run(reason, batchId, userId);
+    removeUndoBackup(batchId);
     return { available: false, reason };
   }
 }

--- a/backend/src/services/roundTripImportLinkUndo.ts
+++ b/backend/src/services/roundTripImportLinkUndo.ts
@@ -1,0 +1,159 @@
+import crypto from "crypto";
+import JSZip from "jszip";
+import { getDb } from "../db/schema";
+import {
+  RoundTripImportUndoError,
+  undoRoundTripImportBatch,
+  type RoundTripImportBatchDetail,
+} from "./roundTripImportBatches";
+
+interface LinkSnapshot {
+  sourceInstanceId: string;
+  workspaceScope: string;
+  beforeRows: Array<Record<string, unknown>>;
+}
+
+interface StoredLinkUndo extends LinkSnapshot {
+  afterHash: string;
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(source).sort().map((key) => [key, stableValue(source[key])]));
+  }
+  return value;
+}
+
+function hashRows(rows: Array<Record<string, unknown>>): string {
+  const sorted = [...rows].sort((a, b) => String(a.id || "").localeCompare(String(b.id || "")));
+  return crypto.createHash("sha256").update(JSON.stringify(stableValue(sorted))).digest("hex");
+}
+
+function currentRows(userId: string, workspaceScope: string, sourceInstanceId: string): Array<Record<string, unknown>> {
+  return getDb().prepare(`
+    SELECT * FROM roundtrip_import_links
+     WHERE userId = ? AND workspaceScope = ? AND sourceInstanceId = ?
+     ORDER BY id
+  `).all(userId, workspaceScope, sourceInstanceId) as Array<Record<string, unknown>>;
+}
+
+export async function captureRoundTripImportLinkUndo(
+  zipBuffer: Buffer,
+  userId: string,
+  workspaceId: string | null | undefined,
+): Promise<LinkSnapshot | null> {
+  try {
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const entry = zip.file("manifest.json");
+    if (!entry) return null;
+    const manifest = JSON.parse(await entry.async("string")) as Record<string, unknown>;
+    const sourceInstanceId = String(manifest.sourceInstanceId || "").trim();
+    if (!sourceInstanceId || manifest.packageKind === "markdown") return null;
+    const scope = workspaceId || "personal";
+    return {
+      sourceInstanceId,
+      workspaceScope: scope,
+      beforeRows: currentRows(userId, scope, sourceInstanceId),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function attachRoundTripImportLinkUndo(
+  userId: string,
+  batchId: string,
+  snapshot: LinkSnapshot | null,
+): { available: boolean; reason: string | null } {
+  if (!snapshot) return { available: true, reason: null };
+  try {
+    const batch = getDb().prepare(`
+      SELECT undoStateJson, undoAvailable FROM roundtrip_import_batches
+       WHERE id = ? AND userId = ?
+    `).get(batchId, userId) as { undoStateJson: string; undoAvailable: number } | undefined;
+    if (!batch) return { available: false, reason: "导入批次不存在，无法记录来源映射撤销点" };
+    const state = JSON.parse(batch.undoStateJson || "{}") as Record<string, unknown>;
+    const stored: StoredLinkUndo = {
+      ...snapshot,
+      afterHash: hashRows(currentRows(userId, snapshot.workspaceScope, snapshot.sourceInstanceId)),
+    };
+    state.sourceLinks = stored;
+    getDb().prepare(`
+      UPDATE roundtrip_import_batches
+         SET undoStateJson = ?
+       WHERE id = ? AND userId = ?
+    `).run(JSON.stringify(state), batchId, userId);
+    return { available: batch.undoAvailable === 1, reason: null };
+  } catch (error) {
+    const reason = `来源映射撤销点记录失败：${error instanceof Error ? error.message : String(error)}`;
+    getDb().prepare(`
+      UPDATE roundtrip_import_batches
+         SET undoAvailable = 0, undoUnavailableReason = ?
+       WHERE id = ? AND userId = ?
+    `).run(reason, batchId, userId);
+    return { available: false, reason };
+  }
+}
+
+function readStoredLinkUndo(userId: string, batchId: string): StoredLinkUndo | null {
+  const row = getDb().prepare(`
+    SELECT undoStateJson FROM roundtrip_import_batches WHERE id = ? AND userId = ?
+  `).get(batchId, userId) as { undoStateJson: string } | undefined;
+  if (!row) return null;
+  try {
+    const state = JSON.parse(row.undoStateJson || "{}") as { sourceLinks?: StoredLinkUndo };
+    return state.sourceLinks || null;
+  } catch {
+    return null;
+  }
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function insertDynamic(table: string, row: Record<string, unknown>): void {
+  const columns = Object.keys(row);
+  getDb().prepare(`INSERT INTO ${quoteIdentifier(table)} (${columns.map(quoteIdentifier).join(", ")}) VALUES (${columns.map(() => "?").join(", ")})`)
+    .run(...columns.map((column) => row[column]));
+}
+
+export async function undoRoundTripImportBatchWithLinks(
+  userId: string,
+  batchId: string,
+): Promise<RoundTripImportBatchDetail> {
+  const links = readStoredLinkUndo(userId, batchId);
+  if (links) {
+    const currentHash = hashRows(currentRows(userId, links.workspaceScope, links.sourceInstanceId));
+    if (currentHash !== links.afterHash) {
+      throw new RoundTripImportUndoError(
+        "该来源在本批次之后又执行过导入或同步，已拒绝回滚旧映射",
+        "IMPORT_BATCH_UNDO_SOURCE_LINK_CONFLICT",
+        409,
+        ["来源映射已发生变化，请优先撤销最新的一次同来源导入"],
+      );
+    }
+  }
+
+  const detail = await undoRoundTripImportBatch(userId, batchId);
+  if (!links) return detail;
+
+  const transaction = getDb().transaction(() => {
+    getDb().prepare(`
+      DELETE FROM roundtrip_import_links
+       WHERE userId = ? AND workspaceScope = ? AND sourceInstanceId = ?
+    `).run(userId, links.workspaceScope, links.sourceInstanceId);
+    for (const row of links.beforeRows) insertDynamic("roundtrip_import_links", row);
+  });
+  try {
+    transaction();
+  } catch (error) {
+    const message = `资源已撤销，但来源映射恢复失败：${error instanceof Error ? error.message : String(error)}`;
+    getDb().prepare("UPDATE roundtrip_import_batches SET undoError = ? WHERE id = ? AND userId = ?")
+      .run(message, batchId, userId);
+    throw new RoundTripImportUndoError(message, "IMPORT_BATCH_UNDO_LINK_RESTORE_FAILED", 409);
+  }
+  return detail;
+}

--- a/backend/src/services/roundTripImportLinkUndo.ts
+++ b/backend/src/services/roundTripImportLinkUndo.ts
@@ -18,6 +18,7 @@ interface ImportIdentitySnapshot {
   packageKind: string | null;
   sourceInstanceId: string | null;
   workspaceScope: string;
+  sourceIds: Record<ResourceType, string[]>;
   beforeRows: Array<Record<string, unknown>>;
 }
 
@@ -121,12 +122,86 @@ function descendantsFromCreatedRoots(rootIds: string[]): { notebookIds: Set<stri
   return { notebookIds, noteIds: new Set(notes.map((row) => row.id)) };
 }
 
+async function readJson(zip: JSZip, filename: string): Promise<unknown> {
+  const entry = zip.file(filename);
+  if (!entry) return null;
+  try { return JSON.parse(await entry.async("string")); }
+  catch { return null; }
+}
+
+function itemIds(value: unknown, idKey = "id"): string[] {
+  const items = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray((value as { items?: unknown[] }).items)
+      ? (value as { items: unknown[] }).items
+      : [];
+  return items
+    .map((item) => item && typeof item === "object" ? String((item as Record<string, unknown>)[idKey] || "") : "")
+    .filter(Boolean);
+}
+
+async function packageSourceIds(zip: JSZip): Promise<Record<ResourceType, string[]>> {
+  const tree = await readJson(zip, "tree.json");
+  const treeNodes = tree && typeof tree === "object" && Array.isArray((tree as { nodes?: unknown[] }).nodes)
+    ? (tree as { nodes: unknown[] }).nodes
+    : [];
+  let notebooks = treeNodes
+    .map((item) => item && typeof item === "object" ? String((item as Record<string, unknown>).sourceId || "") : "")
+    .filter(Boolean);
+  if (!notebooks.length) notebooks = itemIds(await readJson(zip, "notebooks.json"));
+
+  let notes = itemIds(await readJson(zip, "notes.json"));
+  if (!notes.length) {
+    notes = [...new Set(Object.keys(zip.files)
+      .map((filename) => filename.match(/^notes\/([^/]+)\/meta\.json$/)?.[1] || "")
+      .filter(Boolean))];
+  }
+
+  let attachments = itemIds(await readJson(zip, "attachments.json"));
+  if (!attachments.length) {
+    attachments = [...new Set(Object.keys(zip.files)
+      .map((filename) => filename.match(/^attachments\/([^/]+)\/(?:meta\.json|[^/]+)$/)?.[1] || "")
+      .filter(Boolean))];
+  }
+  return { notebook: notebooks, note: notes, attachment: attachments };
+}
+
+function packageLinks(
+  afterLinks: Array<Record<string, unknown>>,
+  sourceIds: Record<ResourceType, string[]>,
+): { rows: Array<Record<string, unknown>>; missing: string[] } {
+  const expected = new Map<ResourceType, Set<string>>([
+    ["notebook", new Set(sourceIds.notebook)],
+    ["note", new Set(sourceIds.note)],
+    ["attachment", new Set(sourceIds.attachment)],
+  ]);
+  const rows = afterLinks.filter((row) => {
+    const type = String(row.resourceType || "") as ResourceType;
+    return expected.get(type)?.has(String(row.sourceResourceId || "")) === true;
+  });
+  const covered = new Map<ResourceType, Set<string>>([
+    ["notebook", new Set()],
+    ["note", new Set()],
+    ["attachment", new Set()],
+  ]);
+  for (const row of rows) {
+    const type = String(row.resourceType || "") as ResourceType;
+    covered.get(type)?.add(String(row.sourceResourceId || ""));
+  }
+  const missing: string[] = [];
+  for (const [type, ids] of expected) {
+    for (const id of ids) if (!covered.get(type)?.has(id)) missing.push(`${type}:${id}`);
+  }
+  return { rows, missing };
+}
+
 function refineUndoState(args: {
   state: MutableUndoState;
   result: Record<string, unknown>;
   importMode: string;
   packageKind: string | null;
-  afterLinks: Array<Record<string, unknown>>;
+  packageLinks: Array<Record<string, unknown>>;
+  stableMappingsExpected: boolean;
 }): { available: boolean; reason: string | null } {
   const beforeNotebooks = stringSet(args.state.beforeScope?.notebooks);
   const beforeNotes = stringSet(args.state.beforeScope?.notes);
@@ -138,10 +213,10 @@ function refineUndoState(args: {
   let createdNotes = new Set<string>();
   let createdAttachments = new Set<string>();
 
-  if (args.afterLinks.length) {
-    createdNotebooks = new Set([...mappedTargets(args.afterLinks, "notebook")].filter((id) => !beforeNotebooks.has(id)));
-    createdNotes = new Set([...mappedTargets(args.afterLinks, "note")].filter((id) => !beforeNotes.has(id)));
-    createdAttachments = new Set([...mappedTargets(args.afterLinks, "attachment")].filter((id) => !beforeAttachments.has(id)));
+  if (args.stableMappingsExpected) {
+    createdNotebooks = new Set([...mappedTargets(args.packageLinks, "notebook")].filter((id) => !beforeNotebooks.has(id)));
+    createdNotes = new Set([...mappedTargets(args.packageLinks, "note")].filter((id) => !beforeNotes.has(id)));
+    createdAttachments = new Set([...mappedTargets(args.packageLinks, "attachment")].filter((id) => !beforeAttachments.has(id)));
   } else if (args.importMode !== "merge") {
     const roots = Array.isArray(args.result.rootNotebookIds)
       ? args.result.rootNotebookIds.map((value) => String(value || "")).filter(Boolean)
@@ -202,6 +277,7 @@ export async function captureRoundTripImportLinkUndo(
       packageKind,
       sourceInstanceId,
       workspaceScope: scope,
+      sourceIds: await packageSourceIds(zip),
       beforeRows: sourceInstanceId && packageKind !== "markdown"
         ? currentRows(userId, scope, sourceInstanceId)
         : [],
@@ -238,15 +314,31 @@ export function attachRoundTripImportLinkUndo(
     const result = JSON.parse(batch.resultJson || "{}") as Record<string, unknown>;
     const sourceInstanceId = snapshot?.sourceInstanceId || null;
     const packageKind = snapshot?.packageKind || batch.packageKind;
-    const afterLinks = sourceInstanceId && packageKind !== "markdown"
-      ? currentRows(userId, snapshot?.workspaceScope || "personal", sourceInstanceId)
+    const stableMappingsExpected = !!sourceInstanceId && packageKind !== "markdown";
+    const afterLinks = stableMappingsExpected
+      ? currentRows(userId, snapshot?.workspaceScope || "personal", sourceInstanceId!)
       : [];
+    const matched = snapshot && stableMappingsExpected
+      ? packageLinks(afterLinks, snapshot.sourceIds)
+      : { rows: [], missing: [] };
+    if (matched.missing.length) {
+      const reason = `来源映射不完整，缺少 ${matched.missing.length} 个资源，已关闭一键撤销`;
+      getDb().prepare(`
+        UPDATE roundtrip_import_batches
+           SET undoAvailable = 0, undoUnavailableReason = ?
+         WHERE id = ? AND userId = ?
+      `).run(reason, batchId, userId);
+      removeUndoBackup(batchId);
+      return { available: false, reason };
+    }
+
     const refined = refineUndoState({
       state,
       result,
       importMode: batch.importMode,
       packageKind,
-      afterLinks,
+      packageLinks: matched.rows,
+      stableMappingsExpected,
     });
     if (!refined.available) {
       getDb().prepare(`

--- a/backend/tests/roundtrip-import-batches.test.ts
+++ b/backend/tests/roundtrip-import-batches.test.ts
@@ -8,6 +8,7 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-import-batch-test-")
 process.env.DB_PATH = path.join(tmpDir, "test.db");
 process.env.ELECTRON_USER_DATA = tmpDir;
 process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS = "24";
+process.env.NOWEN_INSTANCE_ID = "batch-test-instance";
 
 let closeDb: typeof import("../src/db/schema").closeDb;
 

--- a/backend/tests/roundtrip-import-batches.test.ts
+++ b/backend/tests/roundtrip-import-batches.test.ts
@@ -62,6 +62,10 @@ async function seedSource() {
   return { schema, db };
 }
 
+function countRow(value: unknown): number {
+  return Number((value as { count?: number } | undefined)?.count || 0);
+}
+
 test("formal round-trip import persists a report and can be safely undone", async () => {
   const { db } = await seedSource();
   const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
@@ -106,11 +110,11 @@ test("formal round-trip import persists a report and can be safely undone", asyn
 
   const undone = await undoRoundTripImportBatchWithLinks("batch-user", batchId);
   assert.equal(undone.status, "undone");
-  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notebooks WHERE id = ?").get(importedRootId)?.count, 0);
-  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = ?").get(importedNote!.id)?.count, 0);
+  assert.equal(countRow(db.prepare("SELECT COUNT(*) AS count FROM notebooks WHERE id = ?").get(importedRootId)), 0);
+  assert.equal(countRow(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = ?").get(importedNote!.id)), 0);
   assert.equal(fs.existsSync(path.join(tmpDir, "attachments", importedAttachment!.path)), false);
-  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = 'batch-note'").get()?.count, 1);
-  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM roundtrip_import_links").get()?.count, 0);
+  assert.equal(countRow(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = 'batch-note'").get()), 1);
+  assert.equal(countRow(db.prepare("SELECT COUNT(*) AS count FROM roundtrip_import_links").get()), 0);
 });
 
 test("undo refuses to remove a note edited after the import", async () => {
@@ -147,5 +151,6 @@ test("undo refuses to remove a note edited after the import", async () => {
       return true;
     },
   );
-  assert.equal(db.prepare("SELECT title FROM notes WHERE id = ?").get(importedNote!.id)?.title, "用户导入后修改");
+  const titleRow = db.prepare("SELECT title FROM notes WHERE id = ?").get(importedNote!.id) as { title: string } | undefined;
+  assert.equal(titleRow?.title, "用户导入后修改");
 });

--- a/backend/tests/roundtrip-import-batches.test.ts
+++ b/backend/tests/roundtrip-import-batches.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-import-batch-test-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS = "24";
+
+let closeDb: typeof import("../src/db/schema").closeDb;
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function seedSource() {
+  const schema = await import("../src/db/schema");
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run("batch-user", "batch-user", "hash");
+  db.prepare(`
+    INSERT INTO notebooks (id, userId, parentId, name, sortOrder, isExpanded)
+    VALUES (?, ?, NULL, ?, ?, 1)
+  `).run("batch-root", "batch-user", "批次资料", 10);
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, notebookId, title, content, contentText, contentFormat,
+      sortOrder, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "batch-note",
+    "batch-user",
+    "batch-root",
+    "批次记录",
+    "[附件](/api/attachments/batch-attachment)",
+    "批次记录",
+    "markdown",
+    20,
+    "2026-07-22 10:00:00",
+    "2026-07-22 10:30:00",
+  );
+  const attachmentDir = path.join(tmpDir, "attachments");
+  fs.mkdirSync(attachmentDir, { recursive: true });
+  fs.writeFileSync(path.join(attachmentDir, "batch-source.txt"), "batch attachment");
+  db.prepare(`
+    INSERT INTO attachments (id, userId, noteId, filename, mimeType, size, path, createdAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "batch-attachment",
+    "batch-user",
+    "batch-note",
+    "批次附件.txt",
+    "text/plain",
+    16,
+    "batch-source.txt",
+    "2026-07-22 10:15:00",
+  );
+  return { schema, db };
+}
+
+test("formal round-trip import persists a report and can be safely undone", async () => {
+  const { db } = await seedSource();
+  const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  const {
+    getRoundTripImportBatch,
+    listRoundTripImportBatches,
+  } = await import("../src/services/roundTripImportBatches");
+  const { undoRoundTripImportBatchWithLinks } = await import("../src/services/roundTripImportLinkUndo");
+
+  const exported = await createNowenPackageExport({
+    userId: "batch-user",
+    workspaceId: null,
+    packageKind: "nowen",
+  });
+  const imported = await importNowenPackage(exported.buffer, {
+    userId: "batch-user",
+    workspaceId: null,
+    importMode: "new-root",
+  });
+  assert.equal(imported.success, true, imported.errors?.join("; "));
+  assert.ok(imported.importBatch?.id);
+  assert.equal(imported.importBatch?.undoAvailable, true);
+
+  const batchId = String(imported.importBatch.id);
+  const list = listRoundTripImportBatches("batch-user", { workspaceId: null });
+  assert.equal(list[0]?.id, batchId);
+  assert.equal(list[0]?.status, "completed");
+  assert.equal(list[0]?.undo.available, true);
+
+  const detail = getRoundTripImportBatch("batch-user", batchId);
+  assert.equal(detail?.result?.success, true);
+  assert.equal(detail?.counts?.notes, 1);
+
+  const importedRootId = String(imported.rootNotebookId || "");
+  assert.ok(importedRootId);
+  const importedNote = db.prepare("SELECT id FROM notes WHERE notebookId = ?").get(importedRootId) as { id: string } | undefined;
+  assert.ok(importedNote);
+  const importedAttachment = db.prepare("SELECT id, path FROM attachments WHERE noteId = ?").get(importedNote!.id) as { id: string; path: string } | undefined;
+  assert.ok(importedAttachment);
+  assert.equal(fs.existsSync(path.join(tmpDir, "attachments", importedAttachment!.path)), true);
+
+  const undone = await undoRoundTripImportBatchWithLinks("batch-user", batchId);
+  assert.equal(undone.status, "undone");
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notebooks WHERE id = ?").get(importedRootId)?.count, 0);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = ?").get(importedNote!.id)?.count, 0);
+  assert.equal(fs.existsSync(path.join(tmpDir, "attachments", importedAttachment!.path)), false);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM notes WHERE id = 'batch-note'").get()?.count, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM roundtrip_import_links").get()?.count, 0);
+});
+
+test("undo refuses to remove a note edited after the import", async () => {
+  const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  const { undoRoundTripImportBatchWithLinks } = await import("../src/services/roundTripImportLinkUndo");
+  const { RoundTripImportUndoError } = await import("../src/services/roundTripImportBatches");
+  const { getDb } = await import("../src/db/schema");
+  const db = getDb();
+
+  const exported = await createNowenPackageExport({
+    userId: "batch-user",
+    workspaceId: null,
+    packageKind: "nowen",
+  });
+  const imported = await importNowenPackage(exported.buffer, {
+    userId: "batch-user",
+    workspaceId: null,
+    importMode: "new-root",
+  });
+  assert.equal(imported.success, true);
+  const batchId = String(imported.importBatch?.id || "");
+  const importedNote = db.prepare("SELECT id FROM notes WHERE notebookId = ?").get(imported.rootNotebookId) as { id: string } | undefined;
+  assert.ok(importedNote);
+  db.prepare("UPDATE notes SET title = ?, updatedAt = datetime('now') WHERE id = ?")
+    .run("用户导入后修改", importedNote!.id);
+
+  await assert.rejects(
+    () => undoRoundTripImportBatchWithLinks("batch-user", batchId),
+    (error: unknown) => {
+      assert.ok(error instanceof RoundTripImportUndoError);
+      assert.equal(error.code, "IMPORT_BATCH_UNDO_CONFLICT");
+      assert.ok(error.conflicts.some((item) => item.includes("笔记")));
+      return true;
+    },
+  );
+  assert.equal(db.prepare("SELECT title FROM notes WHERE id = ?").get(importedNote!.id)?.title, "用户导入后修改");
+});

--- a/backend/tests/roundtrip-import-batches.test.ts
+++ b/backend/tests/roundtrip-import-batches.test.ts
@@ -117,6 +117,75 @@ test("formal round-trip import persists a report and can be safely undone", asyn
   assert.equal(countRow(db.prepare("SELECT COUNT(*) AS count FROM roundtrip_import_links").get()), 0);
 });
 
+test("sync undo restores the pre-sync target and source mappings", async () => {
+  const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  const { importNowenPackageWithSync } = await import("../src/services/nowenRoundTripSync");
+  const { undoRoundTripImportBatchWithLinks } = await import("../src/services/roundTripImportLinkUndo");
+  const { getDb } = await import("../src/db/schema");
+  const db = getDb();
+
+  const firstPackage = await createNowenPackageExport({
+    userId: "batch-user",
+    workspaceId: null,
+    packageKind: "nowen",
+  });
+  const copied = await importNowenPackage(firstPackage.buffer, {
+    userId: "batch-user",
+    workspaceId: null,
+    importMode: "new-root",
+  });
+  assert.equal(copied.success, true, copied.errors?.join("; "));
+  const copiedNote = db.prepare(`
+    SELECT id, title, content FROM notes WHERE notebookId = ? LIMIT 1
+  `).get(copied.rootNotebookId) as { id: string; title: string; content: string } | undefined;
+  assert.ok(copiedNote);
+  const beforeSync = { title: copiedNote!.title, content: copiedNote!.content };
+
+  db.prepare(`
+    UPDATE notes
+       SET title = ?, content = ?, contentText = ?, updatedAt = ?
+     WHERE id = ?
+  `).run(
+    "来源更新后的标题",
+    "来源更新后的正文",
+    "来源更新后的正文",
+    "2026-07-22 12:00:00",
+    "batch-note",
+  );
+  const updatedPackage = await createNowenPackageExport({
+    userId: "batch-user",
+    workspaceId: null,
+    packageKind: "nowen",
+  });
+  const synced = await importNowenPackage(updatedPackage.buffer, {
+    userId: "batch-user",
+    workspaceId: null,
+    importMode: "sync",
+  });
+  assert.equal(synced.success, true, synced.errors?.join("; "));
+  assert.equal(synced.counts?.updatedNotes, 1);
+  assert.equal(synced.importBatch?.undoAvailable, true);
+
+  const syncedTarget = db.prepare("SELECT title, content FROM notes WHERE id = ?").get(copiedNote!.id) as { title: string; content: string } | undefined;
+  assert.equal(syncedTarget?.title, "来源更新后的标题");
+  assert.equal(syncedTarget?.content, "来源更新后的正文");
+
+  const undone = await undoRoundTripImportBatchWithLinks("batch-user", String(synced.importBatch.id));
+  assert.equal(undone.status, "undone");
+  const restoredTarget = db.prepare("SELECT title, content FROM notes WHERE id = ?").get(copiedNote!.id) as { title: string; content: string } | undefined;
+  assert.deepEqual(restoredTarget, beforeSync);
+
+  const retryPreview = await importNowenPackageWithSync(updatedPackage.buffer, {
+    userId: "batch-user",
+    workspaceId: null,
+    importMode: "sync",
+    dryRun: true,
+  });
+  assert.equal(retryPreview.success, true, retryPreview.errors?.join("; "));
+  assert.equal(retryPreview.counts?.updatedNotes, 1, "restored source hashes should make the same package syncable again");
+});
+
 test("undo refuses to remove a note edited after the import", async () => {
   const { createNowenPackageExport } = await import("../src/services/nowenPackageExport");
   const { importNowenPackage } = await import("../src/services/nowenPackageImport");

--- a/frontend/src/components/RoundTripImportBatchCenter.tsx
+++ b/frontend/src/components/RoundTripImportBatchCenter.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  AlertTriangle,
+  ArchiveRestore,
+  CheckCircle2,
+  Clock3,
+  FileArchive,
+  FolderTree,
+  History,
+  Loader2,
+  Paperclip,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  Tags,
+  Undo2,
+  X,
+} from "lucide-react";
+import RoundTripImportReviewCenter from "./RoundTripImportReviewCenter";
+import { confirm as confirmDialog } from "./ui/confirm";
+import {
+  getRoundTripImportBatch,
+  listRoundTripImportBatches,
+  openRoundTripImportHistory,
+  ROUND_TRIP_IMPORT_COMPLETED_EVENT,
+  ROUND_TRIP_IMPORT_HISTORY_EVENT,
+  undoRoundTripImportBatch,
+  type RoundTripImportBatchDetail,
+  type RoundTripImportBatchSummary,
+} from "@/lib/roundTripImportBatches";
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  try { return date.toLocaleString(); } catch { return value; }
+}
+
+function modeLabel(mode: string): string {
+  if (mode === "sync") return "安全增量同步";
+  if (mode === "merge") return "合并导入";
+  if (mode === "into-target") return "导入到目标目录";
+  return "创建独立副本";
+}
+
+function statusLabel(status: RoundTripImportBatchSummary["status"]): string {
+  if (status === "completed") return "已完成";
+  if (status === "undone") return "已撤销";
+  if (status === "failed") return "失败";
+  return "执行中";
+}
+
+function numeric(value: unknown): number {
+  const result = Number(value);
+  return Number.isFinite(result) && result > 0 ? result : 0;
+}
+
+function HistoryButtonBridge() {
+  const [mount, setMount] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const sync = () => {
+      const title = document.getElementById("round-trip-import-review-title");
+      const header = title?.closest("header");
+      if (!header) {
+        setMount(null);
+        return;
+      }
+      let node = header.querySelector<HTMLElement>("[data-nowen-import-history-mount]");
+      if (!node) {
+        node = document.createElement("span");
+        node.dataset.nowenImportHistoryMount = "true";
+        node.className = "shrink-0";
+        const close = header.querySelector("button[aria-label]");
+        header.insertBefore(node, close || null);
+      }
+      setMount(node);
+    };
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+      const node = document.querySelector<HTMLElement>("[data-nowen-import-history-mount]");
+      node?.remove();
+    };
+  }, []);
+
+  if (!mount) return null;
+  return createPortal(
+    <button
+      type="button"
+      onClick={() => openRoundTripImportHistory()}
+      className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 px-2.5 py-2 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+      title="查看最近导入记录和撤销状态"
+    >
+      <History size={15} />
+      <span className="hidden sm:inline">导入记录</span>
+    </button>,
+    mount,
+  );
+}
+
+function BatchCenterModal({
+  open,
+  initialBatchId,
+  onClose,
+}: {
+  open: boolean;
+  initialBatchId?: string;
+  onClose: () => void;
+}) {
+  const [items, setItems] = useState<RoundTripImportBatchSummary[]>([]);
+  const [selectedId, setSelectedId] = useState(initialBatchId || "");
+  const [detail, setDetail] = useState<RoundTripImportBatchDetail | null>(null);
+  const [loadingList, setLoadingList] = useState(false);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [undoing, setUndoing] = useState(false);
+  const [error, setError] = useState("");
+  const [undoConflicts, setUndoConflicts] = useState<string[]>([]);
+
+  const refreshList = async (preferredId?: string) => {
+    setLoadingList(true);
+    setError("");
+    try {
+      const next = await listRoundTripImportBatches({ limit: 50 });
+      setItems(next);
+      const target = preferredId || selectedId || next[0]?.id || "";
+      setSelectedId(target);
+      return target;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return "";
+    } finally {
+      setLoadingList(false);
+    }
+  };
+
+  const loadDetail = async (id: string) => {
+    if (!id) {
+      setDetail(null);
+      return;
+    }
+    setLoadingDetail(true);
+    setError("");
+    setUndoConflicts([]);
+    try {
+      setDetail(await getRoundTripImportBatch(id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setDetail(null);
+    } finally {
+      setLoadingDetail(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const target = initialBatchId || selectedId;
+    void refreshList(target).then((resolved) => void loadDetail(resolved));
+  }, [open, initialBatchId]);
+
+  useEffect(() => {
+    if (!open || !selectedId || selectedId === detail?.id) return;
+    void loadDetail(selectedId);
+  }, [open, selectedId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || undoing) return;
+      event.preventDefault();
+      onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose, open, undoing]);
+
+  const warnings = useMemo(() => {
+    const result = detail?.result || {};
+    const preview = detail?.preview || {};
+    return Array.isArray(result.warnings) ? result.warnings : Array.isArray(preview.warnings) ? preview.warnings : [];
+  }, [detail]);
+  const errors = useMemo(() => {
+    const result = detail?.result || {};
+    const preview = detail?.preview || {};
+    return Array.isArray(result.errors) ? result.errors : Array.isArray(preview.errors) ? preview.errors : [];
+  }, [detail]);
+  const conflicts = useMemo(() => {
+    const result = detail?.result || {};
+    const preview = detail?.preview || {};
+    return Array.isArray(result.conflicts) ? result.conflicts : Array.isArray(preview.conflicts) ? preview.conflicts : [];
+  }, [detail]);
+
+  const handleUndo = async () => {
+    if (!detail?.undo.available || undoing) return;
+    const confirmed = await confirmDialog({
+      title: "撤销本次导入？",
+      description:
+        "将删除本批次创建的目录、笔记和附件，并恢复本批次同步前的内容。\n\n" +
+        "撤销前会再次校验导入后是否有新的本地修改；发现变化时会停止，不会强制覆盖。",
+      confirmText: "安全撤销",
+      cancelText: "取消",
+      danger: true,
+    });
+    if (!confirmed) return;
+    setUndoing(true);
+    setError("");
+    setUndoConflicts([]);
+    try {
+      const next = await undoRoundTripImportBatch(detail.id);
+      setDetail(next);
+      await refreshList(detail.id);
+    } catch (cause) {
+      const typed = cause as Error & { conflicts?: string[] };
+      setError(typed.message || String(cause));
+      setUndoConflicts(Array.isArray(typed.conflicts) ? typed.conflicts : []);
+    } finally {
+      setUndoing(false);
+    }
+  };
+
+  if (!open || typeof document === "undefined") return null;
+
+  const counts = detail?.counts || {};
+  const cards = [
+    { label: "目录", value: numeric(counts.notebooks) + numeric(counts.updatedNotebooks), icon: FolderTree },
+    { label: "笔记", value: numeric(counts.notes) + numeric(counts.updatedNotes), icon: FileArchive },
+    { label: "标签", value: numeric(counts.tags), icon: Tags },
+    { label: "附件", value: numeric(counts.attachments), icon: Paperclip },
+  ];
+
+  return createPortal(
+    <div className="fixed inset-0 z-[12500] flex items-end justify-center bg-black/50 backdrop-blur-[1px] sm:items-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="round-trip-import-history-title">
+      <div className="flex max-h-[calc(100dvh-0.5rem)] w-full max-w-5xl flex-col overflow-hidden rounded-t-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900 sm:max-h-[min(92dvh,900px)] sm:rounded-2xl">
+        <header className="flex items-start gap-3 border-b border-zinc-200 px-4 py-4 dark:border-zinc-800 sm:px-5">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300"><History size={21} /></span>
+          <div className="min-w-0 flex-1">
+            <h2 id="round-trip-import-history-title" className="text-base font-bold text-zinc-900 dark:text-zinc-100">导入批次记录</h2>
+            <p className="mt-0.5 text-xs leading-5 text-zinc-500 dark:text-zinc-400">查看预检、执行结果、冲突和可撤销状态</p>
+          </div>
+          <button type="button" onClick={() => void refreshList(selectedId).then((id) => void loadDetail(id))} disabled={loadingList || undoing} className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-200" title="刷新"><RefreshCw size={17} className={loadingList ? "animate-spin" : ""} /></button>
+          <button type="button" onClick={onClose} disabled={undoing} className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-200" aria-label="关闭导入记录"><X size={18} /></button>
+        </header>
+
+        <div className="grid min-h-0 flex-1 md:grid-cols-[280px_minmax(0,1fr)]">
+          <aside className="max-h-56 overflow-y-auto border-b border-zinc-200 bg-zinc-50/65 p-2 dark:border-zinc-800 dark:bg-zinc-950/30 md:max-h-none md:border-b-0 md:border-r">
+            {loadingList && !items.length ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-zinc-500"><Loader2 size={17} className="animate-spin" />加载记录…</div>
+            ) : items.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-zinc-500">暂无 Nowen 数据包导入记录</div>
+            ) : items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setSelectedId(item.id)}
+                className={`mb-1.5 w-full rounded-xl border px-3 py-2.5 text-left transition-colors ${selectedId === item.id ? "border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-500/10" : "border-transparent hover:border-zinc-200 hover:bg-white dark:hover:border-zinc-800 dark:hover:bg-zinc-900"}`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">{modeLabel(item.importMode)}</span>
+                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${item.status === "completed" ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300" : item.status === "undone" ? "bg-zinc-200 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300" : item.status === "failed" ? "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300" : "bg-amber-100 text-amber-700"}`}>{statusLabel(item.status)}</span>
+                </div>
+                <div className="mt-1 flex items-center gap-1.5 text-[11px] text-zinc-500"><Clock3 size={12} />{formatDate(item.completedAt || item.createdAt)}</div>
+                <div className="mt-1 text-[11px] text-zinc-400">笔记 {numeric(item.counts.notes) + numeric(item.counts.updatedNotes)} · 附件 {numeric(item.counts.attachments)}</div>
+              </button>
+            ))}
+          </aside>
+
+          <main className="min-h-0 overflow-y-auto px-4 py-4 sm:px-5">
+            {loadingDetail ? (
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-zinc-500"><Loader2 size={18} className="animate-spin" />读取批次报告…</div>
+            ) : !detail ? (
+              <div className="py-16 text-center text-sm text-zinc-500">选择一条导入记录查看详情</div>
+            ) : (
+              <div className="space-y-4">
+                <section className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-3 dark:border-zinc-800 dark:bg-zinc-950/30">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100">{modeLabel(detail.importMode)}</span>
+                    <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">{statusLabel(detail.status)}</span>
+                    <span className="text-xs text-zinc-500">{formatDate(detail.completedAt || detail.createdAt)}</span>
+                  </div>
+                  <div className="mt-2 grid gap-1 text-xs text-zinc-500 sm:grid-cols-2">
+                    <p>数据包：{detail.packageKind === "markdown" ? "Markdown 往返包" : "Nowen 无损包"}</p>
+                    <p className="truncate" title={detail.sourceInstanceId || ""}>来源实例：{detail.sourceInstanceId || "未记录"}</p>
+                    <p>目标空间：{detail.workspaceId || "个人空间"}</p>
+                    <p>导出批次：{detail.sourceExportBatchId || "未记录"}</p>
+                  </div>
+                </section>
+
+                <section className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {cards.map(({ label, value, icon: Icon }) => <div key={label} className="rounded-xl border border-zinc-200 px-3 py-3 dark:border-zinc-800"><div className="flex items-center gap-1.5 text-xs text-zinc-500"><Icon size={14} />{label}</div><div className="mt-1 text-xl font-bold tabular-nums text-zinc-900 dark:text-zinc-100">{value}</div></div>)}
+                </section>
+
+                <section className={`rounded-xl border p-3 ${detail.undo.available ? "border-blue-200 bg-blue-50/55 dark:border-blue-900/50 dark:bg-blue-500/5" : detail.status === "undone" ? "border-emerald-200 bg-emerald-50/50 dark:border-emerald-900/50 dark:bg-emerald-500/5" : "border-zinc-200 dark:border-zinc-800"}`}>
+                  <div className="flex items-start gap-2">
+                    {detail.status === "undone" ? <ArchiveRestore size={17} className="mt-0.5 shrink-0 text-emerald-600" /> : detail.undo.available ? <ShieldCheck size={17} className="mt-0.5 shrink-0 text-blue-600" /> : <ShieldAlert size={17} className="mt-0.5 shrink-0 text-zinc-400" />}
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">{detail.status === "undone" ? "本批次已安全撤销" : detail.undo.available ? "可安全撤销本次导入" : "当前不可撤销"}</h3>
+                      <p className="mt-1 text-[11px] leading-5 text-zinc-500">{detail.status === "undone" ? `撤销时间：${formatDate(detail.undoneAt)}` : detail.undo.available ? `撤销窗口截止：${formatDate(detail.undo.expiresAt)}。执行前会校验导入后的本地修改。` : detail.undo.reason || detail.undo.error || "没有完整撤销快照。"}</p>
+                    </div>
+                    {detail.undo.available && <button type="button" onClick={handleUndo} disabled={undoing} className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-red-600 px-3 py-2 text-xs font-semibold text-white hover:bg-red-700 disabled:opacity-50">{undoing ? <Loader2 size={14} className="animate-spin" /> : <Undo2 size={14} />}撤销本次导入</button>}
+                  </div>
+                </section>
+
+                {(error || undoConflicts.length > 0) && <section className="rounded-xl border border-red-200 bg-red-50/55 p-3 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-500/5 dark:text-red-300"><p className="font-semibold">{error}</p>{undoConflicts.length > 0 && <div className="mt-2 max-h-36 space-y-1 overflow-y-auto">{undoConflicts.map((item, index) => <p key={`${item}-${index}`}>• {item}</p>)}</div>}</section>}
+
+                <section className={`rounded-xl border p-3 ${errors.length ? "border-red-200 bg-red-50/40 dark:border-red-900/50 dark:bg-red-500/5" : warnings.length ? "border-amber-200 bg-amber-50/40 dark:border-amber-900/50 dark:bg-amber-500/5" : "border-emerald-200 bg-emerald-50/40 dark:border-emerald-900/50 dark:bg-emerald-500/5"}`}>
+                  <h3 className="flex items-center gap-1.5 text-xs font-semibold text-zinc-900 dark:text-zinc-100">{errors.length ? <AlertTriangle size={15} className="text-red-600" /> : <CheckCircle2 size={15} className="text-emerald-600" />}执行结果 · 错误 {errors.length} · 警告 {warnings.length}</h3>
+                  {errors.length || warnings.length ? <div className="mt-2 max-h-40 space-y-1 overflow-y-auto text-[11px] leading-5 text-zinc-600 dark:text-zinc-300">{errors.map((item: any, index) => <p key={`e-${index}`}>• {typeof item === "string" ? item : item?.message || JSON.stringify(item)}</p>)}{warnings.map((item: any, index) => <p key={`w-${index}`}>• {typeof item === "string" ? item : item?.message || item?.type || JSON.stringify(item)}</p>)}</div> : <p className="mt-1 text-[11px] text-zinc-500">导入过程未报告错误或警告。</p>}
+                </section>
+
+                <section className="rounded-xl border border-zinc-200 p-3 dark:border-zinc-800">
+                  <h3 className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">变更与冲突 · {conflicts.length}</h3>
+                  {conflicts.length ? <div className="mt-2 max-h-56 space-y-1.5 overflow-y-auto">{conflicts.map((item: any, index) => <div key={`${item?.sourceId || index}-${index}`} className="rounded-lg bg-zinc-50 px-2.5 py-2 text-[11px] text-zinc-600 dark:bg-zinc-950/45 dark:text-zinc-300"><div className="flex flex-wrap items-center gap-1.5"><span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-semibold dark:bg-zinc-700">{item?.action || "change"}</span><span className="font-medium">{item?.originalName || item?.sourceId || "资源"}</span>{item?.importedName && item.importedName !== item.originalName && <span>→ {item.importedName}</span>}</div></div>)}</div> : <p className="mt-1 text-[11px] text-zinc-500">没有需要展示的重命名、同步更新或本地冲突。</p>}
+                </section>
+              </div>
+            )}
+          </main>
+        </div>
+
+        <footer className="flex shrink-0 justify-end border-t border-zinc-200 px-4 pt-3 pb-[max(0.9rem,env(safe-area-inset-bottom))] dark:border-zinc-800 sm:px-5 sm:pb-4">
+          <button type="button" onClick={onClose} disabled={undoing} className="rounded-lg border border-zinc-300 px-4 py-2.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800">关闭</button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default function RoundTripImportBatchCenter() {
+  const [open, setOpen] = useState(false);
+  const [initialBatchId, setInitialBatchId] = useState("");
+
+  useEffect(() => {
+    const openWithEvent = (event: Event) => {
+      const batchId = String((event as CustomEvent<{ batchId?: string }>).detail?.batchId || "");
+      setInitialBatchId(batchId);
+      setOpen(true);
+    };
+    window.addEventListener(ROUND_TRIP_IMPORT_COMPLETED_EVENT, openWithEvent);
+    window.addEventListener(ROUND_TRIP_IMPORT_HISTORY_EVENT, openWithEvent);
+    return () => {
+      window.removeEventListener(ROUND_TRIP_IMPORT_COMPLETED_EVENT, openWithEvent);
+      window.removeEventListener(ROUND_TRIP_IMPORT_HISTORY_EVENT, openWithEvent);
+    };
+  }, []);
+
+  return (
+    <>
+      <RoundTripImportReviewCenter />
+      <HistoryButtonBridge />
+      <BatchCenterModal open={open} initialBatchId={initialBatchId} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/frontend/src/components/TiptapEditorRuntime.tsx
+++ b/frontend/src/components/TiptapEditorRuntime.tsx
@@ -113,7 +113,7 @@ const TiptapEditorRuntime = forwardRef<NoteEditorHandle, RuntimeTiptapEditorProp
       editable: props.editable !== false,
       isGuest: props.isGuest === true,
       presentationMode: props.presentationMode === true,
-      contentFormat: props.note.contentFormat,
+      contentFormat: props.note.contentFormat || "tiptap-json",
     });
     const blockPatchEnabledRef = useRef(blockPatchEnabled);
     blockPatchEnabledRef.current = blockPatchEnabled;

--- a/frontend/src/lib/__tests__/blockPatchApi.test.ts
+++ b/frontend/src/lib/__tests__/blockPatchApi.test.ts
@@ -79,11 +79,11 @@ describe("block patch API client", () => {
       expectedNoteVersion: 10,
       operationId: "block-patch-conflict-test",
       operations: [{ type: "delete", blockId: "blk_alpha00" }],
-    })).rejects.toMatchObject<BlockPatchRequestError>({
+    })).rejects.toMatchObject({
       code: "VERSION_CONFLICT",
       status: 409,
       currentVersion: 11,
-    });
+    } satisfies Partial<BlockPatchRequestError>);
   });
 
   it("creates retry-safe operation identifiers", () => {

--- a/frontend/src/lib/__tests__/markdownYTextRuntime.test.ts
+++ b/frontend/src/lib/__tests__/markdownYTextRuntime.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { computeSingleTextChange } from "@/lib/largeMarkdownSafetyRuntime";
@@ -41,7 +42,7 @@ describe("large Markdown incremental collaboration runtime", () => {
 
   it("keeps both local and remote incremental paths in the runtime shell", () => {
     const source = readFileSync(
-      new URL("../../components/LargeMarkdownSafeEditorRuntime.tsx", import.meta.url),
+      path.resolve(process.cwd(), "src/components/LargeMarkdownSafeEditorRuntime.tsx"),
       "utf-8",
     );
 

--- a/frontend/src/lib/__tests__/roundTripImportBatches.test.ts
+++ b/frontend/src/lib/__tests__/roundTripImportBatches.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  announceRoundTripImportCompleted,
+  listRoundTripImportBatches,
+  ROUND_TRIP_IMPORT_COMPLETED_EVENT,
+  undoRoundTripImportBatch,
+} from "../roundTripImportBatches";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe("round-trip import batch client", () => {
+  it("announces a completed batch and remembers its id", () => {
+    const listener = vi.fn();
+    window.addEventListener(ROUND_TRIP_IMPORT_COMPLETED_EVENT, listener);
+
+    announceRoundTripImportCompleted("batch-123");
+
+    expect(localStorage.getItem("nowen-last-roundtrip-import-batch")).toBe("batch-123");
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({ batchId: "batch-123" });
+    window.removeEventListener(ROUND_TRIP_IMPORT_COMPLETED_EVENT, listener);
+  });
+
+  it("loads persistent batch summaries", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      items: [{
+        id: "batch-1",
+        workspaceId: null,
+        importMode: "new-root",
+        packageKind: "nowen",
+        sourceInstanceId: "instance-1",
+        sourceExportBatchId: "export-1",
+        status: "completed",
+        createdAt: "2026-07-22T10:00:00Z",
+        completedAt: "2026-07-22T10:00:01Z",
+        undoneAt: null,
+        undo: { available: true, expiresAt: "2026-07-29T10:00:01Z", reason: null, error: null },
+        counts: { notes: 2 },
+        warningCount: 0,
+        errorCount: 0,
+      }],
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const items = await listRoundTripImportBatches({ workspaceId: null, limit: 10 });
+
+    expect(items[0]?.id).toBe("batch-1");
+    expect(items[0]?.undo.available).toBe(true);
+    expect(fetchMock.mock.calls[0][0].toString()).toContain("/settings/import-batches?workspaceId=personal&limit=10");
+  });
+
+  it("surfaces guarded undo conflicts from the server", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: "检测到导入后的本地修改，已拒绝破坏性撤销",
+      code: "IMPORT_BATCH_UNDO_CONFLICT",
+      conflicts: ["笔记或其附件已在导入后发生变化：note-1"],
+    }), { status: 409, headers: { "Content-Type": "application/json" } }));
+
+    await expect(undoRoundTripImportBatch("batch-1")).rejects.toMatchObject({
+      message: "检测到导入后的本地修改，已拒绝破坏性撤销",
+      code: "IMPORT_BATCH_UNDO_CONFLICT",
+      conflicts: ["笔记或其附件已在导入后发生变化：note-1"],
+    });
+  });
+});

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -13,7 +13,6 @@ import {
   submitRoundTripPackage,
   type RoundTripImportStrategy,
 } from "./roundTripImportReview";
-import { announceRoundTripImportCompleted } from "./roundTripImportBatches";
 
 export {
   tiptapExtensions,
@@ -209,8 +208,6 @@ export async function importNotes(
             ? `导入完成，共 ${createdNotes} 篇笔记，${warningCount} 项需要检查`
             : `导入完成，共 ${createdNotes} 篇笔记`,
     });
-    const batchId = String(result?.importBatch?.id || "");
-    if (batchId) announceRoundTripImportCompleted(batchId);
     return { success: true, count: decision.strategy === "sync" ? affectedCount : createdNotes };
   } catch (error) {
     onProgress?.({

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -13,6 +13,7 @@ import {
   submitRoundTripPackage,
   type RoundTripImportStrategy,
 } from "./roundTripImportReview";
+import { announceRoundTripImportCompleted } from "./roundTripImportBatches";
 
 export {
   tiptapExtensions,
@@ -208,6 +209,8 @@ export async function importNotes(
             ? `导入完成，共 ${createdNotes} 篇笔记，${warningCount} 项需要检查`
             : `导入完成，共 ${createdNotes} 篇笔记`,
     });
+    const batchId = String(result?.importBatch?.id || "");
+    if (batchId) announceRoundTripImportCompleted(batchId);
     return { success: true, count: decision.strategy === "sync" ? affectedCount : createdNotes };
   } catch (error) {
     onProgress?.({

--- a/frontend/src/lib/largeMarkdownSafety.ts
+++ b/frontend/src/lib/largeMarkdownSafety.ts
@@ -96,12 +96,19 @@ export interface SingleTextChange {
   insert: string;
 }
 
+const TOKEN_CHAR_RE = /[\p{L}\p{N}_]/u;
+
+function isTokenChar(value: string | undefined): boolean {
+  return Boolean(value && TOKEN_CHAR_RE.test(value));
+}
+
 /**
  * Compute one compact replacement range so a one-character edit does not replace/broadcast the
  * entire multi-megabyte Y.Text document.
  *
- * Repeated characters can produce several equally small ranges. Canonicalize pure insertions and
- * deletions to the earliest valid position so local and remote runtimes derive the same operation.
+ * Repeated characters can produce several equally small ranges. When the default range begins in
+ * the middle of a token, rotate a pure insertion/deletion left to the nearest token boundary. End
+ * of document and already-boundary edits remain untouched.
  */
 export function computeSingleTextChange(
   previous: string,
@@ -132,6 +139,9 @@ export function computeSingleTextChange(
   if (deleteCount === 0 && insert.length > 0) {
     while (
       from > 0
+      && from < previous.length
+      && isTokenChar(previous[from - 1])
+      && isTokenChar(previous[from])
       && insert.charCodeAt(insert.length - 1) === previous.charCodeAt(from - 1)
     ) {
       insert = `${previous[from - 1]}${insert.slice(0, -1)}`;
@@ -141,6 +151,9 @@ export function computeSingleTextChange(
     let deleted = previous.slice(from, previousEnd);
     while (
       from > 0
+      && from < next.length
+      && isTokenChar(next[from - 1])
+      && isTokenChar(next[from])
       && deleted.charCodeAt(deleted.length - 1) === next.charCodeAt(from - 1)
     ) {
       deleted = `${next[from - 1]}${deleted.slice(0, -1)}`;

--- a/frontend/src/lib/largeMarkdownSafety.ts
+++ b/frontend/src/lib/largeMarkdownSafety.ts
@@ -99,6 +99,9 @@ export interface SingleTextChange {
 /**
  * Compute one compact replacement range so a one-character edit does not replace/broadcast the
  * entire multi-megabyte Y.Text document.
+ *
+ * Repeated characters can produce several equally small ranges. Canonicalize pure insertions and
+ * deletions to the earliest valid position so local and remote runtimes derive the same operation.
  */
 export function computeSingleTextChange(
   previous: string,
@@ -123,10 +126,32 @@ export function computeSingleTextChange(
     nextEnd -= 1;
   }
 
+  const deleteCount = previousEnd - from;
+  let insert = next.slice(from, nextEnd);
+
+  if (deleteCount === 0 && insert.length > 0) {
+    while (
+      from > 0
+      && insert.charCodeAt(insert.length - 1) === previous.charCodeAt(from - 1)
+    ) {
+      insert = `${previous[from - 1]}${insert.slice(0, -1)}`;
+      from -= 1;
+    }
+  } else if (insert.length === 0 && deleteCount > 0) {
+    let deleted = previous.slice(from, previousEnd);
+    while (
+      from > 0
+      && deleted.charCodeAt(deleted.length - 1) === next.charCodeAt(from - 1)
+    ) {
+      deleted = `${next[from - 1]}${deleted.slice(0, -1)}`;
+      from -= 1;
+    }
+  }
+
   return {
     from,
-    deleteCount: previousEnd - from,
-    insert: next.slice(from, nextEnd),
+    deleteCount,
+    insert,
   };
 }
 

--- a/frontend/src/lib/roundTripImportBatches.ts
+++ b/frontend/src/lib/roundTripImportBatches.ts
@@ -1,0 +1,94 @@
+import { getBaseUrl } from "./api";
+
+export const ROUND_TRIP_IMPORT_COMPLETED_EVENT = "nowen:roundtrip-import-completed";
+export const ROUND_TRIP_IMPORT_HISTORY_EVENT = "nowen:open-roundtrip-import-history";
+
+export interface RoundTripImportBatchSummary {
+  id: string;
+  workspaceId: string | null;
+  importMode: string;
+  packageKind: string | null;
+  sourceInstanceId: string | null;
+  sourceExportBatchId: string | null;
+  status: "running" | "completed" | "failed" | "undone";
+  createdAt: string;
+  completedAt: string | null;
+  undoneAt: string | null;
+  undo: {
+    available: boolean;
+    expiresAt: string | null;
+    reason: string | null;
+    error: string | null;
+  };
+  counts: Record<string, number>;
+  warningCount: number;
+  errorCount: number;
+}
+
+export interface RoundTripImportBatchDetail extends RoundTripImportBatchSummary {
+  preview: Record<string, any>;
+  result: Record<string, any>;
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    credentials: "include",
+    headers: {
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => ({})) as T & {
+    error?: string;
+    code?: string;
+    conflicts?: string[];
+  };
+  if (!response.ok) {
+    const error = new Error(payload.error || `HTTP ${response.status}`) as Error & {
+      code?: string;
+      conflicts?: string[];
+      status?: number;
+    };
+    error.code = payload.code;
+    error.conflicts = payload.conflicts;
+    error.status = response.status;
+    throw error;
+  }
+  return payload;
+}
+
+export async function listRoundTripImportBatches(options: {
+  workspaceId?: string | null;
+  limit?: number;
+} = {}): Promise<RoundTripImportBatchSummary[]> {
+  const params = new URLSearchParams();
+  if (options.workspaceId !== undefined) params.set("workspaceId", options.workspaceId || "personal");
+  if (options.limit) params.set("limit", String(options.limit));
+  const query = params.toString();
+  const payload = await request<{ items: RoundTripImportBatchSummary[] }>(`/settings/import-batches${query ? `?${query}` : ""}`);
+  return Array.isArray(payload.items) ? payload.items : [];
+}
+
+export function getRoundTripImportBatch(batchId: string): Promise<RoundTripImportBatchDetail> {
+  return request(`/settings/import-batches/${encodeURIComponent(batchId)}`);
+}
+
+export function undoRoundTripImportBatch(batchId: string): Promise<RoundTripImportBatchDetail> {
+  return request(`/settings/import-batches/${encodeURIComponent(batchId)}/undo`, { method: "POST" });
+}
+
+export function announceRoundTripImportCompleted(batchId: string): void {
+  if (typeof window === "undefined" || !batchId) return;
+  try {
+    localStorage.setItem("nowen-last-roundtrip-import-batch", batchId);
+  } catch { /* ignore */ }
+  window.dispatchEvent(new CustomEvent(ROUND_TRIP_IMPORT_COMPLETED_EVENT, { detail: { batchId } }));
+}
+
+export function openRoundTripImportHistory(batchId?: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(ROUND_TRIP_IMPORT_HISTORY_EVENT, { detail: { batchId } }));
+}

--- a/frontend/src/lib/roundTripImportReview.ts
+++ b/frontend/src/lib/roundTripImportReview.ts
@@ -1,4 +1,5 @@
 import { api, getBaseUrl, getCurrentWorkspace } from "./api";
+import { announceRoundTripImportCompleted } from "./roundTripImportBatches";
 
 export type RoundTripImportStrategy = "copy" | "merge" | "sync";
 
@@ -78,6 +79,12 @@ export interface RoundTripPackagePreview {
     path?: string;
   }>;
   errors?: string[];
+  importBatch?: {
+    id?: string;
+    undoAvailable?: boolean;
+    undoExpiresAt?: string | null;
+    reason?: string | null;
+  };
 }
 
 export type RoundTripImportReviewDecision =
@@ -128,6 +135,11 @@ function readToken(): string | null {
   }
 }
 
+function announceBatch(payload: RoundTripPackagePreview): void {
+  const batchId = String(payload?.importBatch?.id || "");
+  if (batchId) announceRoundTripImportCompleted(batchId);
+}
+
 export async function submitRoundTripPackage(
   file: File,
   options: SubmitRoundTripPackageOptions,
@@ -165,6 +177,7 @@ export async function submitRoundTripPackage(
       : payload?.error;
     throw new Error(details || `HTTP ${response.status}`);
   }
+  if (!options.dryRun) announceBatch(payload);
   return payload;
 }
 
@@ -280,7 +293,11 @@ export function installRoundTripImportReviewBridge(): void {
   api.importNowenPackage = (async (file: File, opts?: any) => {
     const remembered = selectedDecisionByFile.get(file);
     selectedDecisionByFile.delete(file);
-    if (!remembered) return nativeImport(file, opts);
+    if (!remembered) {
+      const payload = await nativeImport(file, opts) as RoundTripPackagePreview;
+      announceBatch(payload);
+      return payload;
+    }
     return submitRoundTripPackage(file, {
       dryRun: false,
       strategy: remembered.strategy,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -29,7 +29,7 @@ import ServerConnectionCenter from "./components/ServerConnectionCenter";
 import NoteImageExportCenter from "./components/NoteImageExportCenter";
 import DocxImportCenter from "./components/DocxImportCenter";
 import NoteTransferCenter from "./components/NoteTransferCenter";
-import RoundTripImportReviewCenter from "./components/RoundTripImportReviewCenter";
+import RoundTripImportBatchCenter from "./components/RoundTripImportBatchCenter";
 import "./index.css";
 import "./editor-list-markers.css";
 import "./code-block-wrap.css";
@@ -172,7 +172,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <DocxImportCenter />
         <PublicSpaceLauncher />
         <NoteTransferCenter />
-        <RoundTripImportReviewCenter />
+        <RoundTripImportBatchCenter />
         <App />
       </>
     )}


### PR DESCRIPTION
Continues #371 and closes #379.

实现 Nowen Round-trip 导入批次报告与安全一键撤销：

- 每次正式导入持久化预检、执行模式、来源实例、统计、warnings/errors 和冲突；
- 新增 SQLite v54 与 PostgreSQL 对等批次表；
- 记录本批次精确创建的目录、笔记和附件，避免把同空间并发创建的数据误归入撤销范围；
- 同步更新前保存目录、笔记、标签关系和附件字节快照；
- 默认提供 7 天撤销窗口，附件快照支持容量上限和过期清理；
- 撤销前重新校验导入后的资源哈希，发现用户后续修改时拒绝破坏性回滚；
- 同来源后续又导入/同步时要求按最新批次优先撤销，防止旧映射覆盖新映射；
- 撤销恢复同步前正文、目录、附件和 source→target 映射，并删除仅由本批次创建的资源；
- Markdown 合并导入因缺少稳定资源映射，保留报告但主动关闭危险的一键撤销；
- 工作区撤销会重新校验当前 editor 权限；
- 导入成功后自动打开批次报告，预检窗口提供“导入记录”入口，无常驻悬浮按钮；
- 新增批次持久化、复制导入撤销、同步撤销恢复、导入后修改冲突拒绝和前端 API 事件测试。

安全边界：标签没有稳定目标映射，撤销时不会为了清理孤立标签而冒险删除可能并发创建的本地标签。