### PR TITLE
feat(ai): discover and test embedding models

### DIFF
--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -15,6 +15,13 @@ import { getUserWorkspaceRole } from "../middleware/acl";
 import { callAIChat, callAIChatStream, extractTextFromChatCompletion, sanitizeError, type AISettings } from "../services/ai-client";
 import { aiCustomPromptsRepository } from "../repositories";
 import { getUserAISettings, setGuardedUserAISettings } from "../services/user-ai-settings";
+import {
+  discoverEmbeddingModels,
+  embeddingDiscoveryErrorBody,
+  EmbeddingDiscoveryError,
+  testEmbeddingModel,
+  type EmbeddingProbeInput,
+} from "../services/embedding-model-discovery";
 
 const ai = new Hono();
 
@@ -179,6 +186,29 @@ ai.put("/settings", async (c) => {
     ai_embedding_key: settings.ai_embedding_key ? "sk-****" + settings.ai_embedding_key.slice(-4) : "",
     ai_embedding_key_set: !!settings.ai_embedding_key,
   });
+});
+
+// ===== Embedding 模型发现与连通性测试 =====
+ai.post("/embeddings/models", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const body = await c.req.json().catch(() => ({})) as EmbeddingProbeInput;
+  try {
+    return c.json(await discoverEmbeddingModels(userId, body));
+  } catch (error) {
+    const status = error instanceof EmbeddingDiscoveryError ? error.httpStatus : 500;
+    return c.json(embeddingDiscoveryErrorBody(error), status as any);
+  }
+});
+
+ai.post("/embeddings/test", async (c) => {
+  const userId = c.req.header("X-User-Id")!;
+  const body = await c.req.json().catch(() => ({})) as EmbeddingProbeInput;
+  try {
+    return c.json(await testEmbeddingModel(userId, body));
+  } catch (error) {
+    const status = error instanceof EmbeddingDiscoveryError ? error.httpStatus : 500;
+    return c.json(embeddingDiscoveryErrorBody(error), status as any);
+  }
 });
 
 // ===== AI 连接测试 =====

--- a/backend/src/services/embedding-config.ts
+++ b/backend/src/services/embedding-config.ts
@@ -18,7 +18,7 @@ export interface EmbeddingConfigResolution {
   error: string | null;
 }
 
