### PR TITLE
feat: add explicit permission manifests and account mapping

### DIFF
--- a/.github/workflows/roundtrip-permission-transfer-ci.yml
+++ b/.github/workflows/roundtrip-permission-transfer-ci.yml
@@ -1,0 +1,98 @@
+name: Round-trip Permission Transfer CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/src/routes/import-batches.ts"
+      - "backend/src/services/nowenPackageExportStable.ts"
+      - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/roundTripPermissionTransfer.ts"
+      - "backend/src/services/roundTripImportPermissionUndo.ts"
+      - "backend/tests/roundtrip-permission-transfer.test.ts"
+      - "frontend/src/components/DataManager.tsx"
+      - "frontend/src/components/RoundTripPermissionMappingPanel.tsx"
+      - "frontend/src/components/RoundTripImportReviewCenter.tsx"
+      - "frontend/src/lib/importService.ts"
+      - "frontend/src/lib/roundTripImportReview.ts"
+      - "frontend/src/lib/roundTripPermissionExport.ts"
+      - "frontend/src/lib/__tests__/roundTripImportReview.test.ts"
+      - ".github/workflows/roundtrip-permission-transfer-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/routes/import-batches.ts"
+      - "backend/src/services/nowenPackageExportStable.ts"
+      - "backend/src/services/nowenPackageImport.ts"
+      - "backend/src/services/roundTripPermissionTransfer.ts"
+      - "backend/src/services/roundTripImportPermissionUndo.ts"
+      - "backend/tests/roundtrip-permission-transfer.test.ts"
+      - "frontend/src/components/DataManager.tsx"
+      - "frontend/src/components/RoundTripPermissionMappingPanel.tsx"
+      - "frontend/src/components/RoundTripImportReviewCenter.tsx"
+      - "frontend/src/lib/importService.ts"
+      - "frontend/src/lib/roundTripImportReview.ts"
+      - "frontend/src/lib/roundTripPermissionExport.ts"
+      - "frontend/src/lib/__tests__/roundTripImportReview.test.ts"
+      - ".github/workflows/roundtrip-permission-transfer-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: mkdir -p ../ci-logs
+      - name: Permission manifest, mapping and undo tests
+        run: set -o pipefail; node --import tsx --import ./tests/setup-db-isolation.ts --test tests/roundtrip-permission-transfer.test.ts 2>&1 | tee ../ci-logs/backend-tests.log
+      - name: Backend typecheck
+        if: always()
+        run: set -o pipefail; npm run build:tsc 2>&1 | tee ../ci-logs/backend-typecheck.log
+      - name: Upload backend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-permission-backend-logs
+          path: ci-logs/backend-*.log
+          if-no-files-found: error
+          retention-days: 7
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: mkdir -p ../ci-logs
+      - name: Permission review decision tests
+        run: set -o pipefail; npm run test:run -- src/lib/__tests__/roundTripImportReview.test.ts 2>&1 | tee ../ci-logs/frontend-tests.log
+      - name: Frontend typecheck
+        if: always()
+        run: set -o pipefail; npx tsc -b 2>&1 | tee ../ci-logs/frontend-typecheck.log
+      - name: Upload frontend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundtrip-permission-frontend-logs
+          path: ci-logs/frontend-*.log
+          if-no-files-found: error
+          retention-days: 7

--- a/backend/src/routes/import-batches.ts
+++ b/backend/src/routes/import-batches.ts
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
+import { getDb } from "../db/schema";
 import { getUserWorkspaceRole, hasRole, isSystemAdmin } from "../middleware/acl";
 import {
   getRoundTripImportBatch,
   listRoundTripImportBatches,
   RoundTripImportUndoError,
 } from "../services/roundTripImportBatches";
-import { undoRoundTripImportBatchWithLinks } from "../services/roundTripImportLinkUndo";
+import { undoRoundTripImportBatchWithLinksAndPermissions } from "../services/roundTripImportPermissionUndo";
 import { broadcastToUser } from "../services/realtime";
 
 const app = new Hono();
@@ -14,6 +15,131 @@ function parseWorkspaceFilter(raw: string | undefined): string | null | undefine
   if (raw === undefined || raw === "" || raw === "all") return undefined;
   return raw === "personal" ? null : raw;
 }
+
+function parsePackageWorkspace(raw: string | undefined): string | null {
+  const value = String(raw || "").trim();
+  return !value || value === "personal" ? null : value;
+}
+
+function personalFeatureDisabled(
+  userId: string,
+  workspaceId: string | null,
+  column: "personalExportEnabled" | "personalImportEnabled",
+): boolean {
+  if (workspaceId || isSystemAdmin(userId)) return false;
+  const row = getDb().prepare(`SELECT ${column} AS enabled FROM users WHERE id = ?`).get(userId) as
+    | { enabled: number }
+    | undefined;
+  return row?.enabled === 0;
+}
+
+function canManageWorkspace(userId: string, workspaceId: string | null): boolean {
+  if (!workspaceId) return false;
+  return isSystemAdmin(userId) || hasRole(getUserWorkspaceRole(workspaceId, userId), "admin");
+}
+
+app.get("/package", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const workspaceId = parsePackageWorkspace(c.req.query("workspaceId"));
+  const includePermissions = c.req.query("includePermissions") === "true";
+  if (personalFeatureDisabled(userId, workspaceId, "personalExportEnabled")) {
+    return c.json({ error: "管理员已禁用你的个人空间导出功能", code: "FEATURE_DISABLED" }, 403);
+  }
+  if (includePermissions && !workspaceId) {
+    return c.json({ error: "成员与权限只能随工作区 Nowen 无损包导出", code: "PERMISSION_EXPORT_REQUIRES_WORKSPACE" }, 400);
+  }
+  if (includePermissions && !canManageWorkspace(userId, workspaceId)) {
+    return c.json({ error: "只有工作区 owner/admin 可以导出成员与权限清单", code: "PERMISSION_EXPORT_FORBIDDEN" }, 403);
+  }
+
+  try {
+    const { createStableNowenPackageExport } = await import("../services/nowenPackageExportStable");
+    const result = await createStableNowenPackageExport({
+      userId,
+      workspaceId,
+      notebookId: c.req.query("notebookId") || undefined,
+      includeSubNotebooks: c.req.query("includeSubNotebooks") !== "false",
+      includeTrashed: c.req.query("includeTrashed") === "true",
+      includePermissions,
+    });
+    return new Response(new Uint8Array(result.buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${encodeURIComponent(result.filename)}"`,
+        "X-Export-Notes": String(result.stats.notes),
+        "X-Export-Attachments": String(result.stats.attachments),
+        "X-Export-Warnings": String(result.stats.warnings),
+        "X-Export-Permission-Principals": String((result.stats as any).permissionPrincipals || 0),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message, code: "ROUNDTRIP_EXPORT_FAILED" }, 500);
+  }
+});
+
+app.post("/package", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const workspaceId = parsePackageWorkspace(c.req.query("workspaceId"));
+  const dryRun = c.req.query("dryRun") === "1" || c.req.query("dryRun") === "true";
+  const importMode = (c.req.query("importMode") as "new-root" | "into-target" | "merge" | "sync") || "new-root";
+  const targetNotebookId = c.req.query("targetNotebookId") || undefined;
+  if (personalFeatureDisabled(userId, workspaceId, "personalImportEnabled")) {
+    return c.json({ error: "管理员已禁用你的个人空间导入功能", code: "FEATURE_DISABLED" }, 403);
+  }
+
+  try {
+    const body = await c.req.parseBody();
+    const file = body.file;
+    if (!file || !(file instanceof File)) return c.json({ error: "No file uploaded", code: "NO_FILE" }, 400);
+    const applyPermissions = String(body.applyPermissions || "") === "true";
+    if (applyPermissions && !workspaceId) {
+      return c.json({ error: "成员与权限只能恢复到工作区", code: "PERMISSION_IMPORT_REQUIRES_WORKSPACE" }, 400);
+    }
+    if (applyPermissions && !canManageWorkspace(userId, workspaceId)) {
+      return c.json({ error: "只有目标工作区 owner/admin 可以恢复成员与权限", code: "PERMISSION_IMPORT_FORBIDDEN" }, 403);
+    }
+    let permissionMappings: Record<string, string> = {};
+    if (typeof body.permissionMappings === "string" && body.permissionMappings.trim()) {
+      try {
+        const parsed = JSON.parse(body.permissionMappings) as Record<string, unknown>;
+        permissionMappings = Object.fromEntries(Object.entries(parsed)
+          .map(([source, target]) => [String(source || "").trim(), String(target || "").trim()])
+          .filter(([source, target]) => source && target));
+      } catch {
+        return c.json({ error: "permissionMappings 必须是有效 JSON", code: "INVALID_PERMISSION_MAPPINGS" }, 400);
+      }
+    }
+
+    const zipBuffer = Buffer.from(await file.arrayBuffer());
+    const { importNowenPackage } = await import("../services/nowenPackageImport");
+    const result = await importNowenPackage(zipBuffer, {
+      userId,
+      workspaceId,
+      targetNotebookId,
+      importMode,
+      dryRun,
+      applyPermissions,
+      permissionMappings,
+    });
+    if (!result.success) return c.json(result, 400);
+
+    if (!dryRun) {
+      try {
+        broadcastToUser(userId, {
+          type: "notes:imported",
+          payload: { rootNotebookId: result.rootNotebookId, counts: result.counts },
+        } as any);
+        broadcastToUser(userId, { type: "notebooks:changed", payload: {} } as any);
+      } catch { /* best effort */ }
+    }
+    return c.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message, code: "ROUNDTRIP_IMPORT_FAILED" }, 500);
+  }
+});
 
 app.get("/", (c) => {
   const userId = c.req.header("X-User-Id")!;
@@ -48,7 +174,7 @@ app.post("/:id/undo", async (c) => {
   }
 
   try {
-    const item = await undoRoundTripImportBatchWithLinks(userId, batchId);
+    const item = await undoRoundTripImportBatchWithLinksAndPermissions(userId, batchId);
     try {
       broadcastToUser(userId, {
         type: "notes:imported",

--- a/backend/src/services/nowenPackageExportStable.ts
+++ b/backend/src/services/nowenPackageExportStable.ts
@@ -3,16 +3,29 @@ import {
   type PreparedMarkdownPackageNote,
 } from "./nowenPackageExport";
 import { ensureNowenInstanceEnvironment } from "./nowenInstanceIdentity";
+import { addPermissionsToNowenPackageExport } from "./roundTripPermissionTransfer";
 
 export type { PreparedMarkdownPackageNote };
 
+type StableExportParams = Parameters<typeof createNowenPackageExport>[0] & {
+  includePermissions?: boolean;
+};
+
 /**
  * Ensure all user-facing Round-trip packages carry a stable sourceInstanceId.
- * The underlying exporter keeps its existing ZIP layout and streaming/storage behavior.
+ * Permission/member data is an explicit admin-only extension and remains outside the base exporter.
  */
 export async function createStableNowenPackageExport(
-  params: Parameters<typeof createNowenPackageExport>[0],
-): ReturnType<typeof createNowenPackageExport> {
+  params: StableExportParams,
+): Promise<Awaited<ReturnType<typeof createNowenPackageExport>>> {
   ensureNowenInstanceEnvironment();
-  return createNowenPackageExport(params);
+  const { includePermissions = false, ...baseParams } = params;
+  const result = await createNowenPackageExport(baseParams);
+  if (!includePermissions) return result;
+  if (!baseParams.workspaceId) throw new Error("成员与权限只能随工作区 Nowen 无损包导出");
+  return addPermissionsToNowenPackageExport({
+    result,
+    userId: baseParams.userId,
+    workspaceId: baseParams.workspaceId,
+  });
 }

--- a/backend/src/services/nowenPackageImport.ts
+++ b/backend/src/services/nowenPackageImport.ts
@@ -4,15 +4,28 @@ import {
   captureRoundTripImportLinkUndo,
 } from "./roundTripImportLinkUndo";
 import {
+  applyRoundTripPermissions,
+  augmentRoundTripPermissionPreview,
+  type RoundTripPermissionMappings,
+} from "./roundTripPermissionTransfer";
+import {
   importNowenPackageWithSync,
   type RoundTripImportParams,
 } from "./nowenRoundTripSync";
 
-export async function importNowenPackage(zipBuffer: Buffer, params: RoundTripImportParams): Promise<any> {
-  if (params.dryRun) return importNowenPackageWithSync(zipBuffer, params);
+export interface ImportParams extends RoundTripImportParams {
+  applyPermissions?: boolean;
+  permissionMappings?: RoundTripPermissionMappings;
+}
+
+export async function importNowenPackage(zipBuffer: Buffer, params: ImportParams): Promise<any> {
+  if (params.dryRun) {
+    const preview = await importNowenPackageWithSync(zipBuffer, params);
+    return augmentRoundTripPermissionPreview(zipBuffer, params, preview);
+  }
 
   const linkSnapshot = await captureRoundTripImportLinkUndo(zipBuffer, params.userId, params.workspaceId);
-  const result = await executeNowenPackageImportWithBatch(zipBuffer, params);
+  let result = await executeNowenPackageImportWithBatch(zipBuffer, params);
   const batchId = String(result?.importBatch?.id || "");
   if (batchId && result?.success) {
     const attached = attachRoundTripImportLinkUndo(params.userId, batchId, linkSnapshot);
@@ -23,12 +36,12 @@ export async function importNowenPackage(zipBuffer: Buffer, params: RoundTripImp
         reason: attached.reason ?? result.importBatch?.reason ?? null,
       };
     }
+    result = await applyRoundTripPermissions(zipBuffer, params, result, batchId);
   }
   return result;
 }
 
 export type {
-  RoundTripImportParams as ImportParams,
   RoundTripSyncImportMode as RoundTripImportMode,
   RoundTripSyncStrategy as RoundTripConflictStrategy,
 } from "./nowenRoundTripSync";

--- a/backend/src/services/roundTripImportPermissionUndo.ts
+++ b/backend/src/services/roundTripImportPermissionUndo.ts
@@ -1,0 +1,42 @@
+import { getDb } from "../db/schema";
+import {
+  RoundTripImportUndoError,
+  type RoundTripImportBatchDetail,
+} from "./roundTripImportBatches";
+import { undoRoundTripImportBatchWithLinks } from "./roundTripImportLinkUndo";
+import {
+  readPermissionUndoState,
+  restorePermissionUndoState,
+  validatePermissionUndoState,
+} from "./roundTripPermissionTransfer";
+
+export async function undoRoundTripImportBatchWithLinksAndPermissions(
+  userId: string,
+  batchId: string,
+): Promise<RoundTripImportBatchDetail> {
+  const permissionState = readPermissionUndoState(userId, batchId);
+  if (permissionState) {
+    const conflicts = validatePermissionUndoState(permissionState);
+    if (conflicts.length) {
+      throw new RoundTripImportUndoError(
+        "成员或权限已在导入后发生变化，已拒绝破坏性撤销",
+        "IMPORT_BATCH_UNDO_PERMISSION_CONFLICT",
+        409,
+        conflicts,
+      );
+    }
+  }
+
+  const detail = await undoRoundTripImportBatchWithLinks(userId, batchId);
+  if (!permissionState) return detail;
+
+  try {
+    restorePermissionUndoState(permissionState);
+  } catch (error) {
+    const message = `内容已撤销，但成员与权限恢复失败：${error instanceof Error ? error.message : String(error)}`;
+    getDb().prepare("UPDATE roundtrip_import_batches SET undoError = ? WHERE id = ? AND userId = ?")
+      .run(message, batchId, userId);
+    throw new RoundTripImportUndoError(message, "IMPORT_BATCH_UNDO_PERMISSION_RESTORE_FAILED", 409);
+  }
+  return detail;
+}

--- a/backend/src/services/roundTripPermissionTransfer.ts
+++ b/backend/src/services/roundTripPermissionTransfer.ts
@@ -1,0 +1,777 @@
+import crypto from "crypto";
+import JSZip from "jszip";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+import { getUserWorkspaceRole, hasRole, isSystemAdmin } from "../middleware/acl";
+
+export type RoundTripPermissionMappings = Record<string, string>;
+
+export interface RoundTripPermissionImportOptions {
+  userId: string;
+  workspaceId?: string | null;
+  applyPermissions?: boolean;
+  permissionMappings?: RoundTripPermissionMappings;
+}
+
+type WorkspaceRole = "owner" | "admin" | "editor" | "commenter" | "viewer";
+type NotebookRole = "owner" | "editor" | "viewer";
+
+interface PackageManifest {
+  format?: string;
+  formatVersion?: number;
+  app?: string;
+  packageKind?: string;
+  sourceInstanceId?: string | null;
+  exportedAt?: string;
+  permissions?: Record<string, unknown>;
+}
+
+interface PermissionPrincipal {
+  sourceUserId: string;
+  username: string;
+  displayName: string | null;
+  email: string | null;
+}
+
+interface PermissionWorkspaceMember {
+  sourceUserId: string;
+  role: WorkspaceRole;
+  joinedAt?: string | null;
+}
+
+interface PermissionNotebookMember {
+  sourceNotebookId: string;
+  sourceUserId: string;
+  role: NotebookRole;
+  allowDownload: boolean;
+  allowReshare: boolean;
+}
+
+interface PermissionManifest {
+  version: 1;
+  exportedAt: string;
+  workspace: {
+    sourceWorkspaceId: string;
+    name: string;
+  };
+  principals: PermissionPrincipal[];
+  workspaceMembers: PermissionWorkspaceMember[];
+  notebookMembers: PermissionNotebookMember[];
+}
+
+interface PublicTargetUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface RoundTripPermissionInspection {
+  included: boolean;
+  valid: boolean;
+  canApply: boolean;
+  reason: string | null;
+  counts: {
+    principals: number;
+    workspaceMembers: number;
+    notebookMembers: number;
+  };
+  principals: Array<PermissionPrincipal & {
+    workspaceRole: WorkspaceRole | null;
+    suggestedTarget: PublicTargetUser | null;
+    match: "email" | "username" | "ambiguous" | "none";
+  }>;
+  issues: string[];
+}
+
+interface PermissionUndoRow {
+  table: "workspace_members" | "notebook_members";
+  key: Record<string, string>;
+  before: Record<string, unknown> | null;
+  afterHash: string;
+}
+
+export interface PermissionUndoState {
+  version: 1;
+  workspaceId: string;
+  rows: PermissionUndoRow[];
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(source).sort().map((key) => [key, stableValue(source[key])]));
+  }
+  return value;
+}
+
+function hashRow(row: Record<string, unknown> | null): string {
+  return crypto.createHash("sha256").update(JSON.stringify(stableValue(row))).digest("hex");
+}
+
+function normalizedEmail(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function normalizedUsername(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function workspaceScope(workspaceId: string | null | undefined): string {
+  return workspaceId || "personal";
+}
+
+function canManageWorkspace(userId: string, workspaceId: string | null | undefined): boolean {
+  if (!workspaceId) return false;
+  if (isSystemAdmin(userId)) return true;
+  return hasRole(getUserWorkspaceRole(workspaceId, userId), "admin");
+}
+
+function workspaceRoleRank(role: string | null | undefined): number {
+  switch (role) {
+    case "owner": return 5;
+    case "admin": return 4;
+    case "editor": return 3;
+    case "commenter": return 2;
+    case "viewer": return 1;
+    default: return 0;
+  }
+}
+
+function notebookRoleRank(role: string | null | undefined): number {
+  switch (role) {
+    case "owner": return 3;
+    case "editor": return 2;
+    case "viewer": return 1;
+    default: return 0;
+  }
+}
+
+function parseWorkspaceRole(value: unknown): WorkspaceRole | null {
+  return value === "owner" || value === "admin" || value === "editor" || value === "commenter" || value === "viewer"
+    ? value
+    : null;
+}
+
+function parseNotebookRole(value: unknown): NotebookRole | null {
+  return value === "owner" || value === "editor" || value === "viewer" ? value : null;
+}
+
+async function readJson<T>(zip: JSZip, filename: string): Promise<T | null> {
+  const entry = zip.file(filename);
+  if (!entry) return null;
+  try { return JSON.parse(await entry.async("string")) as T; }
+  catch { return null; }
+}
+
+async function readPermissionPackage(zipBuffer: Buffer): Promise<{
+  zip: JSZip;
+  manifest: PackageManifest | null;
+  permissions: PermissionManifest | null;
+  issues: string[];
+}> {
+  const issues: string[] = [];
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(zipBuffer);
+  } catch {
+    return { zip: new JSZip(), manifest: null, permissions: null, issues: ["无法解析数据包"] };
+  }
+  const manifest = await readJson<PackageManifest>(zip, "manifest.json");
+  if (!manifest || manifest.format !== "nowen-package" || manifest.app !== "nowen-note") {
+    issues.push("数据包 manifest 无效");
+  }
+  const raw = await readJson<Record<string, unknown>>(zip, "permissions.json");
+  if (!raw) return { zip, manifest, permissions: null, issues };
+  if (Number(raw.version) !== 1) issues.push("permissions.json 版本不受支持");
+  const workspaceRaw = raw.workspace && typeof raw.workspace === "object"
+    ? raw.workspace as Record<string, unknown>
+    : {};
+  const principalRows = Array.isArray(raw.principals) ? raw.principals : [];
+  const workspaceRows = Array.isArray(raw.workspaceMembers) ? raw.workspaceMembers : [];
+  const notebookRows = Array.isArray(raw.notebookMembers) ? raw.notebookMembers : [];
+  const principals: PermissionPrincipal[] = [];
+  const principalIds = new Set<string>();
+  for (const item of principalRows) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const sourceUserId = String(row.sourceUserId || "").trim();
+    const username = String(row.username || "").trim();
+    if (!sourceUserId || !username || principalIds.has(sourceUserId)) {
+      issues.push("权限成员身份清单存在缺失或重复项");
+      continue;
+    }
+    principalIds.add(sourceUserId);
+    principals.push({
+      sourceUserId,
+      username,
+      displayName: row.displayName == null ? null : String(row.displayName),
+      email: row.email == null ? null : String(row.email),
+    });
+  }
+  const workspaceMembers: PermissionWorkspaceMember[] = [];
+  for (const item of workspaceRows) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const sourceUserId = String(row.sourceUserId || "").trim();
+    const role = parseWorkspaceRole(row.role);
+    if (!sourceUserId || !role || !principalIds.has(sourceUserId)) {
+      issues.push("工作区成员授权引用了无效成员或角色");
+      continue;
+    }
+    workspaceMembers.push({ sourceUserId, role, joinedAt: row.joinedAt == null ? null : String(row.joinedAt) });
+  }
+  const notebookMembers: PermissionNotebookMember[] = [];
+  for (const item of notebookRows) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const sourceNotebookId = String(row.sourceNotebookId || "").trim();
+    const sourceUserId = String(row.sourceUserId || "").trim();
+    const role = parseNotebookRole(row.role);
+    if (!sourceNotebookId || !sourceUserId || !role || !principalIds.has(sourceUserId)) {
+      issues.push("笔记本成员授权引用了无效目录、成员或角色");
+      continue;
+    }
+    notebookMembers.push({
+      sourceNotebookId,
+      sourceUserId,
+      role,
+      allowDownload: row.allowDownload !== false && Number(row.allowDownload) !== 0,
+      allowReshare: row.allowReshare === true || Number(row.allowReshare) === 1,
+    });
+  }
+  const sourceWorkspaceId = String(workspaceRaw.sourceWorkspaceId || "").trim();
+  if (!sourceWorkspaceId) issues.push("权限清单缺少来源工作区标识");
+  const permissions: PermissionManifest = {
+    version: 1,
+    exportedAt: String(raw.exportedAt || manifest?.exportedAt || new Date().toISOString()),
+    workspace: {
+      sourceWorkspaceId,
+      name: String(workspaceRaw.name || "工作区"),
+    },
+    principals,
+    workspaceMembers,
+    notebookMembers,
+  };
+  return { zip, manifest, permissions, issues };
+}
+
+function targetUserByExactEmail(email: string): PublicTargetUser[] {
+  if (!email) return [];
+  return getDb().prepare(`
+    SELECT id, username, displayName, avatarUrl
+      FROM users
+     WHERE isDisabled = 0 AND LOWER(COALESCE(email, '')) = ?
+     ORDER BY username
+  `).all(email) as PublicTargetUser[];
+}
+
+function targetUserByExactUsername(username: string): PublicTargetUser[] {
+  if (!username) return [];
+  return getDb().prepare(`
+    SELECT id, username, displayName, avatarUrl
+      FROM users
+     WHERE isDisabled = 0 AND LOWER(username) = ?
+     ORDER BY username
+  `).all(username) as PublicTargetUser[];
+}
+
+export async function inspectRoundTripPermissions(
+  zipBuffer: Buffer,
+  options: Pick<RoundTripPermissionImportOptions, "userId" | "workspaceId">,
+): Promise<RoundTripPermissionInspection> {
+  const parsed = await readPermissionPackage(zipBuffer);
+  if (!parsed.permissions) {
+    return {
+      included: false,
+      valid: true,
+      canApply: false,
+      reason: null,
+      counts: { principals: 0, workspaceMembers: 0, notebookMembers: 0 },
+      principals: [],
+      issues: parsed.issues,
+    };
+  }
+  const workspaceId = options.workspaceId || null;
+  const issues = [...parsed.issues];
+  if (parsed.manifest?.packageKind === "markdown") issues.push("Markdown 往返包不支持成员与权限恢复");
+  if (!workspaceId) issues.push("成员与权限只能恢复到工作区，不能恢复到个人空间");
+  const canApply = !!workspaceId && canManageWorkspace(options.userId, workspaceId) && issues.length === 0;
+  const roleBySource = new Map(parsed.permissions.workspaceMembers.map((item) => [item.sourceUserId, item.role]));
+  const principals = parsed.permissions.principals.map((principal) => {
+    const emailMatches = targetUserByExactEmail(normalizedEmail(principal.email));
+    if (emailMatches.length === 1) {
+      return { ...principal, workspaceRole: roleBySource.get(principal.sourceUserId) || null, suggestedTarget: emailMatches[0], match: "email" as const };
+    }
+    if (emailMatches.length > 1) {
+      return { ...principal, workspaceRole: roleBySource.get(principal.sourceUserId) || null, suggestedTarget: null, match: "ambiguous" as const };
+    }
+    const usernameMatches = targetUserByExactUsername(normalizedUsername(principal.username));
+    if (usernameMatches.length === 1) {
+      return { ...principal, workspaceRole: roleBySource.get(principal.sourceUserId) || null, suggestedTarget: usernameMatches[0], match: "username" as const };
+    }
+    return {
+      ...principal,
+      workspaceRole: roleBySource.get(principal.sourceUserId) || null,
+      suggestedTarget: null,
+      match: usernameMatches.length > 1 ? "ambiguous" as const : "none" as const,
+    };
+  });
+  return {
+    included: true,
+    valid: issues.length === 0,
+    canApply,
+    reason: !workspaceId
+      ? "请选择目标工作区"
+      : !canManageWorkspace(options.userId, workspaceId)
+        ? "只有目标工作区 owner/admin 可以恢复成员与权限"
+        : issues[0] || null,
+    counts: {
+      principals: parsed.permissions.principals.length,
+      workspaceMembers: parsed.permissions.workspaceMembers.length,
+      notebookMembers: parsed.permissions.notebookMembers.length,
+    },
+    principals,
+    issues,
+  };
+}
+
+function withPermissionInspection(result: any, inspection: RoundTripPermissionInspection): any {
+  return {
+    ...result,
+    package: {
+      ...(result?.package || {}),
+      permissions: inspection,
+    },
+  };
+}
+
+export async function augmentRoundTripPermissionPreview(
+  zipBuffer: Buffer,
+  options: Pick<RoundTripPermissionImportOptions, "userId" | "workspaceId">,
+  result: any,
+): Promise<any> {
+  return withPermissionInspection(result, await inspectRoundTripPermissions(zipBuffer, options));
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function insertDynamic(table: string, row: Record<string, unknown>): void {
+  const columns = Object.keys(row);
+  getDb().prepare(`INSERT INTO ${quoteIdentifier(table)} (${columns.map(quoteIdentifier).join(", ")}) VALUES (${columns.map(() => "?").join(", ")})`)
+    .run(...columns.map((column) => row[column]));
+}
+
+function currentWorkspaceMember(workspaceId: string, userId: string): Record<string, unknown> | null {
+  return getDb().prepare(`SELECT * FROM workspace_members WHERE workspaceId = ? AND userId = ?`)
+    .get(workspaceId, userId) as Record<string, unknown> | undefined || null;
+}
+
+function currentNotebookMember(notebookId: string, userId: string): Record<string, unknown> | null {
+  return getDb().prepare(`SELECT * FROM notebook_members WHERE notebookId = ? AND userId = ?`)
+    .get(notebookId, userId) as Record<string, unknown> | undefined || null;
+}
+
+function mappedTargetNotebooks(userId: string, workspaceId: string, sourceInstanceId: string): Map<string, string> {
+  const rows = getDb().prepare(`
+    SELECT sourceResourceId, targetResourceId
+      FROM roundtrip_import_links
+     WHERE userId = ? AND workspaceScope = ? AND sourceInstanceId = ? AND resourceType = 'notebook'
+  `).all(userId, workspaceScope(workspaceId), sourceInstanceId) as Array<{ sourceResourceId: string; targetResourceId: string }>;
+  return new Map(rows.map((row) => [row.sourceResourceId, row.targetResourceId]));
+}
+
+function activeTargetUsers(ids: string[]): Map<string, { id: string; username: string }> {
+  if (!ids.length) return new Map();
+  const rows = getDb().prepare(`SELECT id, username FROM users WHERE isDisabled = 0 AND id IN (${ids.map(() => "?").join(",")})`)
+    .all(...ids) as Array<{ id: string; username: string }>;
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+function mergeResultWarnings(result: any, messages: string[]): any {
+  if (!messages.length) return result;
+  return {
+    ...result,
+    warnings: [
+      ...(Array.isArray(result?.warnings) ? result.warnings : []),
+      ...messages.map((message) => ({ type: "permission_import", message })),
+    ],
+  };
+}
+
+function updateBatchReports(
+  userId: string,
+  batchId: string,
+  result: any,
+  inspection: RoundTripPermissionInspection,
+): void {
+  const batch = getDb().prepare(`SELECT previewJson FROM roundtrip_import_batches WHERE id = ? AND userId = ?`)
+    .get(batchId, userId) as { previewJson: string } | undefined;
+  if (!batch) return;
+  let preview: any = {};
+  try { preview = JSON.parse(batch.previewJson || "{}"); } catch { preview = {}; }
+  preview = withPermissionInspection(preview, inspection);
+  getDb().prepare(`UPDATE roundtrip_import_batches SET previewJson = ?, resultJson = ? WHERE id = ? AND userId = ?`)
+    .run(JSON.stringify(preview), JSON.stringify(result || {}), batchId, userId);
+}
+
+export async function applyRoundTripPermissions(
+  zipBuffer: Buffer,
+  options: RoundTripPermissionImportOptions,
+  result: any,
+  batchId?: string,
+): Promise<any> {
+  const inspection = await inspectRoundTripPermissions(zipBuffer, options);
+  let finalResult = withPermissionInspection(result, inspection);
+  const parsed = await readPermissionPackage(zipBuffer);
+  const requested = options.applyPermissions === true;
+  const baseReport = {
+    included: inspection.included,
+    requested,
+    applied: false,
+    counts: {
+      mappedPrincipals: 0,
+      workspaceAdded: 0,
+      workspaceUpgraded: 0,
+      workspacePreserved: 0,
+      notebookAdded: 0,
+      notebookUpgraded: 0,
+      notebookPreserved: 0,
+      skipped: 0,
+    },
+    issues: [] as string[],
+  };
+  if (!inspection.included || !requested) {
+    finalResult = { ...finalResult, permissionImport: baseReport };
+    if (batchId) updateBatchReports(options.userId, batchId, finalResult, inspection);
+    return finalResult;
+  }
+  const workspaceId = options.workspaceId || null;
+  if (!parsed.permissions || !parsed.manifest || !workspaceId || !inspection.canApply) {
+    baseReport.issues.push(inspection.reason || inspection.issues[0] || "权限清单不可应用");
+    baseReport.counts.skipped = inspection.counts.workspaceMembers + inspection.counts.notebookMembers;
+    finalResult = mergeResultWarnings({ ...finalResult, permissionImport: baseReport }, baseReport.issues);
+    if (batchId) updateBatchReports(options.userId, batchId, finalResult, inspection);
+    return finalResult;
+  }
+  if (!batchId) {
+    baseReport.issues.push("导入批次不存在，为保证可撤销性，未应用成员与权限");
+    finalResult = mergeResultWarnings({ ...finalResult, permissionImport: baseReport }, baseReport.issues);
+    return finalResult;
+  }
+  if (result?.importBatch?.undoAvailable === false) {
+    baseReport.issues.push(result.importBatch?.reason || "本次导入没有安全撤销点，未应用成员与权限");
+    baseReport.counts.skipped = inspection.counts.workspaceMembers + inspection.counts.notebookMembers;
+    finalResult = mergeResultWarnings({ ...finalResult, permissionImport: baseReport }, baseReport.issues);
+    updateBatchReports(options.userId, batchId, finalResult, inspection);
+    return finalResult;
+  }
+
+  const mappings = Object.fromEntries(Object.entries(options.permissionMappings || {})
+    .map(([source, target]) => [String(source || "").trim(), String(target || "").trim()])
+    .filter(([source, target]) => source && target)) as RoundTripPermissionMappings;
+  const sourceIds = new Set(parsed.permissions.principals.map((item) => item.sourceUserId));
+  const duplicateTargets = new Set<string>();
+  const seenTargets = new Set<string>();
+  for (const [sourceId, targetId] of Object.entries(mappings)) {
+    if (!sourceIds.has(sourceId)) {
+      delete mappings[sourceId];
+      baseReport.issues.push(`忽略未知来源成员映射：${sourceId}`);
+      continue;
+    }
+    if (seenTargets.has(targetId)) duplicateTargets.add(targetId);
+    seenTargets.add(targetId);
+  }
+  if (duplicateTargets.size) {
+    baseReport.issues.push("一个目标账号不能同时映射多个来源成员，请调整映射后重试");
+    baseReport.counts.skipped = inspection.counts.workspaceMembers + inspection.counts.notebookMembers;
+    finalResult = mergeResultWarnings({ ...finalResult, permissionImport: baseReport }, baseReport.issues);
+    updateBatchReports(options.userId, batchId, finalResult, inspection);
+    return finalResult;
+  }
+  const targets = activeTargetUsers(Object.values(mappings));
+  for (const [sourceId, targetId] of Object.entries(mappings)) {
+    if (!targets.has(targetId)) {
+      delete mappings[sourceId];
+      baseReport.issues.push(`目标账号不存在或已停用，已跳过来源成员：${sourceId}`);
+    }
+  }
+  baseReport.counts.mappedPrincipals = Object.keys(mappings).length;
+  const sourceInstanceId = String(parsed.manifest.sourceInstanceId || "").trim();
+  const notebookMap = sourceInstanceId
+    ? mappedTargetNotebooks(options.userId, workspaceId, sourceInstanceId)
+    : new Map<string, string>();
+  if (parsed.permissions.notebookMembers.length && !notebookMap.size) {
+    baseReport.issues.push("未找到来源目录到目标目录的稳定映射，笔记本直接授权将被跳过");
+  }
+
+  const undoRows: PermissionUndoRow[] = [];
+  const tx = getDb().transaction(() => {
+    for (const member of parsed.permissions!.workspaceMembers) {
+      const targetUserId = mappings[member.sourceUserId];
+      if (!targetUserId) {
+        baseReport.counts.skipped += 1;
+        continue;
+      }
+      const before = currentWorkspaceMember(workspaceId, targetUserId);
+      const desired: WorkspaceRole = member.role === "owner" ? "admin" : member.role;
+      if (!before) {
+        getDb().prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+          .run(workspaceId, targetUserId, desired);
+        baseReport.counts.workspaceAdded += 1;
+      } else if (String(before.role) === "owner" || workspaceRoleRank(String(before.role)) >= workspaceRoleRank(desired)) {
+        baseReport.counts.workspacePreserved += 1;
+        continue;
+      } else {
+        getDb().prepare(`UPDATE workspace_members SET role = ? WHERE workspaceId = ? AND userId = ?`)
+          .run(desired, workspaceId, targetUserId);
+        baseReport.counts.workspaceUpgraded += 1;
+      }
+      const after = currentWorkspaceMember(workspaceId, targetUserId)!;
+      undoRows.push({
+        table: "workspace_members",
+        key: { workspaceId, userId: targetUserId },
+        before,
+        afterHash: hashRow(after),
+      });
+    }
+
+    for (const member of parsed.permissions!.notebookMembers) {
+      const targetUserId = mappings[member.sourceUserId];
+      const targetNotebookId = notebookMap.get(member.sourceNotebookId);
+      if (!targetUserId || !targetNotebookId) {
+        baseReport.counts.skipped += 1;
+        continue;
+      }
+      const before = currentNotebookMember(targetNotebookId, targetUserId);
+      const desired: "editor" | "viewer" = member.role === "viewer" ? "viewer" : "editor";
+      if (!before || String(before.status) === "removed") {
+        if (before) {
+          getDb().prepare(`
+            UPDATE notebook_members
+               SET role = ?, status = 'active', allowDownload = ?, allowReshare = ?, source = 'manual', sourceId = NULL,
+                   invitedBy = ?, updatedAt = datetime('now')
+             WHERE notebookId = ? AND userId = ?
+          `).run(desired, member.allowDownload ? 1 : 0, member.allowReshare ? 1 : 0, options.userId, targetNotebookId, targetUserId);
+        } else {
+          getDb().prepare(`
+            INSERT INTO notebook_members (
+              id, notebookId, userId, role, status, allowDownload, allowReshare, source, sourceId, invitedBy
+            ) VALUES (?, ?, ?, ?, 'active', ?, ?, 'manual', NULL, ?)
+          `).run(uuid(), targetNotebookId, targetUserId, desired, member.allowDownload ? 1 : 0, member.allowReshare ? 1 : 0, options.userId);
+        }
+        baseReport.counts.notebookAdded += 1;
+      } else if (String(before.role) === "owner") {
+        baseReport.counts.notebookPreserved += 1;
+        continue;
+      } else {
+        const nextRole = notebookRoleRank(String(before.role)) >= notebookRoleRank(desired) ? String(before.role) : desired;
+        const nextDownload = Number(before.allowDownload) === 1 || member.allowDownload ? 1 : 0;
+        const nextReshare = Number(before.allowReshare) === 1 || member.allowReshare ? 1 : 0;
+        if (
+          nextRole === String(before.role)
+          && nextDownload === Number(before.allowDownload)
+          && nextReshare === Number(before.allowReshare)
+        ) {
+          baseReport.counts.notebookPreserved += 1;
+          continue;
+        }
+        getDb().prepare(`
+          UPDATE notebook_members
+             SET role = ?, allowDownload = ?, allowReshare = ?, updatedAt = datetime('now')
+           WHERE notebookId = ? AND userId = ?
+        `).run(nextRole, nextDownload, nextReshare, targetNotebookId, targetUserId);
+        baseReport.counts.notebookUpgraded += 1;
+      }
+      const after = currentNotebookMember(targetNotebookId, targetUserId)!;
+      undoRows.push({
+        table: "notebook_members",
+        key: { notebookId: targetNotebookId, userId: targetUserId },
+        before,
+        afterHash: hashRow(after),
+      });
+    }
+
+    baseReport.applied = undoRows.length > 0;
+    const batch = getDb().prepare(`SELECT undoStateJson, previewJson FROM roundtrip_import_batches WHERE id = ? AND userId = ?`)
+      .get(batchId, options.userId) as { undoStateJson: string; previewJson: string } | undefined;
+    if (!batch) throw new Error("导入批次不存在，无法保存权限撤销点");
+    let undoState: Record<string, unknown> = {};
+    let previewState: any = {};
+    try { undoState = JSON.parse(batch.undoStateJson || "{}"); } catch { undoState = {}; }
+    try { previewState = JSON.parse(batch.previewJson || "{}"); } catch { previewState = {}; }
+    (undoState as any).permissionMembers = {
+      version: 1,
+      workspaceId,
+      rows: undoRows,
+    } satisfies PermissionUndoState;
+    finalResult = { ...finalResult, permissionImport: baseReport };
+    finalResult = mergeResultWarnings(finalResult, baseReport.issues);
+    previewState = withPermissionInspection(previewState, inspection);
+    getDb().prepare(`
+      UPDATE roundtrip_import_batches
+         SET undoStateJson = ?, previewJson = ?, resultJson = ?
+       WHERE id = ? AND userId = ?
+    `).run(JSON.stringify(undoState), JSON.stringify(previewState), JSON.stringify(finalResult), batchId, options.userId);
+  });
+
+  try {
+    tx();
+  } catch (error) {
+    baseReport.applied = false;
+    baseReport.issues.push(`成员与权限恢复失败，内容已保留且权限变更已回滚：${error instanceof Error ? error.message : String(error)}`);
+    finalResult = mergeResultWarnings({ ...withPermissionInspection(result, inspection), permissionImport: baseReport }, baseReport.issues);
+    updateBatchReports(options.userId, batchId, finalResult, inspection);
+  }
+  return finalResult;
+}
+
+function rowForUndo(item: PermissionUndoRow): Record<string, unknown> | null {
+  return item.table === "workspace_members"
+    ? currentWorkspaceMember(item.key.workspaceId, item.key.userId)
+    : currentNotebookMember(item.key.notebookId, item.key.userId);
+}
+
+export function readPermissionUndoState(userId: string, batchId: string): PermissionUndoState | null {
+  const row = getDb().prepare(`SELECT undoStateJson FROM roundtrip_import_batches WHERE id = ? AND userId = ?`)
+    .get(batchId, userId) as { undoStateJson: string } | undefined;
+  if (!row) return null;
+  try {
+    const state = JSON.parse(row.undoStateJson || "{}") as { permissionMembers?: PermissionUndoState };
+    return state.permissionMembers?.version === 1 ? state.permissionMembers : null;
+  } catch {
+    return null;
+  }
+}
+
+export function validatePermissionUndoState(state: PermissionUndoState): string[] {
+  const conflicts: string[] = [];
+  for (const item of state.rows) {
+    const current = rowForUndo(item);
+    if (hashRow(current) !== item.afterHash) {
+      const target = item.table === "workspace_members"
+        ? `工作区成员 ${item.key.userId}`
+        : `笔记本成员 ${item.key.notebookId}/${item.key.userId}`;
+      conflicts.push(`${target} 已在导入后发生变化`);
+    }
+  }
+  return conflicts;
+}
+
+export function restorePermissionUndoState(state: PermissionUndoState): void {
+  const tx = getDb().transaction(() => {
+    for (const item of state.rows.slice().reverse()) {
+      if (item.table === "workspace_members") {
+        getDb().prepare(`DELETE FROM workspace_members WHERE workspaceId = ? AND userId = ?`)
+          .run(item.key.workspaceId, item.key.userId);
+      } else {
+        getDb().prepare(`DELETE FROM notebook_members WHERE notebookId = ? AND userId = ?`)
+          .run(item.key.notebookId, item.key.userId);
+      }
+      if (item.before) insertDynamic(item.table, item.before);
+    }
+  });
+  tx();
+}
+
+export async function addPermissionsToNowenPackageExport<TStats extends object>(args: {
+  result: { buffer: Buffer; filename: string; stats: TStats };
+  userId: string;
+  workspaceId: string;
+}): Promise<{
+  buffer: Buffer;
+  filename: string;
+  stats: TStats & {
+    permissionPrincipals: number;
+    workspaceMembers: number;
+    notebookMembers: number;
+  };
+}> {
+  if (!canManageWorkspace(args.userId, args.workspaceId)) {
+    throw new Error("只有工作区 owner/admin 可以导出成员与权限清单");
+  }
+  const zip = await JSZip.loadAsync(args.result.buffer);
+  const manifest = await readJson<Record<string, unknown>>(zip, "manifest.json");
+  if (!manifest || manifest.packageKind === "markdown") throw new Error("只有 Nowen 无损包支持权限导出");
+  const tree = await readJson<{ nodes?: Array<{ sourceId?: string }> }>(zip, "tree.json");
+  const notebookIds = (tree?.nodes || []).map((item) => String(item.sourceId || "")).filter(Boolean);
+  const workspace = getDb().prepare(`SELECT id, name FROM workspaces WHERE id = ?`).get(args.workspaceId) as
+    | { id: string; name: string }
+    | undefined;
+  if (!workspace) throw new Error("工作区不存在");
+  const workspaceMembers = getDb().prepare(`
+    SELECT m.userId AS sourceUserId, m.role, m.joinedAt
+      FROM workspace_members m
+      JOIN users u ON u.id = m.userId
+     WHERE m.workspaceId = ?
+     ORDER BY m.joinedAt, m.userId
+  `).all(args.workspaceId) as Array<{ sourceUserId: string; role: WorkspaceRole; joinedAt: string }>;
+  const notebookMembers = notebookIds.length
+    ? getDb().prepare(`
+        SELECT nm.notebookId AS sourceNotebookId, nm.userId AS sourceUserId, nm.role,
+               nm.allowDownload, nm.allowReshare
+          FROM notebook_members nm
+          JOIN users u ON u.id = nm.userId
+         WHERE nm.status != 'removed' AND nm.notebookId IN (${notebookIds.map(() => "?").join(",")})
+         ORDER BY nm.notebookId, nm.userId
+      `).all(...notebookIds) as Array<{
+        sourceNotebookId: string;
+        sourceUserId: string;
+        role: NotebookRole;
+        allowDownload: number;
+        allowReshare: number;
+      }>
+    : [];
+  const principalIds = [...new Set([
+    ...workspaceMembers.map((item) => item.sourceUserId),
+    ...notebookMembers.map((item) => item.sourceUserId),
+  ])];
+  const principals = principalIds.length
+    ? getDb().prepare(`
+        SELECT id AS sourceUserId, username, displayName, email
+          FROM users
+         WHERE id IN (${principalIds.map(() => "?").join(",")})
+         ORDER BY username
+      `).all(...principalIds) as PermissionPrincipal[]
+    : [];
+  const permissions: PermissionManifest = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    workspace: { sourceWorkspaceId: workspace.id, name: workspace.name },
+    principals,
+    workspaceMembers: workspaceMembers.map((item) => ({
+      sourceUserId: item.sourceUserId,
+      role: item.role,
+      joinedAt: item.joinedAt,
+    })),
+    notebookMembers: notebookMembers.map((item) => ({
+      sourceNotebookId: item.sourceNotebookId,
+      sourceUserId: item.sourceUserId,
+      role: item.role,
+      allowDownload: item.allowDownload !== 0,
+      allowReshare: item.allowReshare === 1,
+    })),
+  };
+  zip.file("permissions.json", JSON.stringify(permissions, null, 2));
+  manifest.permissions = {
+    included: true,
+    version: 1,
+    principals: principals.length,
+    workspaceMembers: workspaceMembers.length,
+    notebookMembers: notebookMembers.length,
+  };
+  zip.file("manifest.json", JSON.stringify(manifest, null, 2));
+  return {
+    ...args.result,
+    buffer: await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE", compressionOptions: { level: 6 } }),
+    stats: {
+      ...args.result.stats,
+      permissionPrincipals: principals.length,
+      workspaceMembers: workspaceMembers.length,
+      notebookMembers: notebookMembers.length,
+    },
+  };
+}

--- a/backend/tests/roundtrip-permission-legacy-compat.test.ts
+++ b/backend/tests/roundtrip-permission-legacy-compat.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-permission-legacy-compat-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+let closeDb: typeof import("../src/db/schema").closeDb;
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("integrated permission preflight accepts the earlier workspace-only manifest", async () => {
+  const schema = await import("../src/db/schema");
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+  db.prepare(`INSERT INTO users (id, username, email, passwordHash, role, displayName) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("actor", "actor", "actor@example.com", "hash", "admin", "Actor");
+  db.prepare(`INSERT INTO users (id, username, email, passwordHash, displayName) VALUES (?, ?, ?, ?, ?)`)
+    .run("target-user", "target-user", "legacy@example.com", "hash", "Target User");
+  db.prepare(`INSERT INTO workspaces (id, name, ownerId) VALUES (?, ?, ?)`)
+    .run("target-workspace", "目标工作区", "actor");
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+    .run("target-workspace", "actor", "owner");
+
+  const zip = new JSZip();
+  zip.file("manifest.json", JSON.stringify({
+    format: "nowen-package",
+    formatVersion: 2,
+    app: "nowen-note",
+    packageKind: "nowen",
+    exportedAt: "2026-07-23T00:00:00.000Z",
+    sourceInstanceId: "legacy-permission-source",
+  }));
+  zip.file("permissions.json", JSON.stringify({
+    format: "nowen-workspace-permissions",
+    version: 1,
+    exportedAt: "2026-07-23T00:00:00.000Z",
+    sourceWorkspace: { id: "legacy-workspace", name: "旧版来源工作区" },
+    members: [{
+      sourceUserId: "legacy-member",
+      username: "legacy-user",
+      email: "legacy@example.com",
+      displayName: "Legacy User",
+      role: "editor",
+    }],
+  }));
+
+  const buffer = await zip.generateAsync({ type: "nodebuffer" });
+  const { inspectRoundTripPermissions } = await import("../src/services/roundTripPermissionTransfer");
+  const inspection = await inspectRoundTripPermissions(buffer, {
+    userId: "actor",
+    workspaceId: "target-workspace",
+  });
+
+  assert.equal(inspection.included, true);
+  assert.equal(inspection.valid, true, inspection.issues.join("; "));
+  assert.equal(inspection.canApply, true);
+  assert.deepEqual(inspection.counts, { principals: 1, workspaceMembers: 1, notebookMembers: 0 });
+  assert.equal(inspection.principals[0]?.sourceUserId, "legacy-member");
+  assert.equal(inspection.principals[0]?.workspaceRole, "editor");
+  assert.equal(inspection.principals[0]?.match, "email");
+  assert.equal(inspection.principals[0]?.suggestedTarget?.id, "target-user");
+});

--- a/backend/tests/roundtrip-permission-transfer.test.ts
+++ b/backend/tests/roundtrip-permission-transfer.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-permission-transfer-test-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+process.env.ROUNDTRIP_IMPORT_UNDO_TTL_HOURS = "24";
+process.env.NOWEN_INSTANCE_ID = "permission-transfer-instance";
+
+let closeDb: typeof import("../src/db/schema").closeDb;
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function seed() {
+  const schema = await import("../src/db/schema");
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+  db.prepare(`INSERT INTO users (id, username, email, passwordHash, role, displayName) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("operator", "operator", "operator@example.com", "hash", "admin", "Operator");
+  db.prepare(`INSERT INTO users (id, username, email, passwordHash, displayName) VALUES (?, ?, ?, ?, ?)`)
+    .run("source-member", "source-member", "source@example.com", "hash", "Source Member");
+  db.prepare(`INSERT INTO users (id, username, email, passwordHash, displayName) VALUES (?, ?, ?, ?, ?)`)
+    .run("target-member", "target-member", "target@example.com", "hash", "Target Member");
+
+  db.prepare(`INSERT INTO workspaces (id, name, ownerId) VALUES (?, ?, ?)`)
+    .run("source-workspace", "来源工作区", "operator");
+  db.prepare(`INSERT INTO workspaces (id, name, ownerId) VALUES (?, ?, ?)`)
+    .run("target-workspace", "目标工作区", "operator");
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+    .run("source-workspace", "operator", "owner");
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+    .run("source-workspace", "source-member", "editor");
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+    .run("target-workspace", "operator", "owner");
+  db.prepare(`INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)`)
+    .run("target-workspace", "target-member", "viewer");
+
+  db.prepare(`
+    INSERT INTO notebooks (id, userId, workspaceId, parentId, name, sortOrder, isExpanded)
+    VALUES (?, ?, ?, NULL, ?, 0, 1)
+  `).run("source-notebook", "operator", "source-workspace", "团队资料");
+  db.prepare(`
+    INSERT INTO notebook_members (
+      id, notebookId, userId, role, status, allowDownload, allowReshare, source, invitedBy
+    ) VALUES (?, ?, ?, ?, 'active', 1, 1, 'manual', ?)
+  `).run("source-notebook-member", "source-notebook", "source-member", "editor", "operator");
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, workspaceId, notebookId, title, content, contentText, contentFormat,
+      sortOrder, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+  `).run(
+    "source-note",
+    "operator",
+    "source-workspace",
+    "source-notebook",
+    "权限迁移说明",
+    "# 权限迁移",
+    "权限迁移",
+    "markdown",
+    "2026-07-23 09:00:00",
+    "2026-07-23 09:00:00",
+  );
+  return { db };
+}
+
+test("permission export is opt-in and explicit mappings can be safely undone", async () => {
+  const { db } = await seed();
+  const { createStableNowenPackageExport } = await import("../src/services/nowenPackageExportStable");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  const { undoRoundTripImportBatchWithLinksAndPermissions } = await import("../src/services/roundTripImportPermissionUndo");
+
+  const defaultPackage = await createStableNowenPackageExport({
+    userId: "operator",
+    workspaceId: "source-workspace",
+    packageKind: "nowen",
+  });
+  const defaultZip = await JSZip.loadAsync(defaultPackage.buffer);
+  assert.equal(defaultZip.file("permissions.json"), null, "default export must not disclose member identities");
+
+  const permissionPackage = await createStableNowenPackageExport({
+    userId: "operator",
+    workspaceId: "source-workspace",
+    packageKind: "nowen",
+    includePermissions: true,
+  });
+  const permissionZip = await JSZip.loadAsync(permissionPackage.buffer);
+  const permissionEntry = permissionZip.file("permissions.json");
+  assert.ok(permissionEntry);
+  const permissionManifest = JSON.parse(await permissionEntry!.async("string")) as any;
+  assert.equal(permissionManifest.version, 1);
+  assert.equal(permissionManifest.workspace.sourceWorkspaceId, "source-workspace");
+  assert.equal(permissionManifest.workspaceMembers.length, 2);
+  assert.equal(permissionManifest.notebookMembers.length, 1);
+  assert.equal(permissionManifest.principals.some((item: any) => item.email === "source@example.com"), true);
+
+  const preview = await importNowenPackage(permissionPackage.buffer, {
+    userId: "operator",
+    workspaceId: "target-workspace",
+    importMode: "new-root",
+    dryRun: true,
+  });
+  assert.equal(preview.success, true, preview.errors?.join("; "));
+  assert.equal(preview.package?.permissions?.included, true);
+  assert.equal(preview.package?.permissions?.canApply, true);
+  assert.equal(preview.package?.permissions?.counts?.principals, 2);
+
+  const imported = await importNowenPackage(permissionPackage.buffer, {
+    userId: "operator",
+    workspaceId: "target-workspace",
+    importMode: "new-root",
+    applyPermissions: true,
+    permissionMappings: {
+      "source-member": "target-member",
+    },
+  });
+  assert.equal(imported.success, true, imported.errors?.join("; "));
+  assert.ok(imported.importBatch?.id);
+  assert.equal(imported.permissionImport?.requested, true);
+  assert.equal(imported.permissionImport?.applied, true);
+  assert.equal(imported.permissionImport?.counts?.mappedPrincipals, 1);
+
+  const targetMembership = db.prepare(`
+    SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?
+  `).get("target-workspace", "target-member") as { role: string } | undefined;
+  assert.equal(targetMembership?.role, "editor", "an explicit mapping may upgrade but not downgrade a role");
+  const ownerMembership = db.prepare(`
+    SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?
+  `).get("target-workspace", "operator") as { role: string } | undefined;
+  assert.equal(ownerMembership?.role, "owner", "the target owner must never be replaced or downgraded");
+
+  const importedRootId = String(imported.rootNotebookId || "");
+  assert.ok(importedRootId);
+  const directGrant = db.prepare(`
+    SELECT role, allowDownload, allowReshare
+      FROM notebook_members
+     WHERE notebookId = ? AND userId = ? AND status = 'active'
+  `).get(importedRootId, "target-member") as {
+    role: string;
+    allowDownload: number;
+    allowReshare: number;
+  } | undefined;
+  assert.deepEqual(directGrant, { role: "editor", allowDownload: 1, allowReshare: 1 });
+
+  const undone = await undoRoundTripImportBatchWithLinksAndPermissions("operator", String(imported.importBatch.id));
+  assert.equal(undone.status, "undone");
+  const restoredMembership = db.prepare(`
+    SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?
+  `).get("target-workspace", "target-member") as { role: string } | undefined;
+  assert.equal(restoredMembership?.role, "viewer");
+  const importedRootCount = db.prepare(`SELECT COUNT(*) AS count FROM notebooks WHERE id = ?`)
+    .get(importedRootId) as { count: number };
+  assert.equal(importedRootCount.count, 0);
+});
+
+test("permission undo refuses to overwrite later membership changes", async () => {
+  const { createStableNowenPackageExport } = await import("../src/services/nowenPackageExportStable");
+  const { importNowenPackage } = await import("../src/services/nowenPackageImport");
+  const { undoRoundTripImportBatchWithLinksAndPermissions } = await import("../src/services/roundTripImportPermissionUndo");
+  const { RoundTripImportUndoError } = await import("../src/services/roundTripImportBatches");
+  const { getDb } = await import("../src/db/schema");
+  const db = getDb();
+
+  const permissionPackage = await createStableNowenPackageExport({
+    userId: "operator",
+    workspaceId: "source-workspace",
+    packageKind: "nowen",
+    includePermissions: true,
+  });
+  const imported = await importNowenPackage(permissionPackage.buffer, {
+    userId: "operator",
+    workspaceId: "target-workspace",
+    importMode: "new-root",
+    applyPermissions: true,
+    permissionMappings: { "source-member": "target-member" },
+  });
+  assert.equal(imported.success, true);
+  db.prepare(`UPDATE workspace_members SET role = 'admin' WHERE workspaceId = ? AND userId = ?`)
+    .run("target-workspace", "target-member");
+
+  await assert.rejects(
+    () => undoRoundTripImportBatchWithLinksAndPermissions("operator", String(imported.importBatch.id)),
+    (error: unknown) => {
+      const candidate = error as { code?: string; conflicts?: string[] };
+      assert.equal(candidate.code, "IMPORT_BATCH_UNDO_PERMISSION_CONFLICT");
+      assert.ok(candidate.conflicts?.some((item) => item.includes("工作区成员")));
+      return true;
+    },
+  );
+  const row = db.prepare(`SELECT role FROM workspace_members WHERE workspaceId = ? AND userId = ?`)
+    .get("target-workspace", "target-member") as { role: string };
+  assert.equal(row.role, "admin");
+});

--- a/frontend/src/components/DataManager.tsx
+++ b/frontend/src/components/DataManager.tsx
@@ -21,6 +21,7 @@ import { useApp, useAppActions } from "@/store/AppContext";
 import { api, withSudo, getCurrentWorkspace, setCurrentWorkspace, getBaseUrl } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { scheduleObjectUrlRevocation } from "@/lib/reliableExportDownloadBridge";
+import { downloadRoundTripPermissionPackage } from "@/lib/roundTripPermissionExport";
 import {
   chooseDesktopDataDir,
   getAppInfo,
@@ -394,6 +395,10 @@ export default function DataManager() {
   const [exportProgress, setExportProgress] = useState<ExportProgress | null>(null);
   const [isExporting, setIsExporting] = useState(false);
   const [isExportingNowen, setIsExportingNowen] = useState(false);
+  const [exportIncludePermissions, setExportIncludePermissions] = useState(false);
+  useEffect(() => {
+    if (scope !== "workspace") setExportIncludePermissions(false);
+  }, [scope]);
 
   // Import state
   const [importFiles, setImportFiles] = useState<ImportFileInfo[]>([]);
@@ -454,9 +459,13 @@ export default function DataManager() {
 
   // Nowen 数据包导出
   const handleExportNowenPackage = async () => {
+    if (!effectiveWorkspaceId) return;
     setIsExportingNowen(true);
     try {
-      const { blob, filename } = await api.downloadNowenPackage();
+      const { blob, filename } = await downloadRoundTripPermissionPackage({
+        workspaceId: effectiveWorkspaceId,
+        includePermissions: scope === "workspace" && exportIncludePermissions,
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -1211,10 +1220,29 @@ export default function DataManager() {
               <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
                 {t('note.nowenPackageDesc')}
               </p>
+              {scope === "workspace" && (
+                <label className="mb-3 flex cursor-pointer items-start gap-2 rounded-lg border border-violet-200/70 bg-violet-50/60 px-3 py-2.5 dark:border-violet-900/50 dark:bg-violet-500/5">
+                  <input
+                    type="checkbox"
+                    checked={exportIncludePermissions}
+                    onChange={(event) => setExportIncludePermissions(event.target.checked)}
+                    disabled={isExportingNowen || workspaceScopeNotReady}
+                    className="mt-0.5 h-4 w-4 accent-violet-600"
+                  />
+                  <span className="text-xs">
+                    <span className="block font-medium text-violet-800 dark:text-violet-200">
+                      包含成员与权限（管理员高级选项）
+                    </span>
+                    <span className="mt-0.5 block leading-5 text-violet-700/75 dark:text-violet-300/75">
+                      数据包会包含成员邮箱和目录直接授权。导入时仍需逐个映射目标账号，默认不会自动应用。
+                    </span>
+                  </span>
+                </label>
+              )}
               <button
                 onClick={handleExportNowenPackage}
-                disabled={isExportingNowen || personalExportLocked}
-                className={`flex items-center justify-center w-full py-2 px-4 rounded-lg font-medium text-sm transition-all ${isExportingNowen || personalExportLocked
+                disabled={isExportingNowen || workspaceScopeNotReady || personalExportLocked}
+                className={`flex items-center justify-center w-full py-2 px-4 rounded-lg font-medium text-sm transition-all ${isExportingNowen || workspaceScopeNotReady || personalExportLocked
                   ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 cursor-not-allowed"
                   : "bg-violet-600 hover:bg-violet-700 text-white shadow-md hover:shadow-lg"
                   }`}

--- a/frontend/src/components/RoundTripImportReviewCenter.tsx
+++ b/frontend/src/components/RoundTripImportReviewCenter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   AlertTriangle,
@@ -20,6 +20,7 @@ import {
   Tags,
   X,
 } from "lucide-react";
+import RoundTripPermissionMappingPanel from "@/components/RoundTripPermissionMappingPanel";
 import {
   resolveRoundTripImportReview,
   subscribeRoundTripImportReviews,
@@ -47,6 +48,13 @@ function count(value: unknown): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
+function suggestedMappings(preview: RoundTripPackagePreview): Record<string, string> {
+  const principals = preview.package?.permissions?.principals || [];
+  return Object.fromEntries(principals
+    .filter((item) => item.suggestedTarget?.id)
+    .map((item) => [item.sourceUserId, item.suggestedTarget!.id]));
+}
+
 function RoundTripImportReviewDialog({ request }: { request: RoundTripImportReviewRequest }) {
   const zh = isChineseLocale();
   const [strategy, setStrategy] = useState<RoundTripImportStrategy>(request.initialStrategy);
@@ -56,6 +64,8 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
   const [loadingStrategy, setLoadingStrategy] = useState<RoundTripImportStrategy | null>(null);
   const [loadError, setLoadError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [applyPermissions, setApplyPermissions] = useState(false);
+  const [permissionMappings, setPermissionMappings] = useState<Record<string, string>>(() => suggestedMappings(request.preview));
 
   const preview = previews[strategy] || request.preview;
   const pkg = preview.package || {};
@@ -68,10 +78,22 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
   const canChooseStrategy = typeof request.loadPreview === "function";
   const syncAvailability = request.preview.package?.sync;
   const syncEnabled = syncAvailability?.available === true;
+  const permissionInspection = pkg.permissions;
+
+  useEffect(() => {
+    const suggestions = suggestedMappings(preview);
+    setPermissionMappings((current) => {
+      const next = { ...suggestions, ...current };
+      const allowed = new Set((preview.package?.permissions?.principals || []).map((item) => item.sourceUserId));
+      for (const sourceId of Object.keys(next)) if (!allowed.has(sourceId)) delete next[sourceId];
+      return next;
+    });
+    if (!permissionInspection?.included || !permissionInspection.canApply) setApplyPermissions(false);
+  }, [permissionInspection?.canApply, permissionInspection?.included, preview]);
 
   const copy = zh ? {
     title: "导入预检报告",
-    subtitle: "选择导入方式，并核对目录、附件和冲突处理结果",
+    subtitle: "选择导入方式，并核对目录、附件、账号映射和冲突处理结果",
     packageFile: "数据包",
     target: "导入目标",
     exportedAt: "导出时间",
@@ -100,15 +122,6 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     mergePlanDesc: "同名目录会复用；导入的同名笔记改为“名称 (2)”，不会覆盖正文。",
     syncPlanDesc: "来源和本地同时变化时保留本地版本；来源包中缺少的目录和笔记不会从本地删除。",
     noPlan: strategy === "sync" ? "没有需要新增、更新或处理冲突的资源。" : strategy === "merge" ? "没有需要合并或重命名的内容。" : "目标中未发现同名根目录。",
-    mergeDirectory: "复用目录",
-    renameRoot: "根目录改名",
-    renameNote: "笔记改名",
-    syncCreateDirectory: "新增目录",
-    syncUpdateDirectory: "更新目录",
-    syncCreateNote: "新增笔记",
-    syncUpdateNote: "更新笔记",
-    syncLocalConflict: "保留本地",
-    syncReplaceAttachment: "替换附件",
     actionSummary: "执行摘要",
     createdDirectories: "新建目录",
     mergedDirectories: "复用目录",
@@ -127,7 +140,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     syncSafety: "只有稳定来源映射、来源已变化且目标未被本地修改的资源才会更新。",
     safetyB: strategy === "sync" ? "本地和来源同时变化时保留本地版本，并在报告中标为冲突。" : "附件会生成新的 ID，并重写正文中的附件地址。",
     safetyC: strategy === "sync" ? "同步不会删除目标中已有但本次数据包未包含的目录或笔记。" : "任一步骤失败都会回滚数据库并清理已写入文件。",
-    safetyD: "任一步骤失败都会回滚数据库并清理已写入文件。",
+    permissionSafety: applyPermissions ? "成员权限只应用到已映射账号；目标所有者和更高的已有权限保持不变。" : "成员与权限恢复保持关闭，数据包中的账号信息不会写入目标。",
     cancel: "取消导入",
     confirm: strategy === "sync" ? "确认安全同步" : strategy === "merge" ? "确认合并导入" : "确认创建副本",
     currentSpace: "当前导入空间",
@@ -137,7 +150,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     loadFailed: "无法生成该策略的预检结果",
   } : {
     title: "Import preflight report",
-    subtitle: "Choose an import mode and review the tree, attachments and conflict plan",
+    subtitle: "Choose an import mode and review the tree, attachments, account mappings and conflicts",
     packageFile: "Package",
     target: "Target",
     exportedAt: "Exported",
@@ -166,15 +179,6 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     mergePlanDesc: "Matching folders are reused and duplicate imported notes become “Name (2)”.",
     syncPlanDesc: "Local edits win when both sides changed. Missing source items are not deleted from the target.",
     noPlan: strategy === "sync" ? "No resources need to be created, updated or resolved." : strategy === "merge" ? "Nothing needs to be merged or renamed." : "No conflicting root folders were found.",
-    mergeDirectory: "Reuse folder",
-    renameRoot: "Rename root",
-    renameNote: "Rename note",
-    syncCreateDirectory: "Create folder",
-    syncUpdateDirectory: "Update folder",
-    syncCreateNote: "Create note",
-    syncUpdateNote: "Update note",
-    syncLocalConflict: "Keep local",
-    syncReplaceAttachment: "Replace attachment",
     actionSummary: "Action summary",
     createdDirectories: "New folders",
     mergedDirectories: "Reused folders",
@@ -193,7 +197,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     syncSafety: "Only stable mapped resources changed at the source and untouched locally are updated.",
     safetyB: strategy === "sync" ? "When source and local content both changed, the local version is preserved and reported." : "Attachments receive new IDs and content references are rewritten.",
     safetyC: strategy === "sync" ? "Sync never deletes target folders or notes missing from this package." : "Any failure rolls back the database and removes files already written.",
-    safetyD: "Any failure rolls back the database and removes files already written.",
+    permissionSafety: applyPermissions ? "Permissions are applied only to mapped accounts; the target owner and stronger existing roles are preserved." : "Permission restore remains disabled and no package identities are written to the target.",
     cancel: "Cancel import",
     confirm: strategy === "sync" ? "Confirm safe sync" : strategy === "merge" ? "Confirm merge import" : "Confirm independent copy",
     currentSpace: "Current import space",
@@ -237,20 +241,40 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     setSubmitting(true);
     resolveRoundTripImportReview(
       request.id,
-      accepted ? { accepted: true, strategy } : { accepted: false },
+      accepted
+        ? {
+            accepted: true,
+            strategy,
+            applyPermissions: applyPermissions && permissionInspection?.canApply === true,
+            permissionMappings: applyPermissions ? permissionMappings : {},
+          }
+        : { accepted: false },
     );
   };
 
   const actionLabel = (action?: RoundTripImportConflictAction): string => {
-    if (action === "merge-directory") return copy.mergeDirectory;
-    if (action === "rename-note") return copy.renameNote;
-    if (action === "sync-create-directory") return copy.syncCreateDirectory;
-    if (action === "sync-update-directory") return copy.syncUpdateDirectory;
-    if (action === "sync-create-note") return copy.syncCreateNote;
-    if (action === "sync-update-note") return copy.syncUpdateNote;
-    if (action === "sync-local-conflict") return copy.syncLocalConflict;
-    if (action === "sync-replace-attachment") return copy.syncReplaceAttachment;
-    return copy.renameRoot;
+    const labels: Record<string, string> = zh ? {
+      "merge-directory": "复用目录",
+      "rename-root": "根目录改名",
+      "rename-note": "笔记改名",
+      "sync-create-directory": "新增目录",
+      "sync-update-directory": "更新目录",
+      "sync-create-note": "新增笔记",
+      "sync-update-note": "更新笔记",
+      "sync-local-conflict": "保留本地",
+      "sync-replace-attachment": "替换附件",
+    } : {
+      "merge-directory": "Reuse folder",
+      "rename-root": "Rename root",
+      "rename-note": "Rename note",
+      "sync-create-directory": "Create folder",
+      "sync-update-directory": "Update folder",
+      "sync-create-note": "Create note",
+      "sync-update-note": "Update note",
+      "sync-local-conflict": "Keep local",
+      "sync-replace-attachment": "Replace attachment",
+    };
+    return labels[action || "rename-root"] || labels["rename-root"];
   };
 
   const stats = [
@@ -259,12 +283,27 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
     { label: copy.tags, value: count(counts.tags), icon: Tags },
     { label: copy.attachments, value: count(counts.attachments), icon: Paperclip },
   ];
-
   const strategyClass = strategy === "sync"
     ? "bg-blue-600 hover:bg-blue-700"
     : strategy === "merge"
       ? "bg-violet-600 hover:bg-violet-700"
       : "bg-emerald-600 hover:bg-emerald-700";
+  const summaryItems = strategy === "sync"
+    ? [
+        [copy.createdDirectories, actionCounts.notebooks, FolderPlus],
+        [copy.createdNotes, actionCounts.notes, FileText],
+        [copy.updatedDirectories, actionCounts.updatedNotebooks, FolderTree],
+        [copy.updatedNotes, actionCounts.updatedNotes, PencilLine],
+        [copy.unchangedNotes, actionCounts.unchangedNotes, ShieldCheck],
+        [copy.localConflicts, actionCounts.localConflicts, ShieldAlert],
+      ] as const
+    : strategy === "merge"
+      ? [
+          [copy.createdDirectories, actionCounts.notebooks, FolderPlus],
+          [copy.mergedDirectories, actionCounts.mergedNotebooks, FolderInput],
+          [copy.renamedNotes, actionCounts.renamedNotes, PencilLine],
+        ] as const
+      : [];
 
   return createPortal(
     <div className="fixed inset-0 z-[12000] flex items-end justify-center bg-black/45 backdrop-blur-[1px] sm:items-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="round-trip-import-review-title">
@@ -319,28 +358,20 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
             <div className="mt-2 flex flex-wrap gap-2 text-xs"><span className="rounded-lg bg-sky-50 px-2.5 py-1.5 text-sky-700 dark:bg-sky-500/10 dark:text-sky-300">{copy.markdown} {count(formats.markdown)}</span><span className="rounded-lg bg-violet-50 px-2.5 py-1.5 text-violet-700 dark:bg-violet-500/10 dark:text-violet-300">{copy.richText} {count(formats.richText)}</span><span className="rounded-lg bg-orange-50 px-2.5 py-1.5 text-orange-700 dark:bg-orange-500/10 dark:text-orange-300">{copy.html} {count(formats.html)}</span></div>
           </section>
 
-          {strategy === "merge" && (
-            <section className="rounded-xl border border-violet-200 bg-violet-50/45 p-3 dark:border-violet-900/45 dark:bg-violet-500/5">
-              <h3 className="text-xs font-semibold text-violet-800 dark:text-violet-200">{copy.actionSummary}</h3>
-              <div className="mt-2 grid grid-cols-3 gap-2 text-center text-[11px]"><div className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><div className="text-lg font-bold text-zinc-900 dark:text-zinc-100">{count(actionCounts.notebooks)}</div><div className="text-zinc-500">{copy.createdDirectories}</div></div><div className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><div className="text-lg font-bold text-violet-700 dark:text-violet-300">{count(actionCounts.mergedNotebooks)}</div><div className="text-zinc-500">{copy.mergedDirectories}</div></div><div className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><div className="text-lg font-bold text-amber-700 dark:text-amber-300">{count(actionCounts.renamedNotes)}</div><div className="text-zinc-500">{copy.renamedNotes}</div></div></div>
-            </section>
-          )}
+          <RoundTripPermissionMappingPanel
+            inspection={permissionInspection}
+            enabled={applyPermissions}
+            onEnabledChange={setApplyPermissions}
+            mappings={permissionMappings}
+            onMappingsChange={setPermissionMappings}
+            disabled={submitting || !!loadingStrategy}
+          />
 
-          {strategy === "sync" && (
-            <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5">
-              <h3 className="text-xs font-semibold text-blue-800 dark:text-blue-200">{copy.actionSummary}</h3>
-              <div className="mt-2 grid grid-cols-2 gap-2 text-center text-[11px] sm:grid-cols-3 lg:grid-cols-6">
-                {[
-                  [copy.createdDirectories, actionCounts.notebooks, FolderPlus],
-                  [copy.createdNotes, actionCounts.notes, FileText],
-                  [copy.updatedDirectories, actionCounts.updatedNotebooks, FolderTree],
-                  [copy.updatedNotes, actionCounts.updatedNotes, PencilLine],
-                  [copy.unchangedNotes, actionCounts.unchangedNotes, ShieldCheck],
-                  [copy.localConflicts, actionCounts.localConflicts, ShieldAlert],
-                ].map(([label, value, Icon]) => {
-                  const SummaryIcon = Icon as React.ComponentType<{ size?: number; className?: string }>;
-                  return <div key={String(label)} className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><SummaryIcon size={14} className="mx-auto mb-1 text-blue-500" /><div className="text-lg font-bold text-zinc-900 dark:text-zinc-100">{count(value)}</div><div className="text-zinc-500">{String(label)}</div></div>;
-                })}
+          {summaryItems.length > 0 && (
+            <section className={`rounded-xl border p-3 ${strategy === "sync" ? "border-blue-200 bg-blue-50/45 dark:border-blue-900/45 dark:bg-blue-500/5" : "border-violet-200 bg-violet-50/45 dark:border-violet-900/45 dark:bg-violet-500/5"}`}>
+              <h3 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.actionSummary}</h3>
+              <div className={`mt-2 grid grid-cols-2 gap-2 text-center text-[11px] ${strategy === "sync" ? "sm:grid-cols-3 lg:grid-cols-6" : "sm:grid-cols-3"}`}>
+                {summaryItems.map(([label, value, Icon]) => <div key={String(label)} className="rounded-lg bg-white/75 p-2 dark:bg-zinc-900/50"><Icon size={14} className="mx-auto mb-1 text-blue-500" /><div className="text-lg font-bold text-zinc-900 dark:text-zinc-100">{count(value)}</div><div className="text-zinc-500">{String(label)}</div></div>)}
               </div>
               {count(actionCounts.recreatedResources) > 0 && <p className="mt-2 text-[11px] text-blue-700 dark:text-blue-300">{copy.recreatedResources}：{count(actionCounts.recreatedResources)}</p>}
             </section>
@@ -352,7 +383,7 @@ function RoundTripImportReviewDialog({ request }: { request: RoundTripImportRevi
 
           <section className={`rounded-xl border p-3 ${warnings.length || errors.length ? "border-red-200 bg-red-50/40 dark:border-red-900/50 dark:bg-red-500/5" : "border-zinc-200 dark:border-zinc-800"}`}><h3 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{copy.warningsTitle} · {warnings.length + errors.length}</h3>{warnings.length || errors.length ? <div className="mt-2 max-h-36 space-y-1 overflow-y-auto text-[11px] leading-5 text-red-700 dark:text-red-300">{errors.map((message, index) => <p key={`error-${index}`}>• {message}</p>)}{warnings.map((warning, index) => <p key={`${warning.type || "warning"}-${index}`}>• {warning.message || warning.type || "warning"}</p>)}</div> : <p className="mt-1 text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">{copy.noWarnings}</p>}</section>
 
-          <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5"><h3 className="flex items-center gap-1.5 text-xs font-semibold text-blue-800 dark:text-blue-200"><ShieldCheck size={15} />{copy.safetyTitle}</h3><div className="mt-2 space-y-1 text-[11px] leading-5 text-blue-700/90 dark:text-blue-300/90"><p>• {strategy === "sync" ? copy.syncSafety : strategy === "merge" ? copy.mergeSafety : copy.copySafety}</p><p>• {copy.safetyB}</p><p>• {copy.safetyC}</p>{strategy === "sync" && <p>• {copy.safetyD}</p>}</div></section>
+          <section className="rounded-xl border border-blue-200 bg-blue-50/45 p-3 dark:border-blue-900/45 dark:bg-blue-500/5"><h3 className="flex items-center gap-1.5 text-xs font-semibold text-blue-800 dark:text-blue-200"><ShieldCheck size={15} />{copy.safetyTitle}</h3><div className="mt-2 space-y-1 text-[11px] leading-5 text-blue-700/90 dark:text-blue-300/90"><p>• {strategy === "sync" ? copy.syncSafety : strategy === "merge" ? copy.mergeSafety : copy.copySafety}</p><p>• {copy.safetyB}</p><p>• {copy.safetyC}</p>{permissionInspection?.included && <p>• {copy.permissionSafety}</p>}</div></section>
         </div>
 
         <footer className="flex shrink-0 gap-2 border-t border-zinc-200 px-4 pt-3 pb-[max(0.9rem,env(safe-area-inset-bottom))] dark:border-zinc-800 sm:justify-end sm:px-5 sm:pb-4">

--- a/frontend/src/components/RoundTripPermissionMappingPanel.tsx
+++ b/frontend/src/components/RoundTripPermissionMappingPanel.tsx
@@ -1,0 +1,263 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Check, Loader2, Search, ShieldAlert, UserRoundCheck, UsersRound, X } from "lucide-react";
+import { api } from "@/lib/api";
+import type {
+  RoundTripPermissionInspection,
+  RoundTripPermissionTargetUser,
+} from "@/lib/roundTripImportReview";
+import type { UserPublicInfo } from "@/types";
+
+interface Props {
+  inspection?: RoundTripPermissionInspection;
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  mappings: Record<string, string>;
+  onMappingsChange: (mappings: Record<string, string>) => void;
+  disabled?: boolean;
+}
+
+function displayName(user: { username: string; displayName?: string | null }): string {
+  return user.displayName?.trim() || user.username;
+}
+
+function roleLabel(role: string | null): string {
+  switch (role) {
+    case "owner": return "所有者（导入时按管理员处理）";
+    case "admin": return "管理员";
+    case "editor": return "编辑者";
+    case "commenter": return "评论者";
+    case "viewer": return "查看者";
+    default: return "仅目录授权";
+  }
+}
+
+function MappingRow({
+  principal,
+  selectedId,
+  usedTargetIds,
+  disabled,
+  onSelect,
+}: {
+  principal: RoundTripPermissionInspection["principals"][number];
+  selectedId?: string;
+  usedTargetIds: Set<string>;
+  disabled: boolean;
+  onSelect: (target: RoundTripPermissionTargetUser | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserPublicInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const selected = useMemo(() => {
+    if (!selectedId) return null;
+    if (principal.suggestedTarget?.id === selectedId) return principal.suggestedTarget;
+    const result = results.find((item) => item.id === selectedId);
+    return result || null;
+  }, [principal.suggestedTarget, results, selectedId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      api.searchUsers(query.trim())
+        .then(setResults)
+        .catch(() => setResults([]))
+        .finally(() => setLoading(false));
+    }, 180);
+    return () => window.clearTimeout(timer);
+  }, [open, query]);
+
+  const candidates = results.filter((item) => item.id === selectedId || !usedTargetIds.has(item.id));
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900/60">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              {principal.displayName || principal.username}
+            </span>
+            <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+              @{principal.username}
+            </span>
+            <span className="rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-500/10 dark:text-violet-300">
+              {roleLabel(principal.workspaceRole)}
+            </span>
+          </div>
+          {principal.email && (
+            <p className="mt-1 truncate text-[11px] text-zinc-500 dark:text-zinc-400" title={principal.email}>
+              {principal.email}
+            </p>
+          )}
+          <p className="mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+            {principal.match === "email"
+              ? "已按邮箱找到建议账号"
+              : principal.match === "username"
+                ? "已按用户名找到建议账号"
+                : principal.match === "ambiguous"
+                  ? "存在多个候选，需要手动确认"
+                  : "未自动匹配，可搜索目标账号或保持跳过"}
+          </p>
+        </div>
+
+        <div className="relative w-full sm:w-[280px]">
+          {selectedId ? (
+            <div className="flex min-h-10 items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50/60 px-2.5 dark:border-emerald-900/50 dark:bg-emerald-500/5">
+              <UserRoundCheck size={15} className="shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-800 dark:text-zinc-200">
+                {selected ? displayName(selected) : selectedId}
+                {selected && selected.displayName && <span className="ml-1 font-normal text-zinc-400">@{selected.username}</span>}
+              </span>
+              <button
+                type="button"
+                onClick={() => onSelect(null)}
+                disabled={disabled}
+                className="rounded p-1 text-zinc-400 hover:bg-white hover:text-zinc-700 disabled:opacity-50 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                aria-label="清除账号映射"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setOpen((value) => !value)}
+              disabled={disabled}
+              className="flex min-h-10 w-full items-center gap-2 rounded-lg border border-zinc-300 bg-white px-2.5 text-left text-xs text-zinc-500 transition-colors hover:border-violet-300 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
+            >
+              <Search size={14} />
+              搜索目标实例中的账号
+            </button>
+          )}
+
+          {open && !selectedId && (
+            <div className="absolute right-0 top-[calc(100%+0.35rem)] z-20 w-full overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+              <div className="flex items-center gap-2 border-b border-zinc-200 px-2.5 dark:border-zinc-800">
+                <Search size={14} className="text-zinc-400" />
+                <input
+                  autoFocus
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="用户名或显示名"
+                  className="h-10 min-w-0 flex-1 bg-transparent text-xs text-zinc-800 outline-none placeholder:text-zinc-400 dark:text-zinc-200"
+                />
+                <button type="button" onClick={() => setOpen(false)} className="rounded p-1 text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                  <X size={14} />
+                </button>
+              </div>
+              <div className="max-h-48 overflow-y-auto p-1.5">
+                {loading ? (
+                  <div className="flex items-center justify-center gap-2 py-5 text-xs text-zinc-400"><Loader2 size={14} className="animate-spin" />正在搜索…</div>
+                ) : candidates.length ? (
+                  candidates.map((user) => (
+                    <button
+                      key={user.id}
+                      type="button"
+                      onClick={() => {
+                        onSelect(user);
+                        setOpen(false);
+                        setQuery("");
+                      }}
+                      className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-violet-50 text-xs font-bold text-violet-600 dark:bg-violet-500/10 dark:text-violet-300">
+                        {displayName(user).slice(0, 1).toUpperCase()}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-xs font-medium text-zinc-800 dark:text-zinc-200">{displayName(user)}</span>
+                        <span className="block truncate text-[10px] text-zinc-400">@{user.username}</span>
+                      </span>
+                      <Check size={14} className="text-zinc-300" />
+                    </button>
+                  ))
+                ) : (
+                  <p className="px-2 py-5 text-center text-xs text-zinc-400">没有可用账号</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RoundTripPermissionMappingPanel({
+  inspection,
+  enabled,
+  onEnabledChange,
+  mappings,
+  onMappingsChange,
+  disabled = false,
+}: Props) {
+  if (!inspection?.included) return null;
+
+  const mappedCount = Object.values(mappings).filter(Boolean).length;
+  const usedTargetIds = new Set(Object.values(mappings).filter(Boolean));
+
+  return (
+    <section className="rounded-xl border border-violet-200 bg-violet-50/35 p-3 dark:border-violet-900/45 dark:bg-violet-500/5">
+      <div className="flex items-start gap-2.5">
+        <UsersRound size={17} className="mt-0.5 shrink-0 text-violet-600 dark:text-violet-400" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h3 className="text-xs font-semibold text-violet-900 dark:text-violet-200">恢复成员与权限</h3>
+              <p className="mt-1 text-[11px] leading-5 text-violet-700/80 dark:text-violet-300/80">
+                默认关闭。开启后仅恢复已明确映射的成员，不创建新账号，也不会替换目标工作区所有者或降低已有权限。
+              </p>
+            </div>
+            <label className={`inline-flex shrink-0 items-center gap-2 rounded-lg border px-2.5 py-1.5 text-xs font-medium ${inspection.canApply ? "cursor-pointer border-violet-200 bg-white text-violet-700 dark:border-violet-800 dark:bg-zinc-900 dark:text-violet-300" : "cursor-not-allowed border-zinc-200 bg-zinc-100 text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900/50"}`}>
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(event) => onEnabledChange(event.target.checked)}
+                disabled={disabled || !inspection.canApply}
+                className="h-4 w-4 accent-violet-600"
+              />
+              应用权限
+            </label>
+          </div>
+
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-violet-700 dark:text-violet-300">
+            <span className="rounded bg-white/80 px-2 py-1 dark:bg-zinc-900/60">来源成员 {inspection.counts.principals}</span>
+            <span className="rounded bg-white/80 px-2 py-1 dark:bg-zinc-900/60">工作区授权 {inspection.counts.workspaceMembers}</span>
+            <span className="rounded bg-white/80 px-2 py-1 dark:bg-zinc-900/60">目录直接授权 {inspection.counts.notebookMembers}</span>
+            {enabled && <span className="rounded bg-violet-600 px-2 py-1 font-semibold text-white">已映射 {mappedCount}</span>}
+          </div>
+
+          {!inspection.canApply && (
+            <div className="mt-2 flex items-start gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-2 text-[11px] leading-5 text-amber-700 dark:border-amber-900/50 dark:bg-amber-500/5 dark:text-amber-300">
+              <ShieldAlert size={14} className="mt-0.5 shrink-0" />
+              <span>{inspection.reason || inspection.issues[0] || "当前目标不能恢复成员与权限"}</span>
+            </div>
+          )}
+
+          {enabled && inspection.canApply && (
+            <div className="mt-3 space-y-2">
+              {inspection.principals.map((principal) => (
+                <MappingRow
+                  key={principal.sourceUserId}
+                  principal={principal}
+                  selectedId={mappings[principal.sourceUserId]}
+                  usedTargetIds={usedTargetIds}
+                  disabled={disabled}
+                  onSelect={(target) => {
+                    const next = { ...mappings };
+                    if (target) next[principal.sourceUserId] = target.id;
+                    else delete next[principal.sourceUserId];
+                    onMappingsChange(next);
+                  }}
+                />
+              ))}
+              <p className="text-[10px] leading-4 text-zinc-500 dark:text-zinc-400">
+                未映射成员会被跳过，不影响目录、笔记和附件导入。一个目标账号只能对应一个来源成员。
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/__tests__/roundTripImportReview.test.ts
+++ b/frontend/src/lib/__tests__/roundTripImportReview.test.ts
@@ -7,6 +7,11 @@ import {
   type RoundTripImportReviewRequest,
 } from "../roundTripImportReview";
 
+const noPermissions = {
+  applyPermissions: false,
+  permissionMappings: {},
+} as const;
+
 afterEach(() => {
   roundTripImportReviewTestUtils.reset();
 });
@@ -50,8 +55,8 @@ describe("round-trip import review queue", () => {
     expect(request?.preview.package?.sync?.available).toBe(false);
     expect(request?.preview.conflicts?.[0]?.importedName).toBe("产品资料 (2)");
 
-    resolveRoundTripImportReview(request!.id, { accepted: true, strategy: "copy" });
-    await expect(decision).resolves.toEqual({ accepted: true, strategy: "copy" });
+    resolveRoundTripImportReview(request!.id, { accepted: true, strategy: "copy", ...noPermissions });
+    await expect(decision).resolves.toEqual({ accepted: true, strategy: "copy", ...noPermissions });
     expect(roundTripImportReviewTestUtils.pendingCount()).toBe(0);
     expect(snapshots.at(-1)).toEqual([]);
     unsubscribe();
@@ -82,8 +87,8 @@ describe("round-trip import review queue", () => {
     expect(loadPreview).toHaveBeenCalledWith("merge");
     expect(mergePreview?.counts?.mergedNotebooks).toBe(3);
 
-    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "merge" });
-    await expect(decision).resolves.toEqual({ accepted: true, strategy: "merge" });
+    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "merge", ...noPermissions });
+    await expect(decision).resolves.toEqual({ accepted: true, strategy: "merge", ...noPermissions });
     unsubscribe();
   });
 
@@ -139,8 +144,55 @@ describe("round-trip import review queue", () => {
     expect(syncPreview?.counts?.localConflicts).toBe(1);
     expect(syncPreview?.conflicts?.[0]?.action).toBe("sync-local-conflict");
 
-    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "sync" });
-    await expect(decision).resolves.toEqual({ accepted: true, strategy: "sync" });
+    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "sync", ...noPermissions });
+    await expect(decision).resolves.toEqual({ accepted: true, strategy: "sync", ...noPermissions });
+    unsubscribe();
+  });
+
+  it("returns only explicit source-to-target account mappings", async () => {
+    let current: RoundTripImportReviewRequest[] = [];
+    const unsubscribe = subscribeRoundTripImportReviews((items) => { current = items; });
+    const decision = requestRoundTripImportReview({
+      success: true,
+      strategy: "copy",
+      package: {
+        permissions: {
+          included: true,
+          valid: true,
+          canApply: true,
+          reason: null,
+          counts: { principals: 2, workspaceMembers: 2, notebookMembers: 1 },
+          principals: [{
+            sourceUserId: "source-user-1",
+            username: "alice",
+            displayName: "Alice",
+            email: "alice@example.com",
+            workspaceRole: "editor",
+            suggestedTarget: {
+              id: "target-user-1",
+              username: "alice-target",
+              displayName: "Alice Target",
+              avatarUrl: null,
+            },
+            match: "email",
+          }],
+          issues: [],
+        },
+      },
+    }, { fileName: "permissions.nowen.zip" });
+
+    resolveRoundTripImportReview(current[0].id, {
+      accepted: true,
+      strategy: "copy",
+      applyPermissions: true,
+      permissionMappings: { "source-user-1": "target-user-1" },
+    });
+    await expect(decision).resolves.toEqual({
+      accepted: true,
+      strategy: "copy",
+      applyPermissions: true,
+      permissionMappings: { "source-user-1": "target-user-1" },
+    });
     unsubscribe();
   });
 
@@ -155,8 +207,8 @@ describe("round-trip import review queue", () => {
     await expect(first).resolves.toEqual({ accepted: false });
     expect(current.map((item) => item.fileName)).toEqual(["b.nowen.zip"]);
 
-    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "copy" });
-    await expect(second).resolves.toEqual({ accepted: true, strategy: "copy" });
+    resolveRoundTripImportReview(current[0].id, { accepted: true, strategy: "copy", ...noPermissions });
+    await expect(second).resolves.toEqual({ accepted: true, strategy: "copy", ...noPermissions });
     expect(current).toEqual([]);
     unsubscribe();
   });

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -139,7 +139,7 @@ export async function importNotes(
     targetNotebookId: strategy === "sync" ? undefined : notebookId || undefined,
   });
   try {
-    onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件和来源映射…" });
+    onProgress?.({ phase: "reading", current: 0, total: 1, message: "正在校验目录、附件、来源映射和成员清单…" });
     const copyPreview = await submitRoundTripPackage(file, {
       ...submitOptionsFor("copy"),
       dryRun: true,
@@ -169,22 +169,27 @@ export async function importNotes(
         strategy: decision.strategy,
       });
     const conflicts = Array.isArray(selectedPreview?.conflicts) ? selectedPreview.conflicts.length : 0;
+    const permissionSuffix = decision.applyPermissions
+      ? `，并恢复 ${Object.keys(decision.permissionMappings).length} 个已映射成员`
+      : "";
     onProgress?.({
       phase: "uploading",
       current: 0,
       total: 1,
       message: decision.strategy === "sync"
-        ? `正在执行安全增量同步${conflicts ? `（${conflicts} 项变更或冲突）` : ""}…`
+        ? `正在执行安全增量同步${conflicts ? `（${conflicts} 项变更或冲突）` : ""}${permissionSuffix}…`
         : decision.strategy === "merge"
-          ? `正在按合并计划导入${conflicts ? `（${conflicts} 项处理）` : ""}…`
+          ? `正在按合并计划导入${conflicts ? `（${conflicts} 项处理）` : ""}${permissionSuffix}…`
           : conflicts > 0
-            ? `已确认 ${conflicts} 个重名处理方案，正在创建独立副本`
-            : "预检已确认，正在原样恢复目录和附件…",
+            ? `已确认 ${conflicts} 个重名处理方案，正在创建独立副本${permissionSuffix}`
+            : `预检已确认，正在原样恢复目录和附件${permissionSuffix}…`,
     });
     const result = await submitRoundTripPackage(file, {
       ...submitOptionsFor(decision.strategy),
       dryRun: false,
       strategy: decision.strategy,
+      applyPermissions: decision.applyPermissions,
+      permissionMappings: decision.permissionMappings,
     });
 
     const createdNotes = Number(result?.counts?.notes || 0);
@@ -195,18 +200,28 @@ export async function importNotes(
     const renamedCount = Number(result?.counts?.renamedNotes || 0);
     const unchangedCount = Number(result?.counts?.unchangedNotes || 0);
     const localConflictCount = Number(result?.counts?.localConflicts || 0);
+    const permissionReport = result.permissionImport;
+    const appliedPermissionCount = Number(permissionReport?.counts?.workspaceAdded || 0)
+      + Number(permissionReport?.counts?.workspaceUpgraded || 0)
+      + Number(permissionReport?.counts?.notebookAdded || 0)
+      + Number(permissionReport?.counts?.notebookUpgraded || 0);
+    const permissionDoneSuffix = decision.applyPermissions
+      ? appliedPermissionCount > 0
+        ? `，已应用 ${appliedPermissionCount} 项成员权限`
+        : "，成员权限未产生变更"
+      : "";
 
     onProgress?.({
       phase: "done",
       current: affectedCount,
       total: affectedCount,
       message: decision.strategy === "sync"
-        ? `同步完成，新增 ${createdNotes} 篇、更新 ${updatedNotes} 篇、无需变更 ${unchangedCount} 篇${localConflictCount ? `，${localConflictCount} 项本地修改已保留` : ""}`
+        ? `同步完成，新增 ${createdNotes} 篇、更新 ${updatedNotes} 篇、无需变更 ${unchangedCount} 篇${localConflictCount ? `，${localConflictCount} 项本地修改已保留` : ""}${permissionDoneSuffix}`
         : decision.strategy === "merge"
-          ? `导入完成，共 ${createdNotes} 篇笔记，复用 ${mergedCount} 个目录${renamedCount ? `，${renamedCount} 篇同名笔记已编号` : ""}`
+          ? `导入完成，共 ${createdNotes} 篇笔记，复用 ${mergedCount} 个目录${renamedCount ? `，${renamedCount} 篇同名笔记已编号` : ""}${permissionDoneSuffix}`
           : warningCount > 0
-            ? `导入完成，共 ${createdNotes} 篇笔记，${warningCount} 项需要检查`
-            : `导入完成，共 ${createdNotes} 篇笔记`,
+            ? `导入完成，共 ${createdNotes} 篇笔记，${warningCount} 项需要检查${permissionDoneSuffix}`
+            : `导入完成，共 ${createdNotes} 篇笔记${permissionDoneSuffix}`,
     });
     return { success: true, count: decision.strategy === "sync" ? affectedCount : createdNotes };
   } catch (error) {

--- a/frontend/src/lib/roundTripImportReview.ts
+++ b/frontend/src/lib/roundTripImportReview.ts
@@ -54,6 +54,35 @@ export interface RoundTripSyncAvailability {
   reason?: string | null;
 }
 
+export interface RoundTripPermissionTargetUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface RoundTripPermissionInspection {
+  included: boolean;
+  valid: boolean;
+  canApply: boolean;
+  reason?: string | null;
+  counts: {
+    principals: number;
+    workspaceMembers: number;
+    notebookMembers: number;
+  };
+  principals: Array<{
+    sourceUserId: string;
+    username: string;
+    displayName: string | null;
+    email: string | null;
+    workspaceRole: "owner" | "admin" | "editor" | "commenter" | "viewer" | null;
+    suggestedTarget: RoundTripPermissionTargetUser | null;
+    match: "email" | "username" | "ambiguous" | "none";
+  }>;
+  issues: string[];
+}
+
 export interface RoundTripPackagePreview {
   success: boolean;
   dryRun?: boolean;
@@ -67,6 +96,7 @@ export interface RoundTripPackagePreview {
     sourceInstanceId?: string | null;
     exportBatchId?: string | null;
     sync?: RoundTripSyncAvailability;
+    permissions?: RoundTripPermissionInspection;
     counts?: RoundTripPackageCounts;
     formatStats?: RoundTripPackageFormatStats;
   };
@@ -79,6 +109,13 @@ export interface RoundTripPackagePreview {
     path?: string;
   }>;
   errors?: string[];
+  permissionImport?: {
+    included?: boolean;
+    requested?: boolean;
+    applied?: boolean;
+    counts?: Record<string, number>;
+    issues?: string[];
+  };
   importBatch?: {
     id?: string;
     undoAvailable?: boolean;
@@ -89,7 +126,12 @@ export interface RoundTripPackagePreview {
 
 export type RoundTripImportReviewDecision =
   | { accepted: false }
-  | { accepted: true; strategy: RoundTripImportStrategy };
+  | {
+      accepted: true;
+      strategy: RoundTripImportStrategy;
+      applyPermissions: boolean;
+      permissionMappings: Record<string, string>;
+    };
 
 export interface RoundTripImportReviewRequest {
   id: number;
@@ -101,16 +143,20 @@ export interface RoundTripImportReviewRequest {
   loadPreview?: (strategy: RoundTripImportStrategy) => Promise<RoundTripPackagePreview>;
 }
 
-interface SubmitRoundTripPackageOptions {
+export interface SubmitRoundTripPackageOptions {
   dryRun: boolean;
   strategy: RoundTripImportStrategy;
   workspaceId?: string;
   targetNotebookId?: string;
+  applyPermissions?: boolean;
+  permissionMappings?: Record<string, string>;
 }
 
 interface RememberedImportDecision {
   strategy: RoundTripImportStrategy;
   workspaceId?: string;
+  applyPermissions: boolean;
+  permissionMappings: Record<string, string>;
 }
 
 type Listener = (requests: RoundTripImportReviewRequest[]) => void;
@@ -163,8 +209,12 @@ export async function submitRoundTripPackage(
 
   const form = new FormData();
   form.append("file", file);
+  if (!options.dryRun && options.applyPermissions) {
+    form.append("applyPermissions", "true");
+    form.append("permissionMappings", JSON.stringify(options.permissionMappings || {}));
+  }
   const token = readToken();
-  const response = await fetch(`${getBaseUrl()}/export/import/nowen-package?${params.toString()}`, {
+  const response = await fetch(`${getBaseUrl()}/settings/import-batches/package?${params.toString()}`, {
     method: "POST",
     credentials: "include",
     headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) },
@@ -251,10 +301,7 @@ function currentWorkspaceId(): string | undefined {
 
 /**
  * Enhance the legacy Nowen-package panel without coupling it to the review dialog.
- *
- * All three strategies use the same explicit workspace-aware endpoint. This avoids the historical
- * dry-run/import mismatch where the preview was calculated in personal scope while the UI showed a
- * workspace. Sync is only offered when the server confirms that stable source mappings exist.
+ * All strategies and permission mapping use the same workspace-aware package endpoint.
  */
 export function installRoundTripImportReviewBridge(): void {
   if (bridgeInstalled) return;
@@ -282,7 +329,12 @@ export function installRoundTripImportReviewBridge(): void {
       }),
     });
     if (decision.accepted) {
-      selectedDecisionByFile.set(file, { strategy: decision.strategy, workspaceId });
+      selectedDecisionByFile.set(file, {
+        strategy: decision.strategy,
+        workspaceId,
+        applyPermissions: decision.applyPermissions,
+        permissionMappings: decision.permissionMappings,
+      });
     } else {
       selectedDecisionByFile.delete(file);
     }
@@ -303,6 +355,8 @@ export function installRoundTripImportReviewBridge(): void {
       strategy: remembered.strategy,
       workspaceId: opts?.workspaceId ?? remembered.workspaceId,
       targetNotebookId: opts?.targetNotebookId,
+      applyPermissions: remembered.applyPermissions,
+      permissionMappings: remembered.permissionMappings,
     });
   }) as typeof api.importNowenPackage;
 }

--- a/frontend/src/lib/roundTripPermissionExport.ts
+++ b/frontend/src/lib/roundTripPermissionExport.ts
@@ -1,0 +1,54 @@
+import { getBaseUrl } from "./api";
+
+function readToken(): string | null {
+  try {
+    return localStorage.getItem("nowen-token");
+  } catch {
+    return null;
+  }
+}
+
+function decodeFilename(value: string): string {
+  try { return decodeURIComponent(value); }
+  catch { return value; }
+}
+
+function filenameFromDisposition(value: string | null): string | null {
+  if (!value) return null;
+  const utf8 = /filename\*=UTF-8''([^;]+)/i.exec(value);
+  if (utf8?.[1]) return decodeFilename(utf8[1].trim().replace(/^"|"$/g, ""));
+  const plain = /filename="?([^";]+)"?/i.exec(value);
+  return plain?.[1] ? decodeFilename(plain[1].trim()) : null;
+}
+
+export interface RoundTripPermissionPackageDownloadOptions {
+  workspaceId: string;
+  includePermissions?: boolean;
+}
+
+export async function downloadRoundTripPermissionPackage(
+  options: RoundTripPermissionPackageDownloadOptions,
+): Promise<{ blob: Blob; filename: string }> {
+  const params = new URLSearchParams();
+  if (options.workspaceId && options.workspaceId !== "personal") {
+    params.set("workspaceId", options.workspaceId);
+  }
+  if (options.includePermissions) params.set("includePermissions", "true");
+
+  const token = readToken();
+  const response = await fetch(`${getBaseUrl()}/settings/import-batches/package?${params.toString()}`, {
+    method: "GET",
+    credentials: "include",
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null) as { error?: string } | null;
+    throw new Error(payload?.error || `HTTP ${response.status}`);
+  }
+
+  return {
+    blob: await response.blob(),
+    filename: filenameFromDisposition(response.headers.get("Content-Disposition"))
+      || `nowen-note-${new Date().toISOString().slice(0, 10)}.nowen.zip`,
+  };
+}


### PR DESCRIPTION
Continues #371 and closes #382.

实现 Nowen 无损迁移包的可选成员与权限迁移：

- 默认不导出成员身份和权限；
- 工作区 owner/admin 可显式生成独立 `permissions.json`；
- 权限清单包含来源成员身份、工作区角色和导出范围内的笔记本直接授权；
- 导入预检展示成员、授权数量和邮箱/用户名精确匹配建议；
- 导入前必须显式开启权限恢复，并逐个确认来源账号到目标账号的映射；
- 不自动创建账号，未映射成员只跳过权限，不阻塞内容导入；
- 来源 owner 仅按 admin 处理，不替换目标 owner；
- 已有工作区和笔记本权限不会被降级；
- 仅对本次导入形成稳定目录映射的笔记本恢复直接授权；
- 成员权限结果写入持久化导入批次报告；
- 一键撤销记录权限变更前快照，导入后权限被再次修改时拒绝破坏性回滚；
- 新增权限清单默认关闭、显式映射、owner 保护、升级不降级和撤销冲突测试；
- 新增后端与前端聚焦 CI。

当前导出权限入口由新的 `/api/settings/import-batches/package?includePermissions=true` 提供；普通 Nowen 包行为保持不变。