### PR TITLE
feat: add guarded workspace permission mapping

### DIFF
--- a/.github/workflows/roundtrip-permission-mapping-ci.yml
+++ b/.github/workflows/roundtrip-permission-mapping-ci.yml
@@ -1,0 +1,64 @@
+name: Round-trip Permission Mapping CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/src/routes/settings.ts"
+      - "backend/src/routes/roundtrip-permissions.ts"
+      - "backend/src/services/roundTripPermissionMapping.ts"
+      - "backend/tests/roundtrip-permission-mapping.test.ts"
+      - "frontend/src/lib/roundTripPermissionMapping.ts"
+      - "frontend/src/lib/__tests__/roundTripPermissionMapping.test.ts"
+      - ".github/workflows/roundtrip-permission-mapping-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/routes/settings.ts"
+      - "backend/src/routes/roundtrip-permissions.ts"
+      - "backend/src/services/roundTripPermissionMapping.ts"
+      - "backend/tests/roundtrip-permission-mapping.test.ts"
+      - "frontend/src/lib/roundTripPermissionMapping.ts"
+      - "frontend/src/lib/__tests__/roundTripPermissionMapping.test.ts"
+      - ".github/workflows/roundtrip-permission-mapping-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Permission mapping tests
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-permission-mapping.test.ts
+      - name: Backend typecheck
+        run: npm run build:tsc
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Permission mapping client tests
+        run: npm run test:run -- src/lib/__tests__/roundTripPermissionMapping.test.ts
+      - name: Frontend typecheck
+        run: npx tsc -b

--- a/backend/src/routes/roundtrip-permissions.ts
+++ b/backend/src/routes/roundtrip-permissions.ts
@@ -1,0 +1,102 @@
+import { Hono } from "hono";
+import {
+  applyRoundTripPermissionMappings,
+  createNowenPackageWithPermissions,
+  parsePermissionsFromPackageBuffer,
+  previewRoundTripPermissionMappings,
+} from "../services/roundTripPermissionMapping";
+
+const app = new Hono();
+
+function statusOf(error: unknown): number {
+  const status = Number((error as { status?: unknown })?.status);
+  return Number.isInteger(status) && status >= 400 && status <= 599 ? status : 400;
+}
+
+function codeOf(error: unknown): string {
+  return String((error as { code?: unknown })?.code || "ROUNDTRIP_PERMISSION_ERROR");
+}
+
+app.get("/package", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  const workspaceId = (c.req.query("workspaceId") || "").trim();
+  if (!workspaceId || workspaceId === "personal") {
+    return c.json({ error: "成员权限仅适用于工作区导出", code: "WORKSPACE_REQUIRED" }, 400);
+  }
+  try {
+    const result = await createNowenPackageWithPermissions({
+      userId,
+      workspaceId,
+      notebookId: (c.req.query("notebookId") || "").trim() || undefined,
+      includeSubNotebooks: c.req.query("includeSubNotebooks") !== "false",
+      includeTrashed: c.req.query("includeTrashed") === "true",
+    });
+    return new Response(new Uint8Array(result.buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${encodeURIComponent(result.filename)}"`,
+        "X-Export-Notes": String(result.stats.notes),
+        "X-Export-Attachments": String(result.stats.attachments),
+        "X-Export-Warnings": String(result.stats.warnings),
+        "X-Export-Permissions": "included",
+      },
+    });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error), code: codeOf(error) }, statusOf(error) as any);
+  }
+});
+
+app.post("/preview", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    const body = await c.req.json() as { workspaceId?: string; manifest?: unknown };
+    const workspaceId = String(body.workspaceId || "").trim();
+    if (!workspaceId) return c.json({ error: "缺少目标工作区", code: "WORKSPACE_REQUIRED" }, 400);
+    const suggestions = previewRoundTripPermissionMappings(userId, workspaceId, body.manifest);
+    return c.json({ success: true, suggestions });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error), code: codeOf(error) }, statusOf(error) as any);
+  }
+});
+
+app.post("/preview-package", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    const form = await c.req.formData();
+    const workspaceId = String(form.get("workspaceId") || "").trim();
+    const file = form.get("file");
+    if (!workspaceId) return c.json({ error: "缺少目标工作区", code: "WORKSPACE_REQUIRED" }, 400);
+    if (!(file instanceof File)) return c.json({ error: "缺少导入包", code: "FILE_REQUIRED" }, 400);
+    const manifest = await parsePermissionsFromPackageBuffer(Buffer.from(await file.arrayBuffer()));
+    if (!manifest) return c.json({ success: true, included: false, suggestions: [] });
+    const suggestions = previewRoundTripPermissionMappings(userId, workspaceId, manifest);
+    return c.json({ success: true, included: true, manifest, suggestions });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error), code: codeOf(error) }, statusOf(error) as any);
+  }
+});
+
+app.post("/apply", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    const body = await c.req.json() as {
+      workspaceId?: string;
+      manifest?: unknown;
+      mappings?: Array<{ sourceUserId: string; targetUserId: string; role?: "admin" | "editor" | "viewer" }>;
+    };
+    const workspaceId = String(body.workspaceId || "").trim();
+    if (!workspaceId) return c.json({ error: "缺少目标工作区", code: "WORKSPACE_REQUIRED" }, 400);
+    const result = applyRoundTripPermissionMappings({
+      actorUserId: userId,
+      workspaceId,
+      manifest: body.manifest,
+      mappings: body.mappings || [],
+    });
+    return c.json({ success: true, ...result });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error), code: codeOf(error) }, statusOf(error) as any);
+  }
+});
+
+export default app;

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/public-web-origin";
 import systemUpdateRouter from "./system-update";
 import importBatchesRouter from "./import-batches";
