### PR TITLE
chore(pg): sync latest main before note-link title migration

### DIFF
--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -18,6 +18,7 @@ on:
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
       - "frontend/src/components/__tests__/TiptapRuntimePublicContext.test.tsx"
       - "frontend/src/lib/blockPatchApi.ts"
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
@@ -26,8 +27,10 @@ on:
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
+      - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
       - "docs/block-patch-api.md"
+      - "docs/block-patch-empty-document.md"
       - ".github/workflows/block-patch-ci.yml"
   pull_request:
     paths:
@@ -45,6 +48,7 @@ on:
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
       - "frontend/src/components/__tests__/TiptapRuntimePublicContext.test.tsx"
       - "frontend/src/lib/blockPatchApi.ts"
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
@@ -53,8 +57,10 @@ on:
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
+      - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
       - "docs/block-patch-api.md"
+      - "docs/block-patch-empty-document.md"
       - ".github/workflows/block-patch-ci.yml"
 
 permissions:
@@ -107,9 +113,11 @@ jobs:
           src/lib/__tests__/blockPatchApi.test.ts
           src/lib/__tests__/tiptapBlockPatchPlanner.test.ts
           src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts
+          src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
           src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
           src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx
+          src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
           src/components/__tests__/TiptapRuntimePublicContext.test.tsx
       - name: Frontend typecheck
         run: npx tsc -b

--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -8,31 +8,39 @@ on:
       - "backend/src/lib/blockPatchIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
+      - "backend/src/lib/tiptapListItemMove.ts"
       - "backend/src/runtime/block-patch.ts"
       - "backend/tests/block-patch-incremental-index.test.ts"
       - "backend/tests/block-patch-mixed-index.test.ts"
+      - "backend/tests/block-patch-list-route.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
+      - "backend/tests/tiptap-list-item-move.test.ts"
       - "backend/tests/block-patch-route.test.ts"
       - "backend/tests/block-patch-route-v2.test.ts"
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapRuntimePublicContext.test.tsx"
       - "frontend/src/lib/blockPatchApi.ts"
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
       - "frontend/src/lib/tiptapBlockPatchPlanner.ts"
+      - "frontend/src/lib/tiptapBlockPatchPlannerRuntime.ts"
       - "frontend/src/lib/tiptapBlockPatchRuntime.ts"
+      - "frontend/src/lib/tiptapListItemMovePlanner.ts"
       - "frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts"
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
+      - "frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts"
       - "docs/block-patch-api.md"
       - "docs/block-patch-empty-document.md"
+      - "docs/block-patch-list-hierarchy.md"
       - ".github/workflows/block-patch-ci.yml"
   pull_request:
     paths:
@@ -40,31 +48,39 @@ on:
       - "backend/src/lib/blockPatchIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
+      - "backend/src/lib/tiptapListItemMove.ts"
       - "backend/src/runtime/block-patch.ts"
       - "backend/tests/block-patch-incremental-index.test.ts"
       - "backend/tests/block-patch-mixed-index.test.ts"
+      - "backend/tests/block-patch-list-route.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
+      - "backend/tests/tiptap-list-item-move.test.ts"
       - "backend/tests/block-patch-route.test.ts"
       - "backend/tests/block-patch-route-v2.test.ts"
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapRuntimePublicContext.test.tsx"
       - "frontend/src/lib/blockPatchApi.ts"
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
       - "frontend/src/lib/tiptapBlockPatchPlanner.ts"
+      - "frontend/src/lib/tiptapBlockPatchPlannerRuntime.ts"
       - "frontend/src/lib/tiptapBlockPatchRuntime.ts"
+      - "frontend/src/lib/tiptapListItemMovePlanner.ts"
       - "frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts"
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
+      - "frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts"
       - "docs/block-patch-api.md"
       - "docs/block-patch-empty-document.md"
+      - "docs/block-patch-list-hierarchy.md"
       - ".github/workflows/block-patch-ci.yml"
 
 permissions:
@@ -85,13 +101,15 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
-      - name: Block patch engine, incremental index and route tests
+      - name: Block patch engine, list hierarchy, incremental index and route tests
         run: >-
           node --import tsx --test
           tests/tiptap-block-patch.test.ts
           tests/tiptap-block-patch-v2.test.ts
+          tests/tiptap-list-item-move.test.ts
           tests/block-patch-route.test.ts
           tests/block-patch-route-v2.test.ts
+          tests/block-patch-list-route.test.ts
           tests/block-patch-incremental-index.test.ts
           tests/block-patch-mixed-index.test.ts
       - name: Backend typecheck
@@ -119,10 +137,12 @@ jobs:
           src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts
           src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
           src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
+          src/lib/__tests__/tiptapListItemMovePlanner.test.ts
           src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
           src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx
           src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
+          src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx
           src/components/__tests__/TiptapRuntimePublicContext.test.tsx
       - name: Frontend typecheck
         run: npx tsc -b

--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "backend/src/index.hardened.ts"
       - "backend/src/lib/blockPatchIncrementalIndexes.ts"
+      - "backend/src/lib/blockPatchListIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
       - "backend/src/lib/tiptapListItemMove.ts"
@@ -46,6 +47,7 @@ on:
     paths:
       - "backend/src/index.hardened.ts"
       - "backend/src/lib/blockPatchIncrementalIndexes.ts"
+      - "backend/src/lib/blockPatchListIncrementalIndexes.ts"
       - "backend/src/lib/tiptapBlockPatch.ts"
       - "backend/src/lib/tiptapBlockPatchNode.ts"
       - "backend/src/lib/tiptapListItemMove.ts"

--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -24,11 +24,13 @@ on:
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
       - "frontend/src/lib/tiptapBlockPatchPlanner.ts"
       - "frontend/src/lib/tiptapBlockPatchRuntime.ts"
+      - "frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts"
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
+      - "frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts"
       - "docs/block-patch-api.md"
       - "docs/block-patch-empty-document.md"
       - ".github/workflows/block-patch-ci.yml"
@@ -54,11 +56,13 @@ on:
       - "frontend/src/lib/tiptapBlockPatchNode.ts"
       - "frontend/src/lib/tiptapBlockPatchPlanner.ts"
       - "frontend/src/lib/tiptapBlockPatchRuntime.ts"
+      - "frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts"
       - "frontend/src/lib/__tests__/blockPatchApi.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts"
       - "frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts"
+      - "frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts"
       - "docs/block-patch-api.md"
       - "docs/block-patch-empty-document.md"
       - ".github/workflows/block-patch-ci.yml"
@@ -115,6 +119,7 @@ jobs:
           src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts
           src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
           src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
+          src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
           src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx
           src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx

--- a/backend/src/lib/blockPatchListIncrementalIndexes.ts
+++ b/backend/src/lib/blockPatchListIncrementalIndexes.ts
@@ -1,0 +1,291 @@
+import { createHash } from "node:crypto";
+import type Database from "better-sqlite3";
+
+import type { NoteBlockIndexRow, NoteBlockType } from "./noteBlocks.js";
+import type { IncrementalPatchIndexPlan } from "./blockPatchIncrementalIndexes.js";
+import type { TiptapBlockPatchOperation } from "./tiptapBlockPatch.js";
+
+const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
+const LEAF_BLOCK_TYPES = new Set(["paragraph", "heading", "codeBlock"]);
+const LIST_ITEM_TYPES = new Set(["listItem", "taskItem"]);
+const INDEXED_BLOCK_TYPES = new Set([
+  "heading",
+  "paragraph",
+  "listItem",
+  "taskItem",
+  "blockquote",
+  "codeBlock",
+]);
+
+type ListMoveOperation = Extract<TiptapBlockPatchOperation, { type: "move" }> & {
+  scope: "listItem";
+};
+
+interface ExistingIndexRow {
+  blockId: string;
+  blockType: string;
+  parentBlockId: string | null;
+  blockOrder: number;
+  plainText: string;
+  contentHash: string;
+  path: string;
+}
+
+interface AnalyzedBlock {
+  row: NoteBlockIndexRow;
+}
+
+interface TiptapAnalysis {
+  blocks: AnalyzedBlock[];
+  byId: Map<string, AnalyzedBlock>;
+  contentText: string;
+}
+
+function validBlockId(value: unknown): value is string {
+  return typeof value === "string" && BLOCK_ID_RE.test(value);
+}
+
+function isListMove(operation: TiptapBlockPatchOperation): operation is ListMoveOperation {
+  return operation.type === "move" && operation.scope === "listItem";
+}
+
+function oneListMove(operations: TiptapBlockPatchOperation[]): ListMoveOperation | null {
+  return operations.length === 1 && isListMove(operations[0]) ? operations[0] : null;
+}
+
+function collectNodeText(node: any): string {
+  if (!node || typeof node !== "object") return "";
+  if (node.type === "text") return String(node.text || "");
+  if (node.type === "hardBreak") return "\n";
+  if (!Array.isArray(node.content)) return "";
+  return node.content.map(collectNodeText).join("");
+}
+
+function hashText(type: string, text: string): string {
+  return createHash("sha256")
+    .update(type)
+    .update("\0")
+    .update(text.replace(/\s+/g, " ").trim())
+    .digest("hex");
+}
+
+function analyzeTiptap(noteId: string, content: string): TiptapAnalysis | null {
+  let doc: any;
+  try {
+    doc = JSON.parse(content || "{}");
+  } catch {
+    return null;
+  }
+  if (!doc || typeof doc !== "object" || doc.type !== "doc" || !Array.isArray(doc.content)) {
+    return null;
+  }
+
+  const blocks: AnalyzedBlock[] = [];
+  const byId = new Map<string, AnalyzedBlock>();
+  let order = 0;
+  let invalid = false;
+
+  const visit = (nodes: any[], parentBlockId: string | null, parentPath: number[]) => {
+    for (let index = 0; index < nodes.length; index += 1) {
+      const node = nodes[index];
+      if (!node || typeof node !== "object") continue;
+      const path = [...parentPath, index];
+      let nextParent = parentBlockId;
+
+      if (INDEXED_BLOCK_TYPES.has(node.type)) {
+        const blockId = node.attrs?.blockId;
+        if (!validBlockId(blockId) || byId.has(blockId)) {
+          invalid = true;
+          return;
+        }
+        const plainText = collectNodeText(node).replace(/\u0000/g, "").trim();
+        const analyzed: AnalyzedBlock = {
+          row: {
+            noteId,
+            blockId,
+            blockType: node.type as NoteBlockType,
+            parentBlockId,
+            blockOrder: order,
+            plainText,
+            contentHash: hashText(node.type, plainText),
+            path: path.join("."),
+            startOffset: null,
+            endOffset: null,
+          },
+        };
+        order += 1;
+        blocks.push(analyzed);
+        byId.set(blockId, analyzed);
+        nextParent = blockId;
+      }
+
+      if (Array.isArray(node.content)) {
+        visit(node.content, nextParent, path);
+        if (invalid) return;
+      }
+    }
+  };
+
+  visit(doc.content, null, []);
+  if (invalid) return null;
+  return {
+    blocks,
+    byId,
+    contentText: blocks.map(({ row }) => row.plainText).filter(Boolean).join("\n\n"),
+  };
+}
+
+function loadExistingRows(db: Database.Database, noteId: string): ExistingIndexRow[] {
+  return db.prepare(`
+    SELECT blockId, blockType, parentBlockId, blockOrder, plainText, contentHash, path
+    FROM note_blocks_index
+    WHERE noteId = ?
+    ORDER BY blockOrder ASC
+  `).all(noteId) as ExistingIndexRow[];
+}
+
+function rowsMirrorAnalysis(existing: ExistingIndexRow[], analysis: TiptapAnalysis): boolean {
+  if (existing.length !== analysis.blocks.length) return false;
+  const existingById = new Map(existing.map((row) => [row.blockId, row]));
+  if (existingById.size !== analysis.blocks.length) return false;
+  return analysis.blocks.every(({ row }) => {
+    const previous = existingById.get(row.blockId);
+    return Boolean(previous
+      && previous.blockType === row.blockType
+      && previous.parentBlockId === row.parentBlockId
+      && previous.blockOrder === row.blockOrder
+      && previous.plainText === row.plainText
+      && previous.contentHash === row.contentHash
+      && previous.path === row.path);
+  });
+}
+
+function collectAncestorIds(
+  byId: Map<string, { row: Pick<ExistingIndexRow, "blockId" | "parentBlockId"> }>,
+  startIds: string[],
+): Set<string> {
+  const output = new Set<string>();
+  for (const startId of startIds) {
+    let current: string | null = startId;
+    while (current && !output.has(current)) {
+      output.add(current);
+      current = byId.get(current)?.row.parentBlockId || null;
+    }
+  }
+  return output;
+}
+
+/**
+ * Permit skipping the legacy pre-patch full reindex only for one controlled list-item move whose
+ * persisted index is an exact mirror of the authoritative pre-patch document.
+ */
+export function canUseIncrementalListMoveIndexes(
+  db: Database.Database,
+  noteId: string,
+  content: string,
+  operations: TiptapBlockPatchOperation[],
+): boolean {
+  const operation = oneListMove(operations);
+  if (!operation) return false;
+  const analysis = analyzeTiptap(noteId, content);
+  if (!analysis || !rowsMirrorAnalysis(loadExistingRows(db, noteId), analysis)) return false;
+  const source = analysis.byId.get(operation.blockId)?.row;
+  const target = analysis.byId.get(operation.targetBlockId)?.row;
+  return Boolean(
+    source
+    && target
+    && LIST_ITEM_TYPES.has(source.blockType)
+    && source.blockType === target.blockType,
+  );
+}
+
+/**
+ * Build a minimal post-patch index plan for one already-validated list move. Leaf content and link
+ * sources must remain unchanged; only aggregate ancestors and structural coordinates may differ.
+ */
+export function planIncrementalListMoveIndexes(
+  db: Database.Database,
+  noteId: string,
+  content: string,
+  operations: TiptapBlockPatchOperation[],
+): IncrementalPatchIndexPlan | null {
+  const operation = oneListMove(operations);
+  if (!operation) return null;
+  const analysis = analyzeTiptap(noteId, content);
+  if (!analysis) return null;
+
+  const existing = loadExistingRows(db, noteId);
+  if (existing.length !== analysis.blocks.length) return null;
+  const existingById = new Map(existing.map((row) => [row.blockId, row]));
+  if (existingById.size !== analysis.blocks.length) return null;
+  if (analysis.blocks.some(({ row }) => !existingById.has(row.blockId))) return null;
+
+  const sourceBefore = existingById.get(operation.blockId);
+  const sourceAfter = analysis.byId.get(operation.blockId)?.row;
+  const targetBefore = existingById.get(operation.targetBlockId);
+  const targetAfter = analysis.byId.get(operation.targetBlockId)?.row;
+  if (
+    !sourceBefore
+    || !sourceAfter
+    || !targetBefore
+    || !targetAfter
+    || !LIST_ITEM_TYPES.has(sourceBefore.blockType)
+    || sourceBefore.blockType !== sourceAfter.blockType
+    || sourceBefore.blockType !== targetBefore.blockType
+    || targetBefore.blockType !== targetAfter.blockType
+  ) {
+    return null;
+  }
+
+  const existingAncestorMap = new Map(
+    existing.map((row) => [row.blockId, { row: { blockId: row.blockId, parentBlockId: row.parentBlockId } }]),
+  );
+  const postAncestorMap = new Map(
+    analysis.blocks.map(({ row }) => [
+      row.blockId,
+      { row: { blockId: row.blockId, parentBlockId: row.parentBlockId } },
+    ]),
+  );
+  const aggregateIds = new Set([
+    ...collectAncestorIds(existingAncestorMap, [operation.blockId, operation.targetBlockId]),
+    ...collectAncestorIds(postAncestorMap, [operation.blockId, operation.targetBlockId]),
+  ]);
+
+  const affectedRows: NoteBlockIndexRow[] = [];
+  let sourceStructureChanged = false;
+  for (const { row } of analysis.blocks) {
+    const previous = existingById.get(row.blockId);
+    if (!previous || previous.blockType !== row.blockType) return null;
+
+    const contentChanged = previous.plainText !== row.plainText
+      || previous.contentHash !== row.contentHash;
+    const parentChanged = previous.parentBlockId !== row.parentBlockId;
+    const orderChanged = previous.blockOrder !== row.blockOrder;
+    const pathChanged = previous.path !== row.path;
+
+    // Moving a subtree must never alter actual leaf content, marks or links.
+    if (contentChanged && LEAF_BLOCK_TYPES.has(row.blockType)) return null;
+    if (contentChanged && !aggregateIds.has(row.blockId)) return null;
+    if (parentChanged && row.blockId !== operation.blockId) return null;
+
+    if (row.blockId === operation.blockId && (parentChanged || orderChanged || pathChanged)) {
+      sourceStructureChanged = true;
+    }
+    if (contentChanged || parentChanged || orderChanged || pathChanged) affectedRows.push(row);
+  }
+  if (!sourceStructureChanged || affectedRows.length === 0) return null;
+
+  const indexedBlockIds = affectedRows.map((row) => row.blockId);
+  return {
+    mode: "incremental",
+    // Reuse the established structural apply path; the route exposes the more precise
+    // `list-subtree` observation kind to clients and audit logs.
+    kind: "structural",
+    contentText: analysis.contentText,
+    affectedRows,
+    deletedBlockIds: [],
+    links: [],
+    indexedBlockIds,
+    linkBlockIds: [],
+  };
+}

--- a/backend/src/lib/tiptapBlockPatch.ts
+++ b/backend/src/lib/tiptapBlockPatch.ts
@@ -43,6 +43,7 @@ export type TiptapBlockPatchOperation =
     }
   | {
       type: "move";
+      scope?: undefined;
       blockId: string;
       targetBlockId: string;
       position?: "before" | "after";
@@ -204,7 +205,7 @@ function validateOperation(operation: any, index: number): asserts operation is 
   if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
     throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}] 必须是对象`);
   }
-  if (!["create", "update", "replace", "delete", "move", "moveListItem"].includes(operation.type)) {
+  if (!["create", "update", "replace", "delete", "move"].includes(operation.type)) {
     throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].type 无效`);
   }
 
@@ -249,17 +250,20 @@ function validateOperation(operation: any, index: number): asserts operation is 
     }
     return;
   }
-  if (operation.type === "move" || operation.type === "moveListItem") {
+  if (operation.type === "move") {
     if (!validBlockId(operation.targetBlockId)) {
       throw new TiptapBlockPatchError("INVALID_BLOCK_ID", `operations[${index}].targetBlockId 无效`);
     }
-    const allowedPositions = operation.type === "moveListItem"
-      ? ["before", "after", "inside"]
-      : ["before", "after"];
-    if (
-      operation.position == null
-      || !allowedPositions.includes(operation.position)
-    ) {
+    if (operation.scope === "listItem") {
+      if (!["before", "after", "inside"].includes(operation.position)) {
+        throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].position 无效`);
+      }
+      return;
+    }
+    if (operation.scope != null) {
+      throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].scope 无效`);
+    }
+    if (operation.position != null && !["before", "after"].includes(operation.position)) {
       throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].position 无效`);
     }
   }
@@ -332,7 +336,7 @@ export function applyTiptapBlockPatch(
       return;
     }
 
-    if (operation.type === "moveListItem") {
+    if (operation.type === "move" && operation.scope === "listItem") {
       try {
         affectedBlockIds.push(...applyTiptapListItemMove(doc, operation));
       } catch (error) {

--- a/backend/src/lib/tiptapBlockPatch.ts
+++ b/backend/src/lib/tiptapBlockPatch.ts
@@ -5,6 +5,11 @@ import {
   type NoteBlockType,
 } from "./noteBlocks.js";
 import {
+  applyTiptapListItemMove,
+  TiptapListItemMoveError,
+  type TiptapListItemMoveOperation,
+} from "./tiptapListItemMove.js";
+import {
   normalizeTiptapReplacementNode,
   TiptapBlockNodeValidationError,
   type TiptapPatchJsonNode,
@@ -41,7 +46,8 @@ export type TiptapBlockPatchOperation =
       blockId: string;
       targetBlockId: string;
       position?: "before" | "after";
-    };
+    }
+  | TiptapListItemMoveOperation;
 
 export interface TiptapBlockPatchResult {
   content: string;
@@ -59,6 +65,7 @@ export class TiptapBlockPatchError extends Error {
       | "BLOCK_NOT_FOUND"
       | "BLOCK_MOVE_PARENT_MISMATCH"
       | "BLOCK_MOVE_SELF"
+      | "LIST_MOVE_INVALID"
       | "INVALID_TIPTAP_DOCUMENT",
     message: string,
   ) {
@@ -197,7 +204,7 @@ function validateOperation(operation: any, index: number): asserts operation is 
   if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
     throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}] 必须是对象`);
   }
