### PR TITLE
chore(pg): sync latest main into pg-migration-unified

### DIFF
--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - "backend/src/index.hardened.ts"
+      - "backend/src/lib/blockPatchIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
       - "backend/src/runtime/block-patch.ts"
+      - "backend/tests/block-patch-incremental-index.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
       - "backend/tests/block-patch-route.test.ts"
@@ -29,9 +31,11 @@ on:
   pull_request:
     paths:
       - "backend/src/index.hardened.ts"
+      - "backend/src/lib/blockPatchIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
       - "backend/src/runtime/block-patch.ts"
+      - "backend/tests/block-patch-incremental-index.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
       - "backend/tests/block-patch-route.test.ts"
@@ -69,13 +73,14 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
-      - name: Block patch engine and route tests
+      - name: Block patch engine, incremental index and route tests
         run: >-
           node --import tsx --test
           tests/tiptap-block-patch.test.ts
           tests/tiptap-block-patch-v2.test.ts
           tests/block-patch-route.test.ts
           tests/block-patch-route-v2.test.ts
+          tests/block-patch-incremental-index.test.ts
       - name: Backend typecheck
         run: npm run build:tsc
 

--- a/backend/src/lib/blockPatchIncrementalIndexes.ts
+++ b/backend/src/lib/blockPatchIncrementalIndexes.ts
@@ -1,0 +1,377 @@
+import { createHash } from "node:crypto";
+import { v4 as uuid } from "uuid";
+import type Database from "better-sqlite3";
+
+import type { NoteBlockIndexRow, NoteBlockType } from "./noteBlocks.js";
+import type { TiptapBlockPatchOperation } from "./tiptapBlockPatch.js";
+import type { NoteLinkEntry } from "../repositories/types.js";
+
+const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
+const LEAF_BLOCK_TYPES = new Set(["paragraph", "heading", "codeBlock"]);
+const INDEXED_BLOCK_TYPES = new Set([
+  "heading",
+  "paragraph",
+  "listItem",
+  "taskItem",
+  "blockquote",
+  "codeBlock",
+]);
+const NOTE_LINK_RE = /\[\[note:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:#blk:([a-zA-Z0-9_-]+))?(?:\|([^\]]*))?\]\]/g;
+const NOTE_HREF_RE = /note:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:#blk:([a-zA-Z0-9_-]+))?/g;
+
+interface ExistingIndexRow {
+  blockId: string;
+  blockType: string;
+  parentBlockId: string | null;
+  blockOrder: number;
+  plainText: string;
+  contentHash: string;
+  path: string;
+}
+
+interface AnalyzedBlock {
+  row: NoteBlockIndexRow;
+  node: any;
+}
+
+interface TiptapAnalysis {
+  blocks: AnalyzedBlock[];
+  byId: Map<string, AnalyzedBlock>;
+  contentText: string;
+}
+
+export interface IncrementalPatchIndexPlan {
+  mode: "incremental";
+  contentText: string;
+  affectedRows: NoteBlockIndexRow[];
+  links: NoteLinkEntry[];
+  affectedBlockIds: string[];
+}
+
+function validBlockId(value: unknown): value is string {
+  return typeof value === "string" && BLOCK_ID_RE.test(value);
+}
+
+function collectNodeText(node: any): string {
+  if (!node || typeof node !== "object") return "";
+  if (node.type === "text") return String(node.text || "");
+  if (node.type === "hardBreak") return "\n";
+  if (!Array.isArray(node.content)) return "";
+  return node.content.map(collectNodeText).join("");
+}
+
+function hashText(type: string, text: string): string {
+  return createHash("sha256")
+    .update(type)
+    .update("\0")
+    .update(text.replace(/\s+/g, " ").trim())
+    .digest("hex");
+}
+
+function analyzeTiptap(noteId: string, content: string): TiptapAnalysis | null {
+  let doc: any;
+  try {
+    doc = JSON.parse(content || "{}");
+  } catch {
+    return null;
+  }
+  if (!doc || typeof doc !== "object" || doc.type !== "doc" || !Array.isArray(doc.content)) {
+    return null;
+  }
+
+  const blocks: AnalyzedBlock[] = [];
+  const byId = new Map<string, AnalyzedBlock>();
+  let order = 0;
+  let invalid = false;
+
+  const visit = (nodes: any[], parentBlockId: string | null, parentPath: number[]) => {
+    for (let index = 0; index < nodes.length; index += 1) {
+      const node = nodes[index];
+      if (!node || typeof node !== "object") continue;
+      const path = [...parentPath, index];
+      let nextParent = parentBlockId;
+
+      if (INDEXED_BLOCK_TYPES.has(node.type)) {
+        const blockId = node.attrs?.blockId;
+        if (!validBlockId(blockId) || byId.has(blockId)) {
+          invalid = true;
+          return;
+        }
+        const plainText = collectNodeText(node).replace(/\u0000/g, "").trim();
+        const analyzed: AnalyzedBlock = {
+          row: {
+            noteId,
+            blockId,
+            blockType: node.type as NoteBlockType,
+            parentBlockId,
+            blockOrder: order,
+            plainText,
+            contentHash: hashText(node.type, plainText),
+            path: path.join("."),
+            startOffset: null,
+            endOffset: null,
+          },
+          node,
+        };
+        order += 1;
+        blocks.push(analyzed);
+        byId.set(blockId, analyzed);
+        nextParent = blockId;
+      }
+
+      if (Array.isArray(node.content)) {
+        visit(node.content, nextParent, path);
+        if (invalid) return;
+      }
+    }
+  };
+
+  visit(doc.content, null, []);
+  if (invalid) return null;
+  return {
+    blocks,
+    byId,
+    contentText: blocks.map(({ row }) => row.plainText).filter(Boolean).join("\n\n"),
+  };
+}
+
+function loadExistingRows(db: Database.Database, noteId: string): ExistingIndexRow[] {
+  return db.prepare(`
+    SELECT blockId, blockType, parentBlockId, blockOrder, plainText, contentHash, path
+    FROM note_blocks_index
+    WHERE noteId = ?
+    ORDER BY blockOrder ASC
+  `).all(noteId) as ExistingIndexRow[];
+}
+
+function structuresMatch(
+  existing: ExistingIndexRow[],
+  analysis: TiptapAnalysis,
+  ignoredContentIds: Set<string>,
+): boolean {
+  if (existing.length !== analysis.blocks.length) return false;
+  const existingById = new Map(existing.map((row) => [row.blockId, row]));
+  if (existingById.size !== analysis.blocks.length) return false;
+
+  for (const { row } of analysis.blocks) {
+    const previous = existingById.get(row.blockId);
+    if (!previous) return false;
+    if (
+      previous.blockType !== row.blockType
+      || previous.parentBlockId !== row.parentBlockId
+      || previous.blockOrder !== row.blockOrder
+      || previous.path !== row.path
+    ) {
+      return false;
+    }
+    if (!ignoredContentIds.has(row.blockId) && (
+      previous.contentHash !== row.contentHash
+      || previous.plainText !== row.plainText
+    )) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function addLink(
+  links: NoteLinkEntry[],
+  seen: Set<string>,
+  entry: NoteLinkEntry,
+): void {
+  const key = `${entry.sourceBlockId || ""}:${entry.targetNoteId}:${entry.targetBlockId || ""}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  links.push(entry);
+}
+
+function entriesFromText(
+  text: string,
+  sourceBlockId: string,
+  excerpt: string | null,
+  links: NoteLinkEntry[],
+  seen: Set<string>,
+): void {
+  for (const match of text.matchAll(NOTE_LINK_RE)) {
+    const targetNoteId = match[1].toLowerCase();
+    const targetBlockId = match[2] || null;
+    const displayText = match[3] || null;
+    addLink(links, seen, {
+      targetNoteId,
+      targetBlockId,
+      sourceBlockId,
+      linkType: targetBlockId ? "block" : "note",
+      linkText: displayText,
+      excerpt: excerpt || displayText,
+    });
+  }
+  for (const match of text.matchAll(NOTE_HREF_RE)) {
+    const targetNoteId = match[1].toLowerCase();
+    const targetBlockId = match[2] || null;
+    addLink(links, seen, {
+      targetNoteId,
+      targetBlockId,
+      sourceBlockId,
+      linkType: targetBlockId ? "block" : "note",
+      linkText: null,
+      excerpt,
+    });
+  }
+}
+
+function extractLinksFromLeaf(node: any, sourceBlockId: string, plainText: string): NoteLinkEntry[] {
+  const links: NoteLinkEntry[] = [];
+  const seen = new Set<string>();
+  const excerpt = plainText.replace(/\s+/g, " ").trim().slice(0, 240) || null;
+
+  const visit = (candidate: any) => {
+    if (!candidate || typeof candidate !== "object") return;
+    if (candidate.type === "text") {
+      const text = String(candidate.text || "");
+      entriesFromText(text, sourceBlockId, excerpt, links, seen);
+      for (const mark of Array.isArray(candidate.marks) ? candidate.marks : []) {
+        const href = mark?.attrs?.href;
+        if (mark?.type === "link" && typeof href === "string" && href.startsWith("note:")) {
+          entriesFromText(href, sourceBlockId, excerpt, links, seen);
+        }
+      }
+    }
+    for (const child of Array.isArray(candidate.content) ? candidate.content : []) visit(child);
+  };
+
+  visit(node);
+  return links;
+}
+
+function isLeafOnlyPatch(operations: TiptapBlockPatchOperation[]): boolean {
+  return operations.length > 0 && operations.every(
+    (operation) => operation.type === "update" || operation.type === "replace",
+  );
+}
+
+/**
+ * Check whether the persisted Block index is a complete structural mirror of the current Tiptap
+ * document. This intentionally fails closed: a stale/missing/duplicate ID forces full normalization.
+ */
+export function canUseIncrementalPatchIndexes(
+  db: Database.Database,
+  noteId: string,
+  content: string,
+  operations: TiptapBlockPatchOperation[],
+): boolean {
+  if (!isLeafOnlyPatch(operations)) return false;
+  const analysis = analyzeTiptap(noteId, content);
+  if (!analysis) return false;
+  const affected = new Set(operations.map((operation) => operation.blockId));
+  for (const blockId of affected) {
+    const block = analysis.byId.get(blockId);
+    if (!block || !LEAF_BLOCK_TYPES.has(block.row.blockType)) return false;
+  }
+  return structuresMatch(loadExistingRows(db, noteId), analysis, new Set());
+}
+
+/** Build a post-patch incremental update plan without mutating persistence. */
+export function planIncrementalPatchIndexes(
+  db: Database.Database,
+  userId: string,
+  noteId: string,
+  content: string,
+  operations: TiptapBlockPatchOperation[],
+): IncrementalPatchIndexPlan | null {
+  if (!isLeafOnlyPatch(operations)) return null;
+  const analysis = analyzeTiptap(noteId, content);
+  if (!analysis) return null;
+  const affectedBlockIds = [...new Set(operations.map((operation) => operation.blockId))];
+  const affected = new Set(affectedBlockIds);
+
+  for (const blockId of affectedBlockIds) {
+    const block = analysis.byId.get(blockId);
+    if (!block || !LEAF_BLOCK_TYPES.has(block.row.blockType)) return null;
+  }
+  if (!structuresMatch(loadExistingRows(db, noteId), analysis, affected)) return null;
+
+  const links = affectedBlockIds.flatMap((blockId) => {
+    const block = analysis.byId.get(blockId) as AnalyzedBlock;
+    return extractLinksFromLeaf(block.node, blockId, block.row.plainText)
+      .filter((link) => !(link.targetNoteId === noteId.toLowerCase() && !link.targetBlockId));
+  });
+
+  // Filter inaccessible/nonexistent targets using the same existence rule as full link sync. ACL is
+  // checked when backlinks are read; this avoids leaking targets while preserving source metadata.
+  const targetExists = db.prepare("SELECT id FROM notes WHERE id = ?");
+  const validLinks = links.filter((link) => Boolean(targetExists.get(link.targetNoteId)));
+  void userId;
+
+  return {
+    mode: "incremental",
+    contentText: analysis.contentText,
+    affectedRows: affectedBlockIds.map((blockId) => (analysis.byId.get(blockId) as AnalyzedBlock).row),
+    links: validLinks,
+    affectedBlockIds,
+  };
+}
+
+/** Apply one previously validated incremental plan inside the caller's SQLite transaction. */
+export function applyIncrementalPatchIndexes(
+  db: Database.Database,
+  userId: string,
+  noteId: string,
+  plan: IncrementalPatchIndexPlan,
+): void {
+  const upsert = db.prepare(`
+    INSERT INTO note_blocks_index (
+      noteId, blockId, blockType, parentBlockId, blockOrder, plainText,
+      contentHash, path, startOffset, endOffset, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+    ON CONFLICT(noteId, blockId) DO UPDATE SET
+      blockType = excluded.blockType,
+      parentBlockId = excluded.parentBlockId,
+      blockOrder = excluded.blockOrder,
+      plainText = excluded.plainText,
+      contentHash = excluded.contentHash,
+      path = excluded.path,
+      startOffset = excluded.startOffset,
+      endOffset = excluded.endOffset,
+      updatedAt = datetime('now')
+  `);
+  for (const row of plan.affectedRows) {
+    upsert.run(
+      row.noteId,
+      row.blockId,
+      row.blockType,
+      row.parentBlockId,
+      row.blockOrder,
+      row.plainText,
+      row.contentHash,
+      row.path,
+      row.startOffset,
+      row.endOffset,
+    );
+  }
+
+  const placeholders = plan.affectedBlockIds.map(() => "?").join(",");
+  db.prepare(`
+    DELETE FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId IN (${placeholders})
+  `).run(noteId, ...plan.affectedBlockIds);
+
+  const insertLink = db.prepare(`
+    INSERT OR IGNORE INTO note_links (
+      id, userId, sourceNoteId, targetNoteId, targetBlockId, sourceBlockId,
+      linkType, linkText, excerpt, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+  `);
+  for (const link of plan.links) {
+    insertLink.run(
+      uuid(),
+      userId,
+      noteId,
+      link.targetNoteId,
+      link.targetBlockId,
+      link.sourceBlockId,
+      link.linkType,
+      link.linkText,
+      link.excerpt,
+    );
+  }
+}

--- a/backend/src/lib/blockPatchIncrementalIndexes.ts
+++ b/backend/src/lib/blockPatchIncrementalIndexes.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import { v4 as uuid } from "uuid";
 import type Database from "better-sqlite3";
 
+import type { NoteLinkEntry } from "../repositories/types.js";
 import type { NoteBlockIndexRow, NoteBlockType } from "./noteBlocks.js";
 import type { TiptapBlockPatchOperation } from "./tiptapBlockPatch.js";
-import type { NoteLinkEntry } from "../repositories/types.js";
 
 const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
 const LEAF_BLOCK_TYPES = new Set(["paragraph", "heading", "codeBlock"]);
@@ -45,7 +45,10 @@ export interface IncrementalPatchIndexPlan {
   contentText: string;
   affectedRows: NoteBlockIndexRow[];
   links: NoteLinkEntry[];
-  affectedBlockIds: string[];
+  /** Rows rewritten in note_blocks_index, including indexed ancestors with aggregate text. */
+  indexedBlockIds: string[];
+  /** Source Block rows whose note_links entries are replaced. */
+  linkBlockIds: string[];
 }
 
 function validBlockId(value: unknown): value is string {
@@ -157,17 +160,26 @@ function structuresMatch(
     const previous = existingById.get(row.blockId);
     if (!previous) return false;
     if (
-      previous.blockType !== row.blockType
-      || previous.parentBlockId !== row.parentBlockId
+      previous.parentBlockId !== row.parentBlockId
       || previous.blockOrder !== row.blockOrder
       || previous.path !== row.path
     ) {
       return false;
     }
     if (!ignoredContentIds.has(row.blockId) && (
-      previous.contentHash !== row.contentHash
+      previous.blockType !== row.blockType
+      || previous.contentHash !== row.contentHash
       || previous.plainText !== row.plainText
     )) {
+      return false;
+    }
+    // Only top-level safe leaf replacements may change block type. Nested replacements are already
+    // rejected by the patch engine, and this check keeps the index planner fail-closed as well.
+    if (
+      ignoredContentIds.has(row.blockId)
+      && previous.blockType !== row.blockType
+      && row.parentBlockId !== null
+    ) {
       return false;
     }
   }
@@ -249,6 +261,20 @@ function isLeafOnlyPatch(operations: TiptapBlockPatchOperation[]): boolean {
   );
 }
 
+function collectIndexedAncestors(analysis: TiptapAnalysis, leafBlockIds: string[]): string[] {
+  const output = new Set<string>();
+  for (const leafBlockId of leafBlockIds) {
+    let current: string | null = leafBlockId;
+    while (current && !output.has(current)) {
+      output.add(current);
+      current = analysis.byId.get(current)?.row.parentBlockId || null;
+    }
+  }
+  return analysis.blocks
+    .map(({ row }) => row.blockId)
+    .filter((blockId) => output.has(blockId));
+}
+
 /**
  * Check whether the persisted Block index is a complete structural mirror of the current Tiptap
  * document. This intentionally fails closed: a stale/missing/duplicate ID forces full normalization.
@@ -281,23 +307,24 @@ export function planIncrementalPatchIndexes(
   if (!isLeafOnlyPatch(operations)) return null;
   const analysis = analyzeTiptap(noteId, content);
   if (!analysis) return null;
-  const affectedBlockIds = [...new Set(operations.map((operation) => operation.blockId))];
-  const affected = new Set(affectedBlockIds);
+  const linkBlockIds = [...new Set(operations.map((operation) => operation.blockId))];
 
-  for (const blockId of affectedBlockIds) {
+  for (const blockId of linkBlockIds) {
     const block = analysis.byId.get(blockId);
     if (!block || !LEAF_BLOCK_TYPES.has(block.row.blockType)) return null;
   }
-  if (!structuresMatch(loadExistingRows(db, noteId), analysis, affected)) return null;
+  const indexedBlockIds = collectIndexedAncestors(analysis, linkBlockIds);
+  const ignoredContentIds = new Set(indexedBlockIds);
+  if (!structuresMatch(loadExistingRows(db, noteId), analysis, ignoredContentIds)) return null;
 
-  const links = affectedBlockIds.flatMap((blockId) => {
+  const links = linkBlockIds.flatMap((blockId) => {
     const block = analysis.byId.get(blockId) as AnalyzedBlock;
     return extractLinksFromLeaf(block.node, blockId, block.row.plainText)
       .filter((link) => !(link.targetNoteId === noteId.toLowerCase() && !link.targetBlockId));
   });
 
-  // Filter inaccessible/nonexistent targets using the same existence rule as full link sync. ACL is
-  // checked when backlinks are read; this avoids leaking targets while preserving source metadata.
+  // Filter nonexistent targets using the same existence rule as full link sync. ACL is checked when
+  // backlinks are read, so this does not disclose private targets to the patching client.
   const targetExists = db.prepare("SELECT id FROM notes WHERE id = ?");
   const validLinks = links.filter((link) => Boolean(targetExists.get(link.targetNoteId)));
   void userId;
@@ -305,9 +332,10 @@ export function planIncrementalPatchIndexes(
   return {
     mode: "incremental",
     contentText: analysis.contentText,
-    affectedRows: affectedBlockIds.map((blockId) => (analysis.byId.get(blockId) as AnalyzedBlock).row),
+    affectedRows: indexedBlockIds.map((blockId) => (analysis.byId.get(blockId) as AnalyzedBlock).row),
     links: validLinks,
-    affectedBlockIds,
+    indexedBlockIds,
+    linkBlockIds,
   };
 }
 
@@ -349,11 +377,11 @@ export function applyIncrementalPatchIndexes(
     );
   }
 
-  const placeholders = plan.affectedBlockIds.map(() => "?").join(",");
+  const placeholders = plan.linkBlockIds.map(() => "?").join(",");
   db.prepare(`
     DELETE FROM note_links
     WHERE sourceNoteId = ? AND sourceBlockId IN (${placeholders})
-  `).run(noteId, ...plan.affectedBlockIds);
+  `).run(noteId, ...plan.linkBlockIds);
 
   const insertLink = db.prepare(`
     INSERT OR IGNORE INTO note_links (

--- a/backend/src/runtime/block-patch.ts
+++ b/backend/src/runtime/block-patch.ts
@@ -4,6 +4,11 @@ import { v4 as uuid } from "uuid";
 
 import { getDb } from "../db/schema.js";
 import {
+  applyIncrementalPatchIndexes,
+  canUseIncrementalPatchIndexes,
+  planIncrementalPatchIndexes,
+} from "../lib/blockPatchIncrementalIndexes.js";
+import {
   ensureNoteBlockTables,
   getNoteBlock,
   plainTextFromNoteContent,
@@ -195,11 +200,29 @@ async function patchBlocks(c: Context) {
         throw new BlockPatchRouteError("VERSION_CONFLICT", 409, { currentVersion: note.version });
       }
 
-      // Materialize missing/duplicate stable IDs inside the same transaction. If any later operation
-      // fails, both this normalization and every patch operation roll back together.
-      const normalizedBefore = syncNoteBlocks(db, noteId, note.content, note.contentFormat);
+      // Leaf-only patches can skip the legacy pre-patch DELETE + full reinsert when the persisted
+      // index is already a complete mirror of the current document. Any mismatch fails closed and
+      // falls back to the original normalization path inside this same transaction.
+      const incrementalBase = canUseIncrementalPatchIndexes(
+        db,
+        noteId,
+        note.content,
+        operations,
+      );
+      const normalizedBefore = incrementalBase
+        ? {
+            content: note.content,
+            contentText: note.contentText,
+            blocks: [],
+            changed: false,
+          }
+        : syncNoteBlocks(db, noteId, note.content, note.contentFormat);
       const patch = applyTiptapBlockPatch(normalizedBefore.content, operations);
-      const contentText = plainTextFromNoteContent(patch.content, note.contentFormat);
+      const incrementalPlan = incrementalBase
+        ? planIncrementalPatchIndexes(db, userId, noteId, patch.content, operations)
+        : null;
+      const contentText = incrementalPlan?.contentText
+        || plainTextFromNoteContent(patch.content, note.contentFormat);
       const nextVersion = note.version + 1;
 
       // Match PUT /notes/:id version-history semantics. This insert is inside the same transaction,
@@ -218,8 +241,21 @@ async function patchBlocks(c: Context) {
         });
       }
 
-      const synced = syncNoteBlocks(db, noteId, patch.content, note.contentFormat);
-      syncNoteLinks(db, userId, noteId, synced.content);
+      let persistedContent = patch.content;
+      let persistedContentText = contentText;
+      let postSyncChanged = false;
+      let indexUpdateMode: "incremental" | "full" = "full";
+      if (incrementalPlan) {
+        applyIncrementalPatchIndexes(db, userId, noteId, incrementalPlan);
+        indexUpdateMode = "incremental";
+      } else {
+        const synced = syncNoteBlocks(db, noteId, patch.content, note.contentFormat);
+        syncNoteLinks(db, userId, noteId, synced.content);
+        persistedContent = synced.content;
+        persistedContentText = synced.contentText;
+        postSyncChanged = synced.changed;
+      }
+
       const persisted = readNote(noteId);
       if (!persisted) throw new BlockPatchRouteError("NOT_FOUND", 404);
 
@@ -235,8 +271,8 @@ async function patchBlocks(c: Context) {
         title: persisted.title,
         version: nextVersion,
         updatedAt: persisted.updatedAt,
-        content: synced.content,
-        contentText: synced.contentText,
+        content: persistedContent,
+        contentText: persistedContentText,
         contentFormat: persisted.contentFormat,
         notebookId: persisted.notebookId,
         operationCount: operations.length,
@@ -244,7 +280,11 @@ async function patchBlocks(c: Context) {
         deletedBlockIds,
         createdBlocks: patch.createdBlocks,
         blocks,
-        contentChangedByNormalization: normalizedBefore.changed || synced.changed,
+        indexUpdateMode,
+        indexedBlockIds: indexUpdateMode === "incremental"
+          ? incrementalPlan?.affectedBlockIds || []
+          : patch.affectedBlockIds,
+        contentChangedByNormalization: normalizedBefore.changed || postSyncChanged,
       };
       storeIdempotentResult(userId, noteId, body.operationId, result);
       return result;
@@ -256,6 +296,7 @@ async function patchBlocks(c: Context) {
       version: result.version,
       operationCount: result.operationCount,
       affectedBlockIds: result.affectedBlockIds,
+      indexUpdateMode: result.indexUpdateMode,
     }, { targetType: "note", targetId: noteId });
     broadcastNoteUpdated(noteId, {
       version: result.version,

--- a/backend/src/runtime/block-patch.ts
+++ b/backend/src/runtime/block-patch.ts
@@ -222,7 +222,7 @@ async function patchBlocks(c: Context) {
         ? planIncrementalPatchIndexes(db, userId, noteId, patch.content, operations)
         : null;
       const contentText = incrementalPlan?.contentText
-        || plainTextFromNoteContent(patch.content, note.contentFormat);
+        ?? plainTextFromNoteContent(patch.content, note.contentFormat);
       const nextVersion = note.version + 1;
 
       // Match PUT /notes/:id version-history semantics. This insert is inside the same transaction,
@@ -282,7 +282,7 @@ async function patchBlocks(c: Context) {
         blocks,
         indexUpdateMode,
         indexedBlockIds: indexUpdateMode === "incremental"
-          ? incrementalPlan?.affectedBlockIds || []
+          ? incrementalPlan?.indexedBlockIds || []
           : patch.affectedBlockIds,
         contentChangedByNormalization: normalizedBefore.changed || postSyncChanged,
       };

--- a/backend/tests/block-patch-incremental-index.test.ts
+++ b/backend/tests/block-patch-incremental-index.test.ts
@@ -70,7 +70,8 @@ async function patch(noteId: string, body: unknown) {
 
 function indexRow(noteId: string, blockId: string) {
   return db.prepare(`
-    SELECT blockId, blockType, plainText, contentHash, path, blockOrder, createdAt, updatedAt
+    SELECT blockId, blockType, parentBlockId, plainText, contentHash,
+           path, blockOrder, createdAt, updatedAt
     FROM note_blocks_index
     WHERE noteId = ? AND blockId = ?
   `).get(noteId, blockId) as Record<string, unknown> | undefined;
@@ -165,6 +166,71 @@ test("updates only the affected Block row and source-Block links", async () => {
     ORDER BY targetNoteId
   `).all(noteId, changedBlockId) as Array<{ targetNoteId: string }>;
   assert.deepEqual(changedLinks.map((row) => row.targetNoteId), [secondTarget]);
+});
+
+test("refreshes indexed ancestors but preserves unrelated rows for nested leaf edits", async () => {
+  const noteId = "66666666-6666-4666-8666-666666666666";
+  const itemBlockId = "blk_itemnest";
+  const nestedBlockId = "blk_paranest";
+  const unrelatedBlockId = "blk_unrelated";
+  insertNote(noteId, tiptap(
+    {
+      type: "bulletList",
+      content: [{
+        type: "listItem",
+        attrs: { blockId: itemBlockId },
+        content: [paragraph(nestedBlockId, "Nested before")],
+      }],
+    },
+    paragraph(unrelatedBlockId, "Unrelated"),
+  ));
+
+  const sentinel = "2002-02-02 00:00:00";
+  db.prepare(`
+    UPDATE note_blocks_index SET updatedAt = ?
+    WHERE noteId = ? AND blockId = ?
+  `).run(sentinel, noteId, unrelatedBlockId);
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-nested",
+    operations: [{ type: "update", blockId: nestedBlockId, text: "Nested after" }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [itemBlockId, nestedBlockId]);
+  assert.equal(indexRow(noteId, itemBlockId)?.plainText, "Nested after");
+  assert.equal(indexRow(noteId, nestedBlockId)?.plainText, "Nested after");
+  assert.equal(indexRow(noteId, nestedBlockId)?.parentBlockId, itemBlockId);
+  assert.equal(indexRow(noteId, unrelatedBlockId)?.updatedAt, sentinel);
+});
+
+test("updates a top-level block type incrementally", async () => {
+  const noteId = "77777777-7777-4777-8777-777777777777";
+  const blockId = "blk_convert0";
+  insertNote(noteId, tiptap(paragraph(blockId, "Convertible")));
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-convert",
+    operations: [{
+      type: "replace",
+      blockId,
+      node: {
+        type: "heading",
+        attrs: { blockId, level: 3, textAlign: null, lineHeight: null },
+        content: [{ type: "text", text: "Convertible" }],
+      },
+    }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [blockId]);
+  assert.equal(indexRow(noteId, blockId)?.blockType, "heading");
 });
 
 test("falls back to a full rebuild when the existing index is stale", async () => {

--- a/backend/tests/block-patch-incremental-index.test.ts
+++ b/backend/tests/block-patch-incremental-index.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-block-patch-index-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+const owner = "block-patch-index-owner";
+const notebookId = "block-patch-index-notebook";
+const firstTarget = "11111111-1111-4111-8111-111111111111";
+const secondTarget = "22222222-2222-4222-8222-222222222222";
+
+let db: Database.Database;
+let closeDb: () => void;
+let app: Hono;
+let syncNoteBlocks: typeof import("../src/lib/noteBlocks").syncNoteBlocks;
+let syncNoteLinks: typeof import("../src/lib/noteLinks").syncNoteLinks;
+
+function paragraph(blockId: string, text: string, targetNoteId?: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId, textAlign: null, lineHeight: null },
+    content: text ? [{
+      type: "text",
+      text,
+      ...(targetNoteId ? {
+        marks: [{
+          type: "link",
+          attrs: {
+            href: `note:${targetNoteId}`,
+            target: null,
+            rel: "noopener noreferrer nofollow",
+            class: null,
+          },
+        }],
+      } : {}),
+    }] : [],
+  };
+}
+
+function tiptap(...nodes: unknown[]): string {
+  return JSON.stringify({ type: "doc", content: nodes });
+}
+
+function insertNote(id: string, content: string) {
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked
+    ) VALUES (?, ?, ?, ?, ?, '', 'tiptap-json', 1, 0)
+  `).run(id, owner, notebookId, id, content);
+  const synced = syncNoteBlocks(db, id, content, "tiptap-json");
+  syncNoteLinks(db, owner, id, synced.content);
+}
+
+async function patch(noteId: string, body: unknown) {
+  return app.request(`/api/blocks/${noteId}/patch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": owner,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function indexRow(noteId: string, blockId: string) {
+  return db.prepare(`
+    SELECT blockId, blockType, plainText, contentHash, path, blockOrder, createdAt, updatedAt
+    FROM note_blocks_index
+    WHERE noteId = ? AND blockId = ?
+  `).get(noteId, blockId) as Record<string, unknown> | undefined;
+}
+
+test.before(async () => {
+  const [schema, noteBlocks, noteLinks] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/lib/noteBlocks"),
+    import("../src/lib/noteLinks"),
+  ]);
+  await import("../src/runtime/block-patch");
+  const blockRoute = await import("../src/routes/blocks");
+
+  db = schema.getDb();
+  closeDb = schema.closeDb;
+  syncNoteBlocks = noteBlocks.syncNoteBlocks;
+  syncNoteLinks = noteLinks.syncNoteLinks;
+  app = new Hono();
+  app.route("/api/blocks", blockRoute.default);
+
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(owner, owner, "hash");
+  db.prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run(notebookId, owner, "Incremental indexes");
+  insertNote(firstTarget, tiptap(paragraph("blk_target01", "First target")));
+  insertNote(secondTarget, tiptap(paragraph("blk_target02", "Second target")));
+});
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("updates only the affected Block row and source-Block links", async () => {
+  const noteId = "33333333-3333-4333-8333-333333333333";
+  const changedBlockId = "blk_changed0";
+  const untouchedBlockId = "blk_untouched";
+  insertNote(noteId, tiptap(
+    paragraph(changedBlockId, "First link", firstTarget),
+    paragraph(untouchedBlockId, "Keep link", secondTarget),
+  ));
+
+  const sentinel = "2001-01-01 00:00:00";
+  db.prepare(`
+    UPDATE note_blocks_index SET createdAt = ?, updatedAt = ?
+    WHERE noteId = ? AND blockId = ?
+  `).run(sentinel, sentinel, noteId, untouchedBlockId);
+  db.prepare(`
+    UPDATE note_links SET id = 'keep-link-row', createdAt = ?, updatedAt = ?
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).run(sentinel, sentinel, noteId, untouchedBlockId);
+
+  const replacement = paragraph(changedBlockId, "Changed link", secondTarget);
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-1",
+    operations: [{
+      type: "replace",
+      blockId: changedBlockId,
+      node: replacement,
+    }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [changedBlockId]);
+  assert.match(payload.contentText, /Changed link/);
+  assert.match(payload.contentText, /Keep link/);
+
+  const untouched = indexRow(noteId, untouchedBlockId);
+  assert.equal(untouched?.createdAt, sentinel);
+  assert.equal(untouched?.updatedAt, sentinel);
+  assert.equal(untouched?.plainText, "Keep link");
+
+  const changed = indexRow(noteId, changedBlockId);
+  assert.equal(changed?.plainText, "Changed link");
+  assert.notEqual(changed?.contentHash, "");
+
+  const preservedLink = db.prepare(`
+    SELECT id, targetNoteId, updatedAt FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).get(noteId, untouchedBlockId) as any;
+  assert.equal(preservedLink.id, "keep-link-row");
+  assert.equal(preservedLink.targetNoteId, secondTarget);
+  assert.equal(preservedLink.updatedAt, sentinel);
+
+  const changedLinks = db.prepare(`
+    SELECT targetNoteId FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+    ORDER BY targetNoteId
+  `).all(noteId, changedBlockId) as Array<{ targetNoteId: string }>;
+  assert.deepEqual(changedLinks.map((row) => row.targetNoteId), [secondTarget]);
+});
+
+test("falls back to a full rebuild when the existing index is stale", async () => {
+  const noteId = "44444444-4444-4444-8444-444444444444";
+  const changedBlockId = "blk_stale001";
+  const otherBlockId = "blk_stale002";
+  insertNote(noteId, tiptap(
+    paragraph(changedBlockId, "Before"),
+    paragraph(otherBlockId, "Unchanged"),
+  ));
+  db.prepare(`
+    UPDATE note_blocks_index SET plainText = 'corrupted', contentHash = 'corrupted'
+    WHERE noteId = ? AND blockId = ?
+  `).run(noteId, otherBlockId);
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-stale",
+    operations: [{ type: "update", blockId: changedBlockId, text: "After" }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "full");
+  assert.equal(indexRow(noteId, otherBlockId)?.plainText, "Unchanged");
+});
+
+test("keeps structural create operations on the full rebuild path", async () => {
+  const noteId = "55555555-5555-4555-8555-555555555555";
+  const firstBlockId = "blk_struct01";
+  const createdBlockId = "blk_struct02";
+  insertNote(noteId, tiptap(paragraph(firstBlockId, "First")));
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-create",
+    operations: [{
+      type: "create",
+      blockId: createdBlockId,
+      clientId: createdBlockId,
+      blockType: "paragraph",
+      text: "Created",
+      afterBlockId: firstBlockId,
+    }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "full");
+  assert.equal(indexRow(noteId, createdBlockId)?.plainText, "Created");
+});

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -78,6 +78,9 @@ export interface BlockPatchResult {
     blockId: string;
   }>;
   blocks: BlockPatchIndexRow[];
+  /** Whether the server touched only the affected leaf rows or rebuilt every note index row. */
+  indexUpdateMode: "incremental" | "full";
+  indexedBlockIds: string[];
   contentChangedByNormalization: boolean;
   idempotentReplay?: boolean;
 }


### PR DESCRIPTION
同步 `main` 最新 6 个 Block Patch 增量索引提交到 PostgreSQL 统一迁移分支。

同步范围：
- Block Patch 增量索引实现与祖先索引刷新
- Block Patch runtime 接入
- 前端响应类型补充
- 增量索引回归测试与 CI 路径

该同步不覆盖迁移分支已有 Repository / PostgreSQL Runtime 改造。