### PR TITLE
feat(images): 历史笔记网络图片批量本地化

### DIFF
--- a/.github/workflows/remote-image-localization-ci.yml
+++ b/.github/workflows/remote-image-localization-ci.yml
@@ -1,0 +1,86 @@
+name: Remote Image Localization CI
+
+on:
+  push:
+    branches:
+      - main
+      - issue-346-remote-image-localization
+    paths:
+      - "backend/src/lib/remote-image-localization.ts"
+      - "backend/src/services/remote-image-import.ts"
+      - "backend/src/services/remote-image-localization*.ts"
+      - "backend/src/routes/remote-image-import.ts"
+      - "backend/tests/remote-image-localization*.test.ts"
+      - "frontend/src/lib/remoteImageLocalizationApi.ts"
+      - "frontend/src/components/RemoteImageLocalizationPanel.tsx"
+      - "frontend/src/components/TaskCenter.tsx"
+      - ".github/workflows/remote-image-localization-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/lib/remote-image-localization.ts"
+      - "backend/src/services/remote-image-import.ts"
+      - "backend/src/services/remote-image-localization*.ts"
+      - "backend/src/routes/remote-image-import.ts"
+      - "backend/tests/remote-image-localization*.test.ts"
+      - "frontend/src/lib/remoteImageLocalizationApi.ts"
+      - "frontend/src/components/RemoteImageLocalizationPanel.tsx"
+      - "frontend/src/components/TaskCenter.tsx"
+      - ".github/workflows/remote-image-localization-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --no-audit --no-fund
+      - name: Backend typecheck
+        run: npm run build:tsc -- --noEmit
+      - name: Remote image localization core tests
+        run: node --import tsx --test --test-concurrency=1 tests/remote-image-localization.test.ts
+      - name: Remote image localization service tests
+        run: node --import tsx --test --test-concurrency=1 tests/remote-image-localization-service.test.ts
+      - name: Authority, Yjs and rollback tests
+        run: node --import tsx --test --test-concurrency=1 tests/remote-image-localization-authority.test.ts
+      - name: Build backend bundle
+        run: npm run build
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --no-audit --no-fund
+      - name: Frontend typecheck
+        shell: bash
+        run: |
+          set -o pipefail
+          npx tsc -b 2>&1 | tee /tmp/remote-image-localization-frontend-typecheck.log
+      - name: Upload frontend diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: remote-image-localization-frontend-${{ github.run_id }}
+          path: /tmp/remote-image-localization-frontend-typecheck.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/backend/src/lib/remote-image-localization.ts
+++ b/backend/src/lib/remote-image-localization.ts
@@ -1,0 +1,175 @@
+export type RemoteImageReferenceKind = "remote" | "local" | "ignored";
+
+export interface RemoteImageReference {
+  url: string;
+  kind: RemoteImageReferenceKind;
+}
+
+export interface RemoteImageScanResult {
+  contentFormat: string;
+  totalImageReferences: number;
+  remoteReferenceCount: number;
+  localReferenceCount: number;
+  ignoredReferenceCount: number;
+  remoteUrls: string[];
+  parseError?: string;
+}
+
+export interface RemoteImageReplacementResult {
+  content: string;
+  replacedCount: number;
+  changed: boolean;
+  parseError?: string;
+}
+
+const LOCAL_ATTACHMENT_PATHS = ["/api/attachments/", "/api/files/"];
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(\s*(<[^>\n]+>|(?:\\.|[^)\s])+)(\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g;
+const HTML_IMAGE_TAG_RE = /<img\b[^>]*>/gi;
+const HTML_SRC_RE = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i;
+
+export function classifyImageUrl(rawUrl: unknown): RemoteImageReferenceKind {
+  if (typeof rawUrl !== "string") return "ignored";
+  const value = rawUrl.trim();
+  if (!value) return "ignored";
+  const lower = value.toLowerCase();
+  if (LOCAL_ATTACHMENT_PATHS.some((prefix) => lower.startsWith(prefix))) return "local";
+  if (lower.startsWith("data:") || lower.startsWith("blob:") || lower.startsWith("file:")) return "ignored";
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? "remote" : "ignored";
+  } catch {
+    return "ignored";
+  }
+}
+
+function markdownReferences(content: string): RemoteImageReference[] {
+  const references: RemoteImageReference[] = [];
+  for (const match of content.matchAll(MARKDOWN_IMAGE_RE)) {
+    const token = match[1] || "";
+    const url = token.startsWith("<") && token.endsWith(">") ? token.slice(1, -1).trim() : token.trim();
+    references.push({ url, kind: classifyImageUrl(url) });
+  }
+  return references;
+}
+
+function htmlReferences(content: string): RemoteImageReference[] {
+  const references: RemoteImageReference[] = [];
+  for (const match of content.matchAll(HTML_IMAGE_TAG_RE)) {
+    const srcMatch = match[0].match(HTML_SRC_RE);
+    const url = (srcMatch?.[1] ?? srcMatch?.[2] ?? srcMatch?.[3] ?? "").trim();
+    if (url) references.push({ url, kind: classifyImageUrl(url) });
+  }
+  return references;
+}
+
+type TiptapNode = { type?: string; attrs?: Record<string, unknown>; content?: unknown[] };
+function isImageNode(value: unknown): value is TiptapNode {
+  if (!value || typeof value !== "object") return false;
+  const node = value as TiptapNode;
+  return /image/i.test(String(node.type || "")) && Boolean(node.attrs && "src" in node.attrs);
+}
+function walkTiptapImages(value: unknown, visitor: (node: TiptapNode) => void): void {
+  if (!value || typeof value !== "object") return;
+  const node = value as TiptapNode;
+  if (isImageNode(node)) visitor(node);
+  if (Array.isArray(node.content)) for (const child of node.content) walkTiptapImages(child, visitor);
+}
+function tiptapReferences(content: string): { references: RemoteImageReference[]; parseError?: string } {
+  try {
+    const parsed = JSON.parse(content || "{}");
+    const references: RemoteImageReference[] = [];
+    walkTiptapImages(parsed, (node) => {
+      const url = typeof node.attrs?.src === "string" ? node.attrs.src.trim() : "";
+      if (url) references.push({ url, kind: classifyImageUrl(url) });
+    });
+    return { references };
+  } catch (error) {
+    return { references: [], parseError: `Tiptap JSON 解析失败：${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function detectContentKind(content: string, contentFormat: string): "markdown" | "html" | "tiptap-json" {
+  const normalized = String(contentFormat || "").toLowerCase();
+  if (normalized === "markdown" || normalized === "md") return "markdown";
+  if (normalized === "html" || normalized === "richtext" || normalized === "rich-text") return "html";
+  if (normalized === "tiptap-json" || normalized === "tiptap" || normalized === "json") return "tiptap-json";
+  const trimmed = content.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "tiptap-json";
+  return /<img\b/i.test(content) ? "html" : "markdown";
+}
+
+export function scanRemoteImages(content: string, contentFormat: string): RemoteImageScanResult {
+  const kind = detectContentKind(content || "", contentFormat);
+  const parsed = kind === "markdown"
+    ? { references: markdownReferences(content || "") }
+    : kind === "html"
+      ? { references: htmlReferences(content || "") }
+      : tiptapReferences(content || "");
+  const remote = parsed.references.filter((item) => item.kind === "remote");
+  const local = parsed.references.filter((item) => item.kind === "local");
+  const ignored = parsed.references.filter((item) => item.kind === "ignored");
+  return {
+    contentFormat: kind,
+    totalImageReferences: parsed.references.length,
+    remoteReferenceCount: remote.length,
+    localReferenceCount: local.length,
+    ignoredReferenceCount: ignored.length,
+    remoteUrls: [...new Set(remote.map((item) => item.url))],
+    ...(parsed.parseError ? { parseError: parsed.parseError } : {}),
+  };
+}
+
+function replaceMarkdown(content: string, replacements: ReadonlyMap<string, string>): RemoteImageReplacementResult {
+  let replacedCount = 0;
+  const output = content.replace(MARKDOWN_IMAGE_RE, (fullMatch, destinationToken: string) => {
+    const wrapped = destinationToken.startsWith("<") && destinationToken.endsWith(">");
+    const originalUrl = wrapped ? destinationToken.slice(1, -1).trim() : destinationToken.trim();
+    const localUrl = replacements.get(originalUrl);
+    if (!localUrl || localUrl === originalUrl) return fullMatch;
+    const offset = fullMatch.indexOf(destinationToken);
+    if (offset < 0) return fullMatch;
+    replacedCount += 1;
+    const next = wrapped ? `<${localUrl}>` : localUrl;
+    return fullMatch.slice(0, offset) + next + fullMatch.slice(offset + destinationToken.length);
+  });
+  return { content: output, replacedCount, changed: replacedCount > 0 };
+}
+function replaceHtml(content: string, replacements: ReadonlyMap<string, string>): RemoteImageReplacementResult {
+  let replacedCount = 0;
+  const output = content.replace(HTML_IMAGE_TAG_RE, (tag) => {
+    const srcMatch = tag.match(HTML_SRC_RE);
+    const original = (srcMatch?.[1] ?? srcMatch?.[2] ?? srcMatch?.[3] ?? "").trim();
+    const local = replacements.get(original);
+    if (!srcMatch || !original || !local || local === original || srcMatch.index === undefined) return tag;
+    const raw = srcMatch[1] ?? srcMatch[2] ?? srcMatch[3] ?? "";
+    const valueOffset = srcMatch[0].indexOf(raw);
+    if (valueOffset < 0) return tag;
+    replacedCount += 1;
+    const absolute = srcMatch.index + valueOffset;
+    return tag.slice(0, absolute) + local + tag.slice(absolute + raw.length);
+  });
+  return { content: output, replacedCount, changed: replacedCount > 0 };
+}
+function replaceTiptap(content: string, replacements: ReadonlyMap<string, string>): RemoteImageReplacementResult {
+  try {
+    const parsed = JSON.parse(content || "{}");
+    let replacedCount = 0;
+    walkTiptapImages(parsed, (node) => {
+      const original = typeof node.attrs?.src === "string" ? node.attrs.src.trim() : "";
+      const local = replacements.get(original);
+      if (!original || !local || local === original || !node.attrs) return;
+      node.attrs.src = local;
+      replacedCount += 1;
+    });
+    return { content: replacedCount ? JSON.stringify(parsed) : content, replacedCount, changed: replacedCount > 0 };
+  } catch (error) {
+    return { content, replacedCount: 0, changed: false, parseError: `Tiptap JSON 解析失败：${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+export function replaceRemoteImages(content: string, contentFormat: string, replacements: ReadonlyMap<string, string>): RemoteImageReplacementResult {
+  if (!replacements.size) return { content, replacedCount: 0, changed: false };
+  const kind = detectContentKind(content || "", contentFormat);
+  return kind === "markdown" ? replaceMarkdown(content || "", replacements)
+    : kind === "html" ? replaceHtml(content || "", replacements)
+      : replaceTiptap(content || "", replacements);
+}

--- a/backend/src/routes/remote-image-import.ts
+++ b/backend/src/routes/remote-image-import.ts
@@ -1,202 +1,45 @@
-import { lookup } from "node:dns/promises";
-import crypto from "node:crypto";
-import { v4 as uuid } from "uuid";
-import { Hono } from "hono";
-import { getDb } from "../db/schema";
-import { hasPermission, resolveNotePermission } from "../middleware/acl";
-import { enqueueAttachment } from "../services/embedding-worker";
+import { Hono, type Context } from "hono";
 import {
-  deleteAttachmentObject,
-  getUploadMonthPath,
-  writeAttachmentObject,
-} from "../services/attachment-storage";
-import { createUserAttachmentAccessUrls } from "../lib/attachment-signed-url";
+  importRemoteImageForNote,
+  RemoteImageError,
+} from "../services/remote-image-import";
 import {
-  createDeduplicatedAttachmentRow,
-  type ExistingAttachmentForDedup,
-} from "./attachments-core";
-import {
-  isBlockedRemoteAddress,
-  isBlockedRemoteHostname,
-  normalizeRemoteImageMime,
-  REMOTE_IMAGE_MIME_TO_EXT,
-  sanitizeRemoteImageFilename,
-  sniffRemoteImageMime,
-} from "../lib/remote-image-security";
+  cancelLocalizationJob,
+  createLocalizationJob,
+  getLocalizationJob,
+  listLocalizationJobs,
+  LocalizationJobError,
+  retryLocalizationJob,
+  scanLocalizationScope,
+  type LocalizationScopeInput,
+} from "../services/remote-image-localization";
 import wechatFavoritesImportRouter from "./wechat-favorites-import";
 
 const router = new Hono();
-const MAX_REDIRECTS = 3;
-const DEFAULT_TIMEOUT_MS = 12_000;
-const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
 
-class RemoteImageError extends Error {
-  constructor(
-    message: string,
-    readonly code: string,
-    readonly status: 400 | 403 | 408 | 413 | 415 | 502,
-  ) {
-    super(message);
-  }
-}
-
-function readPositiveEnv(name: string, fallback: number, max: number): number {
-  const value = Number.parseInt(process.env[name] || "", 10);
-  return Number.isFinite(value) && value > 0 ? Math.min(value, max) : fallback;
-}
-
-function getRemoteImageMaxBytes(): number {
-  return readPositiveEnv("REMOTE_IMAGE_MAX_SIZE_MB", DEFAULT_MAX_BYTES / 1024 / 1024, 100) * 1024 * 1024;
-}
-
-function getRemoteImageTimeoutMs(): number {
-  return readPositiveEnv("REMOTE_IMAGE_TIMEOUT_MS", DEFAULT_TIMEOUT_MS, 60_000);
-}
-
-async function assertSafeRemoteUrl(url: URL): Promise<void> {
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new RemoteImageError("仅支持 HTTP/HTTPS 网络图片", "INVALID_REMOTE_IMAGE_URL", 400);
-  }
-  if (url.username || url.password || isBlockedRemoteHostname(url.hostname)) {
-    throw new RemoteImageError("该网络图片地址不允许访问", "REMOTE_IMAGE_SSRF_BLOCKED", 403);
-  }
-
-  let addresses: Array<{ address: string }>;
+async function readJsonBody(c: Context): Promise<Record<string, unknown> | null> {
   try {
-    addresses = await lookup(url.hostname, { all: true, verbatim: true });
+    return await c.req.json() as Record<string, unknown>;
   } catch {
-    throw new RemoteImageError("无法解析网络图片域名", "REMOTE_IMAGE_DNS_FAILED", 502);
-  }
-  if (addresses.length === 0 || addresses.some(({ address }) => isBlockedRemoteAddress(address))) {
-    throw new RemoteImageError("该网络图片地址解析到了内网或保留地址", "REMOTE_IMAGE_SSRF_BLOCKED", 403);
+    return null;
   }
 }
 
-function filenameFromHeaders(headers: Headers, finalUrl: URL, mimeType: string): string {
-  const disposition = headers.get("content-disposition") || "";
-  let candidate = "";
-  const encoded = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)?.[1];
-  if (encoded) {
-    try { candidate = decodeURIComponent(encoded.trim().replace(/^"|"$/g, "")); } catch { /* ignore */ }
+function localizationErrorResponse(c: Context, error: unknown) {
+  if (error instanceof LocalizationJobError || error instanceof RemoteImageError) {
+    return c.json({ error: error.message, code: error.code }, error.status);
   }
-  if (!candidate) {
-    candidate = disposition.match(/filename\s*=\s*"([^"]+)"/i)?.[1]
-      || disposition.match(/filename\s*=\s*([^;]+)/i)?.[1]?.trim()
-      || finalUrl.pathname.split("/").pop()
-      || "remote-image";
-  }
-  return sanitizeRemoteImageFilename(candidate, mimeType);
-}
-
-async function downloadRemoteImage(rawUrl: string): Promise<{
-  buffer: Buffer;
-  mimeType: string;
-  filename: string;
-  finalUrl: string;
-}> {
-  let current: URL;
-  try {
-    current = new URL(rawUrl);
-  } catch {
-    throw new RemoteImageError("网络图片地址无效", "INVALID_REMOTE_IMAGE_URL", 400);
-  }
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), getRemoteImageTimeoutMs());
-  const maxBytes = getRemoteImageMaxBytes();
-
-  try {
-    let response: Response | null = null;
-    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
-      await assertSafeRemoteUrl(current);
-      response = await fetch(current, {
-        redirect: "manual",
-        signal: controller.signal,
-        headers: {
-          Accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/bmp,image/x-icon;q=0.9,*/*;q=0.1",
-          "User-Agent": "Nowen-Note-Remote-Image/1.0",
-        },
-      });
-
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        if (!location || redirectCount === MAX_REDIRECTS) {
-          throw new RemoteImageError("网络图片重定向次数过多", "REMOTE_IMAGE_REDIRECT_LIMIT", 502);
-        }
-        current = new URL(location, current);
-        continue;
-      }
-      break;
-    }
-
-    if (!response || !response.ok) {
-      throw new RemoteImageError(`网络图片下载失败${response ? `（HTTP ${response.status}）` : ""}`, "REMOTE_IMAGE_DOWNLOAD_FAILED", 502);
-    }
-
-    const declaredLength = Number.parseInt(response.headers.get("content-length") || "", 10);
-    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-      throw new RemoteImageError(`网络图片过大（最大 ${Math.round(maxBytes / 1024 / 1024)}MB）`, "REMOTE_IMAGE_TOO_LARGE", 413);
-    }
-    if (!response.body) {
-      throw new RemoteImageError("网络图片响应为空", "REMOTE_IMAGE_DOWNLOAD_FAILED", 502);
-    }
-
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    const reader = response.body.getReader();
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-      total += value.byteLength;
-      if (total > maxBytes) {
-        controller.abort();
-        throw new RemoteImageError(`网络图片过大（最大 ${Math.round(maxBytes / 1024 / 1024)}MB）`, "REMOTE_IMAGE_TOO_LARGE", 413);
-      }
-      chunks.push(value);
-    }
-
-    const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
-    const sniffedMime = sniffRemoteImageMime(buffer);
-    if (!sniffedMime) {
-      throw new RemoteImageError("远程响应不是受支持的图片格式", "REMOTE_IMAGE_NOT_IMAGE", 415);
-    }
-
-    const declaredMime = normalizeRemoteImageMime(response.headers.get("content-type"));
-    if (declaredMime && declaredMime !== "application/octet-stream") {
-      if (!declaredMime.startsWith("image/") || !REMOTE_IMAGE_MIME_TO_EXT[declaredMime]) {
-        throw new RemoteImageError("远程响应的 Content-Type 不是受支持的图片", "REMOTE_IMAGE_NOT_IMAGE", 415);
-      }
-      if (normalizeRemoteImageMime(declaredMime) !== normalizeRemoteImageMime(sniffedMime)) {
-        throw new RemoteImageError("远程图片声明类型与实际内容不一致", "REMOTE_IMAGE_TYPE_MISMATCH", 415);
-      }
-    }
-
-    return {
-      buffer,
-      mimeType: sniffedMime,
-      filename: filenameFromHeaders(response.headers, current, sniffedMime),
-      finalUrl: current.toString(),
-    };
-  } catch (error) {
-    if (error instanceof RemoteImageError) throw error;
-    if ((error as { name?: string })?.name === "AbortError") {
-      throw new RemoteImageError("网络图片下载超时", "REMOTE_IMAGE_TIMEOUT", 408);
-    }
-    throw new RemoteImageError(`网络图片下载失败：${(error as Error)?.message || String(error)}`, "REMOTE_IMAGE_DOWNLOAD_FAILED", 502);
-  } finally {
-    clearTimeout(timer);
-  }
+  console.error("[remote-image-localization] request failed:", error);
+  return c.json({
+    error: error instanceof Error ? error.message : "网络图片本地化失败",
+    code: "REMOTE_IMAGE_LOCALIZATION_FAILED",
+  }, 500);
 }
 
 router.post("/import-remote-image", async (c) => {
   const userId = c.req.header("X-User-Id") || "";
-  let body: { noteId?: unknown; url?: unknown; source?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: "请求格式错误", code: "INVALID_BODY" }, 400);
-  }
+  const body = await readJsonBody(c);
+  if (!body) return c.json({ error: "请求格式错误", code: "INVALID_BODY" }, 400);
 
   const noteId = typeof body.noteId === "string" ? body.noteId.trim() : "";
   const remoteUrl = typeof body.url === "string" ? body.url.trim() : "";
@@ -207,104 +50,86 @@ router.post("/import-remote-image", async (c) => {
     return c.json({ error: "noteId 和 url 必传", code: "INVALID_BODY" }, 400);
   }
 
-  const { permission, workspaceId } = resolveNotePermission(noteId, userId);
-  if (!hasPermission(permission, "write")) {
-    return c.json({ error: "无权修改该笔记", code: "FORBIDDEN" }, 403);
-  }
-
-  let downloaded: Awaited<ReturnType<typeof downloadRemoteImage>>;
   try {
-    downloaded = await downloadRemoteImage(remoteUrl);
-  } catch (error) {
-    const failure = error instanceof RemoteImageError
-      ? error
-      : new RemoteImageError("网络图片下载失败", "REMOTE_IMAGE_DOWNLOAD_FAILED", 502);
-    return c.json({ error: failure.message, code: failure.code }, failure.status);
-  }
-
-  const db = getDb();
-  const hash = crypto.createHash("sha256").update(downloaded.buffer).digest("hex");
-  const dedupRow = db.prepare(
-    workspaceId
-      ? `SELECT id, path, mimeType, size, filename, hash FROM attachments
-           WHERE userId = ? AND workspaceId = ? AND hash = ? LIMIT 1`
-      : `SELECT id, path, mimeType, size, filename, hash FROM attachments
-           WHERE userId = ? AND workspaceId IS NULL AND hash = ? LIMIT 1`,
-  ).get(...(workspaceId ? [userId, workspaceId, hash] : [userId, hash])) as ExistingAttachmentForDedup | undefined;
-
-  if (dedupRow) {
-    try {
-      const clone = createDeduplicatedAttachmentRow({
-        source: dedupRow,
-        noteId,
-        userId,
-        workspaceId,
-        filename: downloaded.filename,
-        hash,
-        uploadSource,
-      });
-      enqueueAttachment({ attachmentId: clone.id, userId, workspaceId, noteId });
-      return c.json({
-        id: clone.id,
-        url: clone.url,
-        mimeType: clone.mimeType,
-        size: clone.size,
-        filename: clone.filename,
-        category: "image",
-        deduplicated: true,
-        sourceUrl: remoteUrl,
-        finalUrl: downloaded.finalUrl,
-        accessUrls: createUserAttachmentAccessUrls(userId, [{ id: clone.id, noteId }]),
-      }, 201);
-    } catch (error) {
-      return c.json({ error: `写入数据库失败：${(error as Error)?.message || error}` }, 500);
-    }
-  }
-
-  const id = uuid();
-  const ext = REMOTE_IMAGE_MIME_TO_EXT[downloaded.mimeType] || "img";
-  const storagePath = `${getUploadMonthPath()}/${id}.${ext}`;
-  try {
-    await writeAttachmentObject(storagePath, downloaded.buffer, downloaded.mimeType);
-  } catch (error) {
-    return c.json({ error: `写入附件失败：${(error as Error)?.message || error}` }, 500);
-  }
-
-  try {
-    db.prepare(
-      `INSERT INTO attachments
-       (id, noteId, userId, filename, mimeType, size, path, workspaceId, hash, uploadSource)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      id,
+    const result = await importRemoteImageForNote({
       noteId,
       userId,
-      downloaded.filename,
-      downloaded.mimeType,
-      downloaded.buffer.byteLength,
-      storagePath,
-      workspaceId,
-      hash,
+      url: remoteUrl,
       uploadSource,
-    );
+    });
+    return c.json(result, 201);
   } catch (error) {
-    try { await deleteAttachmentObject(storagePath); } catch { /* best effort */ }
-    return c.json({ error: `写入数据库失败：${(error as Error)?.message || error}` }, 500);
+    if (error instanceof RemoteImageError) {
+      return c.json({ error: error.message, code: error.code }, error.status);
+    }
+    return c.json({
+      error: `写入附件失败：${error instanceof Error ? error.message : String(error)}`,
+      code: "REMOTE_IMAGE_SAVE_FAILED",
+    }, 500);
   }
+});
 
-  enqueueAttachment({ attachmentId: id, userId, workspaceId, noteId });
-  return c.json({
-    id,
-    url: `/api/attachments/${id}`,
-    mimeType: downloaded.mimeType,
-    size: downloaded.buffer.byteLength,
-    filename: downloaded.filename,
-    category: "image",
-    deduplicated: false,
-    sourceUrl: remoteUrl,
-    finalUrl: downloaded.finalUrl,
-    accessUrls: createUserAttachmentAccessUrls(userId, [{ id, noteId }]),
-  }, 201);
+/**
+ * 扫描历史笔记中的图片引用，不下载、不修改正文。
+ *
+ * Body（二选一）：
+ *   { noteIds: ["..."], expectedVersions?: { [noteId]: version } }
+ *   { notebookId: "...", expectedVersions?: { [noteId]: version } }
+ */
+router.post("/remote-image-localization/scan", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  const body = await readJsonBody(c);
+  if (!body) return c.json({ error: "请求格式错误", code: "INVALID_BODY" }, 400);
+  try {
+    return c.json(scanLocalizationScope(userId, body as LocalizationScopeInput));
+  } catch (error) {
+    return localizationErrorResponse(c, error);
+  }
+});
+
+/** 创建后台任务。页面关闭或移动端切后台不会中断服务端任务。 */
+router.post("/remote-image-localization/jobs", async (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  const body = await readJsonBody(c);
+  if (!body) return c.json({ error: "请求格式错误", code: "INVALID_BODY" }, 400);
+  try {
+    return c.json(createLocalizationJob(userId, body as LocalizationScopeInput), 202);
+  } catch (error) {
+    return localizationErrorResponse(c, error);
+  }
+});
+
+router.get("/remote-image-localization/jobs", (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  const limit = Number.parseInt(c.req.query("limit") || "20", 10);
+  return c.json({ jobs: listLocalizationJobs(userId, limit) });
+});
+
+router.get("/remote-image-localization/jobs/:id", (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    return c.json(getLocalizationJob(userId, c.req.param("id")));
+  } catch (error) {
+    return localizationErrorResponse(c, error);
+  }
+});
+
+router.post("/remote-image-localization/jobs/:id/cancel", (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    return c.json(cancelLocalizationJob(userId, c.req.param("id")));
+  } catch (error) {
+    return localizationErrorResponse(c, error);
+  }
+});
+
+router.post("/remote-image-localization/jobs/:id/retry", (c) => {
+  const userId = c.req.header("X-User-Id") || "";
+  try {
+    return c.json(retryLocalizationJob(userId, c.req.param("id")), 202);
+  } catch (error) {
+    return localizationErrorResponse(c, error);
+  }
 });
 
 router.route("/", wechatFavoritesImportRouter);