-  if (!["create", "update", "replace", "delete", "move"].includes(operation.type)) {
+  if (!["create", "update", "replace", "delete", "move", "moveListItem"].includes(operation.type)) {
     throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].type 无效`);
   }
 
@@ -242,11 +249,17 @@ function validateOperation(operation: any, index: number): asserts operation is 
     }
     return;
   }
-  if (operation.type === "move") {
+  if (operation.type === "move" || operation.type === "moveListItem") {
     if (!validBlockId(operation.targetBlockId)) {
       throw new TiptapBlockPatchError("INVALID_BLOCK_ID", `operations[${index}].targetBlockId 无效`);
     }
-    if (operation.position != null && !["before", "after"].includes(operation.position)) {
+    const allowedPositions = operation.type === "moveListItem"
+      ? ["before", "after", "inside"]
+      : ["before", "after"];
+    if (
+      operation.position == null
+      || !allowedPositions.includes(operation.position)
+    ) {
       throw new TiptapBlockPatchError("INVALID_PATCH", `operations[${index}].position 无效`);
     }
   }
@@ -316,6 +329,18 @@ export function applyTiptapBlockPatch(
         clientId: operation.clientId || null,
         blockId,
       });
+      return;
+    }
+
+    if (operation.type === "moveListItem") {
+      try {
+        affectedBlockIds.push(...applyTiptapListItemMove(doc, operation));
+      } catch (error) {
+        const message = error instanceof TiptapListItemMoveError
+          ? error.message
+          : "列表层级移动无效";
+        throw new TiptapBlockPatchError("LIST_MOVE_INVALID", message);
+      }
       return;
     }
 

--- a/backend/src/lib/tiptapListItemMove.ts
+++ b/backend/src/lib/tiptapListItemMove.ts
@@ -1,0 +1,216 @@
+const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
+const LIST_TYPES = new Set(["bulletList", "orderedList", "taskList"]);
+const ITEM_TYPES = new Set(["listItem", "taskItem"]);
+
+export type TiptapListItemMovePosition = "before" | "after" | "inside";
+
+export interface TiptapListItemMoveOperation {
+  type: "moveListItem";
+  blockId: string;
+  targetBlockId: string;
+  position: TiptapListItemMovePosition;
+}
+
+export class TiptapListItemMoveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TiptapListItemMoveError";
+  }
+}
+
+interface NodeFrame {
+  node: any;
+  parent: any[];
+  index: number;
+}
+
+interface ListItemLocation {
+  item: any;
+  itemFrame: NodeFrame;
+  list: any;
+  listFrame: NodeFrame;
+  path: NodeFrame[];
+  depth: number;
+  parentItemFrame: NodeFrame | null;
+  outerListFrame: NodeFrame | null;
+}
+
+function validBlockId(value: unknown): value is string {
+  return typeof value === "string" && BLOCK_ID_RE.test(value);
+}
+
+function findPath(nodes: any[], blockId: string, ancestors: NodeFrame[] = []): NodeFrame[] | null {
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    if (!node || typeof node !== "object") continue;
+    const frame = { node, parent: nodes, index };
+    const path = [...ancestors, frame];
+    if (node.attrs?.blockId === blockId) return path;
+    if (Array.isArray(node.content)) {
+      const nested = findPath(node.content, blockId, path);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function locateListItem(doc: any, blockId: string): ListItemLocation {
+  const path = findPath(doc.content, blockId);
+  if (!path || path.length < 2) {
+    throw new TiptapListItemMoveError(`列表项不存在: ${blockId}`);
+  }
+  const itemFrame = path[path.length - 1];
+  const listFrame = path[path.length - 2];
+  if (!ITEM_TYPES.has(itemFrame.node?.type) || !LIST_TYPES.has(listFrame.node?.type)) {
+    throw new TiptapListItemMoveError(`目标不是可移动列表项: ${blockId}`);
+  }
+  if (listFrame.node.content !== itemFrame.parent) {
+    throw new TiptapListItemMoveError("列表项父容器无效");
+  }
+
+  let parentItemFrame: NodeFrame | null = null;
+  let outerListFrame: NodeFrame | null = null;
+  for (let index = path.length - 3; index >= 0; index -= 1) {
+    if (!ITEM_TYPES.has(path[index].node?.type)) continue;
+    parentItemFrame = path[index];
+    if (index > 0 && LIST_TYPES.has(path[index - 1].node?.type)) {
+      outerListFrame = path[index - 1];
+    }
+    break;
+  }
+
+  return {
+    item: itemFrame.node,
+    itemFrame,
+    list: listFrame.node,
+    listFrame,
+    path,
+    depth: path.filter((frame) => LIST_TYPES.has(frame.node?.type)).length,
+    parentItemFrame,
+    outerListFrame,
+  };
+}
+
+function expectedItemType(listType: string): string {
+  return listType === "taskList" ? "taskItem" : "listItem";
+}
+
+function validateCompatible(source: ListItemLocation, target: ListItemLocation): void {
+  if (source.item.type !== target.item.type || source.list.type !== target.list.type) {
+    throw new TiptapListItemMoveError("仅支持同类型列表项和列表容器之间移动");
+  }
+  if (source.item.type !== expectedItemType(source.list.type)) {
+    throw new TiptapListItemMoveError("列表项类型与列表容器不匹配");
+  }
+}
+
+function removeListWrapperIfEmpty(location: ListItemLocation): void {
+  if (location.list.content.length > 0) return;
+  const currentIndex = location.listFrame.parent.indexOf(location.list);
+  if (currentIndex >= 0) location.listFrame.parent.splice(currentIndex, 1);
+}
+
+function nestedListForSink(target: ListItemLocation): any {
+  const children = Array.isArray(target.item.content) ? target.item.content : [];
+  const nestedLists = children.filter((child: any) => LIST_TYPES.has(child?.type));
+  if (nestedLists.some((child: any) => child.type !== target.list.type)) {
+    throw new TiptapListItemMoveError("前一列表项包含不同类型的嵌套列表，无法安全缩进");
+  }
+  if (nestedLists.length > 1) {
+    throw new TiptapListItemMoveError("前一列表项包含多个嵌套列表，无法确定缩进目标");
+  }
+  if (nestedLists.length === 1) return nestedLists[0];
+  const nested = { type: target.list.type, content: [] as any[] };
+  if (!Array.isArray(target.item.content)) target.item.content = [];
+  target.item.content.push(nested);
+  return nested;
+}
+
+function sinkListItem(source: ListItemLocation, target: ListItemLocation): void {
+  validateCompatible(source, target);
+  if (source.list !== target.list || source.depth !== target.depth) {
+    throw new TiptapListItemMoveError("缩进只能发生在同一列表层级");
+  }
+  const sourceIndex = source.list.content.indexOf(source.item);
+  const targetIndex = source.list.content.indexOf(target.item);
+  if (sourceIndex < 1 || targetIndex !== sourceIndex - 1) {
+    throw new TiptapListItemMoveError("列表项只能缩进到紧邻的前一项下");
+  }
+  const nested = nestedListForSink(target);
+  source.list.content.splice(sourceIndex, 1);
+  nested.content.push(source.item);
+}
+
+function liftListItem(source: ListItemLocation, target: ListItemLocation): void {
+  validateCompatible(source, target);
+  if (
+    source.depth !== target.depth + 1
+    || source.parentItemFrame?.node !== target.item
+    || !source.outerListFrame
+    || source.outerListFrame.node !== target.list
+    || source.listFrame.parent !== target.item.content
+  ) {
+    throw new TiptapListItemMoveError("提升只能把嵌套项移动到其直接父项之后");
+  }
+
+  const sourceIndex = source.list.content.indexOf(source.item);
+  const targetIndex = target.list.content.indexOf(target.item);
+  if (sourceIndex < 0 || targetIndex < 0) {
+    throw new TiptapListItemMoveError("列表结构已变化，无法完成提升");
+  }
+  source.list.content.splice(sourceIndex, 1);
+  removeListWrapperIfEmpty(source);
+  const refreshedTargetIndex = target.list.content.indexOf(target.item);
+  target.list.content.splice(refreshedTargetIndex + 1, 0, source.item);
+}
+
+function moveAtSameDepth(
+  source: ListItemLocation,
+  target: ListItemLocation,
+  position: "before" | "after",
+): void {
+  validateCompatible(source, target);
+  if (source.depth !== target.depth) {
+    throw new TiptapListItemMoveError("跨列表移动必须保持相同层级");
+  }
+
+  const sourceIndex = source.list.content.indexOf(source.item);
+  if (sourceIndex < 0) throw new TiptapListItemMoveError("源列表项不存在");
+  source.list.content.splice(sourceIndex, 1);
+  if (source.list !== target.list) removeListWrapperIfEmpty(source);
+
+  const targetIndex = target.list.content.indexOf(target.item);
+  if (targetIndex < 0) throw new TiptapListItemMoveError("目标列表项不存在");
+  const destination = position === "after" ? targetIndex + 1 : targetIndex;
+  target.list.content.splice(destination, 0, source.item);
+}
+
+/** Apply one controlled list hierarchy operation to a mutable Tiptap document. */
+export function applyTiptapListItemMove(
+  doc: any,
+  operation: TiptapListItemMoveOperation,
+): string[] {
+  if (!validBlockId(operation.blockId) || !validBlockId(operation.targetBlockId)) {
+    throw new TiptapListItemMoveError("列表项 Block ID 无效");
+  }
+  if (operation.blockId === operation.targetBlockId) {
+    throw new TiptapListItemMoveError("不能把列表项移动到自身");
+  }
+  if (!doc || doc.type !== "doc" || !Array.isArray(doc.content)) {
+    throw new TiptapListItemMoveError("富文本列表文档无效");
+  }
+
+  const source = locateListItem(doc, operation.blockId);
+  const target = locateListItem(doc, operation.targetBlockId);
+  if (operation.position === "inside") {
+    sinkListItem(source, target);
+  } else if (
+    operation.position === "after"
+    && source.depth === target.depth + 1
+  ) {
+    liftListItem(source, target);
+  } else {
+    moveAtSameDepth(source, target, operation.position);
+  }
+  return [operation.blockId, operation.targetBlockId];
+}

--- a/backend/src/lib/tiptapListItemMove.ts
+++ b/backend/src/lib/tiptapListItemMove.ts
@@ -36,6 +36,10 @@ interface ListItemLocation {
   outerListFrame: NodeFrame | null;
 }
 
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
 function validBlockId(value: unknown): value is string {
   return typeof value === "string" && BLOCK_ID_RE.test(value);
 }
@@ -121,7 +125,14 @@ function nestedListForSink(target: ListItemLocation): any {
     throw new TiptapListItemMoveError("前一列表项包含多个嵌套列表，无法确定缩进目标");
   }
   if (nestedLists.length === 1) return nestedLists[0];
-  const nested = { type: target.list.type, content: [] as any[] };
+  const attrs = target.list.attrs && typeof target.list.attrs === "object"
+    ? cloneJson(target.list.attrs)
+    : null;
+  const nested = {
+    type: target.list.type,
+    ...(attrs && Object.keys(attrs).length > 0 ? { attrs } : {}),
+    content: [] as any[],
+  };
   if (!Array.isArray(target.item.content)) target.item.content = [];
   target.item.content.push(nested);
   return nested;

--- a/backend/src/lib/tiptapListItemMove.ts
+++ b/backend/src/lib/tiptapListItemMove.ts
@@ -5,7 +5,8 @@ const ITEM_TYPES = new Set(["listItem", "taskItem"]);
 export type TiptapListItemMovePosition = "before" | "after" | "inside";
 
 export interface TiptapListItemMoveOperation {
-  type: "moveListItem";
+  type: "move";
+  scope: "listItem";
   blockId: string;
   targetBlockId: string;
   position: TiptapListItemMovePosition;

--- a/backend/src/runtime/block-patch.ts
+++ b/backend/src/runtime/block-patch.ts
@@ -9,6 +9,10 @@ import {
   planIncrementalPatchIndexes,
 } from "../lib/blockPatchIncrementalIndexes.js";
 import {
+  canUseIncrementalListMoveIndexes,
+  planIncrementalListMoveIndexes,
+} from "../lib/blockPatchListIncrementalIndexes.js";
+import {
   ensureNoteBlockTables,
   getNoteBlock,
   plainTextFromNoteContent,
@@ -200,15 +204,22 @@ async function patchBlocks(c: Context) {
         throw new BlockPatchRouteError("VERSION_CONFLICT", 409, { currentVersion: note.version });
       }
 
-      // Safe leaf, top-level structural and proven mixed patches can skip the legacy pre-patch
-      // DELETE + full reinsert when the persisted index mirrors the current document. Any mismatch
-      // fails closed and falls back inside this same transaction.
-      const incrementalBase = canUseIncrementalPatchIndexes(
+      // Safe leaf, top-level structural, proven mixed, and one controlled list-subtree move can skip
+      // the legacy pre-patch DELETE + full reinsert when the persisted index mirrors the document.
+      // Any mismatch fails closed and falls back inside this same transaction.
+      const listIncrementalBase = canUseIncrementalListMoveIndexes(
         db,
         noteId,
         note.content,
         operations,
       );
+      const genericIncrementalBase = !listIncrementalBase && canUseIncrementalPatchIndexes(
+        db,
+        noteId,
+        note.content,
+        operations,
+      );
+      const incrementalBase = listIncrementalBase || genericIncrementalBase;
       const normalizedBefore = incrementalBase
         ? {
             content: note.content,
@@ -218,9 +229,12 @@ async function patchBlocks(c: Context) {
           }
         : syncNoteBlocks(db, noteId, note.content, note.contentFormat);
       const patch = applyTiptapBlockPatch(normalizedBefore.content, operations);
-      const incrementalPlan = incrementalBase
-        ? planIncrementalPatchIndexes(db, userId, noteId, patch.content, operations)
+      const listIncrementalPlan = listIncrementalBase
+        ? planIncrementalListMoveIndexes(db, noteId, patch.content, operations)
         : null;
+      const incrementalPlan = listIncrementalPlan ?? (genericIncrementalBase
+        ? planIncrementalPatchIndexes(db, userId, noteId, patch.content, operations)
+        : null);
       const contentText = incrementalPlan?.contentText
         ?? plainTextFromNoteContent(patch.content, note.contentFormat);
       const nextVersion = note.version + 1;
@@ -245,12 +259,12 @@ async function patchBlocks(c: Context) {
       let persistedContentText = contentText;
       let postSyncChanged = false;
       let indexUpdateMode: "incremental" | "full" = "full";
-      let indexUpdateKind: "leaf" | "structural" | "mixed" | "full" = "full";
+      let indexUpdateKind: "leaf" | "structural" | "mixed" | "list-subtree" | "full" = "full";
       let indexedBlockIds: string[] = [];
       if (incrementalPlan) {
         applyIncrementalPatchIndexes(db, userId, noteId, incrementalPlan);
         indexUpdateMode = "incremental";
-        indexUpdateKind = incrementalPlan.kind;
+        indexUpdateKind = listIncrementalPlan ? "list-subtree" : incrementalPlan.kind;
         indexedBlockIds = incrementalPlan.indexedBlockIds;
       } else {
         const synced = syncNoteBlocks(db, noteId, patch.content, note.contentFormat);

--- a/backend/tests/block-patch-list-route.test.ts
+++ b/backend/tests/block-patch-list-route.test.ts
@@ -102,10 +102,35 @@ test.after(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-test("persists a controlled sink with one version and authoritative full indexes", async () => {
+test("persists a controlled sink with one version and incremental list-subtree indexes", async () => {
   const noteId = "12121212-1212-4212-8212-121212121212";
+  const targetNoteId = "56565656-5656-4565-8565-565656565656";
   const original = documentContent();
   insertNote(noteId, original);
+  insertNote(targetNoteId, JSON.stringify({
+    type: "doc",
+    content: [paragraph("blk_target00", "Target")],
+  }));
+
+  db.prepare(`
+    UPDATE note_blocks_index
+    SET createdAt = '2000-01-01 00:00:00', updatedAt = '2000-01-01 00:00:00'
+    WHERE noteId = ?
+  `).run(noteId);
+  db.prepare(`
+    INSERT INTO note_links (
+      id, userId, sourceNoteId, targetNoteId, targetBlockId, sourceBlockId,
+      linkType, linkText, excerpt, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, NULL, ?, 'note', NULL, 'stable', ?, ?)
+  `).run(
+    "list-link-stable",
+    owner,
+    noteId,
+    targetNoteId,
+    "blk_para_b0",
+    "2000-01-01 00:00:00",
+    "2000-01-01 00:00:00",
+  );
 
   const operations = [{
     type: "move",
@@ -119,9 +144,16 @@ test("persists a controlled sink with one version and authoritative full indexes
   assert.equal(response.status, 200);
   const payload = await response.json() as any;
   assert.equal(payload.version, 2);
-  assert.equal(payload.indexUpdateMode, "full");
-  assert.equal(payload.indexUpdateKind, "full");
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.equal(payload.indexUpdateKind, "list-subtree");
   assert.deepEqual(payload.affectedBlockIds.sort(), ["blk_item_a0", "blk_item_b0"].sort());
+  assert.deepEqual(new Set(payload.indexedBlockIds), new Set([
+    "blk_item_a0",
+    "blk_item_b0",
+    "blk_para_b0",
+    "blk_item_c0",
+    "blk_para_c0",
+  ]));
 
   const parsed = JSON.parse(payload.content);
   assert.deepEqual(parsed.content[0].content.map((node: any) => node.attrs.blockId), [
@@ -131,15 +163,36 @@ test("persists a controlled sink with one version and authoritative full indexes
   assert.equal(parsed.content[0].content[0].content[1].content[0].attrs.blockId, "blk_item_b0");
 
   const rows = db.prepare(`
-    SELECT blockId, parentBlockId, path
+    SELECT blockId, parentBlockId, path, updatedAt
     FROM note_blocks_index
     WHERE noteId = ?
-  `).all(noteId) as Array<{ blockId: string; parentBlockId: string | null; path: string }>;
+  `).all(noteId) as Array<{
+    blockId: string;
+    parentBlockId: string | null;
+    path: string;
+    updatedAt: string;
+  }>;
   const byId = new Map(rows.map((row) => [row.blockId, row]));
   assert.equal(byId.get("blk_item_a0")?.parentBlockId, null);
   assert.equal(byId.get("blk_item_b0")?.parentBlockId, "blk_item_a0");
   assert.match(byId.get("blk_item_b0")?.path || "", /^0\.0\./);
   assert.equal(byId.get("blk_para_b0")?.parentBlockId, "blk_item_b0");
+  assert.equal(byId.get("blk_para_a0")?.updatedAt, "2000-01-01 00:00:00");
+  assert.notEqual(byId.get("blk_item_a0")?.updatedAt, "2000-01-01 00:00:00");
+
+  const link = db.prepare(`
+    SELECT id, createdAt, updatedAt FROM note_links
+    WHERE sourceNoteId = ? AND sourceBlockId = ?
+  `).get(noteId, "blk_para_b0") as {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+  } | undefined;
+  assert.deepEqual(link, {
+    id: "list-link-stable",
+    createdAt: "2000-01-01 00:00:00",
+    updatedAt: "2000-01-01 00:00:00",
+  });
 
   const stored = db.prepare("SELECT content, version FROM notes WHERE id = ?").get(noteId) as any;
   assert.equal(stored.content, payload.content);
@@ -151,7 +204,36 @@ test("persists a controlled sink with one version and authoritative full indexes
   const replayPayload = await replay.json() as any;
   assert.equal(replayPayload.idempotentReplay, true);
   assert.equal(replayPayload.content, payload.content);
+  assert.equal(replayPayload.indexUpdateKind, "list-subtree");
   assert.equal(count("SELECT COUNT(*) AS c FROM note_versions WHERE noteId = ?", noteId), 1);
+});
+
+test("falls back to full synchronization when the persisted list index is stale", async () => {
+  const noteId = "78787878-7878-4787-8787-787878787878";
+  insertNote(noteId, documentContent());
+  db.prepare(`
+    UPDATE note_blocks_index SET path = 'broken.path'
+    WHERE noteId = ? AND blockId = 'blk_item_b0'
+  `).run(noteId);
+
+  const response = await patch(noteId, "block-list-stale-index", [{
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_b0",
+    targetBlockId: "blk_item_a0",
+    position: "inside",
+  }]);
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.indexUpdateMode, "full");
+  assert.equal(payload.indexUpdateKind, "full");
+  const row = db.prepare(`
+    SELECT parentBlockId, path FROM note_blocks_index
+    WHERE noteId = ? AND blockId = 'blk_item_b0'
+  `).get(noteId) as { parentBlockId: string | null; path: string };
+  assert.equal(row.parentBlockId, "blk_item_a0");
+  assert.notEqual(row.path, "broken.path");
 });
 
 test("rejects an unsafe non-adjacent sink without changing persistence", async () => {

--- a/backend/tests/block-patch-list-route.test.ts
+++ b/backend/tests/block-patch-list-route.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-block-list-route-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+const owner = "block-list-owner";
+const notebookId = "block-list-notebook";
+
+let db: Database.Database;
+let closeDb: () => void;
+let app: Hono;
+let syncNoteBlocks: typeof import("../src/lib/noteBlocks").syncNoteBlocks;
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function item(blockId: string, paragraphId: string, text: string) {
+  return {
+    type: "listItem",
+    attrs: { blockId },
+    content: [paragraph(paragraphId, text)],
+  };
+}
+
+function documentContent(): string {
+  return JSON.stringify({
+    type: "doc",
+    content: [{
+      type: "bulletList",
+      content: [
+        item("blk_item_a0", "blk_para_a0", "A"),
+        item("blk_item_b0", "blk_para_b0", "B"),
+        item("blk_item_c0", "blk_para_c0", "C"),
+      ],
+    }],
+  });
+}
+
+function insertNote(id: string, content: string) {
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked
+    ) VALUES (?, ?, ?, ?, ?, '', 'tiptap-json', 1, 0)
+  `).run(id, owner, notebookId, id, content);
+  syncNoteBlocks(db, id, content, "tiptap-json");
+}
+
+async function patch(noteId: string, operationId: string, operations: unknown[]) {
+  return app.request(`/api/blocks/${noteId}/patch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": owner,
+    },
+    body: JSON.stringify({
+      expectedNoteVersion: 1,
+      operationId,
+      operations,
+    }),
+  });
+}
+
+function count(sql: string, value: string): number {
+  const row = db.prepare(sql).get(value) as { c: number } | undefined;
+  return row?.c ?? 0;
+}
+
+test.before(async () => {
+  const [schema, noteBlocks] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/lib/noteBlocks"),
+  ]);
+  await import("../src/runtime/block-patch");
+  const blockRoute = await import("../src/routes/blocks");
+
+  db = schema.getDb();
+  closeDb = schema.closeDb;
+  syncNoteBlocks = noteBlocks.syncNoteBlocks;
+  app = new Hono();
+  app.route("/api/blocks", blockRoute.default);
+
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(owner, owner, "hash");
+  db.prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run(notebookId, owner, "List patch");
+});
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("persists a controlled sink with one version and authoritative full indexes", async () => {
+  const noteId = "12121212-1212-4212-8212-121212121212";
+  const original = documentContent();
+  insertNote(noteId, original);
+
+  const operations = [{
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_b0",
+    targetBlockId: "blk_item_a0",
+    position: "inside",
+  }];
+  const response = await patch(noteId, "block-list-sink-route", operations);
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.version, 2);
+  assert.equal(payload.indexUpdateMode, "full");
+  assert.equal(payload.indexUpdateKind, "full");
+  assert.deepEqual(payload.affectedBlockIds.sort(), ["blk_item_a0", "blk_item_b0"].sort());
+
+  const parsed = JSON.parse(payload.content);
+  assert.deepEqual(parsed.content[0].content.map((node: any) => node.attrs.blockId), [
+    "blk_item_a0",
+    "blk_item_c0",
+  ]);
+  assert.equal(parsed.content[0].content[0].content[1].content[0].attrs.blockId, "blk_item_b0");
+
+  const rows = db.prepare(`
+    SELECT blockId, parentBlockId, path
+    FROM note_blocks_index
+    WHERE noteId = ?
+  `).all(noteId) as Array<{ blockId: string; parentBlockId: string | null; path: string }>;
+  const byId = new Map(rows.map((row) => [row.blockId, row]));
+  assert.equal(byId.get("blk_item_a0")?.parentBlockId, null);
+  assert.equal(byId.get("blk_item_b0")?.parentBlockId, "blk_item_a0");
+  assert.match(byId.get("blk_item_b0")?.path || "", /^0\.0\./);
+  assert.equal(byId.get("blk_para_b0")?.parentBlockId, "blk_item_b0");
+
+  const stored = db.prepare("SELECT content, version FROM notes WHERE id = ?").get(noteId) as any;
+  assert.equal(stored.content, payload.content);
+  assert.equal(stored.version, 2);
+  assert.equal(count("SELECT COUNT(*) AS c FROM note_versions WHERE noteId = ?", noteId), 1);
+
+  const replay = await patch(noteId, "block-list-sink-route", operations);
+  assert.equal(replay.status, 200);
+  const replayPayload = await replay.json() as any;
+  assert.equal(replayPayload.idempotentReplay, true);
+  assert.equal(replayPayload.content, payload.content);
+  assert.equal(count("SELECT COUNT(*) AS c FROM note_versions WHERE noteId = ?", noteId), 1);
+});
+
+test("rejects an unsafe non-adjacent sink without changing persistence", async () => {
+  const noteId = "34343434-3434-4434-8434-343434343434";
+  const original = documentContent();
+  insertNote(noteId, original);
+
+  const response = await patch(noteId, "block-list-invalid-route", [{
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_c0",
+    targetBlockId: "blk_item_a0",
+    position: "inside",
+  }]);
+
+  assert.equal(response.status, 400);
+  const payload = await response.json() as any;
+  assert.equal(payload.code, "LIST_MOVE_INVALID");
+
+  const stored = db.prepare("SELECT content, version FROM notes WHERE id = ?").get(noteId) as any;
+  assert.equal(stored.content, original);
+  assert.equal(stored.version, 1);
+  assert.equal(count("SELECT COUNT(*) AS c FROM note_versions WHERE noteId = ?", noteId), 0);
+  assert.equal(count(
+    "SELECT COUNT(*) AS c FROM block_operations WHERE operationId = ?",
+    "block-list-invalid-route",
+  ), 0);
+});

