### PR TITLE
chore(pg): sync latest Block Patch runtime fix

### DIFF
--- a/backend/src/runtime/block-patch.ts
+++ b/backend/src/runtime/block-patch.ts
@@ -200,9 +200,9 @@ async function patchBlocks(c: Context) {
         throw new BlockPatchRouteError("VERSION_CONFLICT", 409, { currentVersion: note.version });
       }
 
-      // Safe leaf and top-level structural patches can skip the legacy pre-patch DELETE + full
-      // reinsert when the persisted index is already a complete mirror of the current document.
-      // Any mismatch fails closed and falls back inside this same transaction.
+      // Safe leaf, top-level structural and proven mixed patches can skip the legacy pre-patch
+      // DELETE + full reinsert when the persisted index mirrors the current document. Any mismatch
+      // fails closed and falls back inside this same transaction.
       const incrementalBase = canUseIncrementalPatchIndexes(
         db,
         noteId,
@@ -245,7 +245,7 @@ async function patchBlocks(c: Context) {
       let persistedContentText = contentText;
       let postSyncChanged = false;
       let indexUpdateMode: "incremental" | "full" = "full";
-      let indexUpdateKind: "leaf" | "structural" | "full" = "full";
+      let indexUpdateKind: "leaf" | "structural" | "mixed" | "full" = "full";
       let indexedBlockIds: string[] = [];
       if (incrementalPlan) {
         applyIncrementalPatchIndexes(db, userId, noteId, incrementalPlan);

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -80,8 +80,8 @@ export interface BlockPatchResult {
   blocks: BlockPatchIndexRow[];
   /** Whether the server updated a proven-safe subset or rebuilt every note index row. */
   indexUpdateMode: "incremental" | "full";
-  /** Distinguishes leaf content updates, top-level structural updates and full fallback. */
-  indexUpdateKind: "leaf" | "structural" | "full";
+  /** Distinguishes leaf, structural, mixed incremental updates and full fallback. */
+  indexUpdateKind: "leaf" | "structural" | "mixed" | "full";
   /** Block IDs inserted, updated or deleted by index synchronization. */
   indexedBlockIds: string[];
   contentChangedByNormalization: boolean;


### PR DESCRIPTION
同步 `main` 当前最新的 Block Patch runtime 修复到 `pg-migration-unified`。该提交仅调整 runtime 返回处理，不修改附件引用 PostgreSQL Runtime 迁移。