--- a/backend/src/services/remote-image-import.ts
+++ b/backend/src/services/remote-image-import.ts
@@ -1,0 +1,355 @@
+import { lookup } from "node:dns/promises";
+import crypto from "node:crypto";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+import { hasPermission, resolveNotePermission } from "../middleware/acl";
+import { enqueueAttachment } from "./embedding-worker";
+import {
+  deleteAttachmentObject,
+  getUploadMonthPath,
+  writeAttachmentObject,
+} from "./attachment-storage";
+import { createUserAttachmentAccessUrls } from "../lib/attachment-signed-url";
+import {
+  createDeduplicatedAttachmentRow,
+  type ExistingAttachmentForDedup,
+} from "../routes/attachments-core";
+import {
+  isBlockedRemoteAddress,
+  isBlockedRemoteHostname,
+  normalizeRemoteImageMime,
+  REMOTE_IMAGE_MIME_TO_EXT,
+  sanitizeRemoteImageFilename,
+  sniffRemoteImageMime,
+} from "../lib/remote-image-security";
+
+const MAX_REDIRECTS = 3;
+const DEFAULT_TIMEOUT_MS = 12_000;
+const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
+
+export class RemoteImageError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: 400 | 403 | 408 | 413 | 415 | 502,
+  ) {
+    super(message);
+  }
+}
+
+export interface DownloadedRemoteImage {
+  buffer: Buffer;
+  mimeType: string;
+  filename: string;
+  finalUrl: string;
+}
+
+export interface ImportedRemoteImage {
+  id: string;
+  url: string;
+  mimeType: string;
+  size: number;
+  filename: string;
+  category: "image";
+  deduplicated: boolean;
+  sourceUrl: string;
+  finalUrl: string;
+  accessUrls: Record<string, string>;
+}
+
+function readPositiveEnv(name: string, fallback: number, max: number): number {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && value > 0 ? Math.min(value, max) : fallback;
+}
+
+export function getRemoteImageMaxBytes(): number {
+  return readPositiveEnv("REMOTE_IMAGE_MAX_SIZE_MB", DEFAULT_MAX_BYTES / 1024 / 1024, 100) * 1024 * 1024;
+}
+
+export function getRemoteImageTimeoutMs(): number {
+  return readPositiveEnv("REMOTE_IMAGE_TIMEOUT_MS", DEFAULT_TIMEOUT_MS, 60_000);
+}
+
+async function assertSafeRemoteUrl(url: URL): Promise<void> {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new RemoteImageError("仅支持 HTTP/HTTPS 网络图片", "INVALID_REMOTE_IMAGE_URL", 400);
+  }
+  if (url.username || url.password || isBlockedRemoteHostname(url.hostname)) {
+    throw new RemoteImageError("该网络图片地址不允许访问", "REMOTE_IMAGE_SSRF_BLOCKED", 403);
+  }
+
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(url.hostname, { all: true, verbatim: true });
+  } catch {
+    throw new RemoteImageError("无法解析网络图片域名", "REMOTE_IMAGE_DNS_FAILED", 502);
+  }
+  if (addresses.length === 0 || addresses.some(({ address }) => isBlockedRemoteAddress(address))) {
+    throw new RemoteImageError("该网络图片地址解析到了内网或保留地址", "REMOTE_IMAGE_SSRF_BLOCKED", 403);
+  }
+}
+
+function filenameFromHeaders(headers: Headers, finalUrl: URL, mimeType: string): string {
+  const disposition = headers.get("content-disposition") || "";
+  let candidate = "";
+  const encoded = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i)?.[1];
+  if (encoded) {
+    try {
+      candidate = decodeURIComponent(encoded.trim().replace(/^"|"$/g, ""));
+    } catch {
+      // Ignore malformed filename and fall back to URL path.
+    }
+  }
+  if (!candidate) {
+    candidate = disposition.match(/filename\s*=\s*"([^"]+)"/i)?.[1]
+      || disposition.match(/filename\s*=\s*([^;]+)/i)?.[1]?.trim()
+      || finalUrl.pathname.split("/").pop()
+      || "remote-image";
+  }
+  return sanitizeRemoteImageFilename(candidate, mimeType);
+}
+
+export async function downloadRemoteImage(rawUrl: string): Promise<DownloadedRemoteImage> {
+  let current: URL;
+  try {
+    current = new URL(rawUrl);
+  } catch {
+    throw new RemoteImageError("网络图片地址无效", "INVALID_REMOTE_IMAGE_URL", 400);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), getRemoteImageTimeoutMs());
+  const maxBytes = getRemoteImageMaxBytes();
+
+  try {
+    let response: Response | null = null;
+    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+      await assertSafeRemoteUrl(current);
+      response = await fetch(current, {
+        redirect: "manual",
+        signal: controller.signal,
+        headers: {
+          Accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/bmp,image/x-icon;q=0.9,*/*;q=0.1",
+          "User-Agent": "Nowen-Note-Remote-Image/1.0",
+        },
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location || redirectCount === MAX_REDIRECTS) {
+          throw new RemoteImageError("网络图片重定向次数过多", "REMOTE_IMAGE_REDIRECT_LIMIT", 502);
+        }
+        current = new URL(location, current);
+        continue;
+      }
+      break;
+    }
+
+    if (!response || !response.ok) {
+      throw new RemoteImageError(
+        `网络图片下载失败${response ? `（HTTP ${response.status}）` : ""}`,
+        "REMOTE_IMAGE_DOWNLOAD_FAILED",
+        502,
+      );
+    }
+
+    const declaredLength = Number.parseInt(response.headers.get("content-length") || "", 10);
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+      throw new RemoteImageError(
+        `网络图片过大（最大 ${Math.round(maxBytes / 1024 / 1024)}MB）`,
+        "REMOTE_IMAGE_TOO_LARGE",
+        413,
+      );
+    }
+    if (!response.body) {
+      throw new RemoteImageError("网络图片响应为空", "REMOTE_IMAGE_DOWNLOAD_FAILED", 502);
+    }
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    const reader = response.body.getReader();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        controller.abort();
+        throw new RemoteImageError(
+          `网络图片过大（最大 ${Math.round(maxBytes / 1024 / 1024)}MB）`,
+          "REMOTE_IMAGE_TOO_LARGE",
+          413,
+        );
+      }
+      chunks.push(value);
+    }
+
+    const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    const sniffedMime = sniffRemoteImageMime(buffer);
+    if (!sniffedMime) {
+      throw new RemoteImageError("远程响应不是受支持的图片格式", "REMOTE_IMAGE_NOT_IMAGE", 415);
+    }
+
+    const declaredMime = normalizeRemoteImageMime(response.headers.get("content-type"));
+    if (declaredMime && declaredMime !== "application/octet-stream") {
+      if (!declaredMime.startsWith("image/") || !REMOTE_IMAGE_MIME_TO_EXT[declaredMime]) {
+        throw new RemoteImageError("远程响应的 Content-Type 不是受支持的图片", "REMOTE_IMAGE_NOT_IMAGE", 415);
+      }
+      if (normalizeRemoteImageMime(declaredMime) !== normalizeRemoteImageMime(sniffedMime)) {
+        throw new RemoteImageError("远程图片声明类型与实际内容不一致", "REMOTE_IMAGE_TYPE_MISMATCH", 415);
+      }
+    }
+
+    return {
+      buffer,
+      mimeType: sniffedMime,
+      filename: filenameFromHeaders(response.headers, current, sniffedMime),
+      finalUrl: current.toString(),
+    };
+  } catch (error) {
+    if (error instanceof RemoteImageError) throw error;
+    if ((error as { name?: string })?.name === "AbortError") {
+      throw new RemoteImageError("网络图片下载超时", "REMOTE_IMAGE_TIMEOUT", 408);
+    }
+    throw new RemoteImageError(
+      `网络图片下载失败：${(error as Error)?.message || String(error)}`,
+      "REMOTE_IMAGE_DOWNLOAD_FAILED",
+      502,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function assertRemoteImageImportPermission(noteId: string, userId: string): { workspaceId: string | null } {
+  const { permission, workspaceId } = resolveNotePermission(noteId, userId);
+  if (!hasPermission(permission, "write")) {
+    throw new RemoteImageError("无权修改该笔记", "FORBIDDEN", 403);
+  }
+  return { workspaceId: workspaceId || null };
+}
+
+export async function saveDownloadedRemoteImageForNote(args: {
+  downloaded: DownloadedRemoteImage;
+  sourceUrl: string;
+  noteId: string;
+  userId: string;
+  workspaceId: string | null;
+  uploadSource?: string;
+}): Promise<ImportedRemoteImage> {
+  const uploadSource = (args.uploadSource || "remote-image").trim().slice(0, 64) || "remote-image";
+  const db = getDb();
+  const hash = crypto.createHash("sha256").update(args.downloaded.buffer).digest("hex");
+  const dedupRow = db.prepare(
+    args.workspaceId
+      ? `SELECT id, noteId, path, mimeType, size, filename, hash FROM attachments
+           WHERE userId = ? AND workspaceId = ? AND hash = ? ORDER BY CASE WHEN noteId = ? THEN 0 ELSE 1 END LIMIT 1`
+      : `SELECT id, noteId, path, mimeType, size, filename, hash FROM attachments
+           WHERE userId = ? AND workspaceId IS NULL AND hash = ? ORDER BY CASE WHEN noteId = ? THEN 0 ELSE 1 END LIMIT 1`,
+  ).get(
+    ...(args.workspaceId
+      ? [args.userId, args.workspaceId, hash, args.noteId]
+      : [args.userId, hash, args.noteId]),
+  ) as (ExistingAttachmentForDedup & { id: string; noteId: string }) | undefined;
+
+  if (dedupRow) {
+    const row = dedupRow.noteId === args.noteId
+      ? {
+          id: dedupRow.id,
+          url: `/api/attachments/${dedupRow.id}`,
+          mimeType: dedupRow.mimeType,
+          size: dedupRow.size,
+          filename: dedupRow.filename || args.downloaded.filename,
+        }
+      : createDeduplicatedAttachmentRow({
+          source: dedupRow,
+          noteId: args.noteId,
+          userId: args.userId,
+          workspaceId: args.workspaceId,
+          filename: args.downloaded.filename,
+          hash,
+          uploadSource,
+        });
+    enqueueAttachment({
+      attachmentId: row.id,
+      userId: args.userId,
+      workspaceId: args.workspaceId,
+      noteId: args.noteId,
+    });
+    return {
+      id: row.id,
+      url: row.url,
+      mimeType: row.mimeType,
+      size: row.size,
+      filename: row.filename,
+      category: "image",
+      deduplicated: true,
+      sourceUrl: args.sourceUrl,
+      finalUrl: args.downloaded.finalUrl,
+      accessUrls: createUserAttachmentAccessUrls(args.userId, [{ id: row.id, noteId: args.noteId }]),
+    };
+  }
+
+  const id = uuid();
+  const ext = REMOTE_IMAGE_MIME_TO_EXT[args.downloaded.mimeType] || "img";
+  const storagePath = `${getUploadMonthPath()}/${id}.${ext}`;
+  await writeAttachmentObject(storagePath, args.downloaded.buffer, args.downloaded.mimeType);
+
+  try {
+    db.prepare(
+      `INSERT INTO attachments
+       (id, noteId, userId, filename, mimeType, size, path, workspaceId, hash, uploadSource)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      args.noteId,
+      args.userId,
+      args.downloaded.filename,
+      args.downloaded.mimeType,
+      args.downloaded.buffer.byteLength,
+      storagePath,
+      args.workspaceId,
+      hash,
+      uploadSource,
+    );
+  } catch (error) {
+    try {
+      await deleteAttachmentObject(storagePath);
+    } catch {
+      // Best effort cleanup only.
+    }
+    throw error;
+  }
+
+  enqueueAttachment({ attachmentId: id, userId: args.userId, workspaceId: args.workspaceId, noteId: args.noteId });
+  return {
+    id,
+    url: `/api/attachments/${id}`,
+    mimeType: args.downloaded.mimeType,
+    size: args.downloaded.buffer.byteLength,
+    filename: args.downloaded.filename,
+    category: "image",
+    deduplicated: false,
+    sourceUrl: args.sourceUrl,
+    finalUrl: args.downloaded.finalUrl,
+    accessUrls: createUserAttachmentAccessUrls(args.userId, [{ id, noteId: args.noteId }]),
+  };
+}
+
+export async function importRemoteImageForNote(args: {
+  noteId: string;
+  userId: string;
+  url: string;
+  uploadSource?: string;
+}): Promise<ImportedRemoteImage> {
+  const { workspaceId } = assertRemoteImageImportPermission(args.noteId, args.userId);
+  const downloaded = await downloadRemoteImage(args.url);
+  return saveDownloadedRemoteImageForNote({
+    downloaded,
+    sourceUrl: args.url,
+    noteId: args.noteId,
+    userId: args.userId,
+    workspaceId,
+    uploadSource: args.uploadSource,
+  });
+}

--- a/backend/src/services/remote-image-localization-core.ts
+++ b/backend/src/services/remote-image-localization-core.ts
@@ -1,0 +1,373 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getDb } from "../db/schema";
+import { hasPermission, resolveNotePermission, resolveNotebookPermission } from "../middleware/acl";
+import { scanRemoteImages, type RemoteImageScanResult } from "../lib/remote-image-localization";
+import { yFlush } from "./yjs";
+
+export const DATA_DIR = process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data");
+export const JOBS_DIR = path.join(DATA_DIR, "jobs", "remote-image-localization");
+const DEFAULT_MAX_NOTES = 100;
+const DEFAULT_MAX_IMAGES = 500;
+const DEFAULT_MAX_TOTAL_BYTES = 500 * 1024 * 1024;
+export const DEFAULT_MAX_ACTIVE_JOBS = 2;
+const JOB_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type LocalizationJobStatus = "queued" | "running" | "completed" | "completed_with_errors" | "cancelled" | "failed";
+export type LocalizationNoteStatus =
+  | "queued" | "completed" | "partial" | "failed" | "skipped"
+  | "forbidden" | "locked" | "trashed" | "conflict" | "parse_error";
+
+export interface LocalizationFailure {
+  noteId: string;
+  url?: string;
+  code: string;
+  message: string;
+}
+
+export interface LocalizationNoteScan {
+  noteId: string;
+  title: string;
+  version: number;
+  contentFormat: string;
+  status: "ready" | "forbidden" | "locked" | "trashed" | "conflict" | "parse_error" | "not_found";
+  reason?: string;
+  scan: RemoteImageScanResult;
+}
+
+export interface LocalizationScopeScan {
+  noteCount: number;
+  readyNoteCount: number;
+  notesWithRemoteImages: number;
+  totalImageReferences: number;
+  remoteReferenceCount: number;
+  localReferenceCount: number;
+  ignoredReferenceCount: number;
+  uniqueRemoteUrlCount: number;
+  uniqueRemoteUrls: string[];
+  skippedNoteCount: number;
+  notes: LocalizationNoteScan[];
+  snapshot: { noteIds: string[]; expectedVersions: Record<string, number> };
+  limits: { maxNotes: number; maxImages: number; maxTotalBytes: number };
+}
+
+export interface LocalizationNoteResult {
+  noteId: string;
+  title: string;
+  scannedVersion: number;
+  finalVersion?: number;
+  status: LocalizationNoteStatus;
+  remoteReferenceCount: number;
+  uniqueRemoteUrlCount: number;
+  localizedReferences: number;
+  localizedUrls: number;
+  deduplicatedAttachments: number;
+  failedUrls: number;
+  skippedUrls: number;
+  failures: LocalizationFailure[];
+  warnings: string[];
+}
+
+export interface LocalizationJob {
+  id: string;
+  userId: string;
+  status: LocalizationJobStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  cancelRequested: boolean;
+  source: "note_ids" | "notebook";
+  notebookId: string | null;
+  noteIds: string[];
+  expectedVersions: Record<string, number>;
+  currentNoteId: string | null;
+  currentNoteTitle: string | null;
+  currentUrl: string | null;
+  error: string | null;
+  summary: {
+    totalNotes: number;
+    scannedNotes: number;
+    processedNotes: number;
+    updatedNotes: number;
+    skippedNotes: number;
+    conflictNotes: number;
+    notesWithFailures: number;
+    totalImageReferences: number;
+    remoteReferenceCount: number;
+    uniqueRemoteUrlCount: number;
+    downloadedUniqueUrls: number;
+    reusedDownloads: number;
+    localizedReferences: number;
+    localizedUrls: number;
+    deduplicatedAttachments: number;
+    failedUrls: number;
+    downloadedBytes: number;
+  };
+  noteResults: LocalizationNoteResult[];
+  failures: LocalizationFailure[];
+}
+
+export interface LocalizationScopeInput {
+  noteIds?: unknown;
+  notebookId?: unknown;
+  expectedVersions?: unknown;
+}
+
+export interface NoteRow {
+  id: string;
+  userId: string;
+  notebookId: string;
+  workspaceId: string | null;
+  title: string;
+  content: string;
+  contentText: string;
+  contentFormat: string;
+  version: number;
+  isLocked: number;
+  isTrashed: number;
+  isPinned: number;
+  updatedAt?: string;
+}
+
+export class LocalizationJobError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: 400 | 403 | 404 | 409 | 413,
+  ) {
+    super(message);
+  }
+}
+
+export const jobs = new Map<string, LocalizationJob>();
+export const activeJobs = new Set<string>();
+export const scheduledJobs = new Set<string>();
+
+export function readPositiveEnv(name: string, fallback: number, max: number): number {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && value > 0 ? Math.min(value, max) : fallback;
+}
+
+export function getLimits() {
+  return {
+    maxNotes: readPositiveEnv("REMOTE_IMAGE_LOCALIZATION_MAX_NOTES", DEFAULT_MAX_NOTES, 1000),
+    maxImages: readPositiveEnv("REMOTE_IMAGE_LOCALIZATION_MAX_IMAGES", DEFAULT_MAX_IMAGES, 5000),
+    maxTotalBytes: readPositiveEnv(
+      "REMOTE_IMAGE_LOCALIZATION_MAX_TOTAL_MB",
+      DEFAULT_MAX_TOTAL_BYTES / 1024 / 1024,
+      10_000,
+    ) * 1024 * 1024,
+  };
+}
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function ensureJobsDir(): void {
+  fs.mkdirSync(JOBS_DIR, { recursive: true, mode: 0o700 });
+}
+
+function jobPath(id: string): string {
+  return path.join(JOBS_DIR, `${id}.json`);
+}
+
+export function persistJob(job: LocalizationJob): void {
+  ensureJobsDir();
+  job.updatedAt = nowIso();
+  const target = jobPath(job.id);
+  const temp = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(temp, JSON.stringify(job, null, 2), { mode: 0o600 });
+  fs.renameSync(temp, target);
+  jobs.set(job.id, job);
+}
+
+export function publicJob(job: LocalizationJob): Omit<LocalizationJob, "userId" | "expectedVersions"> {
+  const clone = JSON.parse(JSON.stringify(job)) as LocalizationJob;
+  delete (clone as Partial<LocalizationJob>).userId;
+  delete (clone as Partial<LocalizationJob>).expectedVersions;
+  return clone;
+}
+
+function loadJobs(): void {
+  ensureJobsDir();
+  const cutoff = Date.now() - JOB_RETENTION_MS;
+  for (const name of fs.readdirSync(JOBS_DIR).filter((entry) => entry.endsWith(".json"))) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.join(JOBS_DIR, name), "utf8")) as LocalizationJob;
+      if (!parsed?.id || !parsed?.userId) continue;
+      if (parsed.status === "queued" || parsed.status === "running") {
+        parsed.status = "failed";
+        parsed.error = "服务在任务执行期间重启；可使用重试重新扫描未完成笔记";
+        parsed.completedAt = nowIso();
+        parsed.currentNoteId = null;
+        parsed.currentNoteTitle = null;
+        parsed.currentUrl = null;
+        parsed.failures = parsed.failures || [];
+        parsed.failures.push({ noteId: "", code: "JOB_INTERRUPTED", message: parsed.error });
+        persistJob(parsed);
+      } else if (new Date(parsed.updatedAt).getTime() >= cutoff) {
+        jobs.set(parsed.id, parsed);
+      } else {
+        try { fs.unlinkSync(path.join(JOBS_DIR, name)); } catch {}
+      }
+    } catch (error) {
+      console.warn("[remote-image-localization] failed to load job:", name, error);
+    }
+  }
+}
+
+loadJobs();
+
+function normalizeExpectedVersions(value: unknown): Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const output: Record<string, number> = {};
+  for (const [noteId, version] of Object.entries(value as Record<string, unknown>)) {
+    const id = noteId.trim();
+    const normalized = Number(version);
+    if (id && Number.isInteger(normalized) && normalized >= 0) output[id] = normalized;
+  }
+  return output;
+}
+
+function normalizeNoteIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean))];
+}
+
+export function resolveScopeNoteIds(userId: string, input: LocalizationScopeInput): {
+  source: "note_ids" | "notebook";
+  notebookId: string | null;
+  noteIds: string[];
+  expectedVersions: Record<string, number>;
+} {
+  const limits = getLimits();
+  const noteIds = normalizeNoteIds(input.noteIds);
+  const notebookId = typeof input.notebookId === "string" ? input.notebookId.trim() : "";
+  const expectedVersions = normalizeExpectedVersions(input.expectedVersions);
+  if ((noteIds.length > 0 && notebookId) || (noteIds.length === 0 && !notebookId)) {
+    throw new LocalizationJobError("noteIds 与 notebookId 必须且只能提供一个", "INVALID_SCOPE", 400);
+  }
+  if (noteIds.length > 0) {
+    if (noteIds.length > limits.maxNotes) {
+      throw new LocalizationJobError(`单次最多处理 ${limits.maxNotes} 篇笔记`, "NOTE_LIMIT_EXCEEDED", 413);
+    }
+    return { source: "note_ids", notebookId: null, noteIds, expectedVersions };
+  }
+  const notebookPermission = resolveNotebookPermission(notebookId, userId);
+  if (!hasPermission(notebookPermission.permission, "read")) {
+    throw new LocalizationJobError("笔记本不存在或无权访问", "NOTEBOOK_FORBIDDEN", 403);
+  }
+  const rows = getDb().prepare(`
+    WITH RECURSIVE descendants(id) AS (
+      SELECT id FROM notebooks WHERE id = ?
+      UNION ALL
+      SELECT n.id FROM notebooks n JOIN descendants d ON n.parentId = d.id
+    )
+    SELECT notes.id FROM notes
+    WHERE notes.notebookId IN (SELECT id FROM descendants) AND notes.isTrashed = 0
+    ORDER BY notes.updatedAt DESC, notes.id ASC LIMIT ?
+  `).all(notebookId, limits.maxNotes + 1) as Array<{ id: string }>;
+  if (rows.length > limits.maxNotes) {
+    throw new LocalizationJobError(
+      `该笔记本超过单次 ${limits.maxNotes} 篇笔记限制，请缩小范围后重试`,
+      "NOTE_LIMIT_EXCEEDED",
+      413,
+    );
+  }
+  return { source: "notebook", notebookId, noteIds: rows.map((row) => row.id), expectedVersions };
+}
+
+export function readNote(noteId: string): NoteRow | undefined {
+  return getDb().prepare(`
+    SELECT id, userId, notebookId, workspaceId, title, content, contentText,
+           contentFormat, version, isLocked, isTrashed, isPinned, updatedAt
+    FROM notes WHERE id = ?
+  `).get(noteId) as NoteRow | undefined;
+}
+
+function emptyScan(contentFormat = "unknown"): RemoteImageScanResult {
+  return {
+    contentFormat,
+    totalImageReferences: 0,
+    remoteReferenceCount: 0,
+    localReferenceCount: 0,
+    ignoredReferenceCount: 0,
+    remoteUrls: [],
+  };
+}
+
+function scanOneNote(userId: string, noteId: string, expectedVersion?: number): LocalizationNoteScan {
+  try { yFlush(noteId); } catch {}
+  const row = readNote(noteId);
+  if (!row) return { noteId, title: "", version: 0, contentFormat: "unknown", status: "not_found", reason: "笔记不存在", scan: emptyScan() };
+  const { permission } = resolveNotePermission(noteId, userId);
+  if (!hasPermission(permission, "write")) {
+    return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "forbidden", reason: "没有写权限", scan: emptyScan(row.contentFormat) };
+  }
+  if (row.isTrashed) return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "trashed", reason: "笔记位于回收站", scan: emptyScan(row.contentFormat) };
+  if (row.isLocked) return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "locked", reason: "笔记已锁定", scan: emptyScan(row.contentFormat) };
+  if (expectedVersion !== undefined && expectedVersion !== row.version) {
+    return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "conflict", reason: `预期版本 ${expectedVersion}，当前版本 ${row.version}`, scan: emptyScan(row.contentFormat) };
+  }
+  const scan = scanRemoteImages(row.content || "", row.contentFormat || "tiptap-json");
+  if (scan.parseError) return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "parse_error", reason: scan.parseError, scan };
+  return { noteId, title: row.title, version: row.version, contentFormat: row.contentFormat, status: "ready", scan };
+}
+
+export function scanLocalizationScope(userId: string, input: LocalizationScopeInput): LocalizationScopeScan {
+  const scope = resolveScopeNoteIds(userId, input);
+  const notes = scope.noteIds.map((noteId) => scanOneNote(userId, noteId, scope.expectedVersions[noteId]));
+  const readyNotes = notes.filter((note) => note.status === "ready");
+  const uniqueRemoteUrls = [...new Set(readyNotes.flatMap((note) => note.scan.remoteUrls))];
+  return {
+    noteCount: notes.length,
+    readyNoteCount: readyNotes.length,
+    notesWithRemoteImages: readyNotes.filter((note) => note.scan.remoteReferenceCount > 0).length,
+    totalImageReferences: readyNotes.reduce((sum, note) => sum + note.scan.totalImageReferences, 0),
+    remoteReferenceCount: readyNotes.reduce((sum, note) => sum + note.scan.remoteReferenceCount, 0),
+    localReferenceCount: readyNotes.reduce((sum, note) => sum + note.scan.localReferenceCount, 0),
+    ignoredReferenceCount: readyNotes.reduce((sum, note) => sum + note.scan.ignoredReferenceCount, 0),
+    uniqueRemoteUrlCount: uniqueRemoteUrls.length,
+    uniqueRemoteUrls,
+    skippedNoteCount: notes.length - readyNotes.length,
+    notes,
+    snapshot: {
+      noteIds: readyNotes.map((note) => note.noteId),
+      expectedVersions: Object.fromEntries(readyNotes.map((note) => [note.noteId, note.version])),
+    },
+    limits: getLimits(),
+  };
+}
+
+export function createInitialNoteResult(scan: LocalizationNoteScan): LocalizationNoteResult {
+  const statusMap: Record<LocalizationNoteScan["status"], LocalizationNoteStatus> = {
+    ready: scan.scan.remoteReferenceCount > 0 ? "queued" : "skipped",
+    forbidden: "forbidden", locked: "locked", trashed: "trashed",
+    conflict: "conflict", parse_error: "parse_error", not_found: "skipped",
+  };
+  const failures: LocalizationFailure[] = scan.status === "ready" ? [] : [{
+    noteId: scan.noteId,
+    code: scan.status.toUpperCase(),
+    message: scan.reason || "笔记已跳过",
+  }];
+  return {
+    noteId: scan.noteId,
+    title: scan.title,
+    scannedVersion: scan.version,
+    status: statusMap[scan.status],
+    remoteReferenceCount: scan.scan.remoteReferenceCount,
+    uniqueRemoteUrlCount: scan.scan.remoteUrls.length,
+    localizedReferences: 0,
+    localizedUrls: 0,
+    deduplicatedAttachments: 0,
+    failedUrls: 0,
+    skippedUrls: scan.status === "ready" && scan.scan.remoteReferenceCount === 0 ? 0 : scan.scan.remoteUrls.length,
+    failures,
+    warnings: [],
+  };
+}

--- a/backend/src/services/remote-image-localization-mutation.ts
+++ b/backend/src/services/remote-image-localization-mutation.ts
@@ -1,0 +1,266 @@
+import crypto from "node:crypto";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+import { hasPermission, resolveNotePermission } from "../middleware/acl";
+import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs";
+import { rebuildBlockAuthorityStore } from "../lib/blockAuthorityStore";
+import { replaceRemoteImages } from "../lib/remote-image-localization";
+import { syncNoteBlocks } from "../lib/noteBlocks";
+import { syncNoteLinks } from "../lib/noteLinks";
+import { noteVersionsRepository } from "../repositories";
+import { deleteAttachmentObject } from "./attachment-storage";
+import { logAudit } from "./audit";
+import {
+  saveDownloadedRemoteImageForNote,
+  type DownloadedRemoteImage,
+  type ImportedRemoteImage,
+} from "./remote-image-import";
+import { broadcastNoteUpdated, broadcastToUser, broadcastYjsUpdate } from "./realtime";
+import type { NoteRow } from "./remote-image-localization-core";
+import { nowIso, readNote } from "./remote-image-localization-core";
+import { rebuildYjsSubdocumentsIfEnabled } from "./yjs-subdocuments";
+import { yFlush, yReplaceContentAsUpdate } from "./yjs";
+
+export interface CreatedAttachment {
+  id: string;
+  path: string;
+  createdPhysicalObject: boolean;
+}
+
+class WholeNoteMutationConflict extends Error {}
+
+export function currentWriteState(userId: string, noteId: string, version: number, content: string): {
+  note: NoteRow;
+  workspaceId: string | null;
+} | null {
+  try { yFlush(noteId); } catch {}
+  const note = readNote(noteId);
+  if (!note || note.version !== version || note.content !== content || note.isLocked || note.isTrashed) return null;
+  const permission = resolveNotePermission(noteId, userId);
+  if (!hasPermission(permission.permission, "write")) return null;
+  return { note, workspaceId: permission.workspaceId || null };
+}
+
+function commitWholeNoteContent(args: {
+  userId: string;
+  noteId: string;
+  expectedVersion: number;
+  expectedContent: string;
+  nextContent: string;
+  contentFormat: string;
+  replacedCount: number;
+}): { final: NoteRow; warnings: string[] } | null {
+  if (!currentWriteState(args.userId, args.noteId, args.expectedVersion, args.expectedContent)) return null;
+  const db = getDb();
+  let committedContent = args.nextContent;
+  let committedText = "";
+  const finalVersion = args.expectedVersion + 1;
+
+  const tx = db.transaction(() => {
+    const current = readNote(args.noteId);
+    const permission = resolveNotePermission(args.noteId, args.userId);
+    if (
+      !current
+      || current.version !== args.expectedVersion
+      || current.content !== args.expectedContent
+      || current.isLocked
+      || current.isTrashed
+      || !hasPermission(permission.permission, "write")
+    ) {
+      throw new WholeNoteMutationConflict("note changed before commit");
+    }
+
+    const synced = syncNoteBlocks(db, current.id, args.nextContent, args.contentFormat);
+    committedContent = synced.content;
+    committedText = synced.contentText;
+
+    noteVersionsRepository.create({
+      id: uuid(),
+      noteId: current.id,
+      userId: args.userId,
+      title: current.title,
+      content: current.content,
+      contentText: current.contentText,
+      contentFormat: current.contentFormat,
+      version: current.version,
+      changeType: "edit",
+      changeSummary: "本地化网络图片",
+    });
+
+    const updated = db.prepare(`
+      UPDATE notes
+         SET content = ?, contentText = ?, version = version + 1, updatedAt = datetime('now')
+       WHERE id = ? AND version = ? AND content = ?
+    `).run(committedContent, committedText, current.id, args.expectedVersion, args.expectedContent);
+    if (Number(updated.changes || 0) !== 1) throw new WholeNoteMutationConflict("optimistic update failed");
+
+    syncAttachmentReferences(db, current.id, committedContent);
+    syncNoteLinks(db, args.userId, current.id, committedContent);
+    if (["tiptap-json", "markdown"].includes(args.contentFormat)) {
+      rebuildBlockAuthorityStore(db, current.id, committedContent, args.contentFormat, {
+        noteVersion: finalVersion,
+        operationType: "whole-save",
+      });
+      rebuildYjsSubdocumentsIfEnabled(db, current.id, committedContent, args.contentFormat);
+    }
+  });
+
+  try {
+    tx();
+  } catch (error) {
+    if (error instanceof WholeNoteMutationConflict) return null;
+    throw error;
+  }
+
+  const warnings: string[] = [];
+  if (args.contentFormat === "markdown") {
+    try {
+      const yjs = yReplaceContentAsUpdate(args.noteId, committedContent, args.userId || null);
+      if (yjs) broadcastYjsUpdate(args.noteId, yjs.updateBase64);
+    } catch (error) {
+      warnings.push(`Yjs 同步失败：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const final = readNote(args.noteId);
+  if (!final) throw new Error("本地化写回后无法读取笔记");
+  try {
+    broadcastNoteUpdated(final.id, {
+      version: final.version,
+      updatedAt: final.updatedAt || nowIso(),
+      title: final.title,
+      contentText: final.contentText,
+      actorUserId: args.userId,
+    });
+    broadcastToUser(args.userId, {
+      type: "note:list-updated" as any,
+      note: {
+        id: final.id,
+        title: final.title,
+        contentText: final.contentText,
+        updatedAt: final.updatedAt || nowIso(),
+        version: final.version,
+        isPinned: final.isPinned,
+        isTrashed: final.isTrashed,
+        notebookId: final.notebookId,
+        workspaceId: final.workspaceId,
+      },
+      actorUserId: args.userId,
+      actorConnectionId: null,
+    } as any);
+  } catch (error) {
+    warnings.push(`实时通知失败：${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    logAudit(
+      args.userId,
+      "note",
+      "update",
+      { noteId: final.id, localizedRemoteImages: args.replacedCount },
+      { targetType: "note", targetId: final.id },
+    );
+  } catch {
+    // Audit is post-commit best effort.
+  }
+  return { final, warnings };
+}
+
+export function applyLocalizedContent(args: {
+  userId: string;
+  noteId: string;
+  scannedVersion: number;
+  scannedContent: string;
+  contentFormat: string;
+  replacements: ReadonlyMap<string, string>;
+}): { updated: boolean; conflict: boolean; replacedCount: number; finalVersion?: number; warnings: string[] } {
+  const state = currentWriteState(args.userId, args.noteId, args.scannedVersion, args.scannedContent);
+  if (!state) return { updated: false, conflict: true, replacedCount: 0, warnings: [] };
+  const replacement = replaceRemoteImages(state.note.content || "", args.contentFormat, args.replacements);
+  if (replacement.parseError) throw new Error(replacement.parseError);
+  if (!replacement.changed) {
+    return { updated: false, conflict: false, replacedCount: 0, finalVersion: state.note.version, warnings: [] };
+  }
+  const committed = commitWholeNoteContent({
+    userId: args.userId,
+    noteId: args.noteId,
+    expectedVersion: args.scannedVersion,
+    expectedContent: args.scannedContent,
+    nextContent: replacement.content,
+    contentFormat: args.contentFormat,
+    replacedCount: replacement.replacedCount,
+  });
+  if (!committed) return { updated: false, conflict: true, replacedCount: 0, warnings: [] };
+  return {
+    updated: true,
+    conflict: false,
+    replacedCount: replacement.replacedCount,
+    finalVersion: committed.final.version,
+    warnings: committed.warnings,
+  };
+}
+
+export async function saveLocalizedAttachment(args: {
+  jobId: string;
+  userId: string;
+  noteId: string;
+  workspaceId: string | null;
+  sourceUrl: string;
+  downloaded: DownloadedRemoteImage;
+}): Promise<{ imported: ImportedRemoteImage; created: CreatedAttachment | null }> {
+  const db = getDb();
+  const hash = crypto.createHash("sha256").update(args.downloaded.buffer).digest("hex");
+  const existingScopeRows = db.prepare(
+    args.workspaceId
+      ? "SELECT id, noteId, path FROM attachments WHERE userId = ? AND workspaceId = ? AND hash = ?"
+      : "SELECT id, noteId, path FROM attachments WHERE userId = ? AND workspaceId IS NULL AND hash = ?",
+  ).all(...(args.workspaceId ? [args.userId, args.workspaceId, hash] : [args.userId, hash])) as Array<{
+    id: string;
+    noteId: string;
+    path: string;
+  }>;
+  const uploadSource = `historical-localization:${args.jobId}`.slice(0, 64);
+  const imported = await saveDownloadedRemoteImageForNote({
+    downloaded: args.downloaded,
+    sourceUrl: args.sourceUrl,
+    noteId: args.noteId,
+    userId: args.userId,
+    workspaceId: args.workspaceId,
+    uploadSource,
+  });
+  const row = db.prepare("SELECT path, uploadSource FROM attachments WHERE id = ?")
+    .get(imported.id) as { path: string; uploadSource: string | null } | undefined;
+  return {
+    imported,
+    created: row?.uploadSource === uploadSource
+      ? { id: imported.id, path: row.path, createdPhysicalObject: existingScopeRows.length === 0 }
+      : null,
+  };
+}
+
+export async function rollbackLocalizedAttachments(created: CreatedAttachment[]): Promise<void> {
+  if (!created.length) return;
+  const db = getDb();
+  const unique = [...new Map(created.map((item) => [item.id, item])).values()];
+  const physicalPaths = new Set<string>();
+  try {
+    db.transaction(() => {
+      for (const item of unique) {
+        const deleted = db.prepare("DELETE FROM attachments WHERE id = ?").run(item.id);
+        if (Number(deleted.changes || 0) > 0 && item.createdPhysicalObject) physicalPaths.add(item.path);
+      }
+    })();
+  } catch (error) {
+    console.warn("[remote-image-localization] rollback attachment rows failed:", error);
+    return;
+  }
+  for (const storagePath of physicalPaths) {
+    const remaining = db.prepare("SELECT COUNT(*) AS count FROM attachments WHERE path = ?")
+      .get(storagePath) as { count: number };
+    if (Number(remaining.count || 0) > 0) continue;
+    try {
+      await deleteAttachmentObject(storagePath);
+    } catch (error) {
+      console.warn("[remote-image-localization] rollback attachment object failed:", storagePath, error);
+    }
+  }
+}

--- a/backend/src/services/remote-image-localization-runner.ts
+++ b/backend/src/services/remote-image-localization-runner.ts
@@ -1,0 +1,324 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { hasPermission, resolveNotePermission } from "../middleware/acl";
+import { scanRemoteImages } from "../lib/remote-image-localization";
+import {
+  downloadRemoteImage,
+  type DownloadedRemoteImage,
+  RemoteImageError,
+} from "./remote-image-import";
+import {
+  activeJobs,
+  DEFAULT_MAX_ACTIVE_JOBS,
+  ensureJobsDir,
+  getLimits,
+  JOBS_DIR,
+  jobs,
+  LocalizationJobError,
+  nowIso,
+  persistJob,
+  readNote,
+  readPositiveEnv,
+  scheduledJobs,
+  type LocalizationFailure,
+  type LocalizationJob,
+  type LocalizationNoteResult,
+} from "./remote-image-localization-core";
+import {
+  applyLocalizedContent,
+  currentWriteState,
+  rollbackLocalizedAttachments,
+  saveLocalizedAttachment,
+  type CreatedAttachment,
+} from "./remote-image-localization-mutation";
+import { yFlush } from "./yjs";
+
+interface CachedDownload {
+  tempPath: string;
+  mimeType: string;
+  filename: string;
+  finalUrl: string;
+  size: number;
+}
+
+export function scheduleQueuedLocalizationJobs(): void {
+  const maxActive = readPositiveEnv(
+    "REMOTE_IMAGE_LOCALIZATION_MAX_ACTIVE_JOBS",
+    DEFAULT_MAX_ACTIVE_JOBS,
+    8,
+  );
+  let reserved = activeJobs.size + scheduledJobs.size;
+  if (reserved >= maxActive) return;
+  const queued = [...jobs.values()]
+    .filter((job) => job.status === "queued" && !activeJobs.has(job.id) && !scheduledJobs.has(job.id))
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  for (const job of queued) {
+    if (reserved >= maxActive) break;
+    scheduledJobs.add(job.id);
+    reserved += 1;
+    setImmediate(() => {
+      scheduledJobs.delete(job.id);
+      void runLocalizationJob(job.id).catch((error) => {
+        console.error("[remote-image-localization] job failed:", error);
+      });
+    });
+  }
+}
+
+
+function pushFailure(job: LocalizationJob, result: LocalizationNoteResult, failure: LocalizationFailure): void {
+  result.failures.push(failure);
+  job.failures.push(failure);
+}
+
+function errorDetails(error: unknown): { code: string; message: string } {
+  if (error instanceof RemoteImageError || error instanceof LocalizationJobError) {
+    return { code: error.code, message: error.message };
+  }
+  return { code: "LOCALIZATION_FAILED", message: error instanceof Error ? error.message : String(error) };
+}
+
+function finishSkipped(job: LocalizationJob, result: LocalizationNoteResult): void {
+  job.summary.processedNotes += 1;
+  job.summary.skippedNotes += 1;
+  if (result.status === "conflict") job.summary.conflictNotes += 1;
+  persistJob(job);
+}
+
+async function runLocalizationJob(jobId: string): Promise<void> {
+  scheduledJobs.delete(jobId);
+  if (activeJobs.has(jobId)) return;
+  const job = jobs.get(jobId);
+  if (!job || job.status !== "queued") return;
+  activeJobs.add(jobId);
+  const limits = getLimits();
+  ensureJobsDir();
+  const downloadDir = path.join(JOBS_DIR, `${jobId}.downloads`);
+  fs.rmSync(downloadDir, { recursive: true, force: true });
+  fs.mkdirSync(downloadDir, { recursive: true, mode: 0o700 });
+  const downloadCache = new Map<string, Promise<CachedDownload>>();
+  const countedDownloads = new Set<string>();
+
+  const getDownloaded = (url: string): Promise<CachedDownload> => {
+    const existing = downloadCache.get(url);
+    if (existing) {
+      job.summary.reusedDownloads += 1;
+      return existing;
+    }
+    const promise = downloadRemoteImage(url).then(async (downloaded) => {
+      const size = downloaded.buffer.byteLength;
+      if (job.summary.downloadedBytes + size > limits.maxTotalBytes) {
+        throw new LocalizationJobError(
+          `任务下载总量超过 ${Math.round(limits.maxTotalBytes / 1024 / 1024)}MB 限制`,
+          "TOTAL_SIZE_LIMIT_EXCEEDED",
+          413,
+        );
+      }
+      if (!countedDownloads.has(url)) {
+        countedDownloads.add(url);
+        job.summary.downloadedUniqueUrls += 1;
+        job.summary.downloadedBytes += size;
+      }
+      const tempPath = path.join(downloadDir, `${crypto.createHash("sha256").update(url).digest("hex")}.bin`);
+      await fs.promises.writeFile(tempPath, downloaded.buffer, { mode: 0o600 });
+      return {
+        tempPath,
+        mimeType: downloaded.mimeType,
+        filename: downloaded.filename,
+        finalUrl: downloaded.finalUrl,
+        size,
+      };
+    });
+    downloadCache.set(url, promise);
+    return promise;
+  };
+
+  try {
+    job.status = "running";
+    job.startedAt = nowIso();
+    persistJob(job);
+
+    for (const result of job.noteResults) {
+      if (result.status !== "queued") continue;
+      try { yFlush(result.noteId); } catch {}
+      const current = readNote(result.noteId);
+      if (!current) {
+        result.status = "skipped";
+        result.skippedUrls = result.uniqueRemoteUrlCount;
+        pushFailure(job, result, { noteId: result.noteId, code: "NOTE_NOT_FOUND", message: "笔记不存在" });
+        finishSkipped(job, result);
+        continue;
+      }
+
+      const permission = resolveNotePermission(current.id, job.userId);
+      if (!hasPermission(permission.permission, "write")) {
+        result.status = "forbidden";
+        result.skippedUrls = result.uniqueRemoteUrlCount;
+        pushFailure(job, result, { noteId: current.id, code: "FORBIDDEN", message: "处理前写权限已失效" });
+        finishSkipped(job, result);
+        continue;
+      }
+      if (current.isLocked || current.isTrashed || current.version !== result.scannedVersion) {
+        result.status = current.isLocked ? "locked" : current.isTrashed ? "trashed" : "conflict";
+        result.skippedUrls = result.uniqueRemoteUrlCount;
+        pushFailure(job, result, {
+          noteId: current.id,
+          code: current.isLocked ? "NOTE_LOCKED" : current.isTrashed ? "NOTE_TRASHED" : "VERSION_CONFLICT",
+          message: current.version !== result.scannedVersion
+            ? `扫描版本 ${result.scannedVersion}，当前版本 ${current.version}`
+            : current.isLocked ? "笔记已锁定" : "笔记位于回收站",
+        });
+        finishSkipped(job, result);
+        continue;
+      }
+
+      const scan = scanRemoteImages(current.content || "", current.contentFormat || "tiptap-json");
+      if (scan.parseError) {
+        result.status = "parse_error";
+        result.skippedUrls = scan.remoteUrls.length;
+        pushFailure(job, result, { noteId: current.id, code: "CONTENT_PARSE_FAILED", message: scan.parseError });
+        finishSkipped(job, result);
+        continue;
+      }
+
+      job.currentNoteId = current.id;
+      job.currentNoteTitle = current.title;
+      const replacements = new Map<string, string>();
+      const createdAttachments: CreatedAttachment[] = [];
+      let cancelledAfterCurrent = false;
+
+      for (const url of scan.remoteUrls) {
+        if (job.cancelRequested) {
+          cancelledAfterCurrent = true;
+          result.skippedUrls += scan.remoteUrls.length - result.localizedUrls - result.failedUrls;
+          break;
+        }
+        job.currentUrl = url;
+        persistJob(job);
+        try {
+          const cached = await getDownloaded(url);
+          const state = currentWriteState(job.userId, current.id, result.scannedVersion, current.content);
+          if (!state) throw new LocalizationJobError("下载期间笔记内容或权限已变化", "VERSION_CONFLICT", 409);
+          const downloaded: DownloadedRemoteImage = {
+            buffer: await fs.promises.readFile(cached.tempPath),
+            mimeType: cached.mimeType,
+            filename: cached.filename,
+            finalUrl: cached.finalUrl,
+          };
+          const saved = await saveLocalizedAttachment({
+            jobId: job.id,
+            userId: job.userId,
+            noteId: current.id,
+            workspaceId: state.workspaceId,
+            sourceUrl: url,
+            downloaded,
+          });
+          replacements.set(url, saved.imported.url);
+          if (saved.created) createdAttachments.push(saved.created);
+          result.localizedUrls += 1;
+          if (saved.imported.deduplicated) result.deduplicatedAttachments += 1;
+        } catch (error) {
+          const details = errorDetails(error);
+          result.failedUrls += 1;
+          pushFailure(job, result, { noteId: current.id, url, code: details.code, message: details.message });
+        }
+        persistJob(job);
+      }
+
+      if (replacements.size > 0) {
+        try {
+          const applied = applyLocalizedContent({
+            userId: job.userId,
+            noteId: current.id,
+            scannedVersion: result.scannedVersion,
+            scannedContent: current.content,
+            contentFormat: current.contentFormat,
+            replacements,
+          });
+          if (applied.conflict) {
+            await rollbackLocalizedAttachments(createdAttachments);
+            result.localizedUrls = 0;
+            result.deduplicatedAttachments = 0;
+            result.status = "conflict";
+            result.skippedUrls += replacements.size;
+            pushFailure(job, result, {
+              noteId: current.id,
+              code: "VERSION_CONFLICT",
+              message: "保存前笔记内容、权限或锁定状态已变化，未覆盖最新正文",
+            });
+            job.summary.conflictNotes += 1;
+          } else if (applied.updated) {
+            result.finalVersion = applied.finalVersion;
+            result.localizedReferences = applied.replacedCount;
+            result.warnings.push(...applied.warnings);
+            result.status = result.failedUrls > 0 ? "partial" : "completed";
+            job.summary.updatedNotes += 1;
+            job.summary.localizedReferences += applied.replacedCount;
+            job.summary.localizedUrls += result.localizedUrls;
+            job.summary.deduplicatedAttachments += result.deduplicatedAttachments;
+          } else {
+            await rollbackLocalizedAttachments(createdAttachments);
+            result.localizedUrls = 0;
+            result.deduplicatedAttachments = 0;
+            result.status = result.failedUrls > 0 ? "failed" : "skipped";
+          }
+        } catch (error) {
+          await rollbackLocalizedAttachments(createdAttachments);
+          result.localizedUrls = 0;
+          result.deduplicatedAttachments = 0;
+          const details = errorDetails(error);
+          result.status = "failed";
+          pushFailure(job, result, { noteId: current.id, code: details.code, message: details.message });
+        }
+      } else {
+        result.status = result.failedUrls > 0 ? "failed" : "skipped";
+      }
+
+      job.summary.failedUrls += result.failedUrls;
+      job.summary.processedNotes += 1;
+      if (["failed", "partial", "conflict", "parse_error"].includes(result.status)) job.summary.notesWithFailures += 1;
+      if (["skipped", "forbidden", "locked", "trashed", "conflict", "parse_error"].includes(result.status)) job.summary.skippedNotes += 1;
+      job.currentUrl = null;
+      persistJob(job);
+
+      if (cancelledAfterCurrent || job.cancelRequested) {
+        job.status = "cancelled";
+        job.completedAt = nowIso();
+        job.currentNoteId = null;
+        job.currentNoteTitle = null;
+        job.currentUrl = null;
+        for (const queued of job.noteResults.filter((entry) => entry.status === "queued")) {
+          queued.status = "skipped";
+          queued.skippedUrls = queued.uniqueRemoteUrlCount;
+          job.summary.processedNotes += 1;
+          job.summary.skippedNotes += 1;
+        }
+        persistJob(job);
+        return;
+      }
+    }
+
+    job.status = job.failures.length > 0 ? "completed_with_errors" : "completed";
+    job.completedAt = nowIso();
+    job.currentNoteId = null;
+    job.currentNoteTitle = null;
+    job.currentUrl = null;
+    persistJob(job);
+  } catch (error) {
+    const details = errorDetails(error);
+    job.status = "failed";
+    job.error = details.message;
+    job.completedAt = nowIso();
+    job.currentNoteId = null;
+    job.currentNoteTitle = null;
+    job.currentUrl = null;
+    job.failures.push({ noteId: "", code: details.code, message: details.message });
+    persistJob(job);
+  } finally {
+    activeJobs.delete(jobId);
+    fs.rmSync(downloadDir, { recursive: true, force: true });
+    scheduleQueuedLocalizationJobs();
+  }
+}
+

--- a/backend/src/services/remote-image-localization.ts
+++ b/backend/src/services/remote-image-localization.ts
@@ -1,0 +1,136 @@
+import { v4 as uuid } from "uuid";
+import {
+  createInitialNoteResult,
+  jobs,
+  LocalizationJobError,
+  nowIso,
+  persistJob,
+  publicJob,
+  resolveScopeNoteIds,
+  scanLocalizationScope,
+  type LocalizationJob,
+  type LocalizationScopeInput,
+} from "./remote-image-localization-core";
+import { scheduleQueuedLocalizationJobs } from "./remote-image-localization-runner";
+
+function hasActiveLocalizationJob(userId: string): boolean {
+  return [...jobs.values()].some(
+    (job) => job.userId === userId && (job.status === "queued" || job.status === "running"),
+  );
+}
+
+export function createLocalizationJob(userId: string, input: LocalizationScopeInput): Omit<LocalizationJob, "userId" | "expectedVersions"> {
+  if (hasActiveLocalizationJob(userId)) {
+    throw new LocalizationJobError(
+      "已有网络图片本地化任务正在排队或执行，请等待完成后重试",
+      "JOB_ALREADY_ACTIVE",
+      409,
+    );
+  }
+  const scope = resolveScopeNoteIds(userId, input);
+  const scan = scanLocalizationScope(userId, input);
+  if (scan.uniqueRemoteUrlCount > scan.limits.maxImages) {
+    throw new LocalizationJobError(
+      `待处理唯一图片 ${scan.uniqueRemoteUrlCount} 张，超过单次 ${scan.limits.maxImages} 张限制`,
+      "IMAGE_LIMIT_EXCEEDED",
+      413,
+    );
+  }
+
+  const noteResults = scan.notes.map(createInitialNoteResult);
+  const initialSkipped = noteResults.filter((result) => result.status !== "queued").length;
+  const initialConflicts = noteResults.filter((result) => result.status === "conflict").length;
+  const job: LocalizationJob = {
+    id: uuid(),
+    userId,
+    status: "queued",
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    startedAt: null,
+    completedAt: null,
+    cancelRequested: false,
+    source: scope.source,
+    notebookId: scope.notebookId,
+    noteIds: scan.snapshot.noteIds,
+    expectedVersions: scan.snapshot.expectedVersions,
+    currentNoteId: null,
+    currentNoteTitle: null,
+    currentUrl: null,
+    error: null,
+    summary: {
+      totalNotes: scan.noteCount,
+      scannedNotes: scan.noteCount,
+      processedNotes: initialSkipped,
+      updatedNotes: 0,
+      skippedNotes: initialSkipped,
+      conflictNotes: initialConflicts,
+      notesWithFailures: noteResults.filter((result) => result.failures.length > 0).length,
+      totalImageReferences: scan.totalImageReferences,
+      remoteReferenceCount: scan.remoteReferenceCount,
+      uniqueRemoteUrlCount: scan.uniqueRemoteUrlCount,
+      downloadedUniqueUrls: 0,
+      reusedDownloads: 0,
+      localizedReferences: 0,
+      localizedUrls: 0,
+      deduplicatedAttachments: 0,
+      failedUrls: 0,
+      downloadedBytes: 0,
+    },
+    noteResults,
+    failures: noteResults.flatMap((result) => result.failures),
+  };
+  persistJob(job);
+  scheduleQueuedLocalizationJobs();
+  return publicJob(job);
+}
+
+function findOwnedJob(userId: string, jobId: string): LocalizationJob {
+  const job = jobs.get(jobId);
+  if (!job || job.userId !== userId) throw new LocalizationJobError("任务不存在", "JOB_NOT_FOUND", 404);
+  return job;
+}
+
+export function getLocalizationJob(userId: string, jobId: string) {
+  return publicJob(findOwnedJob(userId, jobId));
+}
+
+export function listLocalizationJobs(userId: string, limit = 20) {
+  const safeLimit = Math.min(Math.max(Math.floor(limit) || 20, 1), 100);
+  return [...jobs.values()]
+    .filter((job) => job.userId === userId)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .slice(0, safeLimit)
+    .map(publicJob);
+}
+
+export function cancelLocalizationJob(userId: string, jobId: string) {
+  const job = findOwnedJob(userId, jobId);
+  if (job.status !== "queued" && job.status !== "running") {
+    throw new LocalizationJobError("任务已经结束，无法取消", "JOB_NOT_CANCELLABLE", 409);
+  }
+  job.cancelRequested = true;
+  persistJob(job);
+  return publicJob(job);
+}
+
+export function retryLocalizationJob(userId: string, jobId: string) {
+  const job = findOwnedJob(userId, jobId);
+  if (job.status === "queued" || job.status === "running") {
+    throw new LocalizationJobError("任务仍在执行，不能重试", "JOB_STILL_RUNNING", 409);
+  }
+  const retryIds = job.noteResults
+    .filter((result) => ["failed", "partial", "conflict", "parse_error"].includes(result.status))
+    .map((result) => result.noteId)
+    .filter(Boolean);
+  if (retryIds.length === 0) throw new LocalizationJobError("没有可重试的失败笔记", "NO_RETRYABLE_NOTES", 409);
+  return createLocalizationJob(userId, { noteIds: retryIds });
+}
+
+export { scanLocalizationScope, LocalizationJobError } from "./remote-image-localization-core";
+export type {
+  LocalizationScopeInput,
+  LocalizationJob,
+  LocalizationScopeScan,
+  LocalizationNoteResult,
+} from "./remote-image-localization-core";
+export { applyLocalizedContent, rollbackLocalizedAttachments } from "./remote-image-localization-mutation";

--- a/backend/tests/remote-image-localization-authority.test.ts
+++ b/backend/tests/remote-image-localization-authority.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-image-authority-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+process.env.NOWEN_YJS_SUBDOCUMENTS = "1";
+
+const USER_ID = "remote-authority-user";
+const NOTEBOOK_ID = "remote-authority-book";
+const NOTE_ID = "41414141-4141-4414-8414-414141414141";
+let closeDb: (() => void) | undefined;
+
+test.after(() => {
+  closeDb?.();
+  delete process.env.NOWEN_YJS_SUBDOCUMENTS;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function modules() {
+  const [schema, localization, importer, store] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/services/remote-image-localization"),
+    import("../src/services/remote-image-import"),
+    import("../src/lib/blockAuthorityStore"),
+  ]);
+  closeDb = schema.closeDb;
+  return { ...schema, localization, importer, store };
+}
+
+async function seed() {
+  const { getDb } = await modules();
+  const db = getDb();
+  db.prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+  db.prepare("INSERT OR IGNORE INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run(NOTEBOOK_ID, USER_ID, "Authority images");
+  const content = JSON.stringify({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        attrs: { blockId: "blk_remote_authority" },
+        content: [{ type: "text", text: "before" }],
+      },
+      {
+        type: "image",
+        attrs: {
+          blockId: "blk_remote_image",
+          src: "https://cdn.example.com/authority.png",
+          alt: "authority",
+        },
+      },
+    ],
+  });
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked, isTrashed)
+    VALUES (?, ?, ?, ?, ?, ?, 'tiptap-json', 5, 0, 0)
+  `).run(NOTE_ID, USER_ID, NOTEBOOK_ID, "Authority image", content, "before");
+  return content;
+}
+
+function pixelPng(): Buffer {
+  return Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  );
+}
+
+test("whole-note localization rebuilds Block Authority and Yjs subdocuments", async () => {
+  const original = await seed();
+  const { getDb, localization, importer, store } = await modules();
+  const imported = await importer.saveDownloadedRemoteImageForNote({
+    downloaded: {
+      buffer: pixelPng(),
+      mimeType: "image/png",
+      filename: "authority.png",
+      finalUrl: "https://cdn.example.com/authority.png",
+    },
+    sourceUrl: "https://cdn.example.com/authority.png",
+    noteId: NOTE_ID,
+    userId: USER_ID,
+    workspaceId: null,
+    uploadSource: "authority-test",
+  });
+
+  const applied = localization.applyLocalizedContent({
+    userId: USER_ID,
+    noteId: NOTE_ID,
+    scannedVersion: 5,
+    scannedContent: original,
+    contentFormat: "tiptap-json",
+    replacements: new Map([["https://cdn.example.com/authority.png", imported.url]]),
+  });
+  assert.equal(applied.updated, true);
+  assert.equal(applied.conflict, false);
+  assert.equal(applied.finalVersion, 6);
+
+  const db = getDb();
+  const note = db.prepare("SELECT content, version FROM notes WHERE id = ?").get(NOTE_ID) as {
+    content: string;
+    version: number;
+  };
+  assert.equal(note.version, 6);
+  assert.match(note.content, new RegExp(imported.id));
+  assert.equal(store.readAuthoritativeNoteContent(db, NOTE_ID, note.content).source, "blocks");
+  assert.equal(
+    (db.prepare("SELECT status FROM note_block_documents WHERE noteId = ?").get(NOTE_ID) as { status: string }).status,
+    "healthy",
+  );
+  const manifest = db.prepare(
+    "SELECT generation, structureVersion FROM note_y_subdocument_manifests WHERE noteId = ?",
+  ).get(NOTE_ID) as { generation: number; structureVersion: number } | undefined;
+  assert.ok(manifest);
+  assert.ok(manifest.generation >= 1);
+  assert.ok(manifest.structureVersion >= 1);
+});
+
+test("late conflict can roll back task-created attachment rows and objects", async () => {
+  const original = await seed();
+  const { getDb } = await modules();
+  const mutation = await import("../src/services/remote-image-localization-mutation");
+  const saved = await mutation.saveLocalizedAttachment({
+    jobId: "late-conflict-job",
+    userId: USER_ID,
+    noteId: NOTE_ID,
+    workspaceId: null,
+    sourceUrl: "https://cdn.example.com/late.png",
+    downloaded: {
+      buffer: pixelPng(),
+      mimeType: "image/png",
+      filename: "late.png",
+      finalUrl: "https://cdn.example.com/late.png",
+    },
+  });
+  assert.ok(saved.created);
+  const db = getDb();
+  db.prepare("UPDATE notes SET version = version + 1, content = content || ' ' WHERE id = ?").run(NOTE_ID);
+  const applied = mutation.applyLocalizedContent({
+    userId: USER_ID,
+    noteId: NOTE_ID,
+    scannedVersion: 5,
+    scannedContent: original,
+    contentFormat: "tiptap-json",
+    replacements: new Map([["https://cdn.example.com/late.png", saved.imported.url]]),
+  });
+  assert.equal(applied.conflict, true);
+  await mutation.rollbackLocalizedAttachments([saved.created!]);
+  assert.equal(db.prepare("SELECT id FROM attachments WHERE id = ?").get(saved.imported.id), undefined);
+});

--- a/backend/tests/remote-image-localization-service.test.ts
+++ b/backend/tests/remote-image-localization-service.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-image-localization-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+const USER_ID = "user-image-localization";
+const OTHER_USER_ID = "user-image-localization-other";
+const NOTEBOOK_ID = "nb-image-localization";
+const CHILD_NOTEBOOK_ID = "nb-image-localization-child";
+const NOTE_ID = "note-image-localization";
+const SECOND_NOTE_ID = "note-image-localization-second";
+const LOCKED_NOTE_ID = "note-image-localization-locked";
+const TRASHED_NOTE_ID = "note-image-localization-trashed";
+const OTHER_NOTE_ID = "note-image-localization-other";
+
+async function modules() {
+  const [{ getDb }, localization, importer] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/services/remote-image-localization"),
+    import("../src/services/remote-image-import"),
+  ]);
+  return { getDb, localization, importer };
+}
+
+async function seed() {
+  const { getDb } = await modules();
+  const db = getDb();
+  db.prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(USER_ID, USER_ID, "hash");
+  db.prepare("INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(OTHER_USER_ID, OTHER_USER_ID, "hash");
+  db.prepare("INSERT OR IGNORE INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run(NOTEBOOK_ID, USER_ID, "Images");
+  db.prepare("INSERT OR IGNORE INTO notebooks (id, userId, name, parentId) VALUES (?, ?, ?, ?)")
+    .run(CHILD_NOTEBOOK_ID, USER_ID, "Child", NOTEBOOK_ID);
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked, isTrashed)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    NOTE_ID,
+    USER_ID,
+    NOTEBOOK_ID,
+    "Remote images",
+    "![remote](https://cdn.example.com/a.png)\n![local](/api/attachments/local-1)\n![data](data:image/png;base64,AAAA)",
+    "",
+    "markdown",
+    7,
+    0,
+    0,
+  );
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked, isTrashed)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    SECOND_NOTE_ID,
+    USER_ID,
+    CHILD_NOTEBOOK_ID,
+    "Second",
+    "![same](https://cdn.example.com/a.png)",
+    "",
+    "markdown",
+    2,
+    0,
+    0,
+  );
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked, isTrashed)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(LOCKED_NOTE_ID, USER_ID, NOTEBOOK_ID, "Locked", "![x](https://cdn.example.com/x.png)", "", "markdown", 1, 1, 0);
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked, isTrashed)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(TRASHED_NOTE_ID, USER_ID, NOTEBOOK_ID, "Trashed", "![x](https://cdn.example.com/x.png)", "", "markdown", 1, 0, 1);
+
+  db.prepare("INSERT OR IGNORE INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run("nb-image-other", OTHER_USER_ID, "Other");
+  db.prepare(`
+    INSERT OR REPLACE INTO notes
+      (id, userId, notebookId, title, content, contentText, contentFormat, version)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(OTHER_NOTE_ID, OTHER_USER_ID, "nb-image-other", "Other", "![x](https://cdn.example.com/other.png)", "", "markdown", 1);
+}
+
+async function waitForJob(userId: string, jobId: string) {
+  const { localization } = await modules();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const job = localization.getLocalizationJob(userId, jobId);
+    if (!["queued", "running"].includes(job.status)) return job;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("localization job did not finish");
+}
+
+test("scanLocalizationScope reports remote/local/ignored images and permission skips", async () => {
+  await seed();
+  const { localization } = await modules();
+  const scan = localization.scanLocalizationScope(USER_ID, {
+    noteIds: [NOTE_ID, LOCKED_NOTE_ID, TRASHED_NOTE_ID, OTHER_NOTE_ID],
+    expectedVersions: { [NOTE_ID]: 7 },
+  });
+
+  assert.equal(scan.noteCount, 4);
+  assert.equal(scan.readyNoteCount, 1);
+  assert.equal(scan.notesWithRemoteImages, 1);
+  assert.equal(scan.remoteReferenceCount, 1);
+  assert.equal(scan.localReferenceCount, 1);
+  assert.equal(scan.ignoredReferenceCount, 1);
+  assert.equal(scan.uniqueRemoteUrlCount, 1);
+  assert.equal(scan.notes.find((note) => note.noteId === LOCKED_NOTE_ID)?.status, "locked");
+  assert.equal(scan.notes.find((note) => note.noteId === TRASHED_NOTE_ID)?.status, "trashed");
+  assert.equal(scan.notes.find((note) => note.noteId === OTHER_NOTE_ID)?.status, "forbidden");
+});
+
+test("notebook scope includes descendants and deduplicates task URLs", async () => {
+  await seed();
+  const { localization } = await modules();
+  const scan = localization.scanLocalizationScope(USER_ID, { notebookId: NOTEBOOK_ID });
+  assert.ok(scan.notes.some((note) => note.noteId === NOTE_ID));
+  assert.ok(scan.notes.some((note) => note.noteId === SECOND_NOTE_ID));
+  assert.equal(scan.uniqueRemoteUrlCount, 1);
+  assert.equal(scan.remoteReferenceCount, 2);
+});
+
+test("expected version mismatch is recorded without downloading or overwriting", async () => {
+  await seed();
+  const { localization, getDb } = await modules();
+  const created = localization.createLocalizationJob(USER_ID, {
+    noteIds: [NOTE_ID],
+    expectedVersions: { [NOTE_ID]: 6 },
+  });
+  const completed = await waitForJob(USER_ID, created.id);
+  assert.equal(completed.status, "completed_with_errors");
+  assert.equal(completed.noteResults[0].status, "conflict");
+  assert.equal(completed.summary.downloadedUniqueUrls, 0);
+  const row = getDb().prepare("SELECT version, content FROM notes WHERE id = ?").get(NOTE_ID) as { version: number; content: string };
+  assert.equal(row.version, 7);
+  assert.match(row.content, /https:\/\/cdn\.example\.com\/a\.png/);
+});
+
+test("same-note retry reuses an existing attachment row and cross-note dedup shares storage", async () => {
+  await seed();
+  const { importer, getDb } = await modules();
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  );
+  const downloaded = {
+    buffer: png,
+    mimeType: "image/png",
+    filename: "pixel.png",
+    finalUrl: "https://cdn.example.com/pixel.png",
+  };
+
+  const first = await importer.saveDownloadedRemoteImageForNote({
+    downloaded,
+    sourceUrl: downloaded.finalUrl,
+    noteId: NOTE_ID,
+    userId: USER_ID,
+    workspaceId: null,
+    uploadSource: "test-localization",
+  });
+  const sameNote = await importer.saveDownloadedRemoteImageForNote({
+    downloaded,
+    sourceUrl: downloaded.finalUrl,
+    noteId: NOTE_ID,
+    userId: USER_ID,
+    workspaceId: null,
+    uploadSource: "test-localization",
+  });
+  assert.equal(sameNote.id, first.id);
+  assert.equal(sameNote.deduplicated, true);
+
+  const secondNote = await importer.saveDownloadedRemoteImageForNote({
+    downloaded,
+    sourceUrl: downloaded.finalUrl,
+    noteId: SECOND_NOTE_ID,
+    userId: USER_ID,
+    workspaceId: null,
+    uploadSource: "test-localization",
+  });
+  assert.notEqual(secondNote.id, first.id);
+  assert.equal(secondNote.deduplicated, true);
+
+  const rows = getDb().prepare("SELECT id, noteId, path FROM attachments WHERE id IN (?, ?) ORDER BY noteId")
+    .all(first.id, secondNote.id) as Array<{ id: string; noteId: string; path: string }>;
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].path, rows[1].path);
+  const sameNoteCount = getDb().prepare("SELECT COUNT(*) AS count FROM attachments WHERE noteId = ? AND hash IS NOT NULL")
+    .get(NOTE_ID) as { count: number };
+  assert.equal(sameNoteCount.count, 1);
+});
+
+test("job ownership is isolated", async () => {
+  await seed();
+  const { localization } = await modules();
+  const created = localization.createLocalizationJob(USER_ID, { noteIds: [LOCKED_NOTE_ID] });
+  await assert.rejects(
+    async () => localization.getLocalizationJob(OTHER_USER_ID, created.id),
+    (error: any) => error?.code === "JOB_NOT_FOUND",
+  );
+});

--- a/backend/tests/remote-image-localization.test.ts
+++ b/backend/tests/remote-image-localization.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyImageUrl,
+  replaceRemoteImages,
+  scanRemoteImages,
+} from "../src/lib/remote-image-localization";
+
+test("classifyImageUrl separates remote, Nowen local and unsupported schemes", () => {
+  assert.equal(classifyImageUrl("https://cdn.example.com/a.png"), "remote");
+  assert.equal(classifyImageUrl("http://cdn.example.com/a.png"), "remote");
+  assert.equal(classifyImageUrl("/api/attachments/att-1"), "local");
+  assert.equal(classifyImageUrl("/api/files/file-1"), "local");
+  assert.equal(classifyImageUrl("https://notes.example.com/api/files/file-1"), "remote");
+  assert.equal(classifyImageUrl("data:image/png;base64,AAAA"), "ignored");
+  assert.equal(classifyImageUrl("blob:https://notes.example.com/1"), "ignored");
+  assert.equal(classifyImageUrl("file:///tmp/a.png"), "ignored");
+});
+
+test("Markdown scan only counts image destinations and preserves ordinary links", () => {
+  const content = [
+    '![remote](https://cdn.example.com/a.png "title")',
+    "![remote duplicate](<https://cdn.example.com/a.png>)",
+    "![local](/api/attachments/local-1)",
+    "![data](data:image/png;base64,AAAA)",
+    "[ordinary link](https://cdn.example.com/a.png)",
+  ].join("\n");
+  const scan = scanRemoteImages(content, "markdown");
+  assert.equal(scan.totalImageReferences, 4);
+  assert.equal(scan.remoteReferenceCount, 2);
+  assert.equal(scan.localReferenceCount, 1);
+  assert.equal(scan.ignoredReferenceCount, 1);
+  assert.deepEqual(scan.remoteUrls, ["https://cdn.example.com/a.png"]);
+  const replacement = replaceRemoteImages(content, "markdown", new Map([
+    ["https://cdn.example.com/a.png", "/api/attachments/new-1"],
+  ]));
+  assert.equal(replacement.replacedCount, 2);
+  assert.match(replacement.content, /!\[remote\]\(\/api\/attachments\/new-1 "title"\)/);
+  assert.match(replacement.content, /!\[remote duplicate\]\(<\/api\/attachments\/new-1>\)/);
+  assert.match(replacement.content, /\[ordinary link\]\(https:\/\/cdn\.example\.com\/a\.png\)/);
+  const second = replaceRemoteImages(replacement.content, "markdown", new Map([
+    ["https://cdn.example.com/a.png", "/api/attachments/new-1"],
+  ]));
+  assert.equal(second.changed, false);
+  assert.equal(second.replacedCount, 0);
+});
+
+test("HTML replacement changes img src only and preserves attributes", () => {
+  const content = [
+    '<p><img src="https://cdn.example.com/a.webp" alt="A" width="320" data-align="center"></p>',
+    "<img src='/api/attachments/local-1' alt='local'>",
+    '<a href="https://cdn.example.com/a.webp">ordinary</a>',
+  ].join("");
+  const scan = scanRemoteImages(content, "html");
+  assert.equal(scan.remoteReferenceCount, 1);
+  assert.equal(scan.localReferenceCount, 1);
+  const replacement = replaceRemoteImages(content, "html", new Map([
+    ["https://cdn.example.com/a.webp", "/api/attachments/new-html"],
+  ]));
+  assert.equal(replacement.replacedCount, 1);
+  assert.match(replacement.content, /<img src="\/api\/attachments\/new-html" alt="A" width="320" data-align="center">/);
+  assert.match(replacement.content, /href="https:\/\/cdn\.example\.com\/a\.webp"/);
+});
+
+test("Tiptap replacement preserves image node metadata", () => {
+  const document = {
+    type: "doc",
+    content: [
+      { type: "image", attrs: { src: "https://cdn.example.com/a.png", alt: "diagram", title: "Architecture", width: 640, align: "center" } },
+      { type: "paragraph", content: [{ type: "text", text: "https://cdn.example.com/a.png" }] },
+      { type: "image", attrs: { src: "/api/attachments/local-1", width: 100 } },
+    ],
+  };
+  const content = JSON.stringify(document);
+  const scan = scanRemoteImages(content, "tiptap-json");
+  assert.equal(scan.remoteReferenceCount, 1);
+  assert.equal(scan.localReferenceCount, 1);
+  const replacement = replaceRemoteImages(content, "tiptap-json", new Map([
+    ["https://cdn.example.com/a.png", "/api/attachments/new-json"],
+  ]));
+  assert.equal(replacement.replacedCount, 1);
+  const parsed = JSON.parse(replacement.content);
+  assert.deepEqual(parsed.content[0].attrs, {
+    src: "/api/attachments/new-json",
+    alt: "diagram",
+    title: "Architecture",
+    width: 640,
+    align: "center",
+  });
+  assert.equal(parsed.content[1].content[0].text, "https://cdn.example.com/a.png");
+});
+
+test("malformed Tiptap JSON is reported without modifying content", () => {
+  const content = '{"type":"doc","content":[';
+  const scan = scanRemoteImages(content, "tiptap-json");
+  assert.ok(scan.parseError);
+  assert.equal(scan.remoteReferenceCount, 0);
+  const replacement = replaceRemoteImages(content, "tiptap-json", new Map([
+    ["https://cdn.example.com/a.png", "/api/attachments/new-json"],
+  ]));
+  assert.equal(replacement.content, content);
+  assert.equal(replacement.changed, false);
+  assert.ok(replacement.parseError);
+});

--- a/frontend/src/components/RemoteImageLocalizationPanel.tsx
+++ b/frontend/src/components/RemoteImageLocalizationPanel.tsx
@@ -1,0 +1,523 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  FileText,
+  Folder,
+  Image,
+  Loader2,
+  Play,
+  RefreshCw,
+  Search,
+  Square,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { useApp, useAppActions } from "@/store/AppContext";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import {
+  isRemoteImageLocalizationJobActive,
+  remoteImageLocalizationApi,
+  type RemoteImageLocalizationJob,
+  type RemoteImageLocalizationScope,
+  type RemoteImageLocalizationScan,
+} from "@/lib/remoteImageLocalizationApi";
+
+type ScopeMode = "current" | "selected" | "notebook";
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0 B";
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function terminalStatus(status: RemoteImageLocalizationJob["status"]): boolean {
+  return !["queued", "running"].includes(status);
+}
+
+export default function RemoteImageLocalizationPanel() {
+  const { state } = useApp();
+  const actions = useAppActions();
+  const { t, i18n } = useTranslation();
+  const zh = i18n.language.toLowerCase().startsWith("zh");
+  const tr = useCallback(
+    (key: string, chinese: string, english: string) => t(key, { defaultValue: zh ? chinese : english }),
+    [t, zh],
+  );
+
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<ScopeMode>("current");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [notebookId, setNotebookId] = useState("");
+  const [query, setQuery] = useState("");
+  const [scan, setScan] = useState<RemoteImageLocalizationScan | null>(null);
+  const [job, setJob] = useState<RemoteImageLocalizationJob | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const completedRefreshRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!notebookId && state.selectedNotebookId) setNotebookId(state.selectedNotebookId);
+  }, [notebookId, state.selectedNotebookId]);
+
+  const noteById = useMemo(
+    () => new Map(state.notes.map((note) => [note.id, note])),
+    [state.notes],
+  );
+
+  const visibleNotes = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return state.notes;
+    return state.notes.filter((note) =>
+      note.title.toLowerCase().includes(normalized)
+      || note.contentText?.toLowerCase().includes(normalized),
+    );
+  }, [query, state.notes]);
+
+  const expectedVersions = useCallback((ids: string[]) => {
+    const versions: Record<string, number> = {};
+    for (const id of ids) {
+      const note = noteById.get(id);
+      if (note && Number.isInteger(note.version)) versions[id] = note.version;
+      if (state.activeNote?.id === id && Number.isInteger(state.activeNote.version)) {
+        versions[id] = state.activeNote.version;
+      }
+    }
+    return versions;
+  }, [noteById, state.activeNote]);
+
+  const buildScope = useCallback((): RemoteImageLocalizationScope | null => {
+    if (mode === "current") {
+      if (!state.activeNote) return null;
+      return {
+        noteIds: [state.activeNote.id],
+        expectedVersions: { [state.activeNote.id]: state.activeNote.version },
+      };
+    }
+    if (mode === "selected") {
+      const ids = [...selectedIds];
+      if (ids.length === 0) return null;
+      return { noteIds: ids, expectedVersions: expectedVersions(ids) };
+    }
+    if (!notebookId) return null;
+    return { notebookId };
+  }, [expectedVersions, mode, notebookId, selectedIds, state.activeNote]);
+
+  const resetPreview = useCallback(() => {
+    setScan(null);
+    setError("");
+  }, []);
+
+  useEffect(() => {
+    resetPreview();
+  }, [mode, notebookId, selectedIds, resetPreview]);
+
+  const refreshChangedNotes = useCallback(async (completedJob: RemoteImageLocalizationJob) => {
+    if (completedRefreshRef.current.has(completedJob.id)) return;
+    completedRefreshRef.current.add(completedJob.id);
+    actions.refreshNotes();
+    const activeId = state.activeNote?.id;
+    const changedActive = activeId && completedJob.noteResults.some(
+      (result) => result.noteId === activeId && ["completed", "partial"].includes(result.status),
+    );
+    if (changedActive) {
+      try {
+        const latest = await api.getNote(activeId);
+        actions.setActiveNote(latest);
+      } catch {
+        // The list refresh still updates navigation; editor can reload manually.
+      }
+    }
+  }, [actions, state.activeNote?.id]);
+
+  useEffect(() => {
+    if (!open) return;
+    let disposed = false;
+    void remoteImageLocalizationApi.listJobs(10).then(({ jobs }) => {
+      if (disposed || job) return;
+      const active = jobs.find(isRemoteImageLocalizationJobActive);
+      if (active) setJob(active);
+      else if (jobs[0]) setJob(jobs[0]);
+    }).catch(() => {});
+    return () => { disposed = true; };
+  }, [job, open]);
+
+  useEffect(() => {
+    if (!job || !isRemoteImageLocalizationJobActive(job)) return;
+    let disposed = false;
+    const poll = async () => {
+      try {
+        const latest = await remoteImageLocalizationApi.getJob(job.id);
+        if (disposed) return;
+        setJob(latest);
+        if (terminalStatus(latest.status)) void refreshChangedNotes(latest);
+      } catch (pollError) {
+        if (!disposed) setError(pollError instanceof Error ? pollError.message : String(pollError));
+      }
+    };
+    void poll();
+    const timer = window.setInterval(() => void poll(), 1200);
+    return () => {
+      disposed = true;
+      window.clearInterval(timer);
+    };
+  }, [job?.id, job?.status, refreshChangedNotes]);
+
+  const handleScan = useCallback(async () => {
+    const scope = buildScope();
+    if (!scope) {
+      setError(tr("remoteImageLocalization.scopeRequired", "请选择要处理的笔记或笔记本", "Select notes or a notebook first"));
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      const result = await remoteImageLocalizationApi.scan(scope);
+      setScan(result);
+    } catch (scanError) {
+      setError(scanError instanceof Error ? scanError.message : String(scanError));
+    } finally {
+      setBusy(false);
+    }
+  }, [buildScope, tr]);
+
+  const handleStart = useCallback(async () => {
+    const scope = buildScope();
+    if (!scope) return;
+    setBusy(true);
+    setError("");
+    try {
+      const created = await remoteImageLocalizationApi.createJob(scope);
+      setJob(created);
+      setScan(null);
+      toast.success(tr("remoteImageLocalization.started", "网络图片本地化任务已启动", "Image localization job started"));
+    } catch (startError) {
+      setError(startError instanceof Error ? startError.message : String(startError));
+    } finally {
+      setBusy(false);
+    }
+  }, [buildScope, tr]);
+
+  const handleCancel = useCallback(async () => {
+    if (!job) return;
+    setBusy(true);
+    try {
+      setJob(await remoteImageLocalizationApi.cancelJob(job.id));
+    } catch (cancelError) {
+      setError(cancelError instanceof Error ? cancelError.message : String(cancelError));
+    } finally {
+      setBusy(false);
+    }
+  }, [job]);
+
+  const handleRetry = useCallback(async () => {
+    if (!job) return;
+    setBusy(true);
+    setError("");
+    try {
+      const retried = await remoteImageLocalizationApi.retryJob(job.id);
+      setJob(retried);
+      toast.success(tr("remoteImageLocalization.retryStarted", "失败项重试任务已启动", "Retry job started"));
+    } catch (retryError) {
+      setError(retryError instanceof Error ? retryError.message : String(retryError));
+    } finally {
+      setBusy(false);
+    }
+  }, [job, tr]);
+
+  const toggleNote = useCallback((noteId: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(noteId)) next.delete(noteId);
+      else next.add(noteId);
+      return next;
+    });
+  }, []);
+
+  const selectAllVisible = useCallback(() => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      const allSelected = visibleNotes.length > 0 && visibleNotes.every((note) => next.has(note.id));
+      for (const note of visibleNotes) {
+        if (allSelected) next.delete(note.id);
+        else next.add(note.id);
+      }
+      return next;
+    });
+  }, [visibleNotes]);
+
+  const progress = job?.summary.totalNotes
+    ? Math.min(100, Math.round(job.summary.processedNotes / job.summary.totalNotes * 100))
+    : 0;
+  const retryable = Boolean(job && terminalStatus(job.status) && job.noteResults.some(
+    (result) => ["failed", "partial", "conflict", "parse_error"].includes(result.status),
+  ));
+
+  const panel = open ? (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/45 p-3 md:p-6" role="dialog" aria-modal="true">
+      <div className="flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-app-border bg-app-elevated shadow-2xl">
+        <div className="flex items-center justify-between border-b border-app-border px-4 py-3 md:px-5">
+          <div className="flex items-center gap-2">
+            <Image size={20} className="text-accent-primary" />
+            <div>
+              <h2 className="font-semibold text-tx-primary">
+                {tr("remoteImageLocalization.title", "网络图片本地化", "Remote image localization")}
+              </h2>
+              <p className="text-xs text-tx-tertiary">
+                {tr(
+                  "remoteImageLocalization.subtitle",
+                  "将历史笔记中的网络图片保存为 Nowen 附件，失败时保留原链接",
+                  "Save remote images as Nowen attachments while preserving failed URLs",
+                )}
+              </p>
+            </div>
+          </div>
+          <button className="rounded-md p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary" onClick={() => setOpen(false)}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-4 md:p-5">
+          <div className="mb-4 grid grid-cols-3 gap-2 rounded-lg bg-app-bg p-1">
+            {([
+              ["current", tr("remoteImageLocalization.current", "当前笔记", "Current note"), FileText],
+              ["selected", tr("remoteImageLocalization.multiple", "选择多篇", "Select notes"), CheckCircle2],
+              ["notebook", tr("remoteImageLocalization.notebook", "整个笔记本", "Notebook"), Folder],
+            ] as const).map(([value, label, Icon]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setMode(value)}
+                className={cn(
+                  "flex items-center justify-center gap-1.5 rounded-md px-2 py-2 text-xs transition-colors md:text-sm",
+                  mode === value ? "bg-app-elevated text-accent-primary shadow-sm" : "text-tx-secondary hover:text-tx-primary",
+                )}
+              >
+                <Icon size={15} /> {label}
+              </button>
+            ))}
+          </div>
+
+          {mode === "current" && (
+            <div className="rounded-lg border border-app-border bg-app-bg p-3">
+              {state.activeNote ? (
+                <>
+                  <div className="font-medium text-tx-primary">{state.activeNote.title || tr("common.untitled", "无标题笔记", "Untitled")}</div>
+                  <div className="mt-1 text-xs text-tx-tertiary">ID: {state.activeNote.id} · v{state.activeNote.version}</div>
+                </>
+              ) : (
+                <div className="text-sm text-tx-tertiary">
+                  {tr("remoteImageLocalization.noActiveNote", "当前没有打开笔记", "No note is currently open")}
+                </div>
+              )}
+            </div>
+          )}
+
+          {mode === "selected" && (
+            <div className="rounded-lg border border-app-border bg-app-bg">
+              <div className="flex items-center gap-2 border-b border-app-border p-2">
+                <Search size={15} className="text-tx-tertiary" />
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={tr("remoteImageLocalization.searchNotes", "搜索笔记", "Search notes")}
+                  className="min-w-0 flex-1 bg-transparent text-sm text-tx-primary outline-none placeholder:text-tx-tertiary"
+                />
+                <button type="button" onClick={selectAllVisible} className="text-xs text-accent-primary hover:underline">
+                  {visibleNotes.length > 0 && visibleNotes.every((note) => selectedIds.has(note.id))
+                    ? tr("remoteImageLocalization.deselectVisible", "取消当前结果", "Deselect visible")
+                    : tr("remoteImageLocalization.selectVisible", "选择当前结果", "Select visible")}
+                </button>
+              </div>
+              <div className="max-h-52 overflow-y-auto p-1">
+                {visibleNotes.map((note) => (
+                  <label key={note.id} className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-app-hover">
+                    <input type="checkbox" checked={selectedIds.has(note.id)} onChange={() => toggleNote(note.id)} />
+                    <span className="min-w-0 flex-1 truncate text-sm text-tx-primary">{note.title}</span>
+                    <span className="text-[11px] text-tx-tertiary">v{note.version}</span>
+                  </label>
+                ))}
+                {visibleNotes.length === 0 && (
+                  <div className="p-4 text-center text-sm text-tx-tertiary">
+                    {tr("remoteImageLocalization.noNotes", "没有可选择的笔记", "No notes available")}
+                  </div>
+                )}
+              </div>
+              <div className="border-t border-app-border px-3 py-2 text-xs text-tx-tertiary">
+                {tr("remoteImageLocalization.selectedCount", "已选择", "Selected")}: {selectedIds.size}
+              </div>
+            </div>
+          )}
+
+          {mode === "notebook" && (
+            <div className="rounded-lg border border-app-border bg-app-bg p-3">
+              <label className="mb-1 block text-xs text-tx-tertiary">
+                {tr("remoteImageLocalization.notebookScope", "包含该笔记本及全部子笔记本", "Includes this notebook and all descendants")}
+              </label>
+              <select
+                value={notebookId}
+                onChange={(event) => setNotebookId(event.target.value)}
+                className="w-full rounded-md border border-app-border bg-app-elevated px-3 py-2 text-sm text-tx-primary outline-none focus:border-accent-primary"
+              >
+                <option value="">{tr("remoteImageLocalization.chooseNotebook", "选择笔记本", "Choose a notebook")}</option>
+                {state.notebooks.map((notebook) => (
+                  <option key={notebook.id} value={notebook.id}>{notebook.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button onClick={handleScan} disabled={busy || isRemoteImageLocalizationJobActive(job)}>
+              {busy && !job ? <Loader2 size={15} className="mr-1 animate-spin" /> : <Search size={15} className="mr-1" />}
+              {tr("remoteImageLocalization.scan", "扫描网络图片", "Scan images")}
+            </Button>
+            <span className="text-xs text-tx-tertiary">
+              {tr(
+                "remoteImageLocalization.riskHint",
+                "仅处理 HTTP/HTTPS 图片；写入前会重新检查权限和版本",
+                "Only HTTP/HTTPS images are processed; permission and version are rechecked before saving",
+              )}
+            </span>
+          </div>
+
+          {error && (
+            <div className="mt-4 flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-500">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {scan && (
+            <div className="mt-4 rounded-lg border border-app-border bg-app-bg p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="font-medium text-tx-primary">
+                    {tr("remoteImageLocalization.scanResult", "扫描结果", "Scan result")}
+                  </h3>
+                  <p className="text-xs text-tx-tertiary">
+                    {scan.notesWithRemoteImages} / {scan.noteCount} {tr("remoteImageLocalization.notesContainImages", "篇笔记包含网络图片", "notes contain remote images")}
+                  </p>
+                </div>
+                <Button onClick={handleStart} disabled={busy || scan.uniqueRemoteUrlCount === 0}>
+                  {busy ? <Loader2 size={15} className="mr-1 animate-spin" /> : <Play size={15} className="mr-1" />}
+                  {tr("remoteImageLocalization.start", "开始本地化", "Start localization")}
+                </Button>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-sm md:grid-cols-4">
+                <Stat label={tr("remoteImageLocalization.notes", "笔记", "Notes")} value={scan.noteCount} />
+                <Stat label={tr("remoteImageLocalization.remoteRefs", "网络图片引用", "Remote references")} value={scan.remoteReferenceCount} />
+                <Stat label={tr("remoteImageLocalization.uniqueUrls", "唯一 URL", "Unique URLs")} value={scan.uniqueRemoteUrlCount} />
+                <Stat label={tr("remoteImageLocalization.skipped", "跳过笔记", "Skipped notes")} value={scan.skippedNoteCount} />
+              </div>
+              {scan.uniqueRemoteUrlCount === 0 && (
+                <div className="mt-3 text-sm text-tx-tertiary">
+                  {tr("remoteImageLocalization.nothingToDo", "没有需要本地化的网络图片", "No remote images need localization")}
+                </div>
+              )}
+            </div>
+          )}
+
+          {job && (
+            <div className="mt-4 rounded-lg border border-app-border bg-app-bg p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <div className="flex items-center gap-2 font-medium text-tx-primary">
+                    {isRemoteImageLocalizationJobActive(job) && <Loader2 size={16} className="animate-spin text-accent-primary" />}
+                    {!isRemoteImageLocalizationJobActive(job) && job.status === "completed" && <CheckCircle2 size={16} className="text-green-500" />}
+                    {!isRemoteImageLocalizationJobActive(job) && job.status !== "completed" && <AlertTriangle size={16} className="text-amber-500" />}
+                    {job.status}
+                  </div>
+                  <div className="mt-1 text-xs text-tx-tertiary">
+                    {job.currentNoteTitle || tr("remoteImageLocalization.waiting", "等待处理", "Waiting")}
+                    {job.currentUrl ? ` · ${job.currentUrl}` : ""}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  {isRemoteImageLocalizationJobActive(job) && (
+                    <Button variant="outline" onClick={handleCancel} disabled={busy || job.cancelRequested}>
+                      <Square size={14} className="mr-1" />
+                      {job.cancelRequested
+                        ? tr("remoteImageLocalization.cancelling", "正在取消", "Cancelling")
+                        : tr("remoteImageLocalization.cancel", "取消后续处理", "Cancel remaining")}
+                    </Button>
+                  )}
+                  {retryable && (
+                    <Button variant="outline" onClick={handleRetry} disabled={busy}>
+                      <RefreshCw size={14} className="mr-1" />
+                      {tr("remoteImageLocalization.retry", "重试失败项", "Retry failures")}
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-3 h-2 overflow-hidden rounded-full bg-app-border">
+                <div className="h-full rounded-full bg-accent-primary transition-all" style={{ width: `${progress}%` }} />
+              </div>
+              <div className="mt-1 text-right text-xs text-tx-tertiary">
+                {job.summary.processedNotes} / {job.summary.totalNotes} · {progress}%
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4">
+                <Stat label={tr("remoteImageLocalization.updatedNotes", "已更新笔记", "Updated notes")} value={job.summary.updatedNotes} />
+                <Stat label={tr("remoteImageLocalization.localizedImages", "已替换引用", "Localized references")} value={job.summary.localizedReferences} />
+                <Stat label={tr("remoteImageLocalization.deduplicated", "附件去重", "Deduplicated")} value={job.summary.deduplicatedAttachments} />
+                <Stat label={tr("remoteImageLocalization.failures", "失败 URL", "Failed URLs")} value={job.summary.failedUrls} />
+              </div>
+              <div className="mt-2 text-xs text-tx-tertiary">
+                {tr("remoteImageLocalization.downloaded", "已下载", "Downloaded")}: {formatBytes(job.summary.downloadedBytes)} ·
+                {tr("remoteImageLocalization.reusedDownloads", "任务内复用", "Task download reuse")}: {job.summary.reusedDownloads}
+              </div>
+
+              {job.failures.length > 0 && (
+                <details className="mt-3 rounded-md border border-amber-500/25 bg-amber-500/5 p-3">
+                  <summary className="cursor-pointer text-sm font-medium text-amber-600">
+                    {tr("remoteImageLocalization.failureDetails", "失败与跳过明细", "Failure and skip details")} ({job.failures.length})
+                  </summary>
+                  <div className="mt-2 max-h-48 space-y-2 overflow-y-auto">
+                    {job.failures.map((failure, index) => (
+                      <div key={`${failure.noteId}-${failure.url || failure.code}-${index}`} className="text-xs text-tx-secondary">
+                        <div className="font-medium text-tx-primary">{failure.code}</div>
+                        <div>{failure.message}</div>
+                        {failure.url && <div className="truncate text-tx-tertiary">{failure.url}</div>}
+                      </div>
+                    ))}
+                  </div>
+                </details>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-5 right-5 z-[80] flex items-center gap-2 rounded-full border border-app-border bg-app-elevated px-4 py-2.5 text-sm font-medium text-tx-primary shadow-lg transition-transform hover:-translate-y-0.5 hover:bg-app-hover"
+      >
+        <Image size={17} className="text-accent-primary" />
+        {tr("remoteImageLocalization.trigger", "网络图片保护", "Protect remote images")}
+        {job && isRemoteImageLocalizationJobActive(job) && <Loader2 size={14} className="animate-spin text-accent-primary" />}
+      </button>
+      {typeof document !== "undefined" && panel ? createPortal(panel, document.body) : null}
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+      <div className="text-xs text-tx-tertiary">{label}</div>
+      <div className="mt-0.5 font-semibold text-tx-primary">{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
+import RemoteImageLocalizationPanel from "./RemoteImageLocalizationPanel";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
 
 export * from "./TaskCenterImpl";
@@ -36,5 +37,10 @@ export default function TaskCenter() {
     return () => document.removeEventListener("click", handleDeleteCapture, true);
   }, []);
 
-  return <TaskCenterImpl key={workspaceGeneration} />;
+  return (
+    <>
+      <TaskCenterImpl key={workspaceGeneration} />
+      <RemoteImageLocalizationPanel key={`remote-images-${workspaceGeneration}`} />
+    </>
+  );
 }

--- a/frontend/src/lib/remoteImageLocalizationApi.ts
+++ b/frontend/src/lib/remoteImageLocalizationApi.ts
@@ -1,0 +1,82 @@
+import { getBaseUrl } from "@/lib/api";
+
+export type RemoteImageLocalizationJobStatus = "queued" | "running" | "completed" | "completed_with_errors" | "cancelled" | "failed";
+export type RemoteImageLocalizationNoteStatus = "queued" | "completed" | "partial" | "failed" | "skipped" | "forbidden" | "locked" | "trashed" | "conflict" | "parse_error";
+export interface RemoteImageLocalizationFailure { noteId: string; url?: string; code: string; message: string }
+export interface RemoteImageLocalizationScanNote {
+  noteId: string; title: string; version: number; contentFormat: string;
+  status: "ready" | "forbidden" | "locked" | "trashed" | "conflict" | "parse_error" | "not_found";
+  reason?: string;
+  scan: { contentFormat: string; totalImageReferences: number; remoteReferenceCount: number; localReferenceCount: number; ignoredReferenceCount: number; remoteUrls: string[]; parseError?: string };
+}
+export interface RemoteImageLocalizationScan {
+  noteCount: number; readyNoteCount: number; notesWithRemoteImages: number; totalImageReferences: number;
+  remoteReferenceCount: number; localReferenceCount: number; ignoredReferenceCount: number;
+  uniqueRemoteUrlCount: number; uniqueRemoteUrls: string[]; skippedNoteCount: number;
+  notes: RemoteImageLocalizationScanNote[];
+  snapshot: { noteIds: string[]; expectedVersions: Record<string, number> };
+  limits: { maxNotes: number; maxImages: number; maxTotalBytes: number };
+}
+export interface RemoteImageLocalizationNoteResult {
+  noteId: string; title: string; scannedVersion: number; finalVersion?: number; status: RemoteImageLocalizationNoteStatus;
+  remoteReferenceCount: number; uniqueRemoteUrlCount: number; localizedReferences: number; localizedUrls: number;
+  deduplicatedAttachments: number; failedUrls: number; skippedUrls: number;
+  failures: RemoteImageLocalizationFailure[]; warnings: string[];
+}
+export interface RemoteImageLocalizationJob {
+  id: string; status: RemoteImageLocalizationJobStatus; createdAt: string; updatedAt: string;
+  startedAt: string | null; completedAt: string | null; cancelRequested: boolean;
+  source: "note_ids" | "notebook"; notebookId: string | null; noteIds: string[];
+  currentNoteId: string | null; currentNoteTitle: string | null; currentUrl: string | null; error: string | null;
+  summary: {
+    totalNotes: number; scannedNotes: number; processedNotes: number; updatedNotes: number; skippedNotes: number;
+    conflictNotes: number; notesWithFailures: number; totalImageReferences: number; remoteReferenceCount: number;
+    uniqueRemoteUrlCount: number; downloadedUniqueUrls: number; reusedDownloads: number;
+    localizedReferences: number; localizedUrls: number; deduplicatedAttachments: number; failedUrls: number; downloadedBytes: number;
+  };
+  noteResults: RemoteImageLocalizationNoteResult[]; failures: RemoteImageLocalizationFailure[];
+}
+export type RemoteImageLocalizationScope =
+  | { noteIds: string[]; expectedVersions?: Record<string, number> }
+  | { notebookId: string; expectedVersions?: Record<string, number> };
+
+async function authenticatedJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}), ...(init?.headers || {}) },
+  });
+  const text = await response.text();
+  let payload: any = null;
+  if (text) { try { payload = JSON.parse(text); } catch { payload = text; } }
+  if (!response.ok) {
+    const error = new Error(typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`) as Error & { code?: string; status?: number };
+    error.code = payload?.code; error.status = response.status; throw error;
+  }
+  return payload as T;
+}
+
+const ROOT = "/attachments/remote-image-localization";
+let confirmedSnapshot: RemoteImageLocalizationScan["snapshot"] | null = null;
+
+export const remoteImageLocalizationApi = {
+  async scan(scope: RemoteImageLocalizationScope): Promise<RemoteImageLocalizationScan> {
+    const result = await authenticatedJson<RemoteImageLocalizationScan>(`${ROOT}/scan`, { method: "POST", body: JSON.stringify(scope) });
+    confirmedSnapshot = result.snapshot;
+    return result;
+  },
+  createJob(scope: RemoteImageLocalizationScope): Promise<RemoteImageLocalizationJob> {
+    const requestScope = confirmedSnapshot?.noteIds.length
+      ? { noteIds: confirmedSnapshot.noteIds, expectedVersions: confirmedSnapshot.expectedVersions }
+      : scope;
+    confirmedSnapshot = null;
+    return authenticatedJson(`${ROOT}/jobs`, { method: "POST", body: JSON.stringify(requestScope) });
+  },
+  getJob(jobId: string): Promise<RemoteImageLocalizationJob> { return authenticatedJson(`${ROOT}/jobs/${encodeURIComponent(jobId)}`); },
+  listJobs(limit = 20): Promise<{ jobs: RemoteImageLocalizationJob[] }> { return authenticatedJson(`${ROOT}/jobs?limit=${encodeURIComponent(String(limit))}`); },
+  cancelJob(jobId: string): Promise<RemoteImageLocalizationJob> { return authenticatedJson(`${ROOT}/jobs/${encodeURIComponent(jobId)}/cancel`, { method: "POST", body: "{}" }); },
+  retryJob(jobId: string): Promise<RemoteImageLocalizationJob> { return authenticatedJson(`${ROOT}/jobs/${encodeURIComponent(jobId)}/retry`, { method: "POST", body: "{}" }); },
+};
+export function isRemoteImageLocalizationJobActive(job: RemoteImageLocalizationJob | null | undefined): boolean {
+  return job?.status === "queued" || job?.status === "running";
+}


### PR DESCRIPTION
Closes #346

## 实现概览

为历史笔记增加安全的网络图片批量本地化能力，支持当前笔记、多篇笔记和整个笔记本范围，正文格式覆盖 Markdown、HTML 与 Tiptap JSON。

本 PR 已基于最新 `main@f36bbbf09d220e8332be31e6d363f9619a7e548a` 完整重构，并压缩为一个功能提交。

## 核心能力

- 扫描远程图片、Nowen 本地附件和忽略项，保持普通链接不变；
- 保留图片 alt、title、尺寸、对齐和其他节点属性；
- 后端持久化任务，支持进度、取消、失败明细和失败项重试；
- 页面关闭、刷新或移动端切后台不影响服务端任务；
- 复用现有 SSRF、逐跳重定向、DNS/IP、MIME、文件头、大小和超时校验；
- 同一任务内 URL 只下载一次，相同内容复用附件哈希去重；
- 默认限制 100 篇笔记、500 个唯一 URL、500MB 总下载量；
- 同一用户最多一个排队或运行中的任务，全局默认最多并行两个任务；
- 下载缓存写入任务临时目录，不长期保留大体积 Buffer；
- 扫描结果冻结 note ID 和 version，创建任务使用用户已确认的快照；
- 相对 `/api/attachments/`、`/api/files/` 识别为本地附件，第三方绝对 URL 不再误判。

## 数据一致性

正文写回统一在受保护事务中完成：

1. 再次校验写权限、锁定、回收站、版本和正文快照；
2. 规范化 Block ID；
3. 保存版本历史；
4. 乐观锁更新正文、`contentText` 和版本号；
5. 同步附件引用与双链索引；
6. 重建 Block Authority；
7. 开启实验功能时重建 Yjs Subdocuments；
8. 提交后发送实时通知、Yjs 更新和审计记录。

下载完成后若权限、正文、版本或锁定状态发生变化：

- 不覆盖最新正文；
- 回滚本任务新建的附件行；
- 物理对象没有其他引用时一并删除；
- 复用的既有附件不会被误删。

## API

- `POST /api/attachments/remote-image-localization/scan`
- `POST /api/attachments/remote-image-localization/jobs`
- `GET /api/attachments/remote-image-localization/jobs`
- `GET /api/attachments/remote-image-localization/jobs/:id`
- `POST /api/attachments/remote-image-localization/jobs/:id/cancel`
- `POST /api/attachments/remote-image-localization/jobs/:id/retry`

## UI

任务中心新增「网络图片保护」入口，支持：

- 当前笔记；
- 搜索并选择多篇笔记；
- 整个笔记本及子笔记本；
- 扫描确认；
- 实时进度；
- 取消、失败详情和重试。

## 验证

最终 Head：`5bc7ef76b932ce4453db5fa3db1d8f4c181802a8`

Remote Image Localization CI：`30085516569`

- [x] Backend TypeScript
- [x] Markdown / HTML / Tiptap 扫描替换测试
- [x] 权限、锁定、回收站和版本冲突测试
- [x] URL 去重与附件哈希去重测试
- [x] Block Authority healthy 快照测试
- [x] Yjs Subdocuments 重建测试
- [x] 晚到冲突附件回滚测试
- [x] Backend production bundle
- [x] Frontend TypeScript

当前分支与最新 `main` 同步，PR `mergeable: true`。