--- a/backend/tests/tiptap-list-item-move.test.ts
+++ b/backend/tests/tiptap-list-item-move.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyTiptapBlockPatch,
+  TiptapBlockPatchError,
+  validateTiptapBlockPatchOperations,
+} from "../src/lib/tiptapBlockPatch";
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function listItem(blockId: string, text: string, nested?: unknown) {
+  return {
+    type: "listItem",
+    attrs: { blockId },
+    content: [
+      paragraph(`blk_p_${blockId.slice(4)}`, text),
+      ...(nested ? [nested] : []),
+    ],
+  };
+}
+
+function taskItem(blockId: string, text: string, checked = false, nested?: unknown) {
+  return {
+    type: "taskItem",
+    attrs: { blockId, checked },
+    content: [
+      paragraph(`blk_p_${blockId.slice(4)}`, text),
+      ...(nested ? [nested] : []),
+    ],
+  };
+}
+
+function list(type: "bulletList" | "orderedList" | "taskList", items: unknown[]) {
+  return { type, content: items };
+}
+
+function doc(content: unknown[]): string {
+  return JSON.stringify({ type: "doc", content });
+}
+
+function patch(source: string, operation: unknown) {
+  return JSON.parse(applyTiptapBlockPatch(
+    source,
+    validateTiptapBlockPatchOperations([operation]),
+  ).content);
+}
+
+test("sinks one list item under its immediate previous sibling", () => {
+  const source = doc([list("bulletList", [
+    listItem("blk_item_a0", "A"),
+    listItem("blk_item_b0", "B"),
+    listItem("blk_item_c0", "C"),
+  ])]);
+
+  const result = patch(source, {
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_b0",
+    targetBlockId: "blk_item_a0",
+    position: "inside",
+  });
+
+  const outer = result.content[0];
+  assert.deepEqual(outer.content.map((item: any) => item.attrs.blockId), ["blk_item_a0", "blk_item_c0"]);
+  const nested = outer.content[0].content[1];
+  assert.equal(nested.type, "bulletList");
+  assert.deepEqual(nested.content.map((item: any) => item.attrs.blockId), ["blk_item_b0"]);
+  assert.equal(nested.content[0].content[0].content[0].text, "B");
+});
+
+test("lifts one nested list item directly after its parent and removes an empty nested list", () => {
+  const nested = list("bulletList", [listItem("blk_item_b0", "B")]);
+  const source = doc([list("bulletList", [
+    listItem("blk_item_a0", "A", nested),
+    listItem("blk_item_c0", "C"),
+  ])]);
+
+  const result = patch(source, {
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_b0",
+    targetBlockId: "blk_item_a0",
+    position: "after",
+  });
+
+  const outer = result.content[0];
+  assert.deepEqual(outer.content.map((item: any) => item.attrs.blockId), [
+    "blk_item_a0",
+    "blk_item_b0",
+    "blk_item_c0",
+  ]);
+  assert.equal(outer.content[0].content.some((node: any) => node.type === "bulletList"), false);
+});
+
+test("moves an item between same-depth lists and removes the empty source wrapper", () => {
+  const source = doc([
+    list("bulletList", [listItem("blk_item_a0", "A")]),
+    paragraph("blk_separator", "Between"),
+    list("bulletList", [
+      listItem("blk_item_b0", "B"),
+      listItem("blk_item_c0", "C"),
+    ]),
+  ]);
+
+  const result = patch(source, {
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_a0",
+    targetBlockId: "blk_item_c0",
+    position: "after",
+  });
+
+  assert.equal(result.content.length, 2);
+  assert.equal(result.content[0].attrs.blockId, "blk_separator");
+  assert.deepEqual(result.content[1].content.map((item: any) => item.attrs.blockId), [
+    "blk_item_b0",
+    "blk_item_c0",
+    "blk_item_a0",
+  ]);
+});
+
+test("supports task-list sinking while preserving checked state", () => {
+  const source = doc([list("taskList", [
+    taskItem("blk_task_a0", "A", true),
+    taskItem("blk_task_b0", "B", false),
+  ])]);
+
+  const result = patch(source, {
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_task_b0",
+    targetBlockId: "blk_task_a0",
+    position: "inside",
+  });
+
+  const parent = result.content[0].content[0];
+  assert.equal(parent.attrs.checked, true);
+  assert.equal(parent.content[1].type, "taskList");
+  assert.equal(parent.content[1].content[0].attrs.checked, false);
+});
+
+test("rejects non-adjacent sinking and list-type changes", () => {
+  const nonAdjacent = doc([list("bulletList", [
+    listItem("blk_item_a0", "A"),
+    listItem("blk_item_b0", "B"),
+    listItem("blk_item_c0", "C"),
+  ])]);
+  assert.throws(
+    () => patch(nonAdjacent, {
+      type: "move",
+      scope: "listItem",
+      blockId: "blk_item_c0",
+      targetBlockId: "blk_item_a0",
+      position: "inside",
+    }),
+    (error: unknown) => error instanceof TiptapBlockPatchError && error.code === "LIST_MOVE_INVALID",
+  );
+
+  const mixed = doc([
+    list("bulletList", [listItem("blk_item_a0", "A")]),
+    list("orderedList", [listItem("blk_item_b0", "B")]),
+  ]);
+  assert.throws(
+    () => patch(mixed, {
+      type: "move",
+      scope: "listItem",
+      blockId: "blk_item_a0",
+      targetBlockId: "blk_item_b0",
+      position: "after",
+    }),
+    (error: unknown) => error instanceof TiptapBlockPatchError && error.code === "LIST_MOVE_INVALID",
+  );
+});
+
+test("keeps legacy top-level move position optional but requires list scope positions", () => {
+  assert.doesNotThrow(() => validateTiptapBlockPatchOperations([{
+    type: "move",
+    blockId: "blk_alpha00",
+    targetBlockId: "blk_beta000",
+  }]));
+  assert.throws(
+    () => validateTiptapBlockPatchOperations([{
+      type: "move",
+      scope: "listItem",
+      blockId: "blk_item_a0",
+      targetBlockId: "blk_item_b0",
+    }]),
+    (error: unknown) => error instanceof TiptapBlockPatchError && error.code === "INVALID_PATCH",
+  );
+});

--- a/backend/tests/tiptap-list-item-move.test.ts
+++ b/backend/tests/tiptap-list-item-move.test.ts
@@ -37,8 +37,12 @@ function taskItem(blockId: string, text: string, checked = false, nested?: unkno
   };
 }
 