-interface StoredAIProfile {
+export interface StoredAIProfile {
   id: string;
   name: string;
   provider: string;
@@ -28,7 +28,7 @@ interface StoredAIProfile {
 
 const OLLAMA_DOCKER_URL = process.env.OLLAMA_URL || "";
 
-function normalizeServiceUrl(provider: string, rawUrl: string): string {
+export function normalizeServiceUrl(provider: string, rawUrl: string): string {
   let url = rawUrl.trim().replace(/\/+$/, "");
   if (
     OLLAMA_DOCKER_URL
@@ -40,7 +40,7 @@ function normalizeServiceUrl(provider: string, rawUrl: string): string {
   return url;
 }
 
-function readProfiles(userId: string): StoredAIProfile[] {
+export function readProfiles(userId: string): StoredAIProfile[] {
   const raw = getUserAISetting(userId, "ai_profiles_v1");
   if (!raw) return [];
   try {

--- a/backend/src/services/embedding-model-discovery.ts
+++ b/backend/src/services/embedding-model-discovery.ts
@@ -1,0 +1,433 @@
+import { getUserAISettings } from "./user-ai-settings";
+import {
+  normalizeServiceUrl,
+  readProfiles,
+  type EmbeddingCredentialSource,
+} from "./embedding-config";
+
+export interface EmbeddingProbeInput {
+  source?: EmbeddingCredentialSource;
+  profileId?: string;
+  url?: string;
+  apiKey?: string;
+  model?: string;
+}
+
+export interface EmbeddingProbeConfig {
+  source: EmbeddingCredentialSource;
+  profileId: string | null;
+  profileName: string | null;
+  provider: string;
+  url: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface EmbeddingModelOption {
+  id: string;
+  name: string;
+  recommended: boolean;
+}
+
+export interface EmbeddingModelDiscoveryResult {
+  models: EmbeddingModelOption[];
+  source: EmbeddingCredentialSource;
+  endpoint: string;
+  discoveredCount: number;
+  filteredCount: number;
+}
+
+export interface EmbeddingTestResult {
+  success: true;
+  source: EmbeddingCredentialSource;
+  provider: string;
+  model: string;
+  dimension: number;
+  durationMs: number;
+}
+
+export class EmbeddingDiscoveryError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly httpStatus: number,
+    public readonly upstreamStatus: number | null = null,
+  ) {
+    super(message);
+    this.name = "EmbeddingDiscoveryError";
+  }
+}
+
+const DISCOVERY_TIMEOUT_MS = 12_000;
+const TEST_TIMEOUT_MS = 15_000;
+const POSITIVE_MODEL_RE = /(?:^|[-_/:.])(embed(?:ding)?|bge|e5|gte|text2vec|nomic-embed|mxbai-embed|arctic-embed|jina-embeddings?|voyage|multilingual-e5|sentence-transformers?)(?:$|[-_/:.])/i;
+const NEGATIVE_MODEL_RE = /(?:^|[-_/:.])(chat|instruct|vision|image|dall-e|whisper|tts|speech|audio|rerank|moderation|transcribe|claude|gemini-pro-vision|qwen-vl|llava)(?:$|[-_/:.])/i;
+const CHAT_FAMILY_RE = /^(?:gpt-|o[134](?:-|$)|deepseek-(?:chat|reasoner)|claude-|llama\d|mistral(?:-|$)|qwen(?:\d|[-_:])|gemma(?:\d|[-_:]))/i;
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveSource(settings: ReturnType<typeof getUserAISettings>, input: EmbeddingProbeInput): EmbeddingCredentialSource {
+  if (input.source === "chat" || input.source === "profile" || input.source === "custom") return input.source;
+  if (clean(input.profileId) || settings.ai_embedding_profile_id.trim()) return "profile";
+  if (clean(input.url) || clean(input.apiKey) || settings.ai_embedding_url.trim() || settings.ai_embedding_key.trim()) return "custom";
+  return "chat";
+}
+
+export function resolveEmbeddingProbeConfig(
+  userId: string,
+  input: EmbeddingProbeInput,
+  requireModel: boolean,
+): EmbeddingProbeConfig {
+  const settings = getUserAISettings(userId);
+  const source = resolveSource(settings, input);
+  const model = clean(input.model) || settings.ai_embedding_model.trim();
+
+  if (requireModel && !model) {
+    throw new EmbeddingDiscoveryError("EMBEDDING_MODEL_MISSING", "请先填写要测试的 Embedding 模型", 400);
+  }
+
+  if (source === "profile") {
+    const profileId = clean(input.profileId) || settings.ai_embedding_profile_id.trim();
+    if (!profileId) {
+      throw new EmbeddingDiscoveryError("EMBEDDING_PROFILE_REQUIRED", "请先选择 AI Profile", 400);
+    }
+    const profile = readProfiles(userId).find((item) => item.id === profileId);
+    if (!profile) {
+      throw new EmbeddingDiscoveryError(
+        "EMBEDDING_PROFILE_NOT_FOUND",
+        "绑定的 AI 配置已被删除，请重新选择 Embedding 服务",
+        400,
+      );
+    }
+    const url = normalizeServiceUrl(profile.provider, profile.apiUrl);
+    if (!url) {
+      throw new EmbeddingDiscoveryError(
+        "EMBEDDING_PROFILE_URL_MISSING",
+        `AI 配置“${profile.name}”没有可用的 API 地址`,
+        400,
+      );
+    }
+    return {
+      source,
+      profileId: profile.id,
+      profileName: profile.name,
+      provider: profile.provider,
+      url,
+      apiKey: profile.apiKey,
+      model,
+    };
+  }
+
+  if (source === "custom") {
+    const provider = settings.ai_provider.trim() || "openai";
+    const rawUrl = clean(input.url) || settings.ai_embedding_url.trim();
+    const url = normalizeServiceUrl(provider, rawUrl);
+    if (!url) {
+      throw new EmbeddingDiscoveryError("EMBEDDING_URL_MISSING", "请先填写 Embedding API 地址", 400);
+    }
+    const suppliedKey = clean(input.apiKey);
+    const apiKey = suppliedKey && !suppliedKey.includes("****")
+      ? suppliedKey
+      : settings.ai_embedding_key.trim();
+    return {
+      source,
+      profileId: null,
+      profileName: null,
+      provider,
+      url,
+      apiKey,
+      model,
+    };
+  }
+
+  const provider = settings.ai_provider.trim() || "openai";
+  const url = normalizeServiceUrl(provider, settings.ai_api_url);
+  if (!url) {
+    throw new EmbeddingDiscoveryError("EMBEDDING_URL_MISSING", "当前对话配置没有可用的 API 地址", 400);
+  }
+  return {
+    source: "chat",
+    profileId: null,
+    profileName: null,
+    provider,
+    url,
+    apiKey: settings.ai_api_key.trim(),
+    model,
+  };
+}
+
+function requestHeaders(config: EmbeddingProbeConfig): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+    if (config.provider === "gemini") headers["x-goog-api-key"] = config.apiKey;
+  }
+  return headers;
+}
+
+function modelEndpoint(url: string): string {
+  const base = url.replace(/\/+$/, "");
+  return /\/models$/i.test(base) ? base : `${base}/models`;
+}
+
+function modelRows(data: unknown): unknown[] {
+  if (Array.isArray(data)) return data;
+  if (!data || typeof data !== "object") return [];
+  const record = data as Record<string, unknown>;
+  if (Array.isArray(record.data)) return record.data;
+  if (Array.isArray(record.models)) return record.models;
+  return [];
+}
+
+function capabilityText(row: Record<string, unknown>): string {
+  const values = [row.type, row.object, row.task, row.category, row.capability, row.capabilities];
+  return values.map((value) => {
+    if (Array.isArray(value)) return value.join(" ");
+    if (value && typeof value === "object") return Object.entries(value as Record<string, unknown>)
+      .filter(([, enabled]) => enabled === true || enabled === "true")
+      .map(([key]) => key)
+      .join(" ");
+    return String(value || "");
+  }).join(" ").toLowerCase();
+}
+
+function classifyModel(row: unknown): EmbeddingModelOption | null {
+  const record = row && typeof row === "object" ? row as Record<string, unknown> : {};
+  const id = typeof row === "string"
+    ? row.trim()
+    : clean(record.id) || clean(record.name) || clean(record.model);
+  if (!id) return null;
+  const name = typeof row === "string"
+    ? id
+    : clean(record.display_name) || clean(record.displayName) || clean(record.name) || id;
+  const metadata = capabilityText(record);
+  const positive = POSITIVE_MODEL_RE.test(id) || /(?:embedding|embeddings|feature-extraction|sentence-similarity)/i.test(metadata);
+  const negative = NEGATIVE_MODEL_RE.test(id)
+    || CHAT_FAMILY_RE.test(id)
+    || /(?:chat|vision|image|audio|speech|rerank|generation)/i.test(metadata);
+  if (negative && !positive) return null;
+  return { id, name, recommended: positive };
+}
+
+function extractEmbeddingModels(data: unknown): {
+  models: EmbeddingModelOption[];
+  discoveredCount: number;
+  filteredCount: number;
+} {
+  const rows = modelRows(data);
+  const seen = new Set<string>();
+  const models: EmbeddingModelOption[] = [];
+  for (const row of rows) {
+    const model = classifyModel(row);
+    if (!model || seen.has(model.id)) continue;
+    seen.add(model.id);
+    models.push(model);
+  }
+  models.sort((a, b) => Number(b.recommended) - Number(a.recommended) || a.name.localeCompare(b.name));
+  return {
+    models,
+    discoveredCount: rows.length,
+    filteredCount: Math.max(0, rows.length - models.length),
+  };
+}
+
+function timeoutError(error: unknown): boolean {
+  const name = error && typeof error === "object" ? String((error as { name?: unknown }).name || "") : "";
+  const message = error instanceof Error ? error.message : String(error || "");
+  return name === "AbortError" || name === "TimeoutError" || /timeout|timed out/i.test(message);
+}
+
+function upstreamError(status: number, detail: string, action: "discover" | "test"): EmbeddingDiscoveryError {
+  if (status === 401 || status === 403) {
+    return new EmbeddingDiscoveryError(
+      "EMBEDDING_AUTH_FAILED",
+      "Embedding 服务认证失败，请检查 API Key 或 Profile 权限",
+      502,
+      status,
+    );
+  }
+  if (status === 404) {
+    return new EmbeddingDiscoveryError(
+      action === "test" ? "EMBEDDING_ENDPOINT_NOT_FOUND" : "EMBEDDING_MODELS_ENDPOINT_NOT_FOUND",
+      action === "test"
+        ? "服务未提供 /embeddings 接口，请检查 API 地址或兼容模式"
+        : "服务未提供模型列表接口，请手动填写 Embedding 模型",
+      502,
+      status,
+    );
+  }
+  return new EmbeddingDiscoveryError(
+    action === "test" ? "EMBEDDING_TEST_FAILED" : "EMBEDDING_MODEL_DISCOVERY_FAILED",
+    `Embedding 服务返回 HTTP ${status}${detail ? `：${detail.slice(0, 180)}` : ""}`,
+    502,
+    status,
+  );
+}
+
+export async function discoverEmbeddingModels(
+  userId: string,
+  input: EmbeddingProbeInput,
+): Promise<EmbeddingModelDiscoveryResult> {
+  const config = resolveEmbeddingProbeConfig(userId, input, false);
+  const candidates = config.provider === "ollama"
+    ? [
+        `${config.url.replace(/\/+$/, "").replace(/\/v1$/i, "")}/api/tags`,
+        modelEndpoint(config.url),
+      ]
+    : [modelEndpoint(config.url)];
+  const failures: EmbeddingDiscoveryError[] = [];
+
+  for (const endpoint of Array.from(new Set(candidates))) {
+    try {
+      const response = await fetch(endpoint, {
+        headers: requestHeaders(config),
+        signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        failures.push(upstreamError(response.status, await response.text().catch(() => ""), "discover"));
+        continue;
+      }
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch {
+        failures.push(new EmbeddingDiscoveryError(
+          "EMBEDDING_MODELS_RESPONSE_INVALID",
+          "模型列表接口返回了无法解析的响应，请手动填写模型",
+          502,
+          response.status,
+        ));
+        continue;
+      }
+      const extracted = extractEmbeddingModels(data);
+      if (extracted.discoveredCount === 0) {
+        failures.push(new EmbeddingDiscoveryError(
+          "EMBEDDING_MODELS_EMPTY",
+          "模型列表接口没有返回可识别的模型，请手动填写模型",
+          502,
+          response.status,
+        ));
+        continue;
+      }
+      return { ...extracted, source: config.source, endpoint };
+    } catch (error) {
+      if (error instanceof EmbeddingDiscoveryError) {
+        failures.push(error);
+      } else if (timeoutError(error)) {
+        failures.push(new EmbeddingDiscoveryError(
+          "EMBEDDING_DISCOVERY_TIMEOUT",
+          "刷新模型列表超时，请检查服务地址和网络",
+          504,
+        ));
+      } else {
+        failures.push(new EmbeddingDiscoveryError(
+          "EMBEDDING_MODEL_DISCOVERY_FAILED",
+          error instanceof Error ? error.message : "模型列表请求失败",
+          502,
+        ));
+      }
+    }
+  }
+
+  throw failures[failures.length - 1] || new EmbeddingDiscoveryError(
+    "EMBEDDING_MODEL_DISCOVERY_FAILED",
+    "无法获取模型列表，请手动填写模型",
+    502,
+  );
+}
+
+function extractVector(data: unknown): number[] | null {
+  if (!data || typeof data !== "object") return null;
+  const rows = (data as { data?: unknown }).data;
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const first = rows[0];
+  if (!first || typeof first !== "object") return null;
+  const vector = (first as { embedding?: unknown }).embedding;
+  if (!Array.isArray(vector) || vector.length === 0) return null;
+  if (!vector.every((value) => typeof value === "number" && Number.isFinite(value))) return null;
+  return vector as number[];
+}
+
+export async function testEmbeddingModel(
+  userId: string,
+  input: EmbeddingProbeInput,
+): Promise<EmbeddingTestResult> {
+  const config = resolveEmbeddingProbeConfig(userId, input, true);
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(`${config.url.replace(/\/+$/, "")}/embeddings`, {
+      method: "POST",
+      headers: {
+        ...requestHeaders(config),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: config.model,
+        input: ["Nowen Note embedding connectivity test."],
+      }),
+      signal: AbortSignal.timeout(TEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw upstreamError(response.status, await response.text().catch(() => ""), "test");
+    }
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new EmbeddingDiscoveryError(
+        "EMBEDDING_RESPONSE_INVALID",
+        "/embeddings 返回了无法解析的 JSON",
+        502,
+        response.status,
+      );
+    }
+    const vector = extractVector(data);
+    if (!vector) {
+      throw new EmbeddingDiscoveryError(
+        "EMBEDDING_RESPONSE_INVALID",
+        "/embeddings 响应缺少有效的 data[0].embedding 数组",
+        502,
+        response.status,
+      );
+    }
+    return {
+      success: true,
+      source: config.source,
+      provider: config.provider,
+      model: config.model,
+      dimension: vector.length,
+      durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+    };
+  } catch (error) {
+    if (error instanceof EmbeddingDiscoveryError) throw error;
+    if (timeoutError(error)) {
+      throw new EmbeddingDiscoveryError(
+        "EMBEDDING_TEST_TIMEOUT",
+        "测试 Embedding 模型超时，请检查服务状态、模型名称和网络",
+        504,
+      );
+    }
+    throw new EmbeddingDiscoveryError(
+      "EMBEDDING_TEST_FAILED",
+      error instanceof Error ? error.message : "Embedding 连通性测试失败",
+      502,
+    );
+  }
+}
+
+export function embeddingDiscoveryErrorBody(error: unknown): {
+  error: string;
+  code: string;
+  upstreamStatus: number | null;
+} {
+  if (error instanceof EmbeddingDiscoveryError) {
+    return { error: error.message, code: error.code, upstreamStatus: error.upstreamStatus };
+  }
+  return {
+    error: error instanceof Error ? error.message : "Embedding 请求失败",
+    code: "EMBEDDING_REQUEST_FAILED",
+    upstreamStatus: null,
+  };
+}

--- a/backend/tests/embedding-model-discovery.test.ts
+++ b/backend/tests/embedding-model-discovery.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-embedding-discovery-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+let db: Database.Database;
+let closeDb: () => void;
+let app: Hono;
+let setUserAISettings: typeof import("../src/services/user-ai-settings").setUserAISettings;
+const USER_ID = "embedding-discovery-user";
+
+async function request(pathname: string, body: unknown) {
+  const response = await app.request(pathname, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": USER_ID,
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() as any };
+}
+
+test.before(async () => {
+  const [schema, routes, settings] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/routes/ai"),
+    import("../src/services/user-ai-settings"),
+  ]);
+  db = schema.getDb();
+  closeDb = schema.closeDb;
+  setUserAISettings = settings.setUserAISettings;
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+  app = new Hono();
+  app.route("/ai", routes.default);
+});
+
+test.beforeEach(() => {
+  db.prepare("DELETE FROM user_ai_settings WHERE userId = ?").run(USER_ID);
+});
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("discovers models with a saved profile and filters obvious chat/image/audio models", async () => {
+  setUserAISettings(USER_ID, [{
+    key: "ai_profiles_v1",
+    value: JSON.stringify([{
+      id: "profile-embed",
+      name: "Embedding Provider",
+      provider: "openai",
+      apiUrl: "https://models.example/v1",
+      apiKey: "profile-secret",
+      model: "chat-model",
+    }]),
+  }]);
+
+  const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
+  let authorization = "";
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    requestedUrl = String(input);
+    authorization = new Headers(init?.headers).get("authorization") || "";
+    return new Response(JSON.stringify({
+      data: [
+        { id: "text-embedding-3-small" },
+        { id: "bge-m3", task: "feature-extraction" },
+        { id: "acme-semantic-v1" },
+        { id: "gpt-4o" },
+        { id: "dall-e-3" },
+        { id: "whisper-1" },
+      ],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    const result = await request("/ai/embeddings/models", {
+      source: "profile",
+      profileId: "profile-embed",
+    });
+    assert.equal(result.status, 200);
+    assert.equal(requestedUrl, "https://models.example/v1/models");
+    assert.equal(authorization, "Bearer profile-secret");
+    assert.deepEqual(result.body.models.map((model: any) => model.id), [
+      "bge-m3",
+      "text-embedding-3-small",
+      "acme-semantic-v1",
+    ]);
+    assert.equal(result.body.models[0].recommended, true);
+    assert.equal(result.body.models[2].recommended, false);
+    assert.equal(result.body.filteredCount, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("uses Ollama native tags and excludes obvious chat models", async () => {
+  setUserAISettings(USER_ID, [
+    { key: "ai_provider", value: "ollama" },
+    { key: "ai_api_url", value: "http://ollama.local:11434/v1" },
+  ]);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    assert.equal(String(input), "http://ollama.local:11434/api/tags");
+    return new Response(JSON.stringify({
+      models: [
+        { name: "nomic-embed-text:latest" },
+        { name: "mxbai-embed-large" },
+        { name: "llama3.2:latest" },
+      ],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    const result = await request("/ai/embeddings/models", { source: "chat" });
+    assert.equal(result.status, 200);
+    assert.deepEqual(result.body.models.map((model: any) => model.id), [
+      "mxbai-embed-large",
+      "nomic-embed-text:latest",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("tests /embeddings and returns vector dimension and duration", async () => {
+  setUserAISettings(USER_ID, [
+    { key: "ai_provider", value: "openai" },
+    { key: "ai_embedding_url", value: "https://embedding.example/v1" },
+    { key: "ai_embedding_key", value: "stored-secret" },
+  ]);
+  const originalFetch = globalThis.fetch;
+  let requestBody: any;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(String(input), "https://embedding.example/v1/embeddings");
+    assert.equal(new Headers(init?.headers).get("authorization"), "Bearer stored-secret");
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({
+      data: [{ index: 0, embedding: [0.1, 0.2, 0.3, 0.4] }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    const result = await request("/ai/embeddings/test", {
+      source: "custom",
+      url: "https://embedding.example/v1",
+      model: "text-embedding-3-small",
+    });
+    assert.equal(result.status, 200);
+    assert.equal(result.body.success, true);
+    assert.equal(result.body.dimension, 4);
+    assert.equal(result.body.model, "text-embedding-3-small");
+    assert.ok(result.body.durationMs >= 0);
+    assert.deepEqual(requestBody, {
+      model: "text-embedding-3-small",
+      input: ["Nowen Note embedding connectivity test."],
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("reports authentication and endpoint errors with explicit codes", async () => {
+  setUserAISettings(USER_ID, [
+    { key: "ai_provider", value: "openai" },
+    { key: "ai_api_url", value: "https://errors.example/v1" },
+    { key: "ai_api_key", value: "bad-key" },
+  ]);
+  const originalFetch = globalThis.fetch;
+  let status = 401;
+  globalThis.fetch = (async () => new Response("upstream error", { status })) as typeof fetch;
+
+  try {
+    const auth = await request("/ai/embeddings/test", {
+      source: "chat",
+      model: "text-embedding-3-small",
+    });
+    assert.equal(auth.status, 502);
+    assert.equal(auth.body.code, "EMBEDDING_AUTH_FAILED");
+    assert.equal(auth.body.upstreamStatus, 401);
+
+    status = 404;
+    const missing = await request("/ai/embeddings/test", {
+      source: "chat",
+      model: "text-embedding-3-small",
+    });
+    assert.equal(missing.status, 502);
+    assert.equal(missing.body.code, "EMBEDDING_ENDPOINT_NOT_FOUND");
+    assert.equal(missing.body.upstreamStatus, 404);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("reports timeouts and malformed embedding responses", async () => {
+  setUserAISettings(USER_ID, [
+    { key: "ai_provider", value: "openai" },
+    { key: "ai_api_url", value: "https://timeout.example/v1" },
+  ]);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  }) as typeof fetch;
+
+  try {
+    const timeout = await request("/ai/embeddings/test", {
+      source: "chat",
+      model: "text-embedding-3-small",
+    });
+    assert.equal(timeout.status, 504);
+    assert.equal(timeout.body.code, "EMBEDDING_TEST_TIMEOUT");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  globalThis.fetch = (async () => new Response(JSON.stringify({ data: [{ index: 0 }] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })) as typeof fetch;
+  try {
+    const malformed = await request("/ai/embeddings/test", {
+      source: "chat",
+      model: "text-embedding-3-small",
+    });
+    assert.equal(malformed.status, 502);
+    assert.equal(malformed.body.code, "EMBEDDING_RESPONSE_INVALID");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/frontend/src/components/EmbeddingSettingsPanel.tsx
+++ b/frontend/src/components/EmbeddingSettingsPanel.tsx
@@ -7,8 +7,10 @@ import {
   EyeOff,
   KeyRound,
   Layers3,
+  ListFilter,
   Loader2,
   MessageSquare,
+  PlugZap,
   RefreshCw,
   RotateCcw,
   Save,
@@ -18,6 +20,13 @@ import {
 import { api, getBaseUrl, getCurrentWorkspace } from "@/lib/api";
 import { aiProfiles, type AIProfile } from "@/lib/aiProfiles";
 import { getReliableAIStatus, type ReliableStatus } from "@/lib/aiReliable";
+import {
+  discoverEmbeddingModels,
+  mergeEmbeddingModelOptions,
+  testEmbeddingModel,
+  type EmbeddingModelOption,
+  type EmbeddingTestResult,
+} from "@/lib/embeddingModelDiscovery";
 import {
   buildEmbeddingSettingsPayload,
   inferEmbeddingCredentialSource,
@@ -92,6 +101,18 @@ function getCopy() {
       savedKey: "Dedicated key saved (leave empty to keep it)",
       modelPlaceholder: "For example: text-embedding-3-small",
       examples: "Common examples; use a model supported by your provider:",
+      discoverModels: "Refresh models",
+      discoveringModels: "Refreshing…",
+      testModel: "Test embedding model",
+      testingModel: "Testing…",
+      discoveredModels: "Discovered models",
+      recommended: "recommended",
+      noEmbeddingModels: "No likely embedding models were found. You can still enter a model name manually.",
+      modelsFound: (count: number, recommended: number) => `Found ${count} candidate models (${recommended} recommended).`,
+      testSucceeded: (dimension: number, durationMs: number) => `Embedding test passed: ${dimension} dimensions · ${durationMs} ms.`,
+      modelRequired: "Enter an embedding model before testing.",
+      discoverFailed: "Failed to refresh embedding models",
+      testFailed: "Embedding model test failed",
       save: "Save embedding settings",
       rebuild: "Rebuild vector index",
       refresh: "Refresh status",
@@ -146,6 +167,18 @@ function getCopy() {
     savedKey: "已保存独立密钥（留空不修改）",
     modelPlaceholder: "例如：text-embedding-3-small",
     examples: "常用示例，请以服务商实际支持的模型为准：",
+    discoverModels: "刷新模型列表",
+    discoveringModels: "正在刷新…",
+    testModel: "测试 Embedding 模型",
+    testingModel: "正在测试…",
+    discoveredModels: "发现的模型",
+    recommended: "推荐",
+    noEmbeddingModels: "未发现疑似 Embedding 模型，仍可手动填写模型名称。",
+    modelsFound: (count: number, recommended: number) => `发现 ${count} 个候选模型，其中 ${recommended} 个推荐。`,
+    testSucceeded: (dimension: number, durationMs: number) => `Embedding 测试成功：${dimension} 维 · ${durationMs} 毫秒。`,
+    modelRequired: "请先填写要测试的 Embedding 模型。",
+    discoverFailed: "刷新 Embedding 模型失败",
+    testFailed: "Embedding 模型测试失败",
     save: "保存 Embedding 配置",
     rebuild: "重建向量索引",
     refresh: "刷新状态",
@@ -203,6 +236,10 @@ export default function EmbeddingSettingsPanel() {
   const [statusLoading, setStatusLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [discoveredModels, setDiscoveredModels] = useState<EmbeddingModelOption[]>([]);
+  const [testResult, setTestResult] = useState<EmbeddingTestResult | null>(null);
   const [showKey, setShowKey] = useState(false);
   const [message, setMessage] = useState<EmbeddingMessage | null>(null);
 
@@ -237,6 +274,8 @@ export default function EmbeddingSettingsPanel() {
         keySet: !!settings.ai_embedding_key_set,
         model: settings.ai_embedding_model || "",
       });
+      setDiscoveredModels([]);
+      setTestResult(null);
       if (source === "profile" && profileId && !nextProfiles.some((profile) => profile.id === profileId)) {
         setMessage({ type: "warning", text: copy.profileMissingWarning });
       }
@@ -264,6 +303,15 @@ export default function EmbeddingSettingsPanel() {
 
   const selectedProfile = profiles.find((profile) => profile.id === draft.profileId) || null;
   const profileMissing = draft.source === "profile" && !!draft.profileId && !selectedProfile;
+  const modelOptions = useMemo(
+    () => mergeEmbeddingModelOptions(MODEL_SUGGESTIONS, discoveredModels),
+    [discoveredModels],
+  );
+
+  const clearProbeState = () => {
+    setDiscoveredModels([]);
+    setTestResult(null);
+  };
 
   const chooseSource = (source: EmbeddingCredentialSource) => {
     setDraft((current) => ({
@@ -271,7 +319,57 @@ export default function EmbeddingSettingsPanel() {
       source,
       profileId: source === "profile" ? current.profileId || profiles[0]?.id || "" : current.profileId,
     }));
+    clearProbeState();
     setMessage(null);
+  };
+
+  const refreshModels = async () => {
+    if (draft.source === "profile" && !draft.profileId) {
+      setMessage({ type: "warning", text: copy.profileRequired });
+      return;
+    }
+    setDiscovering(true);
+    setMessage(null);
+    setTestResult(null);
+    try {
+      const result = await discoverEmbeddingModels(draft);
+      setDiscoveredModels(result.models);
+      const recommendedCount = result.models.filter((model) => model.recommended).length;
+      setMessage({
+        type: result.models.length > 0 ? "success" : "warning",
+        text: result.models.length > 0
+          ? copy.modelsFound(result.models.length, recommendedCount)
+          : copy.noEmbeddingModels,
+      });
+    } catch (error) {
+      setDiscoveredModels([]);
+      setMessage({ type: "error", text: (error as Error)?.message || copy.discoverFailed });
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const runEmbeddingTest = async () => {
+    if (draft.source === "profile" && !draft.profileId) {
+      setMessage({ type: "warning", text: copy.profileRequired });
+      return;
+    }
+    if (!draft.model.trim()) {
+      setMessage({ type: "warning", text: copy.modelRequired });
+      return;
+    }
+    setTesting(true);
+    setMessage(null);
+    setTestResult(null);
+    try {
+      const result = await testEmbeddingModel(draft);
+      setTestResult(result);
+      setMessage({ type: "success", text: copy.testSucceeded(result.dimension, result.durationMs) });
+    } catch (error) {
+      setMessage({ type: "error", text: (error as Error)?.message || copy.testFailed });
+    } finally {
+      setTesting(false);
+    }
   };
 
   const saveSettings = async () => {
@@ -425,7 +523,11 @@ export default function EmbeddingSettingsPanel() {
                 <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{copy.profileTitle}</span>
                 <select
                   value={draft.profileId}
-                  onChange={(event) => setDraft((current) => ({ ...current, profileId: event.target.value }))}
+                  onChange={(event) => {
+                    setDraft((current) => ({ ...current, profileId: event.target.value }));
+                    clearProbeState();
+                    setMessage(null);
+                  }}
                   className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2.5 text-sm outline-none transition focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 dark:border-zinc-700 dark:bg-zinc-900"
                 >
                   <option value="">{profiles.length ? copy.selectProfile : copy.noProfiles}</option>
@@ -458,7 +560,10 @@ export default function EmbeddingSettingsPanel() {
                 </span>
                 <input
                   value={draft.url}
-                  onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))}
+                  onChange={(event) => {
+                    setDraft((current) => ({ ...current, url: event.target.value }));
+                    clearProbeState();
+                  }}
                   placeholder={copy.urlPlaceholder}
                   className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2.5 text-sm outline-none transition placeholder:text-zinc-400 focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 dark:border-zinc-700 dark:bg-zinc-900"
                 />
@@ -472,7 +577,10 @@ export default function EmbeddingSettingsPanel() {
                   <input
                     type={showKey ? "text" : "password"}
                     value={draft.key}
-                    onChange={(event) => setDraft((current) => ({ ...current, key: event.target.value }))}
+                    onChange={(event) => {
+                      setDraft((current) => ({ ...current, key: event.target.value }));
+                      clearProbeState();
+                    }}
                     placeholder={draft.keySet ? copy.savedKey : copy.keyPlaceholder}
                     className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2.5 pr-10 text-sm outline-none transition placeholder:text-zinc-400 focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 dark:border-zinc-700 dark:bg-zinc-900"
                   />
@@ -492,13 +600,16 @@ export default function EmbeddingSettingsPanel() {
             <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{copy.embeddingModel}</span>
             <input
               value={draft.model}
-              onChange={(event) => setDraft((current) => ({ ...current, model: event.target.value }))}
+              onChange={(event) => {
+                setDraft((current) => ({ ...current, model: event.target.value }));
+                setTestResult(null);
+              }}
               placeholder={copy.modelPlaceholder}
               list="nowen-embedding-model-suggestions"
               className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2.5 text-sm outline-none transition placeholder:text-zinc-400 focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 dark:border-zinc-700 dark:bg-zinc-900"
             />
             <datalist id="nowen-embedding-model-suggestions">
-              {MODEL_SUGGESTIONS.map((model) => <option key={model} value={model} />)}
+              {modelOptions.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
             </datalist>
             <div className="flex flex-wrap items-center gap-1.5 pt-1 text-[10px] text-zinc-400">
               <span>{copy.examples}</span>
@@ -506,13 +617,60 @@ export default function EmbeddingSettingsPanel() {
                 <button
                   key={model}
                   type="button"
-                  onClick={() => setDraft((current) => ({ ...current, model }))}
+                  onClick={() => {
+                    setDraft((current) => ({ ...current, model }));
+                    setTestResult(null);
+                  }}
                   className="rounded-full border border-zinc-200 px-2 py-1 font-mono text-zinc-500 transition hover:border-accent-primary/40 hover:text-accent-primary dark:border-zinc-700 dark:text-zinc-400"
                 >
                   {model}
                 </button>
               ))}
             </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void refreshModels()}
+                disabled={discovering || testing || busy || profileMissing}
+                className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 py-2 text-xs font-medium text-zinc-600 transition hover:border-accent-primary/40 hover:text-accent-primary disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300"
+              >
+                {discovering ? <Loader2 size={13} className="animate-spin" /> : <ListFilter size={13} />}
+                {discovering ? copy.discoveringModels : copy.discoverModels}
+              </button>
+              <button
+                type="button"
+                onClick={() => void runEmbeddingTest()}
+                disabled={discovering || testing || busy || profileMissing || !draft.model.trim()}
+                className="inline-flex min-h-9 items-center gap-1.5 rounded-lg border border-violet-500/30 px-3 py-2 text-xs font-medium text-violet-600 transition hover:bg-violet-500/5 disabled:opacity-50 dark:text-violet-400"
+              >
+                {testing ? <Loader2 size={13} className="animate-spin" /> : <PlugZap size={13} />}
+                {testing ? copy.testingModel : copy.testModel}
+              </button>
+              {discoveredModels.length > 0 && (
+                <select
+                  value=""
+                  onChange={(event) => {
+                    if (!event.target.value) return;
+                    setDraft((current) => ({ ...current, model: event.target.value }));
+                    setTestResult(null);
+                  }}
+                  className="min-h-9 min-w-52 flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs outline-none transition focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 dark:border-zinc-700 dark:bg-zinc-900"
+                >
+                  <option value="">{copy.discoveredModels} · {discoveredModels.length}</option>
+                  {discoveredModels.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.recommended ? "★ " + model.name + " · " + copy.recommended : model.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+            {testResult && (
+              <div className="mt-2 inline-flex items-center gap-1.5 rounded-lg bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+                <CheckCircle2 size={13} />
+                <span>{testResult.dimension} {copy.dimension} · {testResult.durationMs} ms · {testResult.provider}</span>
+              </div>
+            )}
           </label>
 
           <div className="mt-5 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">

--- a/frontend/src/lib/__tests__/embeddingModelDiscovery.test.ts
+++ b/frontend/src/lib/__tests__/embeddingModelDiscovery.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildEmbeddingProbePayload,
+  discoverEmbeddingModels,
+  mergeEmbeddingModelOptions,
+  testEmbeddingModel,
+} from "../embeddingModelDiscovery";
+
+vi.mock("@/lib/api", () => ({
+  getBaseUrl: () => "https://nowen.test/api",
+}));
+
+describe("embedding model discovery client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("builds profile payloads without copying profile secrets", () => {
+    expect(buildEmbeddingProbePayload({
+      source: "profile",
+      profileId: " profile-1 ",
+      url: "https://ignored.example/v1",
+      key: "ignored-secret",
+      model: " bge-m3 ",
+    })).toEqual({
+      source: "profile",
+      profileId: "profile-1",
+      model: "bge-m3",
+    });
+  });
+
+  it("sends only newly typed custom credentials", () => {
+    expect(buildEmbeddingProbePayload({
+      source: "custom",
+      profileId: "",
+      url: " https://embedding.example/v1/ ",
+      key: "new-secret",
+      model: "text-embedding-3-small",
+    })).toEqual({
+      source: "custom",
+      url: "https://embedding.example/v1/",
+      apiKey: "new-secret",
+      model: "text-embedding-3-small",
+    });
+
+    expect(buildEmbeddingProbePayload({
+      source: "custom",
+      profileId: "",
+      url: "https://embedding.example/v1",
+      key: "sk-****1234",
+      model: "",
+    })).toEqual({
+      source: "custom",
+      url: "https://embedding.example/v1",
+    });
+  });
+
+  it("deduplicates defaults and discovered models while keeping recommendations first", () => {
+    expect(mergeEmbeddingModelOptions(
+      ["text-embedding-3-small", "bge-m3"],
+      [
+        { id: "acme-semantic", name: "Acme Semantic", recommended: false },
+        { id: "bge-m3", name: "BGE M3", recommended: true },
+      ],
+    )).toEqual([
+      { id: "bge-m3", name: "BGE M3", recommended: true },
+      { id: "text-embedding-3-small", name: "text-embedding-3-small", recommended: true },
+      { id: "acme-semantic", name: "Acme Semantic", recommended: false },
+    ]);
+  });
+
+  it("calls discovery and test endpoints with auth and exposes errors", async () => {
+    localStorage.setItem("nowen-token", "token-1");
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        models: [{ id: "bge-m3", name: "bge-m3", recommended: true }],
+        source: "profile",
+        endpoint: "https://models.example/v1/models",
+        discoveredCount: 3,
+        filteredCount: 2,
+      }), { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        success: true,
+        source: "profile",
+        provider: "openai",
+        model: "bge-m3",
+        dimension: 1024,
+        durationMs: 86,
+      }), { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "认证失败",
+        code: "EMBEDDING_AUTH_FAILED",
+        upstreamStatus: 401,
+      }), { status: 502, headers: { "content-type": "application/json" } }));
+
+    const draft = {
+      source: "profile" as const,
+      profileId: "profile-1",
+      url: "",
+      key: "",
+      model: "bge-m3",
+    };
+    const models = await discoverEmbeddingModels(draft);
+    const tested = await testEmbeddingModel(draft);
+    expect(models.models[0].id).toBe("bge-m3");
+    expect(tested.dimension).toBe(1024);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://nowen.test/api/ai/embeddings/models");
+    expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get("authorization")).toBe("Bearer token-1");
+
+    await expect(testEmbeddingModel(draft)).rejects.toMatchObject({
+      message: "认证失败",
+      code: "EMBEDDING_AUTH_FAILED",
+      upstreamStatus: 401,
+      status: 502,
+    });
+  });
+});

--- a/frontend/src/lib/embeddingModelDiscovery.ts
+++ b/frontend/src/lib/embeddingModelDiscovery.ts
@@ -1,0 +1,124 @@
+import { getBaseUrl } from "@/lib/api";
+import type { EmbeddingCredentialSource } from "@/lib/embeddingProfileSelection";
+
+export interface EmbeddingProbeDraft {
+  source: EmbeddingCredentialSource;
+  profileId: string;
+  url: string;
+  key: string;
+  model: string;
+}
+
+export interface EmbeddingProbePayload {
+  source: EmbeddingCredentialSource;
+  profileId?: string;
+  url?: string;
+  apiKey?: string;
+  model?: string;
+}
+
+export interface EmbeddingModelOption {
+  id: string;
+  name: string;
+  recommended: boolean;
+}
+
+export interface EmbeddingModelDiscoveryResult {
+  models: EmbeddingModelOption[];
+  source: EmbeddingCredentialSource;
+  endpoint: string;
+  discoveredCount: number;
+  filteredCount: number;
+}
+
+export interface EmbeddingTestResult {
+  success: true;
+  source: EmbeddingCredentialSource;
+  provider: string;
+  model: string;
+  dimension: number;
+  durationMs: number;
+}
+
+export interface EmbeddingRequestError extends Error {
+  code?: string;
+  upstreamStatus?: number | null;
+  status?: number;
+}
+
+export function buildEmbeddingProbePayload(draft: EmbeddingProbeDraft): EmbeddingProbePayload {
+  const payload: EmbeddingProbePayload = { source: draft.source };
+  if (draft.source === "profile" && draft.profileId.trim()) {
+    payload.profileId = draft.profileId.trim();
+  }
+  if (draft.source === "custom") {
+    if (draft.url.trim()) payload.url = draft.url.trim();
+    if (draft.key.trim() && !draft.key.includes("****")) payload.apiKey = draft.key.trim();
+  }
+  if (draft.model.trim()) payload.model = draft.model.trim();
+  return payload;
+}
+
+export function mergeEmbeddingModelOptions(
+  defaults: string[],
+  discovered: EmbeddingModelOption[],
+): EmbeddingModelOption[] {
+  const byId = new Map<string, EmbeddingModelOption>();
+  for (const id of defaults) {
+    const clean = id.trim();
+    if (!clean) continue;
+    byId.set(clean, { id: clean, name: clean, recommended: true });
+  }
+  for (const model of discovered) {
+    const id = model.id.trim();
+    if (!id) continue;
+    const current = byId.get(id);
+    byId.set(id, {
+      id,
+      name: model.name.trim() || current?.name || id,
+      recommended: !!model.recommended || !!current?.recommended,
+    });
+  }
+  return [...byId.values()].sort(
+    (a, b) => Number(b.recommended) - Number(a.recommended) || a.name.localeCompare(b.name),
+  );
+}
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("nowen-token") || "";
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function request<T>(path: string, payload: EmbeddingProbePayload): Promise<T> {
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(body?.error || `请求失败: ${response.status}`) as EmbeddingRequestError;
+    error.code = body?.code;
+    error.upstreamStatus = body?.upstreamStatus ?? null;
+    error.status = response.status;
+    throw error;
+  }
+  return body as T;
+}
+
+export function discoverEmbeddingModels(draft: EmbeddingProbeDraft): Promise<EmbeddingModelDiscoveryResult> {
+  return request<EmbeddingModelDiscoveryResult>(
+    "/ai/embeddings/models",
+    buildEmbeddingProbePayload(draft),
+  );
+}
+
+export function testEmbeddingModel(draft: EmbeddingProbeDraft): Promise<EmbeddingTestResult> {
+  return request<EmbeddingTestResult>(
+    "/ai/embeddings/test",
+    buildEmbeddingProbePayload(draft),
+  );
+}


### PR DESCRIPTION
## Summary

- add Embedding model discovery for current chat config, saved AI Profiles, and custom Embedding services
- reuse OpenAI-compatible `/models` and Ollama `/api/tags` endpoints
- filter obvious chat, image, audio, speech, rerank, and generation models from default candidates
- keep manual model input available when discovery is unsupported or returns no useful candidates
- add a real `/embeddings` connectivity test that reports vector dimension and latency
- return explicit error codes for authentication failure, missing endpoints, timeout, and malformed responses
- never copy a saved Profile API key into the browser payload; the backend resolves it by Profile ID
- add frontend and backend regression tests

## Verification

- backend Embedding model discovery and probe tests passed
- saved Profile, custom service, Ollama `/api/tags`, model filtering, dimension and latency responses were covered
- 401/403, 404, timeout, and malformed response diagnostics were covered
- backend TypeScript build passed
- frontend payload, deduplication, API request, and error propagation tests passed
- frontend TypeScript validation found no errors in the Embedding changes; only the two existing `tiptapListItemStructurePlanner.ts` baseline errors remained
- branch was replayed onto the latest `main`; the 11 concurrent commits changed no files in this PR
- temporary patch and verification files were removed before merge

Closes #413