### PR TITLE
chore(pg): sync complete Block Patch structural tests

### DIFF
--- a/backend/src/runtime/block-patch.ts
+++ b/backend/src/runtime/block-patch.ts
@@ -200,9 +200,9 @@ async function patchBlocks(c: Context) {
         throw new BlockPatchRouteError("VERSION_CONFLICT", 409, { currentVersion: note.version });
       }
 
-      // Leaf-only patches can skip the legacy pre-patch DELETE + full reinsert when the persisted
-      // index is already a complete mirror of the current document. Any mismatch fails closed and
-      // falls back to the original normalization path inside this same transaction.
+      // Safe leaf and top-level structural patches can skip the legacy pre-patch DELETE + full
+      // reinsert when the persisted index is already a complete mirror of the current document.
+      // Any mismatch fails closed and falls back inside this same transaction.
       const incrementalBase = canUseIncrementalPatchIndexes(
         db,
         noteId,
@@ -245,10 +245,12 @@ async function patchBlocks(c: Context) {
       let persistedContentText = contentText;
       let postSyncChanged = false;
       let indexUpdateMode: "incremental" | "full" = "full";
+      let indexUpdateKind: "leaf" | "structural" | "full" = "full";
       let indexedBlockIds: string[] = [];
       if (incrementalPlan) {
         applyIncrementalPatchIndexes(db, userId, noteId, incrementalPlan);
         indexUpdateMode = "incremental";
+        indexUpdateKind = incrementalPlan.kind;
         indexedBlockIds = incrementalPlan.indexedBlockIds;
       } else {
         const synced = syncNoteBlocks(db, noteId, patch.content, note.contentFormat);
@@ -284,6 +286,7 @@ async function patchBlocks(c: Context) {
         createdBlocks: patch.createdBlocks,
         blocks,
         indexUpdateMode,
+        indexUpdateKind,
         indexedBlockIds,
         contentChangedByNormalization: normalizedBefore.changed || postSyncChanged,
       };
@@ -298,6 +301,7 @@ async function patchBlocks(c: Context) {
       operationCount: result.operationCount,
       affectedBlockIds: result.affectedBlockIds,
       indexUpdateMode: result.indexUpdateMode,
+      indexUpdateKind: result.indexUpdateKind,
       indexedBlockCount: result.indexedBlockIds.length,
     }, { targetType: "note", targetId: noteId });
     broadcastNoteUpdated(noteId, {

--- a/backend/tests/block-patch-incremental-index.test.ts
+++ b/backend/tests/block-patch-incremental-index.test.ts
@@ -77,6 +77,13 @@ function indexRow(noteId: string, blockId: string) {
   `).get(noteId, blockId) as Record<string, unknown> | undefined;
 }
 
+function orderedBlockIds(noteId: string): string[] {
+  return (db.prepare(`
+    SELECT blockId FROM note_blocks_index
+    WHERE noteId = ? ORDER BY blockOrder ASC
+  `).all(noteId) as Array<{ blockId: string }>).map((row) => row.blockId);
+}
+
 test.before(async () => {
   const [schema, noteBlocks, noteLinks] = await Promise.all([
     import("../src/db/schema"),
@@ -258,11 +265,19 @@ test("falls back to a full rebuild when the existing index is stale", async () =
   assert.equal(indexRow(noteId, otherBlockId)?.plainText, "Unchanged");
 });
 
-test("keeps structural create operations on the full rebuild path", async () => {
+test("inserts a top-level simple Block and only shifts the affected suffix", async () => {
   const noteId = "55555555-5555-4555-8555-555555555555";
   const firstBlockId = "blk_struct01";
   const createdBlockId = "blk_struct02";
-  insertNote(noteId, tiptap(paragraph(firstBlockId, "First")));
+  const lastBlockId = "blk_struct03";
+  insertNote(noteId, tiptap(
+    paragraph(firstBlockId, "First"),
+    paragraph(lastBlockId, "Last"),
+  ));
+
+  const sentinel = "2003-03-03 00:00:00";
+  db.prepare("UPDATE note_blocks_index SET updatedAt = ? WHERE noteId = ?")
+    .run(sentinel, noteId);
 
   const response = await patch(noteId, {
     expectedNoteVersion: 1,
@@ -272,7 +287,139 @@ test("keeps structural create operations on the full rebuild path", async () => 
       blockId: createdBlockId,
       clientId: createdBlockId,
       blockType: "paragraph",
-      text: "Created",
+      text: `[[note:${firstTarget}|Created]]`,
+      afterBlockId: firstBlockId,
+    }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [createdBlockId, lastBlockId]);
+  assert.deepEqual(orderedBlockIds(noteId), [firstBlockId, createdBlockId, lastBlockId]);
+  assert.equal(indexRow(noteId, firstBlockId)?.updatedAt, sentinel);
+  assert.notEqual(indexRow(noteId, lastBlockId)?.updatedAt, sentinel);
+  assert.equal(indexRow(noteId, createdBlockId)?.path, "1");
+  assert.equal(indexRow(noteId, lastBlockId)?.path, "2");
+  const createdLink = db.prepare(`
+    SELECT targetNoteId FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).get(noteId, createdBlockId) as { targetNoteId: string } | undefined;
+  assert.equal(createdLink?.targetNoteId, firstTarget);
+});
+
+test("deletes a top-level simple Block without rebuilding unrelated prefixes or links", async () => {
+  const noteId = "88888888-8888-4888-8888-888888888888";
+  const firstBlockId = "blk_delete01";
+  const deletedBlockId = "blk_delete02";
+  const lastBlockId = "blk_delete03";
+  insertNote(noteId, tiptap(
+    paragraph(firstBlockId, "Keep first", firstTarget),
+    paragraph(deletedBlockId, "Delete link", secondTarget),
+    paragraph(lastBlockId, "Keep last"),
+  ));
+
+  const sentinel = "2004-04-04 00:00:00";
+  db.prepare("UPDATE note_blocks_index SET updatedAt = ? WHERE noteId = ?")
+    .run(sentinel, noteId);
+  db.prepare(`
+    UPDATE note_links SET id = 'keep-first-link', updatedAt = ?
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).run(sentinel, noteId, firstBlockId);
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-delete",
+    operations: [{ type: "delete", blockId: deletedBlockId }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [deletedBlockId, lastBlockId]);
+  assert.deepEqual(orderedBlockIds(noteId), [firstBlockId, lastBlockId]);
+  assert.equal(indexRow(noteId, deletedBlockId), undefined);
+  assert.equal(indexRow(noteId, firstBlockId)?.updatedAt, sentinel);
+  assert.notEqual(indexRow(noteId, lastBlockId)?.updatedAt, sentinel);
+  assert.equal(indexRow(noteId, lastBlockId)?.path, "1");
+  const deletedLinks = db.prepare(`
+    SELECT COUNT(*) AS count FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).get(noteId, deletedBlockId) as { count: number };
+  assert.equal(deletedLinks.count, 0);
+  const keptLink = db.prepare(`
+    SELECT id, updatedAt FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).get(noteId, firstBlockId) as { id: string; updatedAt: string };
+  assert.equal(keptLink.id, "keep-first-link");
+  assert.equal(keptLink.updatedAt, sentinel);
+});
+
+test("moves top-level simple Blocks while preserving all existing link rows", async () => {
+  const noteId = "99999999-9999-4999-8999-999999999999";
+  const firstBlockId = "blk_move0001";
+  const secondBlockId = "blk_move0002";
+  const thirdBlockId = "blk_move0003";
+  insertNote(noteId, tiptap(
+    paragraph(firstBlockId, "First", firstTarget),
+    paragraph(secondBlockId, "Second", secondTarget),
+    paragraph(thirdBlockId, "Third"),
+  ));
+
+  const linkIdsBefore = db.prepare(`
+    SELECT sourceBlockId, id FROM note_links
+    WHERE sourceNoteId = ? ORDER BY sourceBlockId
+  `).all(noteId) as Array<{ sourceBlockId: string; id: string }>;
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-move",
+    operations: [{
+      type: "move",
+      blockId: thirdBlockId,
+      targetBlockId: firstBlockId,
+      position: "before",
+    }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.deepEqual(payload.indexedBlockIds, [thirdBlockId, firstBlockId, secondBlockId]);
+  assert.deepEqual(orderedBlockIds(noteId), [thirdBlockId, firstBlockId, secondBlockId]);
+  const linkIdsAfter = db.prepare(`
+    SELECT sourceBlockId, id FROM note_links
+    WHERE sourceNoteId = ? ORDER BY sourceBlockId
+  `).all(noteId) as Array<{ sourceBlockId: string; id: string }>;
+  assert.deepEqual(linkIdsAfter, linkIdsBefore);
+});
+
+test("falls back when a structural shift would change nested container indexes", async () => {
+  const noteId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const firstBlockId = "blk_complex01";
+  const itemBlockId = "blk_complex02";
+  const nestedBlockId = "blk_complex03";
+  const createdBlockId = "blk_complex04";
+  insertNote(noteId, tiptap(
+    paragraph(firstBlockId, "First"),
+    {
+      type: "bulletList",
+      content: [{
+        type: "listItem",
+        attrs: { blockId: itemBlockId },
+        content: [paragraph(nestedBlockId, "Nested")],
+      }],
+    },
+  ));
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-complex-fallback",
+    operations: [{
+      type: "create",
+      blockId: createdBlockId,
+      blockType: "paragraph",
+      text: "Inserted before list",
       afterBlockId: firstBlockId,
     }],
   });
@@ -280,5 +427,26 @@ test("keeps structural create operations on the full rebuild path", async () => 
   assert.equal(response.status, 200);
   const payload = await response.json() as any;
   assert.equal(payload.indexUpdateMode, "full");
-  assert.equal(indexRow(noteId, createdBlockId)?.plainText, "Created");
+  assert.equal(indexRow(noteId, createdBlockId)?.plainText, "Inserted before list");
+  assert.equal(indexRow(noteId, itemBlockId)?.path, "2.0");
+  assert.equal(indexRow(noteId, nestedBlockId)?.path, "2.0.0");
+});
+
+test("keeps delete-all identity repair on the full rebuild path", async () => {
+  const noteId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const onlyBlockId = "blk_deleteall";
+  insertNote(noteId, tiptap(paragraph(onlyBlockId, "Only")));
+
+  const response = await patch(noteId, {
+    expectedNoteVersion: 1,
+    operationId: "block-patch-incremental-index-delete-all",
+    operations: [{ type: "delete", blockId: onlyBlockId }],
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "full");
+  assert.equal(payload.createdBlocks.length, 1);
+  assert.equal(orderedBlockIds(noteId).length, 1);
+  assert.notEqual(orderedBlockIds(noteId)[0], onlyBlockId);
 });

--- a/docs/block-patch-api.md
+++ b/docs/block-patch-api.md
@@ -1,6 +1,6 @@
-# Block Patch API V2-B
+# Block Patch API V2-C
 
-Block Patch API applies several Tiptap block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future block-authoritative storage model.
+Block Patch API applies ordered Tiptap block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future block-authoritative storage model.
 
 ## Endpoint
 
@@ -53,6 +53,8 @@ Supported create types:
 
 When `blockId` is omitted, the server generates one and returns the client/server mapping in `createdBlocks`.
 
+Only top-level `paragraph`, `heading` and `codeBlock` creation is currently eligible for structural incremental indexing. Other create types remain valid API operations but use full index synchronization.
+
 ### Plain-text update
 
 ```json
@@ -83,25 +85,14 @@ This keeps the existing block type and attributes while replacing its editable t
       {
         "type": "text",
         "text": "Nowen",
-        "marks": [
-          { "type": "bold" },
-          {
-            "type": "link",
-            "attrs": {
-              "href": "https://example.com",
-              "target": "_blank",
-              "rel": "noopener noreferrer nofollow",
-              "class": null
-            }
-          }
-        ]
+        "marks": [{ "type": "bold" }]
       }
     ]
   }
 }
 ```
 
-V2-A/V2-B do not accept arbitrary ProseMirror JSON. Frontend planning and backend validation enforce the same restricted schema.
+V2 does not accept arbitrary ProseMirror JSON. Frontend planning and backend validation enforce the same restricted schema.
 
 Allowed block nodes:
 
@@ -156,6 +147,8 @@ Additional guards:
 
 The server repairs empty list/quote containers. Deleting the final document block creates a valid empty paragraph. The editor rollout still keeps delete-all on whole-note save until the generated replacement Block ID can be reconciled explicitly.
 
+Only deletion of an existing top-level paragraph, heading or code block is eligible for structural incremental indexing.
+
 ### Move
 
 ```json
@@ -169,26 +162,26 @@ The server repairs empty list/quote containers. Deleting the final document bloc
 
 Moves are supported only inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
 
+Structural incremental indexing additionally requires both the moved block and anchor to be existing top-level paragraphs, headings or code blocks.
+
 ## Atomic semantics
 
 Operations are evaluated in request order. Inside one SQLite transaction, the server:
 
 1. Rechecks note existence, permission, lock state and version.
 2. Verifies whether the current Block index is a complete mirror of the Tiptap document.
-3. Materializes missing stable Block IDs when the verification fails.
+3. Materializes missing stable Block IDs when verification fails.
 4. Validates and applies every operation in memory.
 5. Records the pre-edit version using the same five-minute merge window as `PUT /notes/:id`.
 6. Updates `notes.content`, `contentText`, version and timestamp using optimistic locking.
-7. Applies either incremental or full index synchronization.
+7. Applies a leaf incremental, structural incremental or full index synchronization plan.
 8. Stores the idempotent response.
 
 Any failure rolls back the document, indexes, history row and idempotency record. One successful batch increments the note version exactly once. Replaying the same operation ID returns the stored authoritative result without adding another version.
 
-## Incremental index mode
+## Incremental index modes
 
-V2-B introduces fail-closed incremental synchronization for leaf-only `update` and `replace` batches.
-
-Before enabling it, the server compares the current document and `note_blocks_index` for:
+Before either incremental mode is enabled, the server compares the current document and `note_blocks_index` for:
 
 - total row count;
 - stable and unique Block IDs;
@@ -197,26 +190,51 @@ Before enabling it, the server compares the current document and `note_blocks_in
 - order and path;
 - plain text and content hash.
 
-Incremental mode is used only when this comparison succeeds and every operation targets a supported paragraph, heading or code block.
+Any mismatch fails closed to full synchronization.
 
-When enabled:
+### Leaf incremental mode
 
-- only affected leaf Block rows are upserted;
-- indexed ancestors such as `listItem`, `taskItem` and `blockquote` are also refreshed because their aggregate text/hash changes;
-- only `note_links` rows whose `sourceBlockId` belongs to the changed leaf blocks are deleted and recreated;
-- unrelated Block rows keep their original `createdAt/updatedAt` values;
-- unrelated backlink rows keep their original IDs and timestamps;
-- `contentText` is produced from the same verified document analysis instead of running the legacy full index rebuild again.
+Used for batches containing only safe `update` and `replace` operations.
 
-The server falls back to full synchronization for:
+- Only changed leaf rows are upserted.
+- Indexed ancestors such as `listItem`, `taskItem` and `blockquote` are refreshed when their aggregate text/hash changes.
+- Only `note_links` rows belonging to changed source leaf blocks are recreated.
+- Unrelated Block rows and backlink rows keep their IDs and timestamps.
 
-- create/delete/move operations;
-- stale, missing or inconsistent Block indexes;
-- missing or duplicate Block IDs;
-- unsupported target nodes;
-- structural or parent/path changes that cannot be proven safe.
+### Structural incremental mode
 
-The fallback occurs inside the same transaction and does not change the API's data-safety guarantees.
+Used for batches containing only `create`, `delete` and `move`, when every referenced existing block is a top-level paragraph, heading or code block.
+
+The planner compares the persisted pre-patch index with the final document and computes:
+
+- newly inserted index rows;
+- deleted index rows;
+- existing rows whose `blockOrder` or `path` changed;
+- links belonging to newly created or deleted source blocks.
+
+Behavior:
+
+- inserting a top-level simple block upserts the new row and only the shifted suffix;
+- deleting a top-level simple block removes that row and only updates the shifted suffix;
+- moving top-level simple blocks updates only rows whose order/path changed;
+- move operations preserve all existing backlink row IDs and timestamps;
+- links from deleted blocks are removed;
+- links in newly created block text are indexed;
+- unaffected prefixes retain their original timestamps.
+
+Structural mode falls back to full synchronization when:
+
+- the patch mixes structural operations with `update/replace`;
+- a create operation uses `blockquote`, `listItem` or `taskItem`;
+- a delete or move targets a nested/container Block;
+- a move anchor is nested or a container;
+- a changed order/path would also require rewriting list, task or quote descendants;
+- a create-then-delete sequence makes final identity ambiguous;
+- a deleted ID is reused in the same batch;
+- delete-all creates the server-generated empty replacement Block;
+- added/deleted Block counts do not exactly match the structural operations.
+
+The fallback happens inside the same transaction and preserves the API's data-safety guarantees.
 
 ## Authoritative response
 
@@ -237,13 +255,15 @@ The fallback occurs inside the same transaction and does not change the API's da
   "createdBlocks": [],
   "blocks": [],
   "indexUpdateMode": "incremental",
-  "indexedBlockIds": ["blk_parent000", "blk_alpha000"],
+  "indexUpdateKind": "structural",
+  "indexedBlockIds": ["blk_created00", "blk_shifted00"],
   "contentChangedByNormalization": false
 }
 ```
 
 - `indexUpdateMode` is `incremental` or `full`.
-- `indexedBlockIds` reports the Block rows explicitly refreshed. It may include indexed ancestors in incremental mode.
+- `indexUpdateKind` is `leaf`, `structural` or `full`.
+- `indexedBlockIds` contains Block IDs inserted, updated or deleted by index synchronization. Full mode returns every rebuilt Block ID.
 - `affectedBlockIds` continues to describe the blocks addressed by the patch engine.
 
 The client must use the returned snapshot and version as the base for the next dependent patch. Successful writes emit `note:updated` and `note:list-updated` realtime messages.
@@ -303,14 +323,14 @@ Public, guest and presentation routes never mount the authenticated Block Patch 
 
 ## Attachment boundary
 
-The current schema stores attachment ownership in `attachments.noteId`; it does not maintain a separate content-reference index per Block. Therefore V2-B does not mutate attachment ownership or introduce an unused attachment-reference table. Media/attachment node edits still use whole-note save, while note split continues to handle attachment ownership and physical-path reuse transactionally.
+The current schema stores attachment ownership in `attachments.noteId`; it does not maintain a separate content-reference index per Block. V2-C does not mutate attachment ownership or introduce an unused attachment-reference table. Media/attachment node edits still use whole-note save, while note split continues to handle attachment ownership and physical-path reuse transactionally.
 
 ## Remaining boundaries
 
 - `notes.content` is still the canonical complete document.
 - A successful patch still serializes the full JSON snapshot.
-- Incremental indexes currently cover safe leaf `update/replace`; structural operations use full synchronization.
+- Mixed content-and-structure batches still use full synchronization.
+- Nested structural operations and cross-parent moves are deferred.
 - Table, media, attachment, formula and Mermaid node patches are deferred.
-- Cross-parent moves are deferred.
 - There is no independent Block-authoritative content table yet.
 - Markdown uses its separate CodeMirror/Y.Text incremental path.

--- a/frontend/src/lib/__tests__/blockPatchApi.test.ts
+++ b/frontend/src/lib/__tests__/blockPatchApi.test.ts
@@ -42,6 +42,7 @@ describe("block patch API client", () => {
       createdBlocks: [],
       blocks: [],
       indexUpdateMode: "incremental",
+      indexUpdateKind: "leaf",
       indexedBlockIds: ["blk_alpha00"],
       contentChangedByNormalization: false,
     }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -59,6 +60,7 @@ describe("block patch API client", () => {
       contentFormat: "tiptap-json",
       updatedAt: "2026-07-22T10:00:00.000Z",
       indexUpdateMode: "incremental",
+      indexUpdateKind: "leaf",
       indexedBlockIds: ["blk_alpha00"],
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -78,8 +78,11 @@ export interface BlockPatchResult {
     blockId: string;
   }>;
   blocks: BlockPatchIndexRow[];
-  /** Whether the server touched only the affected leaf rows or rebuilt every note index row. */
+  /** Whether the server updated a proven-safe subset or rebuilt every note index row. */
   indexUpdateMode: "incremental" | "full";
+  /** Distinguishes leaf content updates, top-level structural updates and full fallback. */
+  indexUpdateKind: "leaf" | "structural" | "full";
+  /** Block IDs inserted, updated or deleted by index synchronization. */
   indexedBlockIds: string[];
   contentChangedByNormalization: boolean;
   idempotentReplay?: boolean;


### PR DESCRIPTION
同步 `main` 最新 5 个 Block Patch 提交到 `pg-migration-unified`，包括：

- 顶层结构新增、删除、移动的增量索引回归
- 复杂嵌套结构与 delete-all 的 full fallback 回归
- runtime/API 返回契约和文档更新

主线测试集已覆盖并取代迁移分支刚补的最小结构新增测试。附件引用 PostgreSQL Runtime 迁移保持不变。