-function list(type: "bulletList" | "orderedList" | "taskList", items: unknown[]) {
-  return { type, content: items };
+function list(
+  type: "bulletList" | "orderedList" | "taskList",
+  items: unknown[],
+  attrs?: Record<string, unknown>,
+) {
+  return { type, ...(attrs ? { attrs } : {}), content: items };
 }
 
 function doc(content: unknown[]): string {
@@ -73,6 +77,26 @@ test("sinks one list item under its immediate previous sibling", () => {
   assert.equal(nested.type, "bulletList");
   assert.deepEqual(nested.content.map((item: any) => item.attrs.blockId), ["blk_item_b0"]);
   assert.equal(nested.content[0].content[0].content[0].text, "B");
+});
+
+test("copies ordered-list attrs when a nested list is created", () => {
+  const source = doc([list("orderedList", [
+    listItem("blk_item_a0", "A"),
+    listItem("blk_item_b0", "B"),
+  ], { start: 1 })]);
+
+  const result = patch(source, {
+    type: "move",
+    scope: "listItem",
+    blockId: "blk_item_b0",
+    targetBlockId: "blk_item_a0",
+    position: "inside",
+  });
+
+  const outer = result.content[0];
+  assert.deepEqual(outer.attrs, { start: 1 });
+  assert.deepEqual(outer.content[0].content[1].attrs, { start: 1 });
+  assert.equal(outer.content[0].content[1].type, "orderedList");
 });
 
 test("lifts one nested list item directly after its parent and removes an empty nested list", () => {
@@ -165,7 +189,7 @@ test("rejects non-adjacent sinking and list-type changes", () => {
 
   const mixed = doc([
     list("bulletList", [listItem("blk_item_a0", "A")]),
-    list("orderedList", [listItem("blk_item_b0", "B")]),
+    list("orderedList", [listItem("blk_item_b0", "B")], { start: 1 }),
   ]);
   assert.throws(
     () => patch(mixed, {

--- a/docs/block-patch-api.md
+++ b/docs/block-patch-api.md
@@ -1,4 +1,4 @@
-# Block Patch API V2-E
+# Block Patch API V2-G
 
 Block Patch applies ordered Tiptap Block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future Block-authoritative storage model.
 
@@ -142,7 +142,7 @@ Additional guards:
 
 The server repairs empty list and quote containers.
 
-Deleting every top-level identified Block now remains on Block Patch. The server creates one canonical empty paragraph with a fresh stable Block ID. Its mapping is returned as a server-created entry:
+Deleting every top-level identified Block remains on Block Patch. The server creates one canonical empty paragraph with a fresh stable Block ID. Its mapping is returned as a server-created entry:
 
 ```json
 {
@@ -156,7 +156,7 @@ For an automatic empty replacement, `operationIndex === operationCount` and `cli
 
 Delete-all uses full index synchronization because the generated Block did not exist in the pre-patch index. See `docs/block-patch-empty-document.md` for the editor ACK behavior.
 
-### Move
+### Move a normal Block
 
 ```json
 {
@@ -167,9 +167,45 @@ Delete-all uses full index synchronization because the generated Block did not e
 }
 ```
 
-Moves are currently supported only inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
+Legacy Block moves are supported inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
 
 Incremental indexing requires the moved Block and anchor to be top-level paragraphs, headings or code blocks. They may exist before the request or be explicit Blocks created earlier in the same request.
+
+The legacy `position` remains optional and defaults to `after`.
+
+### Move a list item
+
+List hierarchy operations reuse `move` with an explicit scope:
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_source_item",
+  "targetBlockId": "blk_target_item",
+  "position": "inside"
+}
+```
+
+Supported positions:
+
+- `inside`: sink the source one level under its immediate previous sibling;
+- `after`: lift a nested item after its direct parent, or move at the same depth after another item;
+- `before`: move at the same depth before another item.
+
+Safety requirements:
+
+- source and target item types must match;
+- source and target list types must match exactly;
+- `inside` requires the target to be the immediate previous sibling;
+- lift requires the target to be the source's direct parent item;
+- other cross-depth reparenting is rejected;
+- an empty source list wrapper is removed;
+- the complete item subtree moves unchanged.
+
+Supported type pairs are `listItem/bulletList`, `listItem/orderedList`, and `taskItem/taskList`.
+
+Invalid list hierarchy moves return `400 LIST_MOVE_INVALID`. See `docs/block-patch-list-hierarchy.md` for the complete proof and fallback rules.
 
 ## Atomic semantics
 
@@ -219,7 +255,9 @@ Used when safe leaf and top-level structural operations occur together.
 
 ### `full`
 
-Used when incremental correctness cannot be proven, including stale indexes, nested structural changes, cross-parent operations, identity ambiguity, complex nodes, or delete-all server replacement.
+Used when incremental correctness cannot be proven, including stale indexes, nested structural changes, scoped list-item moves, identity ambiguity, complex nodes, or delete-all server replacement.
+
+List hierarchy V1 deliberately uses full synchronization because changing one item parent changes descendant paths, ancestor aggregate text and global Block order.
 
 All fallback decisions happen inside the same transaction.
 
@@ -263,24 +301,26 @@ localStorage.setItem("nowen.tiptap_block_patch_v1", "off")
 
 The legacy key name is retained for compatibility.
 
-The planner currently sends:
+The runtime planner currently sends:
 
 - plain-text changes as `update`;
 - safe formatting and attrs as `replace`;
 - top-level create/delete/reorder operations;
 - safe content and structure changes as one mixed transaction;
-- final-Block deletion as an `empty-document` delete batch.
+- final-Block deletion as an `empty-document` delete batch;
+- one proven-safe list sink, lift or same-depth move as scoped `move`.
 
-For empty-document ACKs:
-
-- no newer local input: the authoritative server paragraph is replayed and the previous selection is clamped into it;
-- newer local input exists: local content is preserved and the queued patch reconciles against the confirmed server version.
+For list hierarchy snapshots, frontend planning requires the same stable item IDs, unchanged item payloads and non-list structure, and exact reproduction of the final JSON by one controlled operation.
 
 The following continue through whole-note save:
 
 - tables and table structure changes;
 - images, videos, attachments, Mermaid, math and other atom nodes;
-- list hierarchy changes and cross-parent moves;
+- list content changes combined with hierarchy changes;
+- multiple independent list moves;
+- top-level lift out of a list;
+- conversion between bullet, ordered and task lists;
+- arbitrary cross-depth or cross-type reparenting;
 - unsupported complex paste operations;
 - unknown extension nodes or attributes;
 - title/meta changes.
@@ -293,7 +333,8 @@ Public, guest and presentation routes never mount the authenticated Block Patch 
 
 - `notes.content` remains the canonical complete document.
 - A successful patch still serializes a full JSON snapshot.
-- Nested structural and cross-parent operations are deferred.
+- List subtree index updates still use full synchronization.
+- Arbitrary nested structural operations remain deferred.
 - Table, media, attachment, formula and Mermaid node patches are deferred.
 - There is no independent Block-authoritative content table yet.
 - Markdown uses its separate CodeMirror/Y.Text incremental path.

--- a/docs/block-patch-api.md
+++ b/docs/block-patch-api.md
@@ -1,4 +1,4 @@
-# Block Patch API V2-G
+# Block Patch API V2-H
 
 Block Patch applies ordered Tiptap Block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future Block-authoritative storage model.
 
@@ -43,20 +43,9 @@ Only notes whose `contentFormat` is `tiptap-json` are accepted.
 }
 ```
 
-Supported types:
+Supported types are `paragraph`, `heading`, `codeBlock`, `blockquote`, `listItem` and `taskItem`. Heading creation defaults to H2.
 
-- `paragraph`
-- `heading` — created as H2
-- `codeBlock`
-- `blockquote`
-- `listItem`
-- `taskItem`
-
-When `blockId` is omitted, the server generates one and returns the client/server mapping in `createdBlocks`.
-
-Only top-level paragraph, heading and code-block creation is eligible for structural or mixed incremental indexing. Other valid create operations use full index synchronization.
-
-An explicitly identified Block created earlier in the request may be referenced by a later top-level move. Temporary identities are validated in operation order.
+When `blockId` is omitted, the server generates one and returns the client/server mapping in `createdBlocks`. Only top-level paragraph, heading and code-block creation is currently eligible for structural or mixed incremental indexing.
 
 ### Plain-text update
 
@@ -95,41 +84,9 @@ This keeps the existing Block type and attributes while replacing its editable t
 }
 ```
 
-The API does not accept arbitrary ProseMirror JSON. Frontend planning and backend validation enforce the same restricted schema.
+The API does not accept arbitrary ProseMirror JSON. Allowed Block nodes are `paragraph`, `heading` and `codeBlock`; allowed inline nodes are `text` and paragraph/heading `hardBreak`.
 
-Allowed Block nodes:
-
-- `paragraph`
-- `heading`
-- `codeBlock`
-
-Allowed inline nodes:
-
-- `text`
-- `hardBreak` for paragraphs and headings
-
-Allowed marks:
-
-- `bold`
-- `italic`
-- `underline`
-- `strike`
-- `code`
-- `link`
-- `highlight`
-- `textStyle`
-
-Allowed attributes include paragraph/heading alignment and line height, heading levels 1–6, code language and indent, safe colors/font sizes, and validated link attributes.
-
-Script-execution, data and local-file URL schemes are rejected. Unknown fields, attrs, marks or nodes return `400 INVALID_BLOCK_NODE` before persistence.
-
-Additional guards:
-
-- `node.attrs.blockId` must equal the operation target.
-- One replacement node is limited to 256 KB.
-- Code blocks cannot contain inline marks or hard breaks.
-- Top-level paragraph, heading and code blocks may convert among those three types.
-- Nested blocks must retain their original type.
+Allowed marks include bold, italic, underline, strike, inline code, safe links, highlight and text style. Unknown nodes, marks, attrs, fields, dangerous URL schemes, mismatched Block IDs and oversized replacement nodes return `INVALID_BLOCK_NODE` before persistence.
 
 ### Delete
 
@@ -140,21 +97,7 @@ Additional guards:
 }
 ```
 
-The server repairs empty list and quote containers.
-
-Deleting every top-level identified Block remains on Block Patch. The server creates one canonical empty paragraph with a fresh stable Block ID. Its mapping is returned as a server-created entry:
-
-```json
-{
-  "operationIndex": 1,
-  "clientId": null,
-  "blockId": "blk_server_generated"
-}
-```
-
-For an automatic empty replacement, `operationIndex === operationCount` and `clientId === null`.
-
-Delete-all uses full index synchronization because the generated Block did not exist in the pre-patch index. See `docs/block-patch-empty-document.md` for the editor ACK behavior.
+The server repairs empty list and quote containers. Deleting every top-level identified Block creates one canonical empty paragraph with a fresh stable Block ID. Delete-all uses full index synchronization because the replacement Block did not exist in the pre-patch index.
 
 ### Move a normal Block
 
@@ -167,15 +110,9 @@ Delete-all uses full index synchronization because the generated Block did not e
 }
 ```
 
-Legacy Block moves are supported inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
-
-Incremental indexing requires the moved Block and anchor to be top-level paragraphs, headings or code blocks. They may exist before the request or be explicit Blocks created earlier in the same request.
-
-The legacy `position` remains optional and defaults to `after`.
+Legacy Block moves are supported inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`. Incremental indexing currently requires top-level paragraph, heading or code-block identities.
 
 ### Move a list item
-
-List hierarchy operations reuse `move` with an explicit scope:
 
 ```json
 {
@@ -189,42 +126,30 @@ List hierarchy operations reuse `move` with an explicit scope:
 
 Supported positions:
 
-- `inside`: sink the source one level under its immediate previous sibling;
+- `inside`: sink the source under its immediate previous sibling;
 - `after`: lift a nested item after its direct parent, or move at the same depth after another item;
 - `before`: move at the same depth before another item.
 
-Safety requirements:
-
-- source and target item types must match;
-- source and target list types must match exactly;
-- `inside` requires the target to be the immediate previous sibling;
-- lift requires the target to be the source's direct parent item;
-- other cross-depth reparenting is rejected;
-- an empty source list wrapper is removed;
-- the complete item subtree moves unchanged.
-
-Supported type pairs are `listItem/bulletList`, `listItem/orderedList`, and `taskItem/taskList`.
-
-Invalid list hierarchy moves return `400 LIST_MOVE_INVALID`. See `docs/block-patch-list-hierarchy.md` for the complete proof and fallback rules.
+The source and target item/list types must match. Other cross-depth moves, non-adjacent sink, conflicting nested-list types and self moves return `LIST_MOVE_INVALID`. The complete item subtree moves unchanged. See `docs/block-patch-list-hierarchy.md` for the full proof contract.
 
 ## Atomic semantics
 
 Operations are evaluated in request order. Inside one SQLite transaction, the server:
 
 1. Rechecks existence, permissions, lock state and version.
-2. Verifies whether the current Block index mirrors the Tiptap document.
+2. Verifies whether the persisted Block index mirrors the current Tiptap document.
 3. Materializes missing stable IDs when full normalization is required.
 4. Validates and applies every operation in memory.
 5. Records the pre-edit version using the same five-minute merge window as whole-note save.
 6. Updates `notes.content`, `contentText`, version and timestamp with optimistic locking.
-7. Applies a leaf, structural, mixed or full index synchronization plan.
+7. Applies a leaf, structural, mixed, list-subtree or full index synchronization plan.
 8. Stores the idempotent authoritative response.
 
 Any failure rolls back the document, indexes, history row and idempotency record. One successful batch increments the note version exactly once. Idempotent replay returns the same authoritative content and generated IDs.
 
 ## Index update modes
 
-Before incremental mode is enabled, the server compares row count, IDs, types, parents, order, paths, plain text and content hashes. Any mismatch fails closed to full synchronization.
+Before any incremental mode is enabled, the server compares row count, Block IDs, types, parents, order, paths, plain text and content hashes. Any mismatch fails closed to full synchronization.
 
 ### `leaf`
 
@@ -232,7 +157,7 @@ Used for safe `update` and `replace` batches.
 
 - Changed leaf rows are upserted.
 - Indexed ancestors are refreshed when aggregate text/hash changes.
-- Links are recreated only for changed source leaf Blocks.
+- Links are recreated only for changed source leaves.
 - Unrelated rows and links keep their IDs and timestamps.
 
 ### `structural`
@@ -253,11 +178,20 @@ Used when safe leaf and top-level structural operations occur together.
 - Shifted top-level rows are updated.
 - Links are recreated only for changed/new sources and removed for deleted sources.
 
+### `list-subtree`
+
+Used for one controlled scoped list-item move when the old index is an exact mirror of the source document.
+
+- The moved root may change `parentBlockId`.
+- The moved subtree and intervening rows may change `blockOrder/path`.
+- Old/new parent items and their indexed ancestors may change aggregate `plainText/contentHash`.
+- Paragraph, heading and code-block content/hash must remain unchanged.
+- Only proven-different rows are upserted.
+- No `note_links` rows are deleted or recreated, so links inside the moved subtree preserve their IDs and timestamps.
+
 ### `full`
 
-Used when incremental correctness cannot be proven, including stale indexes, nested structural changes, scoped list-item moves, identity ambiguity, complex nodes, or delete-all server replacement.
-
-List hierarchy V1 deliberately uses full synchronization because changing one item parent changes descendant paths, ancestor aggregate text and global Block order.
+Used whenever incremental correctness cannot be proven, including stale indexes, missing or duplicate IDs, unsupported nested mutations, identity ambiguity, complex nodes, delete-all replacement, or a list difference exceeding the single controlled move contract.
 
 All fallback decisions happen inside the same transaction.
 
@@ -274,14 +208,14 @@ All fallback decisions happen inside the same transaction.
   "contentText": "Searchable plain text",
   "contentFormat": "tiptap-json",
   "notebookId": "notebook-id",
-  "operationCount": 3,
-  "affectedBlockIds": ["blk_alpha000"],
+  "operationCount": 1,
+  "affectedBlockIds": ["blk_source_item", "blk_target_item"],
   "deletedBlockIds": [],
   "createdBlocks": [],
   "blocks": [],
   "indexUpdateMode": "incremental",
-  "indexUpdateKind": "mixed",
-  "indexedBlockIds": ["blk_alpha000"],
+  "indexUpdateKind": "list-subtree",
+  "indexedBlockIds": ["blk_source_item", "blk_descendant"],
   "contentChangedByNormalization": false
 }
 ```
@@ -299,18 +233,14 @@ localStorage.setItem("nowen.tiptap_block_patch_v1", "on")
 localStorage.setItem("nowen.tiptap_block_patch_v1", "off")
 ```
 
-The legacy key name is retained for compatibility.
-
 The runtime planner currently sends:
 
 - plain-text changes as `update`;
 - safe formatting and attrs as `replace`;
 - top-level create/delete/reorder operations;
 - safe content and structure changes as one mixed transaction;
-- final-Block deletion as an `empty-document` delete batch;
+- final-Block deletion as an empty-document delete batch;
 - one proven-safe list sink, lift or same-depth move as scoped `move`.
-
-For list hierarchy snapshots, frontend planning requires the same stable item IDs, unchanged item payloads and non-list structure, and exact reproduction of the final JSON by one controlled operation.
 
 The following continue through whole-note save:
 
@@ -325,15 +255,13 @@ The following continue through whole-note save:
 - unknown extension nodes or attributes;
 - title/meta changes.
 
-Only one patch may be in flight per editor. Uncertain outcomes retry with the same idempotency key and never trigger a blind whole-note overwrite.
-
-Public, guest and presentation routes never mount the authenticated Block Patch AppContext bridge.
+Only one patch may be in flight per editor. Uncertain outcomes retry with the same idempotency key and never trigger a blind whole-note overwrite. Public, guest and presentation routes never mount the authenticated Block Patch AppContext bridge.
 
 ## Remaining boundaries
 
 - `notes.content` remains the canonical complete document.
 - A successful patch still serializes a full JSON snapshot.
-- List subtree index updates still use full synchronization.
+- List-item create/delete and multi-item transactions still use full synchronization.
 - Arbitrary nested structural operations remain deferred.
 - Table, media, attachment, formula and Mermaid node patches are deferred.
 - There is no independent Block-authoritative content table yet.

--- a/docs/block-patch-api.md
+++ b/docs/block-patch-api.md
@@ -1,6 +1,6 @@
-# Block Patch API V2-D
+# Block Patch API V2-E
 
-Block Patch API applies ordered Tiptap Block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future Block-authoritative storage model.
+Block Patch applies ordered Tiptap Block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future Block-authoritative storage model.
 
 ## Endpoint
 
@@ -10,7 +10,7 @@ Authorization: Bearer <token>
 Content-Type: application/json
 ```
 
-The endpoint currently accepts only notes whose `contentFormat` is `tiptap-json`.
+Only notes whose `contentFormat` is `tiptap-json` are accepted.
 
 ## Request envelope
 
@@ -23,7 +23,8 @@ The endpoint currently accepts only notes whose `contentFormat` is `tiptap-json`
 ```
 
 - `expectedNoteVersion` is required. A mismatch returns `409 VERSION_CONFLICT` before persistence.
-- `operationId` is a user-level idempotency key, 8–128 characters. An uncertain retry must reuse the same ID for the same note.
+- `operationId` is a user-level idempotency key, 8–128 characters.
+- An uncertain retry must reuse the same operation ID for the same note.
 - Reusing one operation ID on another note returns `409 OPERATION_ID_CONFLICT`.
 - `operations` contains 1–100 ordered operations. The request is limited to approximately 2 MB.
 
@@ -42,7 +43,7 @@ The endpoint currently accepts only notes whose `contentFormat` is `tiptap-json`
 }
 ```
 
-Supported create types:
+Supported types:
 
 - `paragraph`
 - `heading` — created as H2
@@ -53,9 +54,9 @@ Supported create types:
 
 When `blockId` is omitted, the server generates one and returns the client/server mapping in `createdBlocks`.
 
-Only top-level `paragraph`, `heading` and `codeBlock` creation is currently eligible for structural or mixed incremental indexing. Other create types remain valid API operations but use full index synchronization.
+Only top-level paragraph, heading and code-block creation is eligible for structural or mixed incremental indexing. Other valid create operations use full index synchronization.
 
-An explicitly identified Block created earlier in the same request may be referenced by a later top-level `move`. The server validates these temporary identities in operation order before enabling incremental mode.
+An explicitly identified Block created earlier in the request may be referenced by a later top-level move. Temporary identities are validated in operation order.
 
 ### Plain-text update
 
@@ -94,7 +95,7 @@ This keeps the existing Block type and attributes while replacing its editable t
 }
 ```
 
-V2 does not accept arbitrary ProseMirror JSON. Frontend planning and backend validation enforce the same restricted schema.
+The API does not accept arbitrary ProseMirror JSON. Frontend planning and backend validation enforce the same restricted schema.
 
 Allowed Block nodes:
 
@@ -105,7 +106,7 @@ Allowed Block nodes:
 Allowed inline nodes:
 
 - `text`
-- `hardBreak` for paragraphs/headings only
+- `hardBreak` for paragraphs and headings
 
 Allowed marks:
 
@@ -118,25 +119,17 @@ Allowed marks:
 - `highlight`
 - `textStyle`
 
-Allowed attributes:
+Allowed attributes include paragraph/heading alignment and line height, heading levels 1–6, code language and indent, safe colors/font sizes, and validated link attributes.
 
-- paragraph: `blockId`, `textAlign`, `lineHeight`
-- heading: paragraph attrs plus `level` from 1–6
-- code block: `blockId`, `language`, `indent` from 0–8
-- text style: safe hexadecimal `color` and validated `fontSize`
-- highlight: safe hexadecimal `color`
-- link: `href`, `target`, `rel`, `class`
-
-Safe link protocols include `http`, `https`, `mailto`, `tel`, `sms`, `note`, anchors and relative paths. Script-execution, data and local-file schemes are rejected.
+Script-execution, data and local-file URL schemes are rejected. Unknown fields, attrs, marks or nodes return `400 INVALID_BLOCK_NODE` before persistence.
 
 Additional guards:
 
 - `node.attrs.blockId` must equal the operation target.
-- A replacement node is limited to 256 KB.
+- One replacement node is limited to 256 KB.
 - Code blocks cannot contain inline marks or hard breaks.
 - Top-level paragraph, heading and code blocks may convert among those three types.
 - Nested blocks must retain their original type.
-- Unknown fields, attrs, marks or inline nodes return `400 INVALID_BLOCK_NODE` before persistence.
 
 ### Delete
 
@@ -147,9 +140,21 @@ Additional guards:
 }
 ```
 
-The server repairs empty list/quote containers. Deleting the final document Block creates a valid empty paragraph. The editor rollout still keeps delete-all on whole-note save until the generated replacement Block ID can be reconciled explicitly.
+The server repairs empty list and quote containers.
 
-Only deletion of an existing top-level paragraph, heading or code block is eligible for structural or mixed incremental indexing.
+Deleting every top-level identified Block now remains on Block Patch. The server creates one canonical empty paragraph with a fresh stable Block ID. Its mapping is returned as a server-created entry:
+
+```json
+{
+  "operationIndex": 1,
+  "clientId": null,
+  "blockId": "blk_server_generated"
+}
+```
+
+For an automatic empty replacement, `operationIndex === operationCount` and `clientId === null`.
+
+Delete-all uses full index synchronization because the generated Block did not exist in the pre-patch index. See `docs/block-patch-empty-document.md` for the editor ACK behavior.
 
 ### Move
 
@@ -162,98 +167,61 @@ Only deletion of an existing top-level paragraph, heading or code block is eligi
 }
 ```
 
-Moves are supported only inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
+Moves are currently supported only inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`.
 
-Incremental indexing additionally requires the moved Block and anchor to be top-level paragraphs, headings or code blocks. They may either exist before the request or be explicitly identified Blocks created earlier in the same request.
+Incremental indexing requires the moved Block and anchor to be top-level paragraphs, headings or code blocks. They may exist before the request or be explicit Blocks created earlier in the same request.
 
 ## Atomic semantics
 
 Operations are evaluated in request order. Inside one SQLite transaction, the server:
 
-1. Rechecks note existence, permission, lock state and version.
-2. Verifies whether the current Block index is a complete mirror of the Tiptap document.
-3. Materializes missing stable Block IDs when verification fails.
+1. Rechecks existence, permissions, lock state and version.
+2. Verifies whether the current Block index mirrors the Tiptap document.
+3. Materializes missing stable IDs when full normalization is required.
 4. Validates and applies every operation in memory.
-5. Records the pre-edit version using the same five-minute merge window as `PUT /notes/:id`.
-6. Updates `notes.content`, `contentText`, version and timestamp using optimistic locking.
+5. Records the pre-edit version using the same five-minute merge window as whole-note save.
+6. Updates `notes.content`, `contentText`, version and timestamp with optimistic locking.
 7. Applies a leaf, structural, mixed or full index synchronization plan.
-8. Stores the idempotent response.
+8. Stores the idempotent authoritative response.
 
-Any failure rolls back the document, indexes, history row and idempotency record. One successful batch increments the note version exactly once. Replaying the same operation ID returns the stored authoritative result without adding another version.
+Any failure rolls back the document, indexes, history row and idempotency record. One successful batch increments the note version exactly once. Idempotent replay returns the same authoritative content and generated IDs.
 
-## Incremental index modes
+## Index update modes
 
-Before any incremental mode is enabled, the server compares the current document and `note_blocks_index` for:
+Before incremental mode is enabled, the server compares row count, IDs, types, parents, order, paths, plain text and content hashes. Any mismatch fails closed to full synchronization.
 
-- total row count;
-- stable and unique Block IDs;
-- Block type;
-- parent Block ID;
-- order and path;
-- plain text and content hash.
+### `leaf`
 
-Any mismatch fails closed to full synchronization.
+Used for safe `update` and `replace` batches.
 
-### Leaf incremental mode
+- Changed leaf rows are upserted.
+- Indexed ancestors are refreshed when aggregate text/hash changes.
+- Links are recreated only for changed source leaf Blocks.
+- Unrelated rows and links keep their IDs and timestamps.
 
-Used for batches containing only safe `update` and `replace` operations.
+### `structural`
 
-- Only changed leaf rows are upserted.
-- Indexed ancestors such as `listItem`, `taskItem` and `blockquote` are refreshed when their aggregate text/hash changes.
-- Only `note_links` rows belonging to changed source leaf Blocks are recreated.
-- Unrelated Block rows and backlink rows keep their IDs and timestamps.
+Used for top-level create, delete and move batches.
 
-### Structural incremental mode
+- New and deleted rows are inserted or removed.
+- Only shifted `blockOrder/path` rows are updated.
+- Pure moves preserve link rows.
+- New and deleted source links are updated locally.
 
-Used for batches containing only `create`, `delete` and `move`, when all affected structures are top-level paragraphs, headings or code blocks.
+### `mixed`
 
-The planner computes:
+Used when safe leaf and top-level structural operations occur together.
 
-- newly inserted index rows;
-- deleted index rows;
-- existing rows whose `blockOrder` or `path` changed;
-- links belonging to newly created or deleted source Blocks.
+- Leaf changes and indexed ancestors are refreshed.
+- Created/deleted rows are inserted or removed.
+- Shifted top-level rows are updated.
+- Links are recreated only for changed/new sources and removed for deleted sources.
 
-Behavior:
+### `full`
 
-- inserting a top-level simple Block upserts the new row and only the shifted range;
-- deleting a top-level simple Block removes that row and only updates the shifted range;
-- moving top-level simple Blocks updates only rows whose order/path changed;
-- a newly created explicit Block ID may be moved later in the same request;
-- pure moves preserve existing backlink row IDs and timestamps;
-- links from deleted Blocks are removed;
-- links in newly created Block text are indexed.
+Used when incremental correctness cannot be proven, including stale indexes, nested structural changes, cross-parent operations, identity ambiguity, complex nodes, or delete-all server replacement.
 
-### Mixed incremental mode
-
-Used when one request contains both:
-
-- safe `update` or `replace` leaf operations; and
-- safe top-level `create`, `delete` or `move` operations.
-
-The final document is analyzed once and converted into one unified database plan:
-
-- changed leaf rows and their indexed ancestors are refreshed;
-- newly created and deleted rows are inserted or removed;
-- top-level rows whose order/path changed are updated;
-- links are recreated only for changed leaf sources and newly created Blocks;
-- links for deleted Blocks are removed;
-- pure-move source links remain untouched;
-- unaffected rows and links keep their existing IDs and timestamps.
-
-A mixed plan is rejected and falls back to full synchronization when:
-
-- a leaf target is created or deleted in the same request;
-- a move or create anchor is deleted in the same request;
-- a structural shift changes nested list, task or quote paths;
-- a nested Block changes parent or type;
-- create/delete counts do not exactly match the final identity delta;
-- a deleted ID is reused;
-- create-then-delete makes final identity ambiguous;
-- delete-all creates a server-generated empty replacement Block;
-- any content change cannot be explained by the declared leaf operations and their indexed ancestors.
-
-All incremental fallback decisions happen inside the same transaction and preserve the API's data-safety guarantees.
+All fallback decisions happen inside the same transaction.
 
 ## Authoritative response
 
@@ -269,47 +237,22 @@ All incremental fallback decisions happen inside the same transaction and preser
   "contentFormat": "tiptap-json",
   "notebookId": "notebook-id",
   "operationCount": 3,
-  "affectedBlockIds": ["blk_alpha000", "blk_created00"],
+  "affectedBlockIds": ["blk_alpha000"],
   "deletedBlockIds": [],
   "createdBlocks": [],
   "blocks": [],
   "indexUpdateMode": "incremental",
   "indexUpdateKind": "mixed",
-  "indexedBlockIds": ["blk_alpha000", "blk_created00", "blk_shifted00"],
+  "indexedBlockIds": ["blk_alpha000"],
   "contentChangedByNormalization": false
 }
 ```
 
-- `indexUpdateMode` is `incremental` or `full`.
-- `indexUpdateKind` is `leaf`, `structural`, `mixed` or `full`.
-- `indexedBlockIds` contains Block IDs inserted, updated or deleted by index synchronization. Full mode returns every rebuilt Block ID.
-- `affectedBlockIds` continues to describe Blocks addressed by the patch engine.
+The client must use the returned content and version as the base for the next dependent patch. Successful writes emit `note:updated` and `note:list-updated`.
 
-The client must use the returned snapshot and version as the base for the next dependent patch. Successful writes emit `note:updated` and `note:list-updated` realtime messages.
+## Editor rollout
 
-## Error codes
-
-Common errors:
-
-- `INVALID_BLOCK_PATCH`
-- `INVALID_PATCH`
-- `INVALID_BLOCK_ID`
-- `INVALID_BLOCK_NODE`
-- `BLOCK_ID_CONFLICT`
-- `BLOCK_NOT_FOUND`
-- `BLOCK_MOVE_SELF`
-- `BLOCK_MOVE_PARENT_MISMATCH`
-- `INVALID_TIPTAP_DOCUMENT`
-- `NOTE_LOCKED`
-- `VERSION_CONFLICT`
-- `OPERATION_ID_CONFLICT`
-- `BLOCK_FORMAT_UNSUPPORTED`
-
-Known validation errors occur before persistence and may safely fall back to the established whole-note save path. Version conflicts and uncertain network outcomes must not trigger a blind full overwrite.
-
-## Editor grey rollout
-
-`frontend/src/components/TiptapEditorRuntime.tsx` enables Block Patch by default only when the active runtime decision belongs to that note and its mode is `viewport-optimized` or `lightweight-edit`.
+The Tiptap Runtime enables Block Patch by default only for the active note in `viewport-optimized` or `lightweight-edit` mode.
 
 A session override remains available:
 
@@ -323,34 +266,34 @@ The legacy key name is retained for compatibility.
 The planner currently sends:
 
 - plain-text changes as `update`;
-- safe marks, links, line breaks, heading level, alignment, line height, code language and indent as `replace`;
-- simple top-level create/delete/reorder operations as structural operations;
-- safe rich replacements and top-level structural operations together as one mixed transaction.
+- safe formatting and attrs as `replace`;
+- top-level create/delete/reorder operations;
+- safe content and structure changes as one mixed transaction;
+- final-Block deletion as an `empty-document` delete batch.
+
+For empty-document ACKs:
+
+- no newer local input: the authoritative server paragraph is replayed and the previous selection is clamped into it;
+- newer local input exists: local content is preserved and the queued patch reconciles against the confirmed server version.
 
 The following continue through whole-note save:
 
 - tables and table structure changes;
 - images, videos, attachments, Mermaid, math and other atom nodes;
 - list hierarchy changes and cross-parent moves;
-- unsupported or ambiguous complex paste operations;
-- unknown marks, attributes or extension nodes;
-- title/meta changes;
-- delete-all until empty-Block identity reconciliation is implemented.
+- unsupported complex paste operations;
+- unknown extension nodes or attributes;
+- title/meta changes.
 
-Only one patch may be in flight per editor. Later edits and title/meta saves wait for the authoritative version. Timeout/network uncertainty retries once with the same idempotency key; if the result remains unknown, the local draft is retained and no blind whole-note overwrite is issued.
+Only one patch may be in flight per editor. Uncertain outcomes retry with the same idempotency key and never trigger a blind whole-note overwrite.
 
 Public, guest and presentation routes never mount the authenticated Block Patch AppContext bridge.
 
-## Attachment boundary
-
-The current schema stores attachment ownership in `attachments.noteId`; it does not maintain a separate content-reference index per Block. V2-D does not mutate attachment ownership or introduce an unused attachment-reference table. Media/attachment node edits still use whole-note save, while note split continues to handle attachment ownership and physical-path reuse transactionally.
-
 ## Remaining boundaries
 
-- `notes.content` is still the canonical complete document.
-- A successful patch still serializes the full JSON snapshot.
-- Nested structural operations and cross-parent moves are deferred.
+- `notes.content` remains the canonical complete document.
+- A successful patch still serializes a full JSON snapshot.
+- Nested structural and cross-parent operations are deferred.
 - Table, media, attachment, formula and Mermaid node patches are deferred.
-- Empty-document replacement Block ID reconciliation is deferred.
 - There is no independent Block-authoritative content table yet.
 - Markdown uses its separate CodeMirror/Y.Text incremental path.

--- a/docs/block-patch-empty-document.md
+++ b/docs/block-patch-empty-document.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Tiptap optimized modes may now persist deletion of the final identified top-level Block through `POST /api/blocks/:noteId/patch` instead of forcing a whole-note save.
+Tiptap optimized modes may persist deletion of the final identified top-level Block through `POST /api/blocks/:noteId/patch` instead of forcing a whole-note save.
 
 The frontend planner recognizes two transient empty representations:
 
@@ -35,7 +35,7 @@ Complex nested documents remain on whole-note save because deleting an arbitrary
 
 ## Server identity
 
-The existing patch engine already guarantees that a Tiptap document never remains empty. After all requested operations are applied, it creates one empty paragraph with a fresh stable Block ID and returns it through the authoritative response:
+The patch engine guarantees that a Tiptap document never remains empty. After all requested operations are applied, it creates one empty paragraph with a fresh stable Block ID and returns it through the authoritative response:
 
 ```json
 {
@@ -60,11 +60,46 @@ Delete-all deliberately remains on the full index synchronization path. The gene
 
 The runtime always stores the server response as the next authoritative note version.
 
-When the editor snapshot still equals the sent empty snapshot, `preserveLocalEditor` is false. The established Tiptap ACK guard therefore allows the note-content synchronization effect to load the server-generated paragraph. That effect suppresses save emission and clamps the previous selection into the new document, leaving the caret in a valid editable position.
+When the editor snapshot still equals the sent empty snapshot, `preserveLocalEditor` is false. The normal note-content synchronization effect receives the server-generated paragraph. Before Tiptap applies its whole-document `setContent` transaction, `tiptapEmptyBlockIdentityDispatch` verifies that:
 
-When the user types again while the delete request is in flight, the current editor snapshot differs from the sent empty snapshot. `preserveLocalEditor` is true, so the response does not overwrite the newer local input. The queued save is planned against the confirmed server version; it can delete the server-generated empty Block and create or update the local identified Block in one later transaction.
+- both current and incoming documents contain exactly one empty paragraph;
+- document attributes are identical;
+- paragraph attributes are identical except for `blockId`;
+- the incoming Block ID is valid and differs from the local ID.
 
-This preserves the more important user input while still ensuring that the next persistence baseline contains a stable server-confirmed Block identity.
+Only under those conditions, the incoming transaction is replaced with:
+
+```text
+setNodeMarkup(0, { ...currentAttrs, blockId: serverBlockId })
++ addToHistory = false
++ preventUpdate inherited from setContent
+```
+
+Consequences:
+
+- the editor DOM and document content are not rebuilt;
+- the current selection and caret position remain unchanged;
+- no save event is emitted;
+- the server Block ID becomes the local canonical identity;
+- the metadata update is not added to ProseMirror history.
+
+Any text, structure, document attribute or presentation attribute difference bypasses the interceptor and executes the original synchronization transaction.
+
+When the user types again while the delete request is in flight, the current editor snapshot differs from the sent empty snapshot. `preserveLocalEditor` is true, so the response does not overwrite the newer local input. The queued save is planned against the confirmed server version and reconciles the local Block identity in the next confirmed patch.
+
+## Undo behavior
+
+The user's delete transaction remains the latest history event. The later server Block ID assignment is mapped through history but is not stored as an additional undo item.
+
+Therefore, the first Undo after reconciliation restores the content that the user deleted. It does not merely switch the empty paragraph from the server Block ID back to the temporary local Block ID.
+
+The dedicated ProseMirror regression covers:
+
+1. deleting the last paragraph;
+2. applying a server-generated empty paragraph through a setContent-style transaction;
+3. verifying the applied transaction has `addToHistory=false`;
+4. preserving the caret position;
+5. executing Undo and restoring the original text and Block ID.
 
 ## Idempotency and recovery
 
@@ -76,4 +111,4 @@ This preserves the more important user input while still ensuring that the next 
 
 ## Remaining boundary
 
-The current content synchronization effect replays authoritative JSON through the established `setContent(..., { emitUpdate: false })` path. Selection restoration is covered; a dedicated no-history ProseMirror metadata-only reconciliation can be considered later if product testing finds that undo UX after delete-all needs stronger preservation across the server-generated identity change.
+This interceptor is intentionally limited to a single empty paragraph and a Block-ID-only difference. It is not a generic remote-document merge mechanism. Non-empty Block identity changes, multiple-Block documents, formatting changes and structural changes continue through the established guarded content synchronization path.

--- a/docs/block-patch-empty-document.md
+++ b/docs/block-patch-empty-document.md
@@ -1,0 +1,79 @@
+# Block Patch empty-document reconciliation
+
+## Scope
+
+Tiptap optimized modes may now persist deletion of the final identified top-level Block through `POST /api/blocks/:noteId/patch` instead of forcing a whole-note save.
+
+The frontend planner recognizes two transient empty representations:
+
+```json
+{ "type": "doc", "content": [] }
+```
+
+and a schema placeholder paragraph without a valid stable Block ID:
+
+```json
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph",
+      "attrs": {
+        "blockId": null,
+        "textAlign": null,
+        "lineHeight": null
+      },
+      "content": []
+    }
+  ]
+}
+```
+
+It converts either representation into ordered `delete` operations for the previous identified top-level paragraphs, headings and code blocks.
+
+Complex nested documents remain on whole-note save because deleting an arbitrary container tree cannot be expressed safely by the current top-level planner.
+
+## Server identity
+
+The existing patch engine already guarantees that a Tiptap document never remains empty. After all requested operations are applied, it creates one empty paragraph with a fresh stable Block ID and returns it through the authoritative response:
+
+```json
+{
+  "createdBlocks": [
+    {
+      "operationIndex": 1,
+      "clientId": null,
+      "blockId": "blk_server_generated"
+    }
+  ],
+  "content": "{\"type\":\"doc\",\"content\":[...]}",
+  "indexUpdateMode": "full",
+  "indexUpdateKind": "full"
+}
+```
+
+`operationIndex === operationCount` together with `clientId === null` identifies the automatic empty-document replacement rather than a client-requested create operation.
+
+Delete-all deliberately remains on the full index synchronization path. The generated Block did not exist in the pre-patch index and must become the only canonical row; all links from deleted source Blocks are removed transactionally.
+
+## Editor ACK behavior
+
+The runtime always stores the server response as the next authoritative note version.
+
+When the editor snapshot still equals the sent empty snapshot, `preserveLocalEditor` is false. The established Tiptap ACK guard therefore allows the note-content synchronization effect to load the server-generated paragraph. That effect suppresses save emission and clamps the previous selection into the new document, leaving the caret in a valid editable position.
+
+When the user types again while the delete request is in flight, the current editor snapshot differs from the sent empty snapshot. `preserveLocalEditor` is true, so the response does not overwrite the newer local input. The queued save is planned against the confirmed server version; it can delete the server-generated empty Block and create or update the local identified Block in one later transaction.
+
+This preserves the more important user input while still ensuring that the next persistence baseline contains a stable server-confirmed Block identity.
+
+## Idempotency and recovery
+
+- Retrying an uncertain delete-all request uses the same `operationId`.
+- An idempotent replay returns the same generated Block ID and authoritative content.
+- A version conflict does not trigger a blind whole-note overwrite.
+- Failure before commit leaves the original Block, version history and indexes unchanged.
+- Successful deletion and replacement increase the note version exactly once.
+
+## Remaining boundary
+
+The current content synchronization effect replays authoritative JSON through the established `setContent(..., { emitUpdate: false })` path. Selection restoration is covered; a dedicated no-history ProseMirror metadata-only reconciliation can be considered later if product testing finds that undo UX after delete-all needs stronger preservation across the server-generated identity change.

--- a/docs/block-patch-list-hierarchy.md
+++ b/docs/block-patch-list-hierarchy.md
@@ -1,4 +1,4 @@
-# Block Patch list hierarchy V1
+# Block Patch list hierarchy V2
 
 ## Scope
 
@@ -69,7 +69,7 @@ Requirements:
 
 The source becomes the immediate sibling after its former parent. An empty nested list wrapper is removed.
 
-Top-level lift out of a list into a paragraph is not part of V1 and remains on whole-note save.
+Top-level lift out of a list into a paragraph is not part of V2 and remains on whole-note save.
 
 ### Move at the same depth
 
@@ -169,7 +169,28 @@ List hierarchy operations retain the normal Block Patch guarantees:
 - authoritative response content;
 - complete rollback on failure.
 
-V1 deliberately uses:
+When the persisted Block index exactly mirrors the pre-patch Tiptap document, one controlled list move uses:
+
+```json
+{
+  "indexUpdateMode": "incremental",
+  "indexUpdateKind": "list-subtree"
+}
+```
+
+The post-patch planner compares every indexed row by stable Block ID and allows only these differences:
+
+- the moved root list item's `parentBlockId` may change;
+- moved descendants and intervening rows may change `blockOrder` and `path`;
+- the old parent, new parent and their indexed ancestors may change aggregate `plainText` and `contentHash`;
+- Block type and identity must remain unchanged;
+- paragraph, heading and code-block content/hash must remain unchanged.
+
+Only rows with a proven difference are upserted. Unaffected rows keep their `createdAt` and `updatedAt` values.
+
+Because leaf content and marks are unchanged, `note_links` rows are not deleted or recreated. Links inside the moved subtree retain their IDs and timestamps. Attachment ownership is also unchanged because the complete subtree remains inside the same note.
+
+The server automatically returns to:
 
 ```json
 {
@@ -178,9 +199,7 @@ V1 deliberately uses:
 }
 ```
 
-Changing a list item's parent affects the item, its descendant paths, ancestor aggregate text and global Block order. Until a dedicated subtree index plan is proven, the server rebuilds Block and note-link indexes inside the same transaction.
-
-Attachment ownership is unchanged because the complete item subtree moves inside the same note.
+when the old index is stale, incomplete, missing stable IDs, or the post-patch difference exceeds the single controlled move contract. The fallback still runs inside the same SQLite transaction.
 
 ## Remaining boundaries
 
@@ -189,5 +208,5 @@ Attachment ownership is unchanged because the complete item subtree moves inside
 - No arbitrary cross-depth reparenting.
 - No multi-item list transaction planning.
 - No mixed list hierarchy plus content/mark patch in one request.
-- No list-subtree incremental index update yet.
+- No list-item creation/deletion incremental plan yet.
 - `notes.content` remains the canonical complete Tiptap document.

--- a/docs/block-patch-list-hierarchy.md
+++ b/docs/block-patch-list-hierarchy.md
@@ -44,7 +44,9 @@ Requirements:
 - list container types match exactly;
 - an existing nested list under the target must have the same type and be unique.
 
-The source item is appended to the target's nested list. If no nested list exists, the server creates one with the same type as the source list.
+The source item is appended to the target's nested list. If no nested list exists, the server creates one with the same type and a cloned copy of the current list's JSON attributes. This preserves canonical ordered-list attributes such as `start` without inventing schema fields.
+
+The frontend still compares the complete result with the actual Tiptap snapshot. A custom ordered-list configuration whose generated nested attrs differ from this canonical copy fails closed to whole-note save.
 
 ### Lift one level
 
@@ -99,7 +101,7 @@ The source and target may be in the same list or in separate list containers, pr
 - list types match exactly;
 - item types match exactly.
 
-When the source list becomes empty, its wrapper is removed. The complete item subtree, including nested lists, marks, checked state and stable Block IDs, moves unchanged.
+When the source list becomes empty, its wrapper is removed. The complete item subtree, including large nested subtrees, marks, checked state and stable Block IDs, moves unchanged.
 
 ## Type compatibility
 
@@ -130,7 +132,7 @@ This is a known pre-persistence rejection, so the editor may safely use the esta
 
 ## Frontend proof
 
-The runtime does not infer a list operation merely because the document shape changed. It compares the complete pre-save and post-save Tiptap JSON and sends a list patch only when one controlled move can reproduce the final JSON.
+The runtime does not infer a list operation merely because the document shape changed. It compares the complete pre-save and post-save Tiptap JSON and sends a list patch only when a controlled single move can reproduce the final JSON.
 
 Before planning, it verifies:
 
@@ -138,12 +140,16 @@ Before planning, it verifies:
 - each item's content, marks, checked state and non-list attributes are unchanged;
 - non-list document structure is unchanged;
 - list and item types remain compatible;
-- the final JSON is exactly reproduced by the candidate move.
+- the final JSON is exactly reproduced by a candidate move.
+
+Large moved subtrees are supported without treating every descendant depth change as a separate move. Candidate generation is limited to items whose parent or sibling identity changed; all descendants are still validated by the final full-JSON replay.
+
+Two equivalent operations can describe an adjacent swap. When several safe candidates reproduce the exact same JSON, the planner uses a stable semantic and lexical rank to choose one deterministic request.
 
 A snapshot falls back to whole-note save when it includes:
 
 - list content edits together with hierarchy changes;
-- multiple independent list moves;
+- multiple independent list moves that no single operation can reproduce;
 - list type conversion;
 - item creation or deletion;
 - unstable or duplicate list-item IDs;

--- a/docs/block-patch-list-hierarchy.md
+++ b/docs/block-patch-list-hierarchy.md
@@ -1,0 +1,187 @@
+# Block Patch list hierarchy V1
+
+## Scope
+
+Optimized Tiptap sessions can persist one proven-safe list hierarchy move through the existing Block Patch endpoint:
+
+```http
+POST /api/blocks/:noteId/patch
+```
+
+The protocol reuses the existing `move` operation with an explicit scope:
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_source_item",
+  "targetBlockId": "blk_target_item",
+  "position": "inside"
+}
+```
+
+This avoids exposing an arbitrary tree-reparent API while keeping legacy top-level `move` requests compatible.
+
+## Supported operations
+
+### Sink one level
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_item_b",
+  "targetBlockId": "blk_item_a",
+  "position": "inside"
+}
+```
+
+Requirements:
+
+- source and target are in the same list container and at the same depth;
+- target is the source's immediate previous sibling;
+- item types match;
+- list container types match exactly;
+- an existing nested list under the target must have the same type and be unique.
+
+The source item is appended to the target's nested list. If no nested list exists, the server creates one with the same type as the source list.
+
+### Lift one level
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_nested_item",
+  "targetBlockId": "blk_parent_item",
+  "position": "after"
+}
+```
+
+Requirements:
+
+- the source is exactly one list depth below the target;
+- the target is the source item's direct parent list item;
+- the nested and outer list types match;
+- source and target item types match.
+
+The source becomes the immediate sibling after its former parent. An empty nested list wrapper is removed.
+
+Top-level lift out of a list into a paragraph is not part of V1 and remains on whole-note save.
+
+### Move at the same depth
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_source_item",
+  "targetBlockId": "blk_target_item",
+  "position": "before"
+}
+```
+
+or:
+
+```json
+{
+  "type": "move",
+  "scope": "listItem",
+  "blockId": "blk_source_item",
+  "targetBlockId": "blk_target_item",
+  "position": "after"
+}
+```
+
+The source and target may be in the same list or in separate list containers, provided that:
+
+- both are at the same list depth;
+- list types match exactly;
+- item types match exactly.
+
+When the source list becomes empty, its wrapper is removed. The complete item subtree, including nested lists, marks, checked state and stable Block IDs, moves unchanged.
+
+## Type compatibility
+
+Supported pairs:
+
+- `listItem` inside `bulletList`;
+- `listItem` inside `orderedList`;
+- `taskItem` inside `taskList`.
+
+The server rejects:
+
+- bullet-list to ordered-list moves;
+- list-item to task-item moves;
+- different-depth moves that are not the exact lift operation;
+- sinking under a non-adjacent item;
+- sinking into an item containing a conflicting or ambiguous nested list;
+- moving an item to itself.
+
+Rejected operations return:
+
+```json
+{
+  "code": "LIST_MOVE_INVALID"
+}
+```
+
+This is a known pre-persistence rejection, so the editor may safely use the established whole-note save fallback.
+
+## Frontend proof
+
+The runtime does not infer a list operation merely because the document shape changed. It compares the complete pre-save and post-save Tiptap JSON and sends a list patch only when one controlled move can reproduce the final JSON.
+
+Before planning, it verifies:
+
+- the same stable list-item IDs exist before and after;
+- each item's content, marks, checked state and non-list attributes are unchanged;
+- non-list document structure is unchanged;
+- list and item types remain compatible;
+- the final JSON is exactly reproduced by the candidate move.
+
+A snapshot falls back to whole-note save when it includes:
+
+- list content edits together with hierarchy changes;
+- multiple independent list moves;
+- list type conversion;
+- item creation or deletion;
+- unstable or duplicate list-item IDs;
+- any unsupported structure.
+
+The existing Block Patch serialization rule still allows only one confirmed request in flight per editor.
+
+## Transaction and indexes
+
+List hierarchy operations retain the normal Block Patch guarantees:
+
+- permission and lock checks;
+- optimistic note version validation;
+- user-level idempotency keys;
+- pre-edit version history in the five-minute merge window;
+- one version increment per successful request;
+- authoritative response content;
+- complete rollback on failure.
+
+V1 deliberately uses:
+
+```json
+{
+  "indexUpdateMode": "full",
+  "indexUpdateKind": "full"
+}
+```
+
+Changing a list item's parent affects the item, its descendant paths, ancestor aggregate text and global Block order. Until a dedicated subtree index plan is proven, the server rebuilds Block and note-link indexes inside the same transaction.
+
+Attachment ownership is unchanged because the complete item subtree moves inside the same note.
+
+## Remaining boundaries
+
+- No top-level lift from a list into a standalone paragraph.
+- No conversion between bullet, ordered and task lists.
+- No arbitrary cross-depth reparenting.
+- No multi-item list transaction planning.
+- No mixed list hierarchy plus content/mark patch in one request.
+- No list-subtree incremental index update yet.
+- `notes.content` remains the canonical complete Tiptap document.

--- a/frontend/src/components/MindMapAppearanceBridge.css
+++ b/frontend/src/components/MindMapAppearanceBridge.css
@@ -1,0 +1,38 @@
+html[data-nowen-mindmap-node-style="minimal"] [data-mindmap-node-id]:not([data-mindmap-node-id="root"]) {
+  background: transparent !important;
+  border-color: transparent !important;
+  border-radius: 4px !important;
+  color: rgb(55, 65, 81) !important;
+  padding-left: 6px !important;
+  padding-right: 6px !important;
+}
+
+html[data-nowen-mindmap-node-style="minimal"] [data-mindmap-node-id]:not([data-mindmap-node-id="root"]):not(.ring-2):not([style*="59, 130, 246"]) {
+  box-shadow: none !important;
+}
+
+html[data-nowen-mindmap-node-style="minimal"] [data-mindmap-node-id]:not([data-mindmap-node-id="root"]):hover {
+  background: rgba(15, 23, 42, 0.045) !important;
+}
+
+.dark[data-nowen-mindmap-node-style="minimal"] [data-mindmap-node-id]:not([data-mindmap-node-id="root"]):hover {
+  background: rgba(255, 255, 255, 0.06) !important;
+}
+
+html[data-nowen-mindmap-node-style="minimal"] svg[data-nowen-mindmap-minimap="true"] rect:not(:last-of-type) {
+  stroke: transparent !important;
+}
+
+@media (max-width: 767px) {
+  [data-mindmap-appearance-control="true"] {
+    display: flex !important;
+    position: fixed;
+    right: 12px;
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    z-index: 45;
+  }
+}
+
+.dark[data-nowen-mindmap-node-style="minimal"] [data-mindmap-node-id]:not([data-mindmap-node-id="root"]) {
+  color: rgb(228, 228, 231) !important;
+}

--- a/frontend/src/components/MindMapAppearanceBridge.tsx
+++ b/frontend/src/components/MindMapAppearanceBridge.tsx
@@ -1,0 +1,339 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { AlignLeft, LayoutTemplate, Loader2 } from "lucide-react";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import type { MindMap } from "@/types";
+import {
+  escapeMindMapXml,
+  getMindMapNodeStyle,
+  getMindMapRootText,
+  parseMindMapDocument,
+  preserveMindMapNodeStyleInSerializedData,
+  transformMindMapExportSvg,
+  withMindMapNodeStyle,
+  type MindMapDocument,
+  type MindMapNodeStyle,
+} from "@/lib/mindMapAppearance";
+import "./MindMapAppearanceBridge.css";
+
+const API_PATCH_FLAG = Symbol.for("nowen.mindMapAppearance.apiPatch");
+const BLOB_PATCH_FLAG = Symbol.for("nowen.mindMapAppearance.blobPatch");
+const APPEARANCE_EVENT = "nowen:mindmap-appearance-state";
+const MAX_RECENT_MAPS = 12;
+
+type MindMapSnapshot = {
+  map: MindMap;
+  document: MindMapDocument;
+  nodeStyle: MindMapNodeStyle;
+  rootText: string;
+};
+
+type MindMapAppearanceState = {
+  active: MindMapSnapshot | null;
+  candidates: MindMapSnapshot[];
+};
+
+const runtimeState: MindMapAppearanceState = {
+  active: null,
+  candidates: [],
+};
+
+function dispatchAppearanceState(): void {
+  window.dispatchEvent(new CustomEvent(APPEARANCE_EVENT, {
+    detail: {
+      activeId: runtimeState.active?.map.id || null,
+      nodeStyle: runtimeState.active?.nodeStyle || "card",
+    },
+  }));
+}
+
+function setDocumentNodeStyle(nodeStyle: MindMapNodeStyle): void {
+  document.documentElement.dataset.nowenMindmapNodeStyle = nodeStyle;
+}
+
+function toSnapshot(map: MindMap): MindMapSnapshot | null {
+  const document = parseMindMapDocument(map.data);
+  if (!document) return null;
+  return {
+    map,
+    document,
+    nodeStyle: getMindMapNodeStyle(document),
+    rootText: getMindMapRootText(document),
+  };
+}
+
+function rememberCandidate(map: MindMap): void {
+  const snapshot = toSnapshot(map);
+  if (!snapshot) return;
+  runtimeState.candidates = [
+    snapshot,
+    ...runtimeState.candidates.filter((candidate) => candidate.map.id !== snapshot.map.id),
+  ].slice(0, MAX_RECENT_MAPS);
+}
+
+function activateSnapshot(snapshot: MindMapSnapshot): void {
+  runtimeState.active = snapshot;
+  setDocumentNodeStyle(snapshot.nodeStyle);
+  dispatchAppearanceState();
+}
+
+function syncActiveMap(map: MindMap): void {
+  const snapshot = toSnapshot(map);
+  if (!snapshot) return;
+  rememberCandidate(map);
+  if (runtimeState.active?.map.id === map.id) activateSnapshot(snapshot);
+}
+
+function getDisplayedMindMapIdentity(): { title: string; rootText: string } | null {
+  const rootNode = document.querySelector<HTMLElement>('[data-mindmap-node-id="root"]');
+  if (!rootNode) return null;
+  const content = rootNode.closest<HTMLElement>(".flex-1.flex.overflow-hidden");
+  const shell = content?.parentElement;
+  if (!content || !shell) return null;
+  const header = Array.from(shell.children).find((child) =>
+    child instanceof HTMLElement && child.classList.contains("border-b"));
+  const title = header?.querySelector("h1")?.textContent?.trim() || "";
+  const rootText = rootNode.textContent?.replace(/[+−]\d*$/, "").trim() || "";
+  return { title, rootText };
+}
+
+function resolveDisplayedSnapshot(): MindMapSnapshot | null {
+  const identity = getDisplayedMindMapIdentity();
+  if (!identity) return null;
+  if (
+    runtimeState.active
+    && runtimeState.active.map.title === identity.title
+    && runtimeState.active.rootText === identity.rootText
+  ) {
+    return runtimeState.active;
+  }
+  return runtimeState.candidates.find((candidate) =>
+    candidate.map.title === identity.title && candidate.rootText === identity.rootText) || null;
+}
+
+function findMindMapToolbarHost(): HTMLElement | null {
+  const rootNode = document.querySelector<HTMLElement>('[data-mindmap-node-id="root"]');
+  const content = rootNode?.closest<HTMLElement>(".flex-1.flex.overflow-hidden");
+  const shell = content?.parentElement;
+  if (!rootNode || !content || !shell) return null;
+  const header = Array.from(shell.children).find((child) =>
+    child instanceof HTMLElement && child.classList.contains("border-b"));
+  const host = header?.lastElementChild;
+  return host instanceof HTMLElement ? host : null;
+}
+
+function markMindMapMiniMaps(): void {
+  const rootNode = document.querySelector<HTMLElement>('[data-mindmap-node-id="root"]');
+  const content = rootNode?.closest<HTMLElement>(".flex-1.flex.overflow-hidden");
+  if (!content) return;
+  content.querySelectorAll<SVGSVGElement>("svg.cursor-pointer").forEach((svg) => {
+    if (svg.querySelector("rect")) svg.dataset.nowenMindmapMinimap = "true";
+  });
+}
+
+function resolveSvgNodeStyle(svg: string): MindMapNodeStyle {
+  const matchingCandidate = runtimeState.candidates.find((candidate) => {
+    if (!candidate.rootText) return false;
+    return svg.includes(`>${escapeMindMapXml(candidate.rootText)}</text>`);
+  });
+  return matchingCandidate?.nodeStyle || runtimeState.active?.nodeStyle || "card";
+}
+
+function installMindMapBlobPatch(): void {
+  if (typeof window === "undefined") return;
+  const taggedWindow = window as typeof window & Record<PropertyKey, unknown>;
+  if (taggedWindow[BLOB_PATCH_FLAG]) return;
+  taggedWindow[BLOB_PATCH_FLAG] = true;
+
+  const NativeBlob = window.Blob;
+  class MindMapAwareBlob extends NativeBlob {
+    constructor(blobParts: BlobPart[] = [], options: BlobPropertyBag = {}) {
+      const isSvg = options.type?.toLowerCase().includes("image/svg+xml");
+      const nextParts = isSvg
+        ? blobParts.map((part) => {
+          if (typeof part !== "string") return part;
+          return transformMindMapExportSvg(part, resolveSvgNodeStyle(part));
+        })
+        : blobParts;
+      super(nextParts, options);
+    }
+  }
+
+  Object.defineProperty(window, "Blob", {
+    configurable: true,
+    writable: true,
+    value: MindMapAwareBlob,
+  });
+}
+
+function installMindMapApiPatch(): void {
+  if (typeof window === "undefined") return;
+  const taggedApi = api as typeof api & Record<PropertyKey, unknown>;
+  if (taggedApi[API_PATCH_FLAG]) return;
+  taggedApi[API_PATCH_FLAG] = true;
+
+  const nativeGetMindMap = api.getMindMap.bind(api);
+  const nativeUpdateMindMap = api.updateMindMap.bind(api);
+
+  api.getMindMap = (async (...args: Parameters<typeof nativeGetMindMap>) => {
+    const map = await nativeGetMindMap(...args);
+    rememberCandidate(map);
+    window.requestAnimationFrame(() => {
+      const displayed = resolveDisplayedSnapshot();
+      if (displayed) activateSnapshot(displayed);
+    });
+    return map;
+  }) as typeof api.getMindMap;
+
+  api.updateMindMap = (async (...args: Parameters<typeof nativeUpdateMindMap>) => {
+    const [mapId, payload] = args;
+    let nextArgs = args;
+    const active = runtimeState.active;
+    if (
+      active?.map.id === mapId
+      && payload
+      && typeof payload === "object"
+      && typeof (payload as { data?: unknown }).data === "string"
+    ) {
+      const nextPayload = {
+        ...payload,
+        data: preserveMindMapNodeStyleInSerializedData(
+          (payload as { data: string }).data,
+          active.nodeStyle,
+        ),
+      };
+      nextArgs = [mapId, nextPayload] as Parameters<typeof nativeUpdateMindMap>;
+    }
+
+    const updated = await nativeUpdateMindMap(...nextArgs);
+    syncActiveMap(updated);
+    return updated;
+  }) as typeof api.updateMindMap;
+}
+
+installMindMapApiPatch();
+installMindMapBlobPatch();
+
+function useAppearanceCopy() {
+  const language = (localStorage.getItem("i18nextLng") || navigator.language || "").toLowerCase();
+  return language.startsWith("zh")
+    ? {
+      label: "节点样式",
+      card: "卡片",
+      minimal: "简洁",
+      saveFailed: "思维导图样式保存失败",
+    }
+    : {
+      label: "Node style",
+      card: "Card",
+      minimal: "Minimal",
+      saveFailed: "Failed to save mind map style",
+    };
+}
+
+export default function MindMapAppearanceBridge() {
+  const copy = useAppearanceCopy();
+  const [active, setActive] = useState<MindMapSnapshot | null>(runtimeState.active);
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const refreshDomState = useCallback(() => {
+    const displayed = resolveDisplayedSnapshot();
+    if (displayed && displayed.map.id !== runtimeState.active?.map.id) activateSnapshot(displayed);
+    const nextHost = findMindMapToolbarHost();
+    markMindMapMiniMaps();
+    setHost((current) => current === nextHost ? current : nextHost);
+    setVisible(Boolean(nextHost && displayed));
+    setActive(runtimeState.active);
+  }, []);
+
+  useEffect(() => {
+    const onState = () => refreshDomState();
+    window.addEventListener(APPEARANCE_EVENT, onState);
+    window.addEventListener("nowen:workspace-changed", onState);
+
+    let frame = 0;
+    const observer = new MutationObserver(() => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(refreshDomState);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    refreshDomState();
+
+    return () => {
+      observer.disconnect();
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener(APPEARANCE_EVENT, onState);
+      window.removeEventListener("nowen:workspace-changed", onState);
+    };
+  }, [refreshDomState]);
+
+  const changeStyle = async (nodeStyle: MindMapNodeStyle) => {
+    const current = runtimeState.active;
+    if (!current || current.nodeStyle === nodeStyle || saving) return;
+
+    const previous = current;
+    const optimistic: MindMapSnapshot = {
+      ...current,
+      document: withMindMapNodeStyle(current.document, nodeStyle),
+      nodeStyle,
+    };
+    activateSnapshot(optimistic);
+    setActive(optimistic);
+    setSaving(true);
+    try {
+      const updated = await api.updateMindMap(current.map.id, {
+        data: JSON.stringify(optimistic.document),
+      });
+      const next = toSnapshot(updated);
+      if (next) activateSnapshot(next);
+    } catch (error) {
+      activateSnapshot(previous);
+      toast.error((error as Error)?.message || copy.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!visible || !host || !active) return null;
+
+  return createPortal(
+    <div
+      data-mindmap-appearance-control="true"
+      className="ml-1 hidden items-center gap-0.5 rounded-lg border border-app-border/70 bg-app-surface/80 p-0.5 shadow-sm backdrop-blur sm:flex"
+      title={copy.label}
+    >
+      <button
+        type="button"
+        aria-pressed={active.nodeStyle === "card"}
+        disabled={saving}
+        onClick={() => void changeStyle("card")}
+        className={`inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] font-medium transition ${
+          active.nodeStyle === "card"
+            ? "bg-accent-primary text-white shadow-sm"
+            : "text-tx-secondary hover:bg-app-hover"
+        }`}
+      >
+        <LayoutTemplate size={12} />
+        {copy.card}
+      </button>
+      <button
+        type="button"
+        aria-pressed={active.nodeStyle === "minimal"}
+        disabled={saving}
+        onClick={() => void changeStyle("minimal")}
+        className={`inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] font-medium transition ${
+          active.nodeStyle === "minimal"
+            ? "bg-accent-primary text-white shadow-sm"
+            : "text-tx-secondary hover:bg-app-hover"
+        }`}
+      >
+        {saving ? <Loader2 size={12} className="animate-spin" /> : <AlignLeft size={12} />}
+        {copy.minimal}
+      </button>
+    </div>,
+    host,
+  );
+}

--- a/frontend/src/components/TaskCenterImpl.tsx
+++ b/frontend/src/components/TaskCenterImpl.tsx
@@ -36,6 +36,7 @@ import { TaskBoardView } from "./tasks/TaskBoardView";
 import { TaskCalendarView } from "./tasks/TaskCalendarView";
 import TaskGanttView from "./tasks/TaskGanttView";
 import { compareTasksByDueTime, moveTaskToDate } from "./tasks/taskDateUtils";
+import { haveSameTaskCompletionState, orderTasksCompletedLast } from "./tasks/taskCompletionOrder";
 import { TaskTemplatePicker } from "./tasks/TaskTemplatePicker";
 import { ReminderCenter } from "./tasks/ReminderCenter";
 import { TaskCalendarFeedSettings } from "./tasks/TaskCalendarFeedSettings";
@@ -184,10 +185,12 @@ export default function TaskCenter() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
 
   const treeSourceTasks = useMemo(() => {
-    if (!sortByDueTime) return tasks;
-    const roots = tasks.filter((task) => !task.parentId).sort(compareTasksByDueTime);
+    const roots = tasks.filter((task) => !task.parentId);
     const children = tasks.filter((task) => task.parentId);
-    return [...roots, ...children];
+    return [
+      ...orderTasksCompletedLast(roots, sortByDueTime ? compareTasksByDueTime : undefined),
+      ...orderTasksCompletedLast(children),
+    ];
   }, [tasks, sortByDueTime]);
 
   // tree hook
@@ -235,8 +238,14 @@ export default function TaskCenter() {
   // filtered tasks by search query
   const displayTasks = useMemo(() => {
     const source = searchQuery.trim() ? tasks.filter((t) => taskMatchesSearch(t, searchQuery)) : tasks;
-    return sortByDueTime ? [...source].sort(compareTasksByDueTime) : source;
-  }, [tasks, searchQuery, sortByDueTime]);
+    if (viewMode !== "list") {
+      return sortByDueTime ? [...source].sort(compareTasksByDueTime) : source;
+    }
+    return orderTasksCompletedLast(
+      source,
+      sortByDueTime ? compareTasksByDueTime : undefined,
+    );
+  }, [tasks, searchQuery, sortByDueTime, viewMode]);
 
   // recompute flatOrdered for display (search-filtered)
   const displayFlatOrdered = useMemo(() => {
@@ -688,6 +697,11 @@ export default function TaskCenter() {
     const targetTask = tasks.find((t) => t.id === targetId);
     if (!dragTask || !targetTask) { setDragId(null); setDragOverId(null); return; }
     if ((dragTask.parentId ?? null) !== (targetTask.parentId ?? null)) {
+      setDragId(null);
+      setDragOverId(null);
+      return;
+    }
+    if (!haveSameTaskCompletionState(dragTask, targetTask)) {
       setDragId(null);
       setDragOverId(null);
       return;

--- a/frontend/src/components/TiptapEditorRuntime.tsx
+++ b/frontend/src/components/TiptapEditorRuntime.tsx
@@ -22,7 +22,7 @@ import {
   createBlockPatchOperationId,
   patchTiptapBlocks,
 } from "@/lib/blockPatchApi";
-import { planTiptapBlockPatch } from "@/lib/tiptapBlockPatchPlanner";
+import { planTiptapBlockPatch } from "@/lib/tiptapBlockPatchPlannerRuntime";
 import {
   resolveTiptapBlockPatchEnabled,
   shouldFallbackTiptapBlockPatchToWholeSave,

--- a/frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
+++ b/frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  baseProps: null as any,
+  snapshot: null as { content: string; contentText: string } | null,
+  acknowledgeSave: vi.fn(),
+  actions: {
+    setActiveNote: vi.fn(),
+    updateNoteInList: vi.fn(),
+    updateNoteTab: vi.fn(),
+    setSyncStatus: vi.fn(),
+    setLastSynced: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/AppContext", () => ({
+  useAppActions: () => fixture.actions,
+}));
+
+vi.mock("@/lib/draftStorage", () => ({
+  saveDraft: vi.fn(),
+  clearDraft: vi.fn(),
+}));
+
+vi.mock("@/lib/api.impl", () => ({
+  getBaseUrl: () => "/api",
+}));
+
+vi.mock("../TiptapEditor", async () => {
+  const ReactModule = await import("react");
+  const Base = ReactModule.forwardRef((props: any, ref) => {
+    fixture.baseProps = props;
+    ReactModule.useImperativeHandle(ref, () => ({
+      flushSave: vi.fn(),
+      discardPending: vi.fn(),
+      getSnapshot: () => fixture.snapshot,
+      acknowledgeSave: fixture.acknowledgeSave,
+      isReady: () => true,
+      appendMarkdown: () => false,
+    }));
+    return ReactModule.createElement("div", { "data-base-tiptap": "" });
+  });
+  Base.displayName = "MockEmptyDocumentTiptapEditor";
+  return { default: Base };
+});
+
+import TiptapEditorRuntime from "../TiptapEditorRuntime";
+import { resolveEditorRuntimeDecision } from "@/lib/editorRuntimePolicy";
+import {
+  clearActiveEditorRuntimeDecision,
+  setActiveEditorRuntimeDecision,
+} from "@/lib/editorRuntimeStore";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function doc(content: unknown[]) {
+  return JSON.stringify({ type: "doc", content });
+}
+
+function note(id: string) {
+  return {
+    id,
+    title: "Empty document",
+    content: doc([paragraph("blk_empty001", "Last text")]),
+    contentText: "Last text",
+    contentFormat: "tiptap-json",
+    version: 1,
+    updatedAt: "2026-07-23T09:00:00.000Z",
+    notebookId: "notebook-1",
+    workspaceId: null,
+    isLocked: false,
+    isTrashed: false,
+    isPinned: false,
+    isFavorite: false,
+  } as any;
+}
+
+function optimizedDecision() {
+  return resolveEditorRuntimeDecision({
+    content: doc([paragraph("blk_perf0000", "x".repeat(220_000))]),
+    contentFormat: "tiptap-json",
+  });
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function emptyPatchResponse(current: any, serverContent: string) {
+  return new Response(JSON.stringify({
+    success: true,
+    noteId: current.id,
+    title: current.title,
+    version: 2,
+    updatedAt: "2026-07-23T10:00:00.000Z",
+    content: serverContent,
+    contentText: "",
+    contentFormat: "tiptap-json",
+    notebookId: current.notebookId,
+    operationCount: 1,
+    affectedBlockIds: ["blk_empty001", "blk_serverempty"],
+    deletedBlockIds: ["blk_empty001"],
+    createdBlocks: [{
+      operationIndex: 1,
+      clientId: null,
+      blockId: "blk_serverempty",
+    }],
+    blocks: [{
+      noteId: current.id,
+      blockId: "blk_serverempty",
+      blockType: "paragraph",
+      parentBlockId: null,
+      blockOrder: 0,
+      plainText: "",
+      contentHash: "hash",
+      path: "0",
+      startOffset: null,
+      endOffset: null,
+    }],
+    indexUpdateMode: "full",
+    indexUpdateKind: "full",
+    indexedBlockIds: ["blk_serverempty"],
+    contentChangedByNormalization: false,
+  }), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  fixture.baseProps = null;
+  fixture.snapshot = null;
+  fixture.acknowledgeSave.mockClear();
+  Object.values(fixture.actions).forEach((mock) => mock.mockClear());
+  clearActiveEditorRuntimeDecision();
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  clearActiveEditorRuntimeDecision();
+  vi.restoreAllMocks();
+});
+
+describe("Tiptap empty document Block identity", () => {
+  it("uses Block Patch and requests authoritative content replay when no newer input exists", async () => {
+    const current = note("empty-note");
+    const sentContent = doc([]);
+    const serverContent = doc([paragraph("blk_serverempty", "")]);
+    fixture.snapshot = { content: sentContent, contentText: "" };
+    setActiveEditorRuntimeDecision(current.id, optimizedDecision());
+    const wholeSave = vi.fn();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      emptyPatchResponse(current, serverContent),
+    );
+
+    await act(async () => {
+      root.render(<TiptapEditorRuntime note={current} onUpdate={wholeSave} />);
+    });
+    await act(async () => {
+      fixture.baseProps.onUpdate({
+        title: current.title,
+        content: sentContent,
+        contentText: "",
+        _noteId: current.id,
+        _saveGeneration: 1,
+      });
+      await flushAsync();
+    });
+
+    expect(wholeSave).not.toHaveBeenCalled();
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      operations: [{ type: "delete", blockId: "blk_empty001" }],
+    });
+    expect(fixture.acknowledgeSave).toHaveBeenCalledWith({
+      noteId: current.id,
+      version: 2,
+      content: serverContent,
+      saveGeneration: 1,
+      preserveLocalEditor: false,
+    });
+    expect(fixture.actions.setActiveNote).toHaveBeenCalledWith(expect.objectContaining({
+      id: current.id,
+      version: 2,
+      content: serverContent,
+    }));
+  });
+
+  it("preserves newer local typing and lets the queued patch reconcile against the server ID", async () => {
+    const current = note("empty-note-typing");
+    const sentContent = doc([]);
+    const serverContent = doc([paragraph("blk_serverempty", "")]);
+    fixture.snapshot = {
+      content: doc([paragraph("blk_localtyped", "New typing")]),
+      contentText: "New typing",
+    };
+    setActiveEditorRuntimeDecision(current.id, optimizedDecision());
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(emptyPatchResponse(current, serverContent));
+
+    await act(async () => {
+      root.render(<TiptapEditorRuntime note={current} onUpdate={vi.fn()} />);
+    });
+    await act(async () => {
+      fixture.baseProps.onUpdate({
+        title: current.title,
+        content: sentContent,
+        contentText: "",
+        _noteId: current.id,
+        _saveGeneration: 2,
+      });
+      await flushAsync();
+    });
+
+    expect(fixture.acknowledgeSave).toHaveBeenCalledWith(expect.objectContaining({
+      noteId: current.id,
+      content: serverContent,
+      saveGeneration: 2,
+      preserveLocalEditor: true,
+    }));
+  });
+});

--- a/frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx
+++ b/frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  baseProps: null as any,
+  snapshot: null as { content: string; contentText: string } | null,
+  acknowledgeSave: vi.fn(),
+  actions: {
+    setActiveNote: vi.fn(),
+    updateNoteInList: vi.fn(),
+    updateNoteTab: vi.fn(),
+    setSyncStatus: vi.fn(),
+    setLastSynced: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/AppContext", () => ({
+  useAppActions: () => fixture.actions,
+}));
+
+vi.mock("@/lib/draftStorage", () => ({
+  saveDraft: vi.fn(),
+  clearDraft: vi.fn(),
+}));
+
+vi.mock("@/lib/api.impl", () => ({
+  getBaseUrl: () => "/api",
+}));
+
+vi.mock("../TiptapEditor", async () => {
+  const ReactModule = await import("react");
+  const Base = ReactModule.forwardRef((props: any, ref) => {
+    fixture.baseProps = props;
+    ReactModule.useImperativeHandle(ref, () => ({
+      flushSave: vi.fn(),
+      discardPending: vi.fn(),
+      getSnapshot: () => fixture.snapshot,
+      acknowledgeSave: fixture.acknowledgeSave,
+      isReady: () => true,
+      appendMarkdown: () => false,
+    }));
+    return ReactModule.createElement("div", { "data-base-tiptap": "" });
+  });
+  Base.displayName = "MockBaseTiptapListRuntime";
+  return { default: Base };
+});
+
+import TiptapEditorRuntime from "../TiptapEditorRuntime";
+import { resolveEditorRuntimeDecision } from "@/lib/editorRuntimePolicy";
+import {
+  clearActiveEditorRuntimeDecision,
+  setActiveEditorRuntimeDecision,
+} from "@/lib/editorRuntimeStore";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function item(blockId: string, text: string, nested?: unknown) {
+  return {
+    type: "listItem",
+    attrs: { blockId },
+    content: [
+      paragraph(`blk_p_${blockId.slice(4)}`, text),
+      ...(nested ? [nested] : []),
+    ],
+  };
+}
+
+function list(content: unknown[]) {
+  return { type: "bulletList", content };
+}
+
+function doc(content: unknown[]) {
+  return JSON.stringify({ type: "doc", content });
+}
+
+function note(id: string, content: string) {
+  return {
+    id,
+    title: "List note",
+    content,
+    contentText: "A\nB\nC",
+    contentFormat: "tiptap-json",
+    version: 1,
+    updatedAt: "2026-07-23T09:00:00.000Z",
+    notebookId: "notebook-1",
+    workspaceId: null,
+    isLocked: false,
+    isTrashed: false,
+    isPinned: false,
+    isFavorite: false,
+  } as any;
+}
+
+function optimizedDecision() {
+  return resolveEditorRuntimeDecision({
+    content: JSON.stringify({
+      type: "doc",
+      content: [paragraph("blk_runtime0", "x".repeat(220_000))],
+    }),
+    contentFormat: "tiptap-json",
+  });
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  fixture.baseProps = null;
+  fixture.snapshot = null;
+  fixture.acknowledgeSave.mockClear();
+  Object.values(fixture.actions).forEach((mock) => mock.mockClear());
+  clearActiveEditorRuntimeDecision();
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  clearActiveEditorRuntimeDecision();
+  vi.restoreAllMocks();
+});
+
+describe("Tiptap list hierarchy Block Patch runtime", () => {
+  it("sends one controlled sink operation in optimized mode", async () => {
+    const baseContent = doc([list([
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+    ])]);
+    const nextContent = doc([list([
+      item("blk_item_a0", "A", list([item("blk_item_b0", "B")])),
+      item("blk_item_c0", "C"),
+    ])]);
+    const current = note("list-runtime-note", baseContent);
+    fixture.snapshot = { content: nextContent, contentText: "A\nB\nC" };
+    setActiveEditorRuntimeDecision(current.id, optimizedDecision());
+    const wholeSave = vi.fn();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      noteId: current.id,
+      title: current.title,
+      version: 2,
+      updatedAt: "2026-07-23T10:00:00.000Z",
+      content: nextContent,
+      contentText: "A\nB\nC",
+      contentFormat: "tiptap-json",
+      notebookId: current.notebookId,
+      operationCount: 1,
+      affectedBlockIds: ["blk_item_b0", "blk_item_a0"],
+      deletedBlockIds: [],
+      createdBlocks: [],
+      blocks: [],
+      indexUpdateMode: "full",
+      indexUpdateKind: "full",
+      indexedBlockIds: [],
+      contentChangedByNormalization: false,
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await act(async () => {
+      root.render(<TiptapEditorRuntime note={current} onUpdate={wholeSave} />);
+    });
+    await act(async () => {
+      fixture.baseProps.onUpdate({
+        title: current.title,
+        content: nextContent,
+        contentText: "A\nB\nC",
+        _noteId: current.id,
+        _saveGeneration: 1,
+      });
+      await flushAsync();
+    });
+
+    expect(wholeSave).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(request.operations).toEqual([{
+      type: "move",
+      scope: "listItem",
+      blockId: "blk_item_b0",
+      targetBlockId: "blk_item_a0",
+      position: "inside",
+    }]);
+    expect(fixture.acknowledgeSave).toHaveBeenCalledWith(expect.objectContaining({
+      noteId: current.id,
+      version: 2,
+      content: nextContent,
+    }));
+  });
+});

--- a/frontend/src/components/tasks/__tests__/taskCompletionOrder.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskCompletionOrder.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/types";
+import { buildTaskTree } from "../taskProgress";
+import {
+  haveSameTaskCompletionState,
+  orderTasksCompletedLast,
+} from "../taskCompletionOrder";
+
+function task(id: string, patch: Partial<Task> = {}): Task {
+  return {
+    id,
+    userId: "user-1",
+    workspaceId: null,
+    title: id,
+    description: "",
+    priority: 2,
+    status: patch.isCompleted ? "done" : "todo",
+    isCompleted: 0,
+    completedAt: null,
+    startDate: null,
+    dueDate: null,
+    dueAt: null,
+    parentId: null,
+    projectId: null,
+    noteId: null,
+    sortOrder: 0,
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-07-20T00:00:00.000Z",
+    ...patch,
+  } as Task;
+}
+
+describe("task completion ordering", () => {
+  it("moves completed tasks after pending tasks without changing group order", () => {
+    const ordered = orderTasksCompletedLast([
+      task("done-a", { isCompleted: 1 }),
+      task("todo-a"),
+      task("done-b", { isCompleted: 1 }),
+      task("todo-b"),
+    ]);
+
+    expect(ordered.map((item) => item.id)).toEqual(["todo-a", "todo-b", "done-a", "done-b"]);
+  });
+
+  it("keeps completion ahead of a secondary due-time comparator", () => {
+    const ordered = orderTasksCompletedLast(
+      [
+        task("done-early", { isCompleted: 1, dueDate: "2026-07-20" }),
+        task("todo-late", { dueDate: "2026-07-25" }),
+        task("todo-early", { dueDate: "2026-07-21" }),
+      ],
+      (left, right) => (left.dueDate || "9999").localeCompare(right.dueDate || "9999"),
+    );
+
+    expect(ordered.map((item) => item.id)).toEqual(["todo-early", "todo-late", "done-early"]);
+  });
+
+  it("orders roots and each sibling group without breaking the task tree", () => {
+    const rootDone = task("root-done", { isCompleted: 1 });
+    const rootTodo = task("root-todo");
+    const childDone = task("child-done", { parentId: "root-todo", isCompleted: 1 });
+    const childTodo = task("child-todo", { parentId: "root-todo" });
+    const source = [rootDone, childDone, rootTodo, childTodo];
+    const ordered = [
+      ...orderTasksCompletedLast(source.filter((item) => !item.parentId)),
+      ...orderTasksCompletedLast(source.filter((item) => item.parentId)),
+    ];
+    const tree = buildTaskTree(ordered);
+
+    expect(tree.map((item) => item.id)).toEqual(["root-todo", "root-done"]);
+    expect(tree[0].children.map((item) => item.id)).toEqual(["child-todo", "child-done"]);
+  });
+
+  it("allows manual reorder only inside the same completion group", () => {
+    expect(haveSameTaskCompletionState(task("a"), task("b"))).toBe(true);
+    expect(haveSameTaskCompletionState(task("a", { isCompleted: 1 }), task("b", { isCompleted: 1 }))).toBe(true);
+    expect(haveSameTaskCompletionState(task("a"), task("b", { isCompleted: 1 }))).toBe(false);
+  });
+});

--- a/frontend/src/components/tasks/taskCompletionOrder.ts
+++ b/frontend/src/components/tasks/taskCompletionOrder.ts
@@ -1,0 +1,34 @@
+import type { Task } from "@/types";
+
+export type TaskOrderComparator = (left: Task, right: Task) => number;
+
+export function isTaskCompleted(task: Pick<Task, "isCompleted">): boolean {
+  return Number(task.isCompleted) === 1;
+}
+
+/**
+ * Stable presentation ordering for task lists. Completion is the primary key, while the optional
+ * comparator controls ordering inside the pending and completed groups. The persisted sortOrder is
+ * intentionally left untouched.
+ */
+export function orderTasksCompletedLast(
+  tasks: readonly Task[],
+  compareWithinGroup?: TaskOrderComparator,
+): Task[] {
+  return tasks
+    .map((task, index) => ({ task, index }))
+    .sort((left, right) => {
+      const completionDelta = Number(isTaskCompleted(left.task)) - Number(isTaskCompleted(right.task));
+      if (completionDelta !== 0) return completionDelta;
+      const compared = compareWithinGroup?.(left.task, right.task) ?? 0;
+      return compared !== 0 ? compared : left.index - right.index;
+    })
+    .map(({ task }) => task);
+}
+
+export function haveSameTaskCompletionState(
+  left: Pick<Task, "isCompleted">,
+  right: Pick<Task, "isCompleted">,
+): boolean {
+  return isTaskCompleted(left) === isTaskCompleted(right);
+}

--- a/frontend/src/lib/__tests__/blockPatchApi.test.ts
+++ b/frontend/src/lib/__tests__/blockPatchApi.test.ts
@@ -74,6 +74,49 @@ describe("block patch API client", () => {
     });
   });
 
+  it("accepts list-subtree index observations without changing the authoritative contract", async () => {
+    const authoritativeContent = JSON.stringify({ type: "doc", content: [] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      noteId: "note-list",
+      title: "List",
+      version: 3,
+      updatedAt: "2026-07-23T10:00:00.000Z",
+      content: authoritativeContent,
+      contentText: "A\n\nB",
+      contentFormat: "tiptap-json",
+      notebookId: "notebook-1",
+      operationCount: 1,
+      affectedBlockIds: ["blk_item_a0", "blk_item_b0"],
+      deletedBlockIds: [],
+      createdBlocks: [],
+      blocks: [],
+      indexUpdateMode: "incremental",
+      indexUpdateKind: "list-subtree",
+      indexedBlockIds: ["blk_item_a0", "blk_item_b0"],
+      contentChangedByNormalization: false,
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const result = await patchTiptapBlocks("note-list", {
+      expectedNoteVersion: 2,
+      operationId: "block-patch-list-subtree-test",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "inside",
+      }],
+    });
+
+    expect(result).toMatchObject({
+      version: 3,
+      indexUpdateMode: "incremental",
+      indexUpdateKind: "list-subtree",
+      indexedBlockIds: ["blk_item_a0", "blk_item_b0"],
+    });
+  });
+
   it("preserves server conflict metadata for retry/rebase decisions", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       error: "Version conflict",

--- a/frontend/src/lib/__tests__/mindMapAppearance.test.ts
+++ b/frontend/src/lib/__tests__/mindMapAppearance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMindMapNodeStyle,
+  parseMindMapDocument,
+  preserveMindMapNodeStyleInSerializedData,
+  transformMindMapExportSvg,
+  withMindMapNodeStyle,
+} from "../mindMapAppearance";
+
+describe("mind map appearance", () => {
+  it("keeps old mind maps on the card style by default", () => {
+    const document = parseMindMapDocument('{"root":{"id":"root","text":"Map"}}');
+    expect(getMindMapNodeStyle(document)).toBe("card");
+  });
+
+  it("stores the style without removing existing document fields", () => {
+    const document = withMindMapNodeStyle({
+      root: { id: "root", text: "Map" },
+      layout: "left-right",
+      appearance: { density: "comfortable" },
+    }, "minimal");
+
+    expect(document.layout).toBe("left-right");
+    expect(document.appearance).toEqual({ density: "comfortable", nodeStyle: "minimal" });
+  });
+
+  it("preserves an active style across legacy editor autosaves", () => {
+    const merged = preserveMindMapNodeStyleInSerializedData(
+      '{"root":{"id":"root","text":"Map"},"viewport":{"zoom":1}}',
+      "minimal",
+    );
+    expect(JSON.parse(merged).appearance.nodeStyle).toBe("minimal");
+
+    const explicit = preserveMindMapNodeStyleInSerializedData(
+      '{"root":{"id":"root","text":"Map"},"appearance":{"nodeStyle":"card"}}',
+      "minimal",
+    );
+    expect(JSON.parse(explicit).appearance.nodeStyle).toBe("card");
+  });
+
+  it("keeps the root card but removes descendant cards from exports", () => {
+    const svg = [
+      '<svg xmlns="http://www.w3.org/2000/svg">',
+      '<rect x="0" fill="#6366f1" stroke="#4f46e5" stroke-width="1.5"/>',
+      '<text dominant-baseline="central">Root</text>',
+      '<rect x="100" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1.5"/>',
+      '<text dominant-baseline="central">Child</text>',
+      "</svg>",
+    ].join("\n");
+
+    const transformed = transformMindMapExportSvg(svg, "minimal");
+    expect(transformed).toContain('fill="#6366f1" stroke="#4f46e5" stroke-width="1.5"');
+    expect(transformed).toContain('fill="transparent" stroke="none" stroke-width="0"');
+    expect(transformed).toContain('<text dominant-baseline="central" fill="#374151">Child</text>');
+  });
+});

--- a/frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
+++ b/frontend/src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { planTiptapBlockPatch } from "@/lib/tiptapBlockPatchPlanner";
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function doc(content: unknown[]) {
+  return JSON.stringify({ type: "doc", content });
+}
+
+describe("Tiptap empty document Block reconciliation", () => {
+  it("deletes the final persisted Block and lets the server create the canonical empty paragraph", () => {
+    expect(planTiptapBlockPatch(
+      doc([paragraph("blk_empty001", "Last text")]),
+      doc([]),
+    )).toEqual({
+      kind: "empty-document",
+      operations: [{ type: "delete", blockId: "blk_empty001" }],
+      affectedBlockIds: ["blk_empty001"],
+    });
+  });
+
+  it("handles the schema placeholder paragraph when it has no stable Block ID", () => {
+    expect(planTiptapBlockPatch(
+      doc([
+        paragraph("blk_empty001", "First"),
+        paragraph("blk_empty002", "Second"),
+      ]),
+      doc([{
+        type: "paragraph",
+        attrs: { blockId: null, textAlign: null, lineHeight: null },
+        content: [],
+      }]),
+    )).toEqual({
+      kind: "empty-document",
+      operations: [
+        { type: "delete", blockId: "blk_empty001" },
+        { type: "delete", blockId: "blk_empty002" },
+      ],
+      affectedBlockIds: ["blk_empty001", "blk_empty002"],
+    });
+  });
+
+  it("keeps identified empty paragraphs and complex documents on their established paths", () => {
+    expect(planTiptapBlockPatch(
+      doc([paragraph("blk_empty001", "Text")]),
+      doc([paragraph("blk_local000", "")]),
+    )).toMatchObject({
+      kind: "top-level-structural",
+      operations: [
+        { type: "delete", blockId: "blk_empty001" },
+        { type: "create", blockId: "blk_local000", text: "" },
+      ],
+    });
+
+    expect(planTiptapBlockPatch(
+      doc([{
+        type: "bulletList",
+        content: [{
+          type: "listItem",
+          attrs: { blockId: "blk_item0000" },
+          content: [paragraph("blk_nested00", "Nested")],
+        }],
+      }]),
+      doc([]),
+    )).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts
+++ b/frontend/src/lib/__tests__/tiptapBlockPatchPlanner.test.ts
@@ -263,11 +263,15 @@ describe("Tiptap Block Patch planner", () => {
     )).toBeNull();
   });
 
-  it("keeps delete-all on the whole-document path until empty Block IDs can reconcile", () => {
+  it("plans delete-all so the server can return a canonical empty Block ID", () => {
     expect(planTiptapBlockPatch(
       doc([paragraph("blk_only000", "Only")]),
       doc([]),
-    )).toBeNull();
+    )).toEqual({
+      kind: "empty-document",
+      operations: [{ type: "delete", blockId: "blk_only000" }],
+      affectedBlockIds: ["blk_only000"],
+    });
   });
 
   it("rejects rich created blocks, non-default created headings and unstable IDs", () => {

--- a/frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
+++ b/frontend/src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
@@ -45,6 +45,11 @@ describe("Tiptap Block Patch rollout", () => {
     expect(shouldRetryTiptapBlockPatch(invalidNode)).toBe(false);
     expect(shouldFallbackTiptapBlockPatchToWholeSave(invalidNode)).toBe(true);
 
+    const invalidListMove = new BlockPatchRequestError("invalid list move");
+    invalidListMove.code = "LIST_MOVE_INVALID";
+    expect(shouldRetryTiptapBlockPatch(invalidListMove)).toBe(false);
+    expect(shouldFallbackTiptapBlockPatchToWholeSave(invalidListMove)).toBe(true);
+
     const conflict = new BlockPatchRequestError("conflict");
     conflict.code = "VERSION_CONFLICT";
     expect(shouldFallbackTiptapBlockPatchToWholeSave(conflict)).toBe(false);

--- a/frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
+++ b/frontend/src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { Schema, type Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { history, undo } from "@tiptap/pm/history";
+import { EditorState, TextSelection, type Transaction } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+
+import {
+  EMPTY_BLOCK_ID_RECONCILIATION_META,
+  isEmptyBlockIdentityOnlyChange,
+  rewriteEmptyBlockIdentityTransaction,
+} from "@/lib/tiptapEmptyBlockIdentityDispatch";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+      attrs: {
+        blockId: { default: null },
+        textAlign: { default: null },
+        lineHeight: { default: null },
+      },
+      toDOM: (node) => ["p", { "data-block-id": node.attrs.blockId }, 0],
+      parseDOM: [{ tag: "p" }],
+    },
+    text: { group: "inline" },
+  },
+});
+
+function paragraphDoc(blockId: string | null, text = "", attrs: Record<string, unknown> = {}): ProseMirrorNode {
+  return schema.node("doc", null, [
+    schema.node(
+      "paragraph",
+      { blockId, textAlign: null, lineHeight: null, ...attrs },
+      text ? [schema.text(text)] : undefined,
+    ),
+  ]);
+}
+
+const views: EditorView[] = [];
+
+afterEach(() => {
+  while (views.length > 0) views.pop()?.destroy();
+  document.body.innerHTML = "";
+});
+
+describe("empty Tiptap Block identity dispatch", () => {
+  it("rewrites an identity-only setContent into a non-history metadata transaction", () => {
+    const current = paragraphDoc("blk_local000", "");
+    const server = paragraphDoc("blk_server00", "");
+    const state = EditorState.create({ doc: current, plugins: [history()] });
+    const original = state.tr
+      .replaceWith(0, state.doc.content.size, server.content)
+      .setMeta("preventUpdate", true);
+
+    const rewritten = rewriteEmptyBlockIdentityTransaction({ state }, original);
+
+    expect(rewritten).not.toBe(original);
+    expect(rewritten.getMeta("addToHistory")).toBe(false);
+    expect(rewritten.getMeta("preventUpdate")).toBe(true);
+    expect(rewritten.getMeta(EMPTY_BLOCK_ID_RECONCILIATION_META)).toBe(true);
+    expect(rewritten.selection.from).toBe(state.selection.from);
+    expect(rewritten.doc.firstChild?.attrs.blockId).toBe("blk_server00");
+    expect(rewritten.doc.textContent).toBe("");
+  });
+
+  it("keeps the first Undo focused on the user's deletion, not the server Block ID", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const seen: Transaction[] = [];
+    let view!: EditorView;
+    view = new EditorView(host, {
+      state: EditorState.create({
+        doc: paragraphDoc("blk_original", "Only text"),
+        plugins: [history()],
+      }),
+      dispatchTransaction(transaction) {
+        seen.push(transaction);
+        view.updateState(view.state.apply(transaction));
+      },
+    });
+    views.push(view);
+
+    const localEmpty = paragraphDoc("blk_local000", "");
+    let deletion = view.state.tr.replaceWith(0, view.state.doc.content.size, localEmpty.content);
+    deletion = deletion.setSelection(TextSelection.create(deletion.doc, 1));
+    view.dispatch(deletion);
+    expect(view.state.doc.textContent).toBe("");
+    expect(view.state.doc.firstChild?.attrs.blockId).toBe("blk_local000");
+
+    const serverEmpty = paragraphDoc("blk_server00", "");
+    view.dispatch(
+      view.state.tr
+        .replaceWith(0, view.state.doc.content.size, serverEmpty.content)
+        .setMeta("preventUpdate", true),
+    );
+
+    const reconciliation = seen.at(-1);
+    expect(reconciliation?.getMeta(EMPTY_BLOCK_ID_RECONCILIATION_META)).toBe(true);
+    expect(reconciliation?.getMeta("addToHistory")).toBe(false);
+    expect(view.state.selection.from).toBe(1);
+    expect(view.state.doc.firstChild?.attrs.blockId).toBe("blk_server00");
+
+    expect(undo(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.textContent).toBe("Only text");
+    expect(view.state.doc.firstChild?.attrs.blockId).toBe("blk_original");
+  });
+
+  it("does not rewrite content, structure or presentation changes", () => {
+    const emptyLocal = paragraphDoc("blk_local000", "");
+    expect(isEmptyBlockIdentityOnlyChange(
+      emptyLocal,
+      paragraphDoc("blk_server00", "new text"),
+    )).toBe(false);
+    expect(isEmptyBlockIdentityOnlyChange(
+      emptyLocal,
+      paragraphDoc("blk_server00", "", { textAlign: "center" }),
+    )).toBe(false);
+
+    const state = EditorState.create({ doc: paragraphDoc("blk_local000", "Text") });
+    const server = paragraphDoc("blk_server00", "Text");
+    const transaction = state.tr.replaceWith(0, state.doc.content.size, server.content);
+    expect(rewriteEmptyBlockIdentityTransaction({ state }, transaction)).toBe(transaction);
+  });
+});

--- a/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
+++ b/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
@@ -159,11 +159,11 @@ describe("Tiptap controlled list hierarchy planner", () => {
       operations: [{
         type: "move",
         scope: "listItem",
-        blockId: "blk_item_a0",
-        targetBlockId: "blk_item_b0",
-        position: "after",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "before",
       }],
-      affectedBlockIds: ["blk_item_a0", "blk_item_b0"],
+      affectedBlockIds: ["blk_item_b0", "blk_item_a0"],
     });
   });
 

--- a/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
+++ b/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
@@ -40,6 +40,18 @@ function list(
   return { type, ...(attrs ? { attrs } : {}), content };
 }
 
+function nestedChain(length: number): unknown {
+  let current: unknown = item(`blk_deep_${String(length).padStart(2, "0")}`, `Deep ${length}`);
+  for (let index = length - 1; index >= 0; index -= 1) {
+    current = item(
+      `blk_deep_${String(index).padStart(2, "0")}`,
+      `Deep ${index}`,
+      list("bulletList", [current]),
+    );
+  }
+  return current;
+}
+
 function doc(content: unknown[]) {
   return JSON.stringify({ type: "doc", content });
 }
@@ -66,6 +78,31 @@ describe("Tiptap controlled list hierarchy planner", () => {
         position: "inside",
       }],
       affectedBlockIds: ["blk_item_b0", "blk_item_a0"],
+    });
+  });
+
+  it("plans sinking an item whose subtree changes more than eight descendant depths", () => {
+    const subtree = nestedChain(10);
+    const movable = item("blk_item_b0", "B", list("bulletList", [subtree]));
+    const base = doc([list("bulletList", [
+      item("blk_item_a0", "A"),
+      movable,
+      item("blk_item_c0", "C"),
+    ])]);
+    const next = doc([list("bulletList", [
+      item("blk_item_a0", "A", list("bulletList", [movable])),
+      item("blk_item_c0", "C"),
+    ])]);
+
+    expect(planTiptapBlockPatch(base, next)).toMatchObject({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "inside",
+      }],
     });
   });
 

--- a/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
+++ b/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
@@ -32,8 +32,12 @@ function taskItem(blockId: string, text: string, checked: boolean, nested?: unkn
   };
 }
 
-function list(type: "bulletList" | "orderedList" | "taskList", content: unknown[]) {
-  return { type, content };
+function list(
+  type: "bulletList" | "orderedList" | "taskList",
+  content: unknown[],
+  attrs?: Record<string, unknown>,
+) {
+  return { type, ...(attrs ? { attrs } : {}), content };
 }
 
 function doc(content: unknown[]) {
@@ -62,6 +66,28 @@ describe("Tiptap controlled list hierarchy planner", () => {
         position: "inside",
       }],
       affectedBlockIds: ["blk_item_b0", "blk_item_a0"],
+    });
+  });
+
+  it("plans ordered-list sinking with canonical list attrs", () => {
+    const attrs = { start: 1 };
+    const base = doc([list("orderedList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+    ], attrs)]);
+    const next = doc([list("orderedList", [
+      item("blk_item_a0", "A", list("orderedList", [item("blk_item_b0", "B")], attrs)),
+    ], attrs)]);
+
+    expect(planTiptapBlockPatch(base, next)).toMatchObject({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "inside",
+      }],
     });
   });
 
@@ -116,6 +142,31 @@ describe("Tiptap controlled list hierarchy planner", () => {
     });
   });
 
+  it("chooses one stable equivalent operation for an adjacent swap", () => {
+    const base = doc([list("bulletList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+    ])]);
+    const next = doc([list("bulletList", [
+      item("blk_item_b0", "B"),
+      item("blk_item_a0", "A"),
+      item("blk_item_c0", "C"),
+    ])]);
+
+    expect(planTiptapBlockPatch(base, next)).toEqual({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_a0",
+        targetBlockId: "blk_item_b0",
+        position: "after",
+      }],
+      affectedBlockIds: ["blk_item_a0", "blk_item_b0"],
+    });
+  });
+
   it("plans task-list sinking without losing checked state", () => {
     const base = doc([list("taskList", [
       taskItem("blk_task_a0", "A", true),
@@ -164,7 +215,7 @@ describe("Tiptap controlled list hierarchy planner", () => {
       item("blk_item_b0", "B"),
       item("blk_item_c0", "C"),
       item("blk_item_d0", "D"),
-    ])]);
+    ], { start: 1 })]);
     expect(planTiptapBlockPatch(base, ordered)).toBeNull();
   });
 });

--- a/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
+++ b/frontend/src/lib/__tests__/tiptapListItemMovePlanner.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { planTiptapBlockPatch } from "@/lib/tiptapBlockPatchPlannerRuntime";
+
+function paragraph(blockId: string, text: string) {
+  return {
+    type: "paragraph",
+    attrs: { blockId },
+    content: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function item(blockId: string, text: string, nested?: unknown) {
+  return {
+    type: "listItem",
+    attrs: { blockId },
+    content: [
+      paragraph(`blk_p_${blockId.slice(4)}`, text),
+      ...(nested ? [nested] : []),
+    ],
+  };
+}
+
+function taskItem(blockId: string, text: string, checked: boolean, nested?: unknown) {
+  return {
+    type: "taskItem",
+    attrs: { blockId, checked },
+    content: [
+      paragraph(`blk_p_${blockId.slice(4)}`, text),
+      ...(nested ? [nested] : []),
+    ],
+  };
+}
+
+function list(type: "bulletList" | "orderedList" | "taskList", content: unknown[]) {
+  return { type, content };
+}
+
+function doc(content: unknown[]) {
+  return JSON.stringify({ type: "doc", content });
+}
+
+describe("Tiptap controlled list hierarchy planner", () => {
+  it("plans one immediate sibling sink", () => {
+    const base = doc([list("bulletList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+    ])]);
+    const next = doc([list("bulletList", [
+      item("blk_item_a0", "A", list("bulletList", [item("blk_item_b0", "B")])),
+      item("blk_item_c0", "C"),
+    ])]);
+
+    expect(planTiptapBlockPatch(base, next)).toEqual({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "inside",
+      }],
+      affectedBlockIds: ["blk_item_b0", "blk_item_a0"],
+    });
+  });
+
+  it("plans one nested item lift after its direct parent", () => {
+    const base = doc([list("bulletList", [
+      item("blk_item_a0", "A", list("bulletList", [item("blk_item_b0", "B")])),
+      item("blk_item_c0", "C"),
+    ])]);
+    const next = doc([list("bulletList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+    ])]);
+
+    expect(planTiptapBlockPatch(base, next)).toMatchObject({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_b0",
+        targetBlockId: "blk_item_a0",
+        position: "after",
+      }],
+    });
+  });
+
+  it("plans one same-depth move between separate lists", () => {
+    const separator = paragraph("blk_separator", "Between");
+    const base = doc([
+      list("bulletList", [item("blk_item_a0", "A")]),
+      separator,
+      list("bulletList", [item("blk_item_b0", "B"), item("blk_item_c0", "C")]),
+    ]);
+    const next = doc([
+      separator,
+      list("bulletList", [
+        item("blk_item_b0", "B"),
+        item("blk_item_c0", "C"),
+        item("blk_item_a0", "A"),
+      ]),
+    ]);
+
+    expect(planTiptapBlockPatch(base, next)).toMatchObject({
+      kind: "list-hierarchy",
+      operations: [{
+        type: "move",
+        scope: "listItem",
+        blockId: "blk_item_a0",
+        targetBlockId: "blk_item_c0",
+        position: "after",
+      }],
+    });
+  });
+
+  it("plans task-list sinking without losing checked state", () => {
+    const base = doc([list("taskList", [
+      taskItem("blk_task_a0", "A", true),
+      taskItem("blk_task_b0", "B", false),
+    ])]);
+    const next = doc([list("taskList", [
+      taskItem(
+        "blk_task_a0",
+        "A",
+        true,
+        list("taskList", [taskItem("blk_task_b0", "B", false)]),
+      ),
+    ])]);
+
+    expect(planTiptapBlockPatch(base, next)).toMatchObject({
+      kind: "list-hierarchy",
+      operations: [{ position: "inside", blockId: "blk_task_b0" }],
+    });
+  });
+
+  it("rejects content changes, multiple moves and list-type conversion", () => {
+    const base = doc([list("bulletList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+      item("blk_item_d0", "D"),
+    ])]);
+
+    const sinkWithTextChange = doc([list("bulletList", [
+      item("blk_item_a0", "A", list("bulletList", [item("blk_item_b0", "B changed")])),
+      item("blk_item_c0", "C"),
+      item("blk_item_d0", "D"),
+    ])]);
+    expect(planTiptapBlockPatch(base, sinkWithTextChange)).toBeNull();
+
+    const twoMoves = doc([list("bulletList", [
+      item("blk_item_b0", "B"),
+      item("blk_item_a0", "A"),
+      item("blk_item_d0", "D"),
+      item("blk_item_c0", "C"),
+    ])]);
+    expect(planTiptapBlockPatch(base, twoMoves)).toBeNull();
+
+    const ordered = doc([list("orderedList", [
+      item("blk_item_a0", "A"),
+      item("blk_item_b0", "B"),
+      item("blk_item_c0", "C"),
+      item("blk_item_d0", "D"),
+    ])]);
+    expect(planTiptapBlockPatch(base, ordered)).toBeNull();
+  });
+});

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -37,6 +37,12 @@ export type BlockPatchOperation =
       blockId: string;
       targetBlockId: string;
       position?: "before" | "after";
+    }
+  | {
+      type: "moveListItem";
+      blockId: string;
+      targetBlockId: string;
+      position: "before" | "after" | "inside";
     };
 
 export interface BlockPatchRequest {

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -34,12 +34,14 @@ export type BlockPatchOperation =
     }
   | {
       type: "move";
+      scope?: undefined;
       blockId: string;
       targetBlockId: string;
       position?: "before" | "after";
     }
   | {
-      type: "moveListItem";
+      type: "move";
+      scope: "listItem";
       blockId: string;
       targetBlockId: string;
       position: "before" | "after" | "inside";

--- a/frontend/src/lib/blockPatchApi.ts
+++ b/frontend/src/lib/blockPatchApi.ts
@@ -88,8 +88,8 @@ export interface BlockPatchResult {
   blocks: BlockPatchIndexRow[];
   /** Whether the server updated a proven-safe subset or rebuilt every note index row. */
   indexUpdateMode: "incremental" | "full";
-  /** Distinguishes leaf, structural, mixed incremental updates and full fallback. */
-  indexUpdateKind: "leaf" | "structural" | "mixed" | "full";
+  /** Distinguishes leaf, top-level structural, mixed, list-subtree updates and full fallback. */
+  indexUpdateKind: "leaf" | "structural" | "mixed" | "list-subtree" | "full";
   /** Block IDs inserted, updated or deleted by index synchronization. */
   indexedBlockIds: string[];
   contentChangedByNormalization: boolean;

--- a/frontend/src/lib/mindMapAppearance.ts
+++ b/frontend/src/lib/mindMapAppearance.ts
@@ -1,0 +1,117 @@
+export type MindMapNodeStyle = "card" | "minimal";
+
+export interface MindMapAppearance {
+  nodeStyle?: MindMapNodeStyle;
+  [key: string]: unknown;
+}
+
+export interface MindMapDocument extends Record<string, unknown> {
+  root?: {
+    id?: string;
+    text?: string;
+    [key: string]: unknown;
+  };
+  appearance?: MindMapAppearance;
+}
+
+export function parseMindMapDocument(value: unknown): MindMapDocument | null {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as MindMapDocument
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as MindMapDocument
+    : null;
+}
+
+export function getMindMapNodeStyle(document: MindMapDocument | null | undefined): MindMapNodeStyle {
+  return document?.appearance?.nodeStyle === "minimal" ? "minimal" : "card";
+}
+
+export function withMindMapNodeStyle(
+  document: MindMapDocument,
+  nodeStyle: MindMapNodeStyle,
+): MindMapDocument {
+  return {
+    ...document,
+    appearance: {
+      ...(document.appearance || {}),
+      nodeStyle,
+    },
+  };
+}
+
+/**
+ * The current editor does not know about the optional appearance field yet. Merge the active
+ * style into every autosave payload so an ordinary node edit cannot accidentally remove it.
+ */
+export function preserveMindMapNodeStyleInSerializedData(
+  serializedData: string,
+  fallbackStyle: MindMapNodeStyle,
+): string {
+  const document = parseMindMapDocument(serializedData);
+  if (!document) return serializedData;
+  if (document.appearance?.nodeStyle === "card" || document.appearance?.nodeStyle === "minimal") {
+    return serializedData;
+  }
+  return JSON.stringify(withMindMapNodeStyle(document, fallbackStyle));
+}
+
+function replaceAttribute(tag: string, attribute: string, value: string): string {
+  const pattern = new RegExp(`\\s${attribute}="[^"]*"`);
+  if (pattern.test(tag)) return tag.replace(pattern, ` ${attribute}="${value}"`);
+  return tag.replace(/\s*\/>$/, ` ${attribute}="${value}"/>`);
+}
+
+/**
+ * MindMapEditor builds SVG and PNG exports from the same generated SVG string. Keep the root card
+ * intact, then remove fill/border from all descendant node rectangles in minimal mode.
+ */
+export function transformMindMapExportSvg(
+  svg: string,
+  nodeStyle: MindMapNodeStyle,
+): string {
+  if (nodeStyle !== "minimal") return svg;
+  if (!svg.includes('dominant-baseline="central"') || !svg.includes("<rect")) return svg;
+
+  let nodeRectIndex = 0;
+  const withoutCards = svg.replace(/<rect\b[^>]*\/>/g, (tag) => {
+    nodeRectIndex += 1;
+    if (nodeRectIndex === 1) return tag;
+    return replaceAttribute(
+      replaceAttribute(
+        replaceAttribute(tag, "fill", "transparent"),
+        "stroke",
+        "none",
+      ),
+      "stroke-width",
+      "0",
+    );
+  });
+
+  let nodeTextIndex = 0;
+  return withoutCards.replace(/<text\b[^>]*>/g, (tag) => {
+    nodeTextIndex += 1;
+    if (nodeTextIndex === 1) return tag;
+    return replaceAttribute(tag, "fill", "#374151");
+  });
+}
+
+export function getMindMapRootText(document: MindMapDocument | null | undefined): string {
+  return typeof document?.root?.text === "string" ? document.root.text : "";
+}
+
+export function escapeMindMapXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/frontend/src/lib/tiptapBlockPatchPlanner.ts
+++ b/frontend/src/lib/tiptapBlockPatchPlanner.ts
@@ -36,7 +36,7 @@ interface TopLevelBlock {
 
 export interface TiptapBlockPatchPlan {
   operations: BlockPatchOperation[];
-  kind: "top-level-structural" | "text-only" | "node-replace";
+  kind: "top-level-structural" | "empty-document" | "text-only" | "node-replace";
   affectedBlockIds: string[];
 }
 
@@ -125,6 +125,38 @@ function uniqueTopLevelBlocks(nodes: JsonNode[]): TopLevelBlock[] | null {
     blocks.push({ id, type, node, normalized, simple: asSimpleBlock(node) });
   }
   return blocks;
+}
+
+function isUnidentifiedEmptyDocument(doc: JsonNode): boolean {
+  const nodes = Array.isArray(doc.content) ? doc.content : [];
+  if (nodes.length === 0) return true;
+  if (nodes.length !== 1) return false;
+
+  const node = nodes[0];
+  if (!node || node.type !== "paragraph" || validBlockId(node.attrs?.blockId)) return false;
+  const attrs = normalizedAttrs(node);
+  if (!Object.values(attrs).every(isDefaultValue)) return false;
+  const content = Array.isArray(node.content) ? node.content : [];
+  return content.every((child) => (
+    child?.type === "text"
+    && (child.text || "") === ""
+    && (!Array.isArray(child.marks) || child.marks.length === 0)
+  ));
+}
+
+function planEmptyDocumentReset(baseDoc: JsonNode, nextDoc: JsonNode): TiptapBlockPatchPlan | null {
+  if (!isUnidentifiedEmptyDocument(nextDoc)) return null;
+  const base = uniqueTopLevelBlocks(baseDoc.content || []);
+  if (!base || base.length === 0 || base.length > 100) return null;
+  const operations: BlockPatchOperation[] = base.map((block) => ({
+    type: "delete",
+    blockId: block.id,
+  }));
+  return {
+    operations,
+    kind: "empty-document",
+    affectedBlockIds: base.map((block) => block.id),
+  };
 }
 
 function planTopLevelStructural(baseDoc: JsonNode, nextDoc: JsonNode): TiptapBlockPatchPlan | null {
@@ -337,7 +369,8 @@ export function planTiptapBlockPatch(
   const baseDoc = parseDocument(baseContent);
   const nextDoc = parseDocument(nextContent);
   if (!baseDoc || !nextDoc) return null;
-  return planTopLevelStructural(baseDoc, nextDoc)
+  return planEmptyDocumentReset(baseDoc, nextDoc)
+    || planTopLevelStructural(baseDoc, nextDoc)
     || planTextOnly(baseDoc, nextDoc)
     || planNodeReplacements(baseDoc, nextDoc);
 }

--- a/frontend/src/lib/tiptapBlockPatchPlannerRuntime.ts
+++ b/frontend/src/lib/tiptapBlockPatchPlannerRuntime.ts
@@ -1,0 +1,50 @@
+import type { BlockPatchOperation } from "@/lib/blockPatchApi";
+import {
+  planTiptapBlockPatch as planBaseTiptapBlockPatch,
+  type TiptapBlockPatchPlan as BaseTiptapBlockPatchPlan,
+} from "@/lib/tiptapBlockPatchPlanner";
+import { planTiptapListItemMove } from "@/lib/tiptapListItemMovePlanner";
+
+interface JsonNode {
+  type?: string;
+  attrs?: Record<string, unknown> | null;
+  content?: JsonNode[];
+  text?: string;
+  [key: string]: unknown;
+}
+
+export type TiptapBlockPatchPlan = BaseTiptapBlockPatchPlan | {
+  operations: BlockPatchOperation[];
+  kind: "list-hierarchy";
+  affectedBlockIds: string[];
+};
+
+function parseDocument(content: string): JsonNode | null {
+  try {
+    const parsed = JSON.parse(content || "{}");
+    if (!parsed || parsed.type !== "doc" || !Array.isArray(parsed.content)) return null;
+    return parsed as JsonNode;
+  } catch {
+    return null;
+  }
+}
+
+/** Combine the established planner with the fail-closed single list hierarchy move planner. */
+export function planTiptapBlockPatch(
+  baseContent: string,
+  nextContent: string,
+): TiptapBlockPatchPlan | null {
+  const basePlan = planBaseTiptapBlockPatch(baseContent, nextContent);
+  if (basePlan) return basePlan;
+  if (!baseContent || !nextContent || baseContent === nextContent) return null;
+  const baseDoc = parseDocument(baseContent);
+  const nextDoc = parseDocument(nextContent);
+  if (!baseDoc || !nextDoc) return null;
+  const operation = planTiptapListItemMove(baseDoc, nextDoc);
+  if (!operation) return null;
+  return {
+    operations: [operation],
+    kind: "list-hierarchy",
+    affectedBlockIds: [operation.blockId, operation.targetBlockId],
+  };
+}

--- a/frontend/src/lib/tiptapBlockPatchRuntime.ts
+++ b/frontend/src/lib/tiptapBlockPatchRuntime.ts
@@ -38,6 +38,7 @@ export function shouldFallbackTiptapBlockPatchToWholeSave(error: unknown): boole
     "BLOCK_NOT_FOUND",
     "BLOCK_MOVE_SELF",
     "BLOCK_MOVE_PARENT_MISMATCH",
+    "LIST_MOVE_INVALID",
     "INVALID_TIPTAP_DOCUMENT",
   ].includes(error.code || "");
 }

--- a/frontend/src/lib/tiptapBlockPatchRuntime.ts
+++ b/frontend/src/lib/tiptapBlockPatchRuntime.ts
@@ -1,5 +1,6 @@
 import type { EditorRuntimeMode } from "@/lib/editorRuntimePolicy";
 import { BlockPatchRequestError } from "@/lib/blockPatchApi";
+import "@/lib/tiptapEmptyBlockIdentityDispatch";
 
 export const TIPTAP_BLOCK_PATCH_OVERRIDE_KEY = "nowen.tiptap_block_patch_v1";
 

--- a/frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts
+++ b/frontend/src/lib/tiptapEmptyBlockIdentityDispatch.ts
@@ -1,0 +1,101 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Transaction } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+
+const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
+const INSTALL_SYMBOL = Symbol.for("nowen.tiptap.empty-block-identity-dispatch");
+
+export const EMPTY_BLOCK_ID_RECONCILIATION_META = "nowen:empty-block-id-reconciliation";
+
+interface EmptyParagraphIdentity {
+  blockId: string | null;
+  attrsWithoutBlockId: Record<string, unknown>;
+}
+
+function normalizedAttrs(node: ProseMirrorNode): Record<string, unknown> {
+  const attrs = { ...(node.attrs || {}) } as Record<string, unknown>;
+  delete attrs.blockId;
+  return attrs;
+}
+
+function describeEmptyParagraph(doc: ProseMirrorNode): EmptyParagraphIdentity | null {
+  if (doc.type.name !== "doc" || doc.childCount !== 1) return null;
+  const paragraph = doc.firstChild;
+  if (!paragraph || paragraph.type.name !== "paragraph" || paragraph.content.size !== 0) return null;
+
+  const rawBlockId = paragraph.attrs?.blockId;
+  const blockId = typeof rawBlockId === "string" && rawBlockId.length > 0
+    ? rawBlockId
+    : null;
+  return {
+    blockId,
+    attrsWithoutBlockId: normalizedAttrs(paragraph),
+  };
+}
+
+/**
+ * Empty-document reconciliation is safe only when the complete ProseMirror document differs by the
+ * single paragraph's stable Block ID. Any text, node, document-attribute or presentation-attribute
+ * change must continue through the original transaction.
+ */
+export function isEmptyBlockIdentityOnlyChange(
+  currentDoc: ProseMirrorNode,
+  nextDoc: ProseMirrorNode,
+): boolean {
+  if (currentDoc.type !== nextDoc.type) return false;
+  if (JSON.stringify(currentDoc.attrs) !== JSON.stringify(nextDoc.attrs)) return false;
+
+  const current = describeEmptyParagraph(currentDoc);
+  const next = describeEmptyParagraph(nextDoc);
+  if (!current || !next || !next.blockId || !BLOCK_ID_RE.test(next.blockId)) return false;
+  if (current.blockId === next.blockId) return false;
+  return JSON.stringify(current.attrsWithoutBlockId) === JSON.stringify(next.attrsWithoutBlockId);
+}
+
+/**
+ * Convert Tiptap's whole-document setContent transaction into one metadata-only node-markup step.
+ * The replacement keeps the exact selection and is excluded from ProseMirror history, so the next
+ * Undo still restores the user's deletion rather than merely undoing the server Block ID.
+ */
+export function rewriteEmptyBlockIdentityTransaction(
+  view: Pick<EditorView, "state">,
+  transaction: Transaction,
+): Transaction {
+  if (!transaction.docChanged || !isEmptyBlockIdentityOnlyChange(view.state.doc, transaction.doc)) {
+    return transaction;
+  }
+
+  const currentParagraph = view.state.doc.firstChild;
+  const nextParagraph = transaction.doc.firstChild;
+  if (!currentParagraph || !nextParagraph) return transaction;
+
+  const rewritten = view.state.tr
+    .setNodeMarkup(0, undefined, {
+      ...currentParagraph.attrs,
+      blockId: nextParagraph.attrs.blockId,
+    })
+    .setMeta("addToHistory", false)
+    .setMeta(EMPTY_BLOCK_ID_RECONCILIATION_META, true);
+
+  const preventUpdate = transaction.getMeta("preventUpdate");
+  if (preventUpdate !== undefined) rewritten.setMeta("preventUpdate", preventUpdate);
+  if (transaction.scrolledIntoView) rewritten.scrollIntoView();
+  return rewritten;
+}
+
+/** Install once for every Tiptap/ProseMirror editor sharing this bundle. */
+export function installTiptapEmptyBlockIdentityDispatch(): void {
+  const prototype = EditorView.prototype as EditorView & Record<PropertyKey, unknown>;
+  if (prototype[INSTALL_SYMBOL]) return;
+
+  const originalDispatch = EditorView.prototype.dispatch;
+  EditorView.prototype.dispatch = function dispatchWithEmptyBlockIdentity(
+    this: EditorView,
+    transaction: Transaction,
+  ): void {
+    originalDispatch.call(this, rewriteEmptyBlockIdentityTransaction(this, transaction));
+  };
+  prototype[INSTALL_SYMBOL] = true;
+}
+
+installTiptapEmptyBlockIdentityDispatch();

--- a/frontend/src/lib/tiptapListItemMovePlanner.ts
+++ b/frontend/src/lib/tiptapListItemMovePlanner.ts
@@ -4,7 +4,7 @@ const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
 const LIST_TYPES = new Set(["bulletList", "orderedList", "taskList"]);
 const ITEM_TYPES = new Set(["listItem", "taskItem"]);
 
-type ListMoveOperation = Extract<BlockPatchOperation, { type: "moveListItem" }>;
+type ListMoveOperation = Extract<BlockPatchOperation, { type: "move"; scope: "listItem" }>;
 
 interface JsonNode {
   type?: string;
@@ -284,16 +284,16 @@ export function planTiptapListItemMove(
     const before = base.get(blockId)!;
     const after = next.get(blockId)!;
     if (after.parentItemId && after.depth === before.depth + 1) {
-      add({ type: "moveListItem", blockId, targetBlockId: after.parentItemId, position: "inside" });
+      add({ type: "move", scope: "listItem", blockId, targetBlockId: after.parentItemId, position: "inside" });
     }
     if (after.previousId) {
-      add({ type: "moveListItem", blockId, targetBlockId: after.previousId, position: "after" });
+      add({ type: "move", scope: "listItem", blockId, targetBlockId: after.previousId, position: "after" });
     }
     if (after.nextId) {
-      add({ type: "moveListItem", blockId, targetBlockId: after.nextId, position: "before" });
+      add({ type: "move", scope: "listItem", blockId, targetBlockId: after.nextId, position: "before" });
     }
     if (before.parentItemId && after.depth === before.depth - 1) {
-      add({ type: "moveListItem", blockId, targetBlockId: before.parentItemId, position: "after" });
+      add({ type: "move", scope: "listItem", blockId, targetBlockId: before.parentItemId, position: "after" });
     }
   }
 

--- a/frontend/src/lib/tiptapListItemMovePlanner.ts
+++ b/frontend/src/lib/tiptapListItemMovePlanner.ts
@@ -1,0 +1,309 @@
+import type { BlockPatchOperation } from "@/lib/blockPatchApi";
+
+const BLOCK_ID_RE = /^blk_[A-Za-z0-9_-]{6,}$/;
+const LIST_TYPES = new Set(["bulletList", "orderedList", "taskList"]);
+const ITEM_TYPES = new Set(["listItem", "taskItem"]);
+
+type ListMoveOperation = Extract<BlockPatchOperation, { type: "moveListItem" }>;
+
+interface JsonNode {
+  type?: string;
+  attrs?: Record<string, unknown> | null;
+  content?: JsonNode[];
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface NodeFrame {
+  node: JsonNode;
+  parent: JsonNode[];
+  index: number;
+}
+
+interface ListItemLocation {
+  item: JsonNode;
+  list: JsonNode;
+  listFrame: NodeFrame;
+  depth: number;
+  parentItemFrame: NodeFrame | null;
+  outerListFrame: NodeFrame | null;
+}
+
+interface ItemDescriptor {
+  id: string;
+  itemType: string;
+  listType: string;
+  depth: number;
+  parentItemId: string | null;
+  previousId: string | null;
+  nextId: string | null;
+  payload: string;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function validBlockId(value: unknown): value is string {
+  return typeof value === "string" && BLOCK_ID_RE.test(value);
+}
+
+function findPath(nodes: JsonNode[], blockId: string, ancestors: NodeFrame[] = []): NodeFrame[] | null {
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    if (!node || typeof node !== "object") continue;
+    const frame = { node, parent: nodes, index };
+    const path = [...ancestors, frame];
+    if (node.attrs?.blockId === blockId) return path;
+    if (Array.isArray(node.content)) {
+      const nested = findPath(node.content, blockId, path);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function locateListItem(doc: JsonNode, blockId: string): ListItemLocation | null {
+  if (!Array.isArray(doc.content)) return null;
+  const path = findPath(doc.content, blockId);
+  if (!path || path.length < 2) return null;
+  const itemFrame = path[path.length - 1];
+  const listFrame = path[path.length - 2];
+  if (!ITEM_TYPES.has(itemFrame.node.type || "") || !LIST_TYPES.has(listFrame.node.type || "")) {
+    return null;
+  }
+  if (listFrame.node.content !== itemFrame.parent) return null;
+
+  let parentItemFrame: NodeFrame | null = null;
+  let outerListFrame: NodeFrame | null = null;
+  for (let index = path.length - 3; index >= 0; index -= 1) {
+    if (!ITEM_TYPES.has(path[index].node.type || "")) continue;
+    parentItemFrame = path[index];
+    if (index > 0 && LIST_TYPES.has(path[index - 1].node.type || "")) {
+      outerListFrame = path[index - 1];
+    }
+    break;
+  }
+
+  return {
+    item: itemFrame.node,
+    list: listFrame.node,
+    listFrame,
+    depth: path.filter((frame) => LIST_TYPES.has(frame.node.type || "")).length,
+    parentItemFrame,
+    outerListFrame,
+  };
+}
+
+function expectedItemType(listType: string): string {
+  return listType === "taskList" ? "taskItem" : "listItem";
+}
+
+function compatible(source: ListItemLocation, target: ListItemLocation): boolean {
+  return source.item.type === target.item.type
+    && source.list.type === target.list.type
+    && source.item.type === expectedItemType(source.list.type || "");
+}
+
+function removeListWrapperIfEmpty(location: ListItemLocation): void {
+  if ((location.list.content || []).length > 0) return;
+  const currentIndex = location.listFrame.parent.indexOf(location.list);
+  if (currentIndex >= 0) location.listFrame.parent.splice(currentIndex, 1);
+}
+
+function nestedListForSink(target: ListItemLocation): JsonNode | null {
+  const children = Array.isArray(target.item.content) ? target.item.content : [];
+  const nestedLists = children.filter((child) => LIST_TYPES.has(child.type || ""));
+  if (nestedLists.some((child) => child.type !== target.list.type) || nestedLists.length > 1) {
+    return null;
+  }
+  if (nestedLists.length === 1) return nestedLists[0];
+  const nested: JsonNode = { type: target.list.type, content: [] };
+  if (!Array.isArray(target.item.content)) target.item.content = [];
+  target.item.content.push(nested);
+  return nested;
+}
+
+function applyListMove(doc: JsonNode, operation: ListMoveOperation): boolean {
+  const source = locateListItem(doc, operation.blockId);
+  const target = locateListItem(doc, operation.targetBlockId);
+  if (!source || !target || !compatible(source, target) || source.item === target.item) return false;
+
+  if (operation.position === "inside") {
+    if (source.list !== target.list || source.depth !== target.depth) return false;
+    const sourceIndex = source.list.content?.indexOf(source.item) ?? -1;
+    const targetIndex = source.list.content?.indexOf(target.item) ?? -1;
+    if (sourceIndex < 1 || targetIndex !== sourceIndex - 1) return false;
+    const nested = nestedListForSink(target);
+    if (!nested || !Array.isArray(nested.content) || !Array.isArray(source.list.content)) return false;
+    source.list.content.splice(sourceIndex, 1);
+    nested.content.push(source.item);
+    return true;
+  }
+
+  const isLift = operation.position === "after" && source.depth === target.depth + 1;
+  if (isLift) {
+    if (
+      source.parentItemFrame?.node !== target.item
+      || !source.outerListFrame
+      || source.outerListFrame.node !== target.list
+      || source.listFrame.parent !== target.item.content
+      || !Array.isArray(source.list.content)
+      || !Array.isArray(target.list.content)
+    ) return false;
+    const sourceIndex = source.list.content.indexOf(source.item);
+    if (sourceIndex < 0) return false;
+    source.list.content.splice(sourceIndex, 1);
+    removeListWrapperIfEmpty(source);
+    const targetIndex = target.list.content.indexOf(target.item);
+    if (targetIndex < 0) return false;
+    target.list.content.splice(targetIndex + 1, 0, source.item);
+    return true;
+  }
+
+  if (source.depth !== target.depth || !Array.isArray(source.list.content) || !Array.isArray(target.list.content)) {
+    return false;
+  }
+  const sourceIndex = source.list.content.indexOf(source.item);
+  if (sourceIndex < 0) return false;
+  source.list.content.splice(sourceIndex, 1);
+  if (source.list !== target.list) removeListWrapperIfEmpty(source);
+  const targetIndex = target.list.content.indexOf(target.item);
+  if (targetIndex < 0) return false;
+  target.list.content.splice(operation.position === "after" ? targetIndex + 1 : targetIndex, 0, source.item);
+  return true;
+}
+
+function itemPayload(node: JsonNode): string {
+  const clone = cloneJson(node);
+  clone.content = (clone.content || []).filter((child) => !LIST_TYPES.has(child.type || ""));
+  return JSON.stringify(clone);
+}
+
+function collectDescriptors(doc: JsonNode): Map<string, ItemDescriptor> | null {
+  const output = new Map<string, ItemDescriptor>();
+  let invalid = false;
+
+  const visit = (nodes: JsonNode[], depth: number, parentItemId: string | null) => {
+    for (const node of nodes) {
+      if (!node || typeof node !== "object") continue;
+      if (LIST_TYPES.has(node.type || "")) {
+        const items = Array.isArray(node.content) ? node.content : [];
+        for (let index = 0; index < items.length; index += 1) {
+          const item = items[index];
+          const id = item.attrs?.blockId;
+          if (
+            !ITEM_TYPES.has(item.type || "")
+            || !validBlockId(id)
+            || output.has(id)
+            || item.type !== expectedItemType(node.type || "")
+          ) {
+            invalid = true;
+            return;
+          }
+          const previousId = index > 0 ? items[index - 1]?.attrs?.blockId : null;
+          const nextId = index + 1 < items.length ? items[index + 1]?.attrs?.blockId : null;
+          if ((previousId != null && !validBlockId(previousId)) || (nextId != null && !validBlockId(nextId))) {
+            invalid = true;
+            return;
+          }
+          output.set(id, {
+            id,
+            itemType: item.type || "",
+            listType: node.type || "",
+            depth: depth + 1,
+            parentItemId,
+            previousId: previousId || null,
+            nextId: nextId || null,
+            payload: itemPayload(item),
+          });
+          visit(item.content || [], depth + 1, id);
+          if (invalid) return;
+        }
+        continue;
+      }
+      if (Array.isArray(node.content)) {
+        visit(node.content, depth, parentItemId);
+        if (invalid) return;
+      }
+    }
+  };
+
+  visit(doc.content || [], 0, null);
+  return invalid || output.size === 0 ? null : output;
+}
+
+function nonListSkeleton(doc: JsonNode): string {
+  const clone = cloneJson(doc);
+  const strip = (nodes: JsonNode[]): JsonNode[] => nodes
+    .filter((node) => !LIST_TYPES.has(node.type || ""))
+    .map((node) => {
+      if (Array.isArray(node.content)) node.content = strip(node.content);
+      return node;
+    });
+  clone.content = strip(clone.content || []);
+  return JSON.stringify(clone);
+}
+
+function descriptorChanged(left: ItemDescriptor, right: ItemDescriptor): boolean {
+  return left.parentItemId !== right.parentItemId
+    || left.depth !== right.depth
+    || left.previousId !== right.previousId
+    || left.nextId !== right.nextId
+    || left.listType !== right.listType;
+}
+
+/**
+ * Prove that exactly one controlled list item move transforms the complete base JSON into next JSON.
+ * Content, marks, checked state and non-list structure must remain byte-for-byte equivalent.
+ */
+export function planTiptapListItemMove(
+  baseDoc: JsonNode,
+  nextDoc: JsonNode,
+): ListMoveOperation | null {
+  if (nonListSkeleton(baseDoc) !== nonListSkeleton(nextDoc)) return null;
+  const base = collectDescriptors(baseDoc);
+  const next = collectDescriptors(nextDoc);
+  if (!base || !next || base.size !== next.size || base.size > 5000) return null;
+
+  for (const [id, before] of base) {
+    const after = next.get(id);
+    if (!after || before.itemType !== after.itemType || before.payload !== after.payload) return null;
+  }
+
+  const changedIds = [...base.keys()].filter((id) => descriptorChanged(base.get(id)!, next.get(id)!));
+  if (changedIds.length === 0 || changedIds.length > 8) return null;
+
+  const candidates = new Map<string, ListMoveOperation>();
+  const add = (operation: ListMoveOperation) => {
+    if (!validBlockId(operation.targetBlockId) || operation.blockId === operation.targetBlockId) return;
+    candidates.set(JSON.stringify(operation), operation);
+  };
+
+  for (const blockId of changedIds) {
+    const before = base.get(blockId)!;
+    const after = next.get(blockId)!;
+    if (after.parentItemId && after.depth === before.depth + 1) {
+      add({ type: "moveListItem", blockId, targetBlockId: after.parentItemId, position: "inside" });
+    }
+    if (after.previousId) {
+      add({ type: "moveListItem", blockId, targetBlockId: after.previousId, position: "after" });
+    }
+    if (after.nextId) {
+      add({ type: "moveListItem", blockId, targetBlockId: after.nextId, position: "before" });
+    }
+    if (before.parentItemId && after.depth === before.depth - 1) {
+      add({ type: "moveListItem", blockId, targetBlockId: before.parentItemId, position: "after" });
+    }
+  }
+
+  const targetJson = JSON.stringify(nextDoc);
+  const matches: ListMoveOperation[] = [];
+  for (const operation of candidates.values()) {
+    const simulated = cloneJson(baseDoc);
+    if (applyListMove(simulated, operation) && JSON.stringify(simulated) === targetJson) {
+      matches.push(operation);
+    }
+  }
+  return matches.length === 1 ? matches[0] : null;
+}

--- a/frontend/src/lib/tiptapListItemMovePlanner.ts
+++ b/frontend/src/lib/tiptapListItemMovePlanner.ts
@@ -118,7 +118,14 @@ function nestedListForSink(target: ListItemLocation): JsonNode | null {
     return null;
   }
   if (nestedLists.length === 1) return nestedLists[0];
-  const nested: JsonNode = { type: target.list.type, content: [] };
+  const attrs = target.list.attrs && typeof target.list.attrs === "object"
+    ? cloneJson(target.list.attrs)
+    : null;
+  const nested: JsonNode = {
+    type: target.list.type,
+    ...(attrs && Object.keys(attrs).length > 0 ? { attrs } : {}),
+    content: [],
+  };
   if (!Array.isArray(target.item.content)) target.item.content = [];
   target.item.content.push(nested);
   return nested;
@@ -253,9 +260,25 @@ function descriptorChanged(left: ItemDescriptor, right: ItemDescriptor): boolean
     || left.listType !== right.listType;
 }
 
+function operationRank(
+  operation: ListMoveOperation,
+  base: Map<string, ItemDescriptor>,
+  next: Map<string, ItemDescriptor>,
+): string {
+  const before = base.get(operation.blockId);
+  const after = next.get(operation.blockId);
+  const hierarchyChanged = before && after && (
+    before.depth !== after.depth || before.parentItemId !== after.parentItemId
+  );
+  const semanticRank = operation.position === "inside" ? 0 : hierarchyChanged ? 1 : 2;
+  const positionRank = operation.position === "before" ? 0 : operation.position === "after" ? 1 : 2;
+  return `${semanticRank}:${positionRank}:${operation.blockId}:${operation.targetBlockId}`;
+}
+
 /**
- * Prove that exactly one controlled list item move transforms the complete base JSON into next JSON.
- * Content, marks, checked state and non-list structure must remain byte-for-byte equivalent.
+ * Prove that one controlled list item move can reproduce the complete target JSON. Content, marks,
+ * checked state and non-list structure must remain byte-for-byte equivalent. When two equivalent
+ * moves produce the same target (for example an adjacent swap), a stable rank selects one request.
  */
 export function planTiptapListItemMove(
   baseDoc: JsonNode,
@@ -305,5 +328,6 @@ export function planTiptapListItemMove(
       matches.push(operation);
     }
   }
-  return matches.length === 1 ? matches[0] : null;
+  matches.sort((left, right) => operationRank(left, base, next).localeCompare(operationRank(right, base, next)));
+  return matches[0] || null;
 }

--- a/frontend/src/lib/tiptapListItemMovePlanner.ts
+++ b/frontend/src/lib/tiptapListItemMovePlanner.ts
@@ -275,6 +275,10 @@ function operationRank(
   return `${semanticRank}:${positionRank}:${operation.blockId}:${operation.targetBlockId}`;
 }
 
+function compareRanks(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /**
  * Prove that one controlled list item move can reproduce the complete target JSON. Content, marks,
  * checked state and non-list structure must remain byte-for-byte equivalent. When two equivalent
@@ -295,7 +299,15 @@ export function planTiptapListItemMove(
   }
 
   const changedIds = [...base.keys()].filter((id) => descriptorChanged(base.get(id)!, next.get(id)!));
-  if (changedIds.length === 0 || changedIds.length > 8) return null;
+  if (changedIds.length === 0) return null;
+  const candidateSourceIds = changedIds.filter((id) => {
+    const before = base.get(id)!;
+    const after = next.get(id)!;
+    return before.parentItemId !== after.parentItemId
+      || before.previousId !== after.previousId
+      || before.nextId !== after.nextId;
+  });
+  if (candidateSourceIds.length === 0 || candidateSourceIds.length > 16) return null;
 
   const candidates = new Map<string, ListMoveOperation>();
   const add = (operation: ListMoveOperation) => {
@@ -303,7 +315,7 @@ export function planTiptapListItemMove(
     candidates.set(JSON.stringify(operation), operation);
   };
 
-  for (const blockId of changedIds) {
+  for (const blockId of candidateSourceIds) {
     const before = base.get(blockId)!;
     const after = next.get(blockId)!;
     if (after.parentItemId && after.depth === before.depth + 1) {
@@ -328,6 +340,9 @@ export function planTiptapListItemMove(
       matches.push(operation);
     }
   }
-  matches.sort((left, right) => operationRank(left, base, next).localeCompare(operationRank(right, base, next)));
+  matches.sort((left, right) => compareRanks(
+    operationRank(left, base, next),
+    operationRank(right, base, next),
+  ));
   return matches[0] || null;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import Toaster from "./components/Toaster";
 import NoteIconBridge from "./components/NoteIconBridge";
 import AIProfileSwitcherBridge from "./components/AIProfileSwitcherBridge";
 import MarkdownExperienceBridge from "./components/MarkdownExperienceBridge";
+import MindMapAppearanceBridge from "./components/MindMapAppearanceBridge";
 import EmbedPasswordBridge from "./components/EmbedPasswordBridge";
 import ImageExperienceBridge from "./components/ImageExperienceBridge";
 import MediaExperienceBridge from "./components/MediaExperienceBridge";
@@ -157,6 +158,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <NoteIconBridge />
         <AIProfileSwitcherBridge />
         <MarkdownExperienceBridge />
+        <MindMapAppearanceBridge />
         <EmbedPasswordBridge />
         <ImageExperienceBridge />
         <MediaExperienceBridge />


### PR DESCRIPTION
同步 `main` 最新 49 个提交到 `pg-migration-unified`。Block Patch 工作流已先与 `main` 对齐，避免同文件冲突；合并后再恢复诊断日志能力。

同步完成后继续 #249 的 note-link title PostgreSQL Runtime 边界迁移。