+import roundTripPermissionsRouter from "./roundtrip-permissions";
 
 const settings = new Hono();
 
@@ -127,5 +128,7 @@ settings.put("/", async (c) => {
 settings.route("/system-update", systemUpdateRouter);
 // Round-trip 导入批次报告属于当前登录用户的数据，不要求管理员权限。
 settings.route("/import-batches", importBatchesRouter);
+// 可选工作区成员权限迁移：默认包不包含权限，只有 owner/系统管理员能显式导出和应用映射。
+settings.route("/roundtrip-permissions", roundTripPermissionsRouter);
 
 export default settings;

--- a/backend/src/services/roundTripPermissionMapping.ts
+++ b/backend/src/services/roundTripPermissionMapping.ts
@@ -1,0 +1,271 @@
+import JSZip from "jszip";
+import { getDb } from "../db/schema";
+import { getUserWorkspaceRole, hasRole, isSystemAdmin, type WorkspaceRole } from "../middleware/acl";
+import { createStableNowenPackageExport } from "./nowenPackageExportStable";
+
+export const ROUND_TRIP_PERMISSIONS_VERSION = 1;
+
+export type ExportedWorkspaceRole = "owner" | "admin" | "editor" | "viewer";
+
+export interface RoundTripPermissionMember {
+  sourceUserId: string;
+  username: string;
+  email: string | null;
+  displayName: string | null;
+  role: ExportedWorkspaceRole;
+}
+
+export interface RoundTripPermissionsManifest {
+  format: "nowen-workspace-permissions";
+  version: 1;
+  exportedAt: string;
+  sourceWorkspace: {
+    id: string;
+    name: string;
+  };
+  members: RoundTripPermissionMember[];
+}
+
+export interface PermissionMappingSuggestion {
+  sourceUserId: string;
+  username: string;
+  email: string | null;
+  sourceRole: ExportedWorkspaceRole;
+  suggestedTargetUserId: string | null;
+  suggestedTargetUsername: string | null;
+  match: "email" | "username" | "none" | "ambiguous";
+  appliedRole: Exclude<ExportedWorkspaceRole, "owner">;
+  warning?: string;
+}
+
+export interface PermissionMappingInput {
+  sourceUserId: string;
+  targetUserId: string;
+  role?: Exclude<ExportedWorkspaceRole, "owner">;
+}
+
+function assertWorkspaceOwner(userId: string, workspaceId: string): void {
+  if (isSystemAdmin(userId)) return;
+  if (!hasRole(getUserWorkspaceRole(workspaceId, userId), "owner")) {
+    const error = new Error("仅目标工作区所有者或系统管理员可迁移成员权限");
+    (error as Error & { code?: string; status?: number }).code = "WORKSPACE_OWNER_REQUIRED";
+    (error as Error & { code?: string; status?: number }).status = 403;
+    throw error;
+  }
+}
+
+function normalizeRole(role: unknown): ExportedWorkspaceRole {
+  return role === "owner" || role === "admin" || role === "editor" || role === "viewer"
+    ? role
+    : "viewer";
+}
+
+function roleForApply(role: ExportedWorkspaceRole): Exclude<ExportedWorkspaceRole, "owner"> {
+  return role === "owner" ? "admin" : role;
+}
+
+export function buildRoundTripPermissionsManifest(userId: string, workspaceId: string): RoundTripPermissionsManifest {
+  assertWorkspaceOwner(userId, workspaceId);
+  const db = getDb();
+  const workspace = db.prepare("SELECT id, name FROM workspaces WHERE id = ?").get(workspaceId) as
+    | { id: string; name: string }
+    | undefined;
+  if (!workspace) {
+    const error = new Error("工作区不存在");
+    (error as Error & { code?: string; status?: number }).code = "WORKSPACE_NOT_FOUND";
+    (error as Error & { code?: string; status?: number }).status = 404;
+    throw error;
+  }
+
+  const rows = db.prepare(`
+    SELECT m.userId AS sourceUserId, m.role, u.username, u.email, u.displayName
+      FROM workspace_members m
+      JOIN users u ON u.id = m.userId
+     WHERE m.workspaceId = ?
+     ORDER BY CASE m.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'editor' THEN 2 ELSE 3 END,
+              lower(u.username), u.id
+  `).all(workspaceId) as Array<{
+    sourceUserId: string;
+    role: string;
+    username: string;
+    email: string | null;
+    displayName: string | null;
+  }>;
+
+  return {
+    format: "nowen-workspace-permissions",
+    version: ROUND_TRIP_PERMISSIONS_VERSION,
+    exportedAt: new Date().toISOString(),
+    sourceWorkspace: workspace,
+    members: rows.map((row) => ({
+      sourceUserId: row.sourceUserId,
+      username: row.username,
+      email: row.email || null,
+      displayName: row.displayName || null,
+      role: normalizeRole(row.role),
+    })),
+  };
+}
+
+export function validateRoundTripPermissionsManifest(value: unknown): RoundTripPermissionsManifest {
+  const manifest = value as Partial<RoundTripPermissionsManifest> | null;
+  if (!manifest || manifest.format !== "nowen-workspace-permissions" || manifest.version !== 1) {
+    const error = new Error("权限清单格式或版本不受支持");
+    (error as Error & { code?: string; status?: number }).code = "INVALID_PERMISSION_MANIFEST";
+    (error as Error & { code?: string; status?: number }).status = 400;
+    throw error;
+  }
+  if (!manifest.sourceWorkspace?.id || !Array.isArray(manifest.members)) {
+    const error = new Error("权限清单缺少工作区或成员信息");
+    (error as Error & { code?: string; status?: number }).code = "INVALID_PERMISSION_MANIFEST";
+    (error as Error & { code?: string; status?: number }).status = 400;
+    throw error;
+  }
+  const members = manifest.members.map((member) => {
+    if (!member?.sourceUserId || !member.username) {
+      const error = new Error("权限清单包含无效成员");
+      (error as Error & { code?: string; status?: number }).code = "INVALID_PERMISSION_MEMBER";
+      (error as Error & { code?: string; status?: number }).status = 400;
+      throw error;
+    }
+    return {
+      sourceUserId: String(member.sourceUserId),
+      username: String(member.username),
+      email: member.email ? String(member.email) : null,
+      displayName: member.displayName ? String(member.displayName) : null,
+      role: normalizeRole(member.role),
+    };
+  });
+  return {
+    format: "nowen-workspace-permissions",
+    version: 1,
+    exportedAt: String(manifest.exportedAt || ""),
+    sourceWorkspace: {
+      id: String(manifest.sourceWorkspace.id),
+      name: String(manifest.sourceWorkspace.name || ""),
+    },
+    members,
+  };
+}
+
+export async function createNowenPackageWithPermissions(params: {
+  userId: string;
+  workspaceId: string;
+  notebookId?: string;
+  includeSubNotebooks?: boolean;
+  includeTrashed?: boolean;
+}): Promise<Awaited<ReturnType<typeof createStableNowenPackageExport>>> {
+  const manifest = buildRoundTripPermissionsManifest(params.userId, params.workspaceId);
+  const result = await createStableNowenPackageExport(params);
+  const zip = await JSZip.loadAsync(result.buffer);
+  zip.file("permissions.json", JSON.stringify(manifest, null, 2));
+  const mainManifest = zip.file("manifest.json");
+  if (mainManifest) {
+    const parsed = JSON.parse(await mainManifest.async("string")) as Record<string, unknown>;
+    parsed.permissions = {
+      included: true,
+      file: "permissions.json",
+      version: ROUND_TRIP_PERMISSIONS_VERSION,
+      memberCount: manifest.members.length,
+    };
+    zip.file("manifest.json", JSON.stringify(parsed, null, 2));
+  }
+  return { ...result, buffer: await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" }) };
+}
+
+export function previewRoundTripPermissionMappings(
+  userId: string,
+  workspaceId: string,
+  manifestValue: unknown,
+): PermissionMappingSuggestion[] {
+  assertWorkspaceOwner(userId, workspaceId);
+  const manifest = validateRoundTripPermissionsManifest(manifestValue);
+  const db = getDb();
+  const users = db.prepare("SELECT id, username, email FROM users ORDER BY id").all() as Array<{
+    id: string;
+    username: string;
+    email: string | null;
+  }>;
+
+  return manifest.members.map((source) => {
+    const emailMatches = source.email
+      ? users.filter((target) => target.email && target.email.toLowerCase() === source.email!.toLowerCase())
+      : [];
+    const usernameMatches = users.filter((target) => target.username.toLowerCase() === source.username.toLowerCase());
+    const candidates = emailMatches.length ? emailMatches : usernameMatches;
+    const match: PermissionMappingSuggestion["match"] = candidates.length > 1
+      ? "ambiguous"
+      : candidates.length === 1
+        ? (emailMatches.length ? "email" : "username")
+        : "none";
+    const candidate = candidates.length === 1 ? candidates[0] : null;
+    return {
+      sourceUserId: source.sourceUserId,
+      username: source.username,
+      email: source.email,
+      sourceRole: source.role,
+      suggestedTargetUserId: candidate?.id || null,
+      suggestedTargetUsername: candidate?.username || null,
+      match,
+      appliedRole: roleForApply(source.role),
+      warning: source.role === "owner" ? "源工作区 owner 将降级为 admin；目标 owner 不会被替换" : undefined,
+    };
+  });
+}
+
+export function applyRoundTripPermissionMappings(params: {
+  actorUserId: string;
+  workspaceId: string;
+  manifest: unknown;
+  mappings: PermissionMappingInput[];
+}): { applied: number; skipped: number; items: Array<{ sourceUserId: string; targetUserId: string; role: string }> } {
+  assertWorkspaceOwner(params.actorUserId, params.workspaceId);
+  const manifest = validateRoundTripPermissionsManifest(params.manifest);
+  const sourceById = new Map(manifest.members.map((member) => [member.sourceUserId, member]));
+  const db = getDb();
+  const targetWorkspace = db.prepare("SELECT id, ownerId FROM workspaces WHERE id = ?").get(params.workspaceId) as
+    | { id: string; ownerId: string }
+    | undefined;
+  if (!targetWorkspace) throw new Error("工作区不存在");
+
+  const items: Array<{ sourceUserId: string; targetUserId: string; role: string }> = [];
+  let skipped = 0;
+  const transaction = db.transaction(() => {
+    for (const mapping of params.mappings || []) {
+      const source = sourceById.get(String(mapping.sourceUserId || ""));
+      const targetUserId = String(mapping.targetUserId || "");
+      if (!source || !targetUserId) {
+        skipped += 1;
+        continue;
+      }
+      const target = db.prepare("SELECT id FROM users WHERE id = ?").get(targetUserId) as { id: string } | undefined;
+      if (!target) {
+        skipped += 1;
+        continue;
+      }
+      if (targetUserId === targetWorkspace.ownerId) {
+        skipped += 1;
+        continue;
+      }
+      const role = mapping.role === "admin" || mapping.role === "editor" || mapping.role === "viewer"
+        ? mapping.role
+        : roleForApply(source.role);
+      db.prepare(`
+        INSERT INTO workspace_members (workspaceId, userId, role)
+        VALUES (?, ?, ?)
+        ON CONFLICT(workspaceId, userId) DO UPDATE SET role = excluded.role
+      `).run(params.workspaceId, targetUserId, role);
+      items.push({ sourceUserId: source.sourceUserId, targetUserId, role });
+    }
+  });
+  transaction();
+  return { applied: items.length, skipped, items };
+}
+
+export function parsePermissionsFromPackageBuffer(buffer: Buffer): Promise<RoundTripPermissionsManifest | null> {
+  return JSZip.loadAsync(buffer).then(async (zip) => {
+    const entry = zip.file("permissions.json");
+    if (!entry) return null;
+    return validateRoundTripPermissionsManifest(JSON.parse(await entry.async("string")));
+  });
+}

--- a/backend/tests/roundtrip-permission-mapping.test.ts
+++ b/backend/tests/roundtrip-permission-mapping.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import JSZip from "jszip";
+import { getDb } from "../src/db/schema";
+import {
+  applyRoundTripPermissionMappings,
+  buildRoundTripPermissionsManifest,
+  createNowenPackageWithPermissions,
+  previewRoundTripPermissionMappings,
+} from "../src/services/roundTripPermissionMapping";
+
+function reset(): void {
+  const db = getDb();
+  db.exec(`
+    DELETE FROM workspace_members;
+    DELETE FROM workspace_invites;
+    DELETE FROM workspaces;
+    DELETE FROM notes;
+    DELETE FROM notebooks;
+    DELETE FROM users;
+  `);
+}
+
+function user(id: string, username: string, email: string | null = null, role = "user"): void {
+  getDb().prepare(`
+    INSERT INTO users (id, username, email, passwordHash, displayName, role)
+    VALUES (?, ?, ?, 'hash', ?, ?)
+  `).run(id, username, email, username, role);
+}
+
+function workspace(id: string, ownerId: string): void {
+  const db = getDb();
+  db.prepare("INSERT INTO workspaces (id, name, description, ownerId) VALUES (?, ?, '', ?)")
+    .run(id, `Workspace ${id}`, ownerId);
+  db.prepare("INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, 'owner')")
+    .run(id, ownerId);
+}
+
+test.beforeEach(reset);
+
+test("exports only minimal member identity and roles", () => {
+  user("owner", "owner-user", "owner@example.com");
+  user("editor", "editor-user", "editor@example.com");
+  workspace("source", "owner");
+  getDb().prepare("INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, 'editor')")
+    .run("source", "editor");
+
+  const manifest = buildRoundTripPermissionsManifest("owner", "source");
+  assert.equal(manifest.format, "nowen-workspace-permissions");
+  assert.equal(manifest.members.length, 2);
+  assert.deepEqual(Object.keys(manifest.members[0] || {}).sort(), [
+    "displayName", "email", "role", "sourceUserId", "username",
+  ]);
+  assert.equal(JSON.stringify(manifest).includes("passwordHash"), false);
+});
+
+test("rejects permission export by non-owner workspace members", () => {
+  user("owner", "owner-user");
+  user("editor", "editor-user");
+  workspace("source", "owner");
+  getDb().prepare("INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, 'editor')")
+    .run("source", "editor");
+
+  assert.throws(() => buildRoundTripPermissionsManifest("editor", "source"), /所有者/);
+});
+
+test("embeds permissions.json only in the explicit privileged package endpoint", async () => {
+  user("owner", "owner-user", "owner@example.com");
+  workspace("source", "owner");
+  getDb().prepare(`
+    INSERT INTO notebooks (id, userId, workspaceId, name, icon)
+    VALUES ('notebook-1', 'owner', 'source', 'Root', '📒')
+  `).run();
+
+  const result = await createNowenPackageWithPermissions({ userId: "owner", workspaceId: "source" });
+  const zip = await JSZip.loadAsync(result.buffer);
+  assert.ok(zip.file("permissions.json"));
+  const manifest = JSON.parse(await zip.file("manifest.json")!.async("string"));
+  assert.equal(manifest.permissions?.included, true);
+  assert.equal(manifest.permissions?.memberCount, 1);
+});
+
+test("previews exact email matches and downgrades imported owner role", () => {
+  user("target-owner", "target-owner");
+  user("target-editor", "renamed-user", "same@example.com");
+  workspace("target", "target-owner");
+
+  const suggestions = previewRoundTripPermissionMappings("target-owner", "target", {
+    format: "nowen-workspace-permissions",
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    sourceWorkspace: { id: "source", name: "Source" },
+    members: [{
+      sourceUserId: "source-owner",
+      username: "old-name",
+      email: "same@example.com",
+      displayName: "Old",
+      role: "owner",
+    }],
+  });
+
+  assert.equal(suggestions[0]?.match, "email");
+  assert.equal(suggestions[0]?.suggestedTargetUserId, "target-editor");
+  assert.equal(suggestions[0]?.appliedRole, "admin");
+  assert.match(suggestions[0]?.warning || "", /降级/);
+});
+
+test("applies only explicit mappings and never replaces the target owner", () => {
+  user("target-owner", "target-owner");
+  user("mapped", "mapped-user");
+  workspace("target", "target-owner");
+  const manifest = {
+    format: "nowen-workspace-permissions",
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    sourceWorkspace: { id: "source", name: "Source" },
+    members: [
+      { sourceUserId: "source-owner", username: "source-owner", email: null, displayName: null, role: "owner" },
+      { sourceUserId: "source-editor", username: "source-editor", email: null, displayName: null, role: "editor" },
+    ],
+  } as const;
+
+  const result = applyRoundTripPermissionMappings({
+    actorUserId: "target-owner",
+    workspaceId: "target",
+    manifest,
+    mappings: [
+      { sourceUserId: "source-owner", targetUserId: "target-owner" },
+      { sourceUserId: "source-editor", targetUserId: "mapped" },
+    ],
+  });
+  assert.equal(result.applied, 1);
+  assert.equal(result.skipped, 1);
+  const owner = getDb().prepare("SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?")
+    .get("target", "target-owner") as { role: string };
+  const mapped = getDb().prepare("SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?")
+    .get("target", "mapped") as { role: string };
+  assert.equal(owner.role, "owner");
+  assert.equal(mapped.role, "editor");
+});

--- a/frontend/src/lib/__tests__/roundTripPermissionMapping.test.ts
+++ b/frontend/src/lib/__tests__/roundTripPermissionMapping.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({ getBaseUrl: () => "/api" }));
+
+import {
+  applyPermissionMappings,
+  previewPermissionManifest,
+  type RoundTripPermissionsManifest,
+} from "@/lib/roundTripPermissionMapping";
+
+const manifest: RoundTripPermissionsManifest = {
+  format: "nowen-workspace-permissions",
+  version: 1,
+  exportedAt: "2026-07-23T00:00:00.000Z",
+  sourceWorkspace: { id: "source", name: "Source" },
+  members: [{
+    sourceUserId: "source-user",
+    username: "alice",
+    email: "alice@example.com",
+    displayName: "Alice",
+    role: "editor",
+  }],
+};
+
+describe("round-trip permission mapping client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem("nowen-token", "token-1");
+    vi.restoreAllMocks();
+  });
+
+  it("requests mapping preview without applying permissions", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      suggestions: [{
+        sourceUserId: "source-user",
+        username: "alice",
+        email: "alice@example.com",
+        sourceRole: "editor",
+        suggestedTargetUserId: "target-user",
+        suggestedTargetUsername: "alice",
+        match: "email",
+        appliedRole: "editor",
+      }],
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const suggestions = await previewPermissionManifest("target-workspace", manifest);
+    expect(suggestions[0]?.match).toBe("email");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/settings/roundtrip-permissions/preview");
+    expect(init?.method).toBe("POST");
+    expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer token-1");
+    expect(JSON.parse(String(init?.body))).toMatchObject({ workspaceId: "target-workspace" });
+  });
+
+  it("sends only explicit user mappings to the apply endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      applied: 1,
+      skipped: 0,
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const result = await applyPermissionMappings({
+      workspaceId: "target-workspace",
+      manifest,
+      mappings: [{ sourceUserId: "source-user", targetUserId: "target-user", role: "viewer" }],
+    });
+    expect(result.applied).toBe(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      mappings: [{ sourceUserId: "source-user", targetUserId: "target-user", role: "viewer" }],
+    });
+  });
+});

--- a/frontend/src/lib/roundTripPermissionMapping.ts
+++ b/frontend/src/lib/roundTripPermissionMapping.ts
@@ -1,0 +1,105 @@
+import { getBaseUrl } from "./api";
+
+export type WorkspacePermissionRole = "owner" | "admin" | "editor" | "viewer";
+
+export interface RoundTripPermissionMember {
+  sourceUserId: string;
+  username: string;
+  email: string | null;
+  displayName: string | null;
+  role: WorkspacePermissionRole;
+}
+
+export interface RoundTripPermissionsManifest {
+  format: "nowen-workspace-permissions";
+  version: 1;
+  exportedAt: string;
+  sourceWorkspace: { id: string; name: string };
+  members: RoundTripPermissionMember[];
+}
+
+export interface PermissionMappingSuggestion {
+  sourceUserId: string;
+  username: string;
+  email: string | null;
+  sourceRole: WorkspacePermissionRole;
+  suggestedTargetUserId: string | null;
+  suggestedTargetUsername: string | null;
+  match: "email" | "username" | "none" | "ambiguous";
+  appliedRole: "admin" | "editor" | "viewer";
+  warning?: string;
+}
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("nowen-token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => ({})) as T & { error?: string; code?: string };
+  if (!response.ok) {
+    const error = new Error(payload.error || `HTTP ${response.status}`) as Error & { code?: string; status?: number };
+    error.code = payload.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload;
+}
+
+export async function downloadNowenPackageWithPermissions(workspaceId: string): Promise<{ blob: Blob; filename: string }> {
+  const params = new URLSearchParams({ workspaceId });
+  const response = await fetch(`${getBaseUrl()}/settings/roundtrip-permissions/package?${params}`, {
+    credentials: "include",
+    headers: authHeaders(),
+  });
+  if (!response.ok) await parseResponse(response);
+  const disposition = response.headers.get("content-disposition") || "";
+  const encoded = /filename="([^"]+)"/.exec(disposition)?.[1] || "nowen-workspace-with-permissions.zip";
+  let filename = encoded;
+  try { filename = decodeURIComponent(encoded); } catch { /* keep encoded fallback */ }
+  return { blob: await response.blob(), filename };
+}
+
+export async function previewPermissionManifest(
+  workspaceId: string,
+  manifest: RoundTripPermissionsManifest,
+): Promise<PermissionMappingSuggestion[]> {
+  const response = await fetch(`${getBaseUrl()}/settings/roundtrip-permissions/preview`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ workspaceId, manifest }),
+  });
+  const payload = await parseResponse<{ success: boolean; suggestions: PermissionMappingSuggestion[] }>(response);
+  return payload.suggestions || [];
+}
+
+export async function previewPermissionPackage(
+  workspaceId: string,
+  file: File,
+): Promise<{ included: boolean; manifest?: RoundTripPermissionsManifest; suggestions: PermissionMappingSuggestion[] }> {
+  const form = new FormData();
+  form.set("workspaceId", workspaceId);
+  form.set("file", file);
+  const response = await fetch(`${getBaseUrl()}/settings/roundtrip-permissions/preview-package`, {
+    method: "POST",
+    credentials: "include",
+    headers: authHeaders(),
+    body: form,
+  });
+  return parseResponse(response);
+}
+
+export async function applyPermissionMappings(options: {
+  workspaceId: string;
+  manifest: RoundTripPermissionsManifest;
+  mappings: Array<{ sourceUserId: string; targetUserId: string; role?: "admin" | "editor" | "viewer" }>;
+}): Promise<{ applied: number; skipped: number }> {
+  const response = await fetch(`${getBaseUrl()}/settings/roundtrip-permissions/apply`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(options),
+  });
+  return parseResponse(response);
+}


### PR DESCRIPTION
Continues #371 and closes #384.

实现可选的工作区成员权限迁移安全阶段：

- 默认 Nowen Round-trip 包仍不包含权限数据；
- 新增显式的带权限导出端点，仅工作区 owner 或系统管理员可调用；
- 包内新增独立 `permissions.json`，只记录 source user id、用户名、邮箱、显示名和工作区角色；
- 不导出密码哈希、令牌、邀请码、OAuth、AI 密钥或系统管理员角色；
- 导入前可从 JSON 清单或 ZIP 包生成账号映射预览；
- 优先按邮箱精确匹配，其次按用户名匹配；歧义和未匹配不会自动赋权；
- 只有目标工作区 owner 或系统管理员可应用显式映射；
- 源 owner 始终降级为 admin，目标 owner 不会被替换或降权；
- 不自动创建用户，目标账号不存在时跳过；
- 新增后端权限清单、越权拒绝、映射预览、角色应用测试，以及前端客户端请求测试；
- 新增独立 CI，执行后端测试与类型检查、前端测试与类型检查。

API：

- `GET /api/settings/roundtrip-permissions/package?workspaceId=...`
- `POST /api/settings/roundtrip-permissions/preview`
- `POST /api/settings/roundtrip-permissions/preview-package`
- `POST /api/settings/roundtrip-permissions/apply`

说明：权限恢复采用显式映射 API，不会在普通内容导入时静默恢复成员。