### PR TITLE
chore(db): sync latest Block Patch route image tests

### DIFF
--- a/.github/workflows/block-patch-ci.yml
+++ b/.github/workflows/block-patch-ci.yml
@@ -19,6 +19,7 @@ on:
       - "backend/tests/block-patch-mixed-index.test.ts"
       - "backend/tests/block-patch-list-route.test.ts"
       - "backend/tests/block-patch-list-structure-route.test.ts"
+      - "backend/tests/block-patch-route-image.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
       - "backend/tests/tiptap-block-patch-image.test.ts"
@@ -29,6 +30,7 @@ on:
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchListStructureRuntime.test.tsx"
@@ -76,6 +78,7 @@ on:
       - "backend/tests/block-patch-mixed-index.test.ts"
       - "backend/tests/block-patch-list-route.test.ts"
       - "backend/tests/block-patch-list-structure-route.test.ts"
+      - "backend/tests/block-patch-route-image.test.ts"
       - "backend/tests/tiptap-block-patch.test.ts"
       - "backend/tests/tiptap-block-patch-v2.test.ts"
       - "backend/tests/tiptap-block-patch-image.test.ts"
@@ -86,6 +89,7 @@ on:
       - "frontend/src/components/TiptapEditorRuntime.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx"
+      - "frontend/src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx"
       - "frontend/src/components/__tests__/TiptapBlockPatchListStructureRuntime.test.tsx"
@@ -146,6 +150,7 @@ jobs:
           tests/tiptap-list-item-structure.test.ts
           tests/block-patch-route.test.ts
           tests/block-patch-route-v2.test.ts
+          tests/block-patch-route-image.test.ts
           tests/block-patch-list-route.test.ts
           tests/block-patch-list-structure-route.test.ts
           tests/block-patch-incremental-index.test.ts
@@ -184,6 +189,7 @@ jobs:
           src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
           src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx
+          src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
           src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx
           src/components/__tests__/TiptapBlockPatchListStructureRuntime.test.tsx

--- a/backend/tests/block-patch-route-image.test.ts
+++ b/backend/tests/block-patch-route-image.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-block-patch-image-route-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+
+const owner = "block-patch-image-owner";
+const notebookId = "block-patch-image-notebook";
+
+let db: Database.Database;
+let closeDb: () => void;
+let app: Hono;
+let syncNoteBlocks: typeof import("../src/lib/noteBlocks").syncNoteBlocks;
+
+function paragraph(blockId: string, content: unknown[]) {
+  return {
+    type: "paragraph",
+    attrs: { blockId, textAlign: null, lineHeight: null },
+    content,
+  };
+}
+
+function documentWith(...nodes: unknown[]): string {
+  return JSON.stringify({ type: "doc", content: nodes });
+}
+
+function insertNote(id: string, content: string) {
+  db.prepare(`
+    INSERT INTO notes (
+      id, userId, notebookId, title, content, contentText, contentFormat, version, isLocked
+    ) VALUES (?, ?, ?, ?, ?, '', 'tiptap-json', 1, 0)
+  `).run(id, owner, notebookId, id, content);
+  syncNoteBlocks(db, id, content, "tiptap-json");
+}
+
+async function patch(noteId: string, operationId: string, node: unknown) {
+  return app.request(`/api/blocks/${noteId}/patch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": owner,
+    },
+    body: JSON.stringify({
+      expectedNoteVersion: 1,
+      operationId,
+      operations: [{ type: "replace", blockId: "blk_image_route", node }],
+    }),
+  });
+}
+
+function count(sql: string, value: string): number {
+  const row = db.prepare(sql).get(value) as { c: number } | undefined;
+  return row?.c ?? 0;
+}
+
+test.before(async () => {
+  const [schema, noteBlocks] = await Promise.all([
+    import("../src/db/schema"),
+    import("../src/lib/noteBlocks"),
+  ]);
+  await import("../src/runtime/block-patch");
+  const blockRoute = await import("../src/routes/blocks");
+
+  db = schema.getDb();
+  closeDb = schema.closeDb;
+  syncNoteBlocks = noteBlocks.syncNoteBlocks;
+  app = new Hono();
+  app.route("/api/blocks", blockRoute.default);
+
+  db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+    .run(owner, owner, "hash");
+  db.prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
+    .run(notebookId, owner, "Image Block Patch");
+});
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("persists safe image presentation attrs through one incremental leaf transaction", async () => {
+  const noteId = "11111111-aaaa-4111-8111-111111111111";
+  const src = "/api/attachments/22222222-bbbb-4222-8222-222222222222/content";
+  const originalNode = paragraph("blk_image_route", [
+    { type: "text", text: "Before " },
+    {
+      type: "image",
+      attrs: {
+        src,
+        alt: "Diagram",
+        title: null,
+        width: 320,
+        height: 180,
+        rotation: 0,
+        flipX: false,
+      },
+    },
+    { type: "text", text: " after" },
+  ]);
+  const outside = paragraph("blk_image_outside", [{ type: "text", text: "Outside" }]);
+  const original = documentWith(originalNode, outside);
+  insertNote(noteId, original);
+  db.prepare(`
+    UPDATE note_blocks_index
+    SET createdAt = '2000-01-01 00:00:00', updatedAt = '2000-01-01 00:00:00'
+    WHERE noteId = ?
+  `).run(noteId);
+
+  const nextNode = paragraph("blk_image_route", [
+    { type: "text", text: "Before " },
+    {
+      type: "image",
+      attrs: {
+        src,
+        alt: "Diagram",
+        title: "Rotated diagram",
+        width: 640,
+        height: 360,
+        rotation: 90,
+        flipX: true,
+      },
+    },
+    { type: "text", text: " after" },
+  ]);
+  const response = await patch(noteId, "block-patch-image-route-safe", nextNode);
+
+  assert.equal(response.status, 200);
+  const payload = await response.json() as any;
+  assert.equal(payload.version, 2);
+  assert.equal(payload.indexUpdateMode, "incremental");
+  assert.equal(payload.indexUpdateKind, "leaf");
+  assert.deepEqual(payload.affectedBlockIds, ["blk_image_route"]);
+  assert.ok(payload.indexedBlockIds.includes("blk_image_route"));
+
+  const stored = db.prepare(
+    "SELECT content, contentText, version FROM notes WHERE id = ?",
+  ).get(noteId) as any;
+  const parsed = JSON.parse(stored.content);
+  assert.equal(stored.version, 2);
+  assert.equal(stored.contentText, "Before  after\n\nOutside");
+  assert.deepEqual(parsed.content[0], nextNode);
+  assert.equal(payload.content, stored.content);
+
+  const imageRow = db.prepare(`
+    SELECT plainText FROM note_blocks_index WHERE noteId = ? AND blockId = ?
+  `).get(noteId, "blk_image_route") as any;
+  assert.equal(imageRow.plainText, "Before  after");
+
+  const outsideRow = db.prepare(`
+    SELECT updatedAt FROM note_blocks_index WHERE noteId = ? AND blockId = ?
+  `).get(noteId, "blk_image_outside") as any;
+  assert.equal(outsideRow.updatedAt, "2000-01-01 00:00:00");
+
+  const version = db.prepare(`
+    SELECT content, version FROM note_versions WHERE noteId = ?
+  `).get(noteId) as any;
+  assert.equal(version.content, original);
+  assert.equal(version.version, 1);
+});
+
+test("rejects an unsafe image source before persistence", async () => {
+  const noteId = "33333333-cccc-4333-8333-333333333333";
+  const originalNode = paragraph("blk_image_route", [
+    { type: "image", attrs: { src: "https://example.com/safe.png", width: 320 } },
+  ]);
+  const original = documentWith(originalNode);
+  insertNote(noteId, original);
+
+  const unsafeNode = paragraph("blk_image_route", [
+    { type: "image", attrs: { src: "javascript:alert(1)", width: 640 } },
+  ]);
+  const response = await patch(noteId, "block-patch-image-route-unsafe", unsafeNode);
+
+  assert.equal(response.status, 400);
+  const payload = await response.json() as any;
+  assert.equal(payload.code, "INVALID_BLOCK_NODE");
+
+  const stored = db.prepare("SELECT content, version FROM notes WHERE id = ?").get(noteId) as any;
+  assert.equal(stored.content, original);
+  assert.equal(stored.version, 1);
+  assert.equal(count("SELECT COUNT(*) AS c FROM note_versions WHERE noteId = ?", noteId), 0);
+  assert.equal(count(
+    "SELECT COUNT(*) AS c FROM block_operations WHERE operationId = ?",
+    "block-patch-image-route-unsafe",
+  ), 0);
+});

--- a/docs/block-patch-api.md
+++ b/docs/block-patch-api.md
@@ -1,6 +1,6 @@
-# Block Patch API V2-I
+# Block Patch API V2-J
 
-Block Patch applies ordered Tiptap Block mutations as one confirmed transaction. It is the persistence boundary between whole-note saves and the future Block-authoritative storage model.
+Block Patch applies ordered Tiptap mutations as one confirmed transaction. `notes.content` remains the canonical document; this API reduces the amount of editor-side and derived-index work without exposing arbitrary ProseMirror JSON.
 
 ## Endpoint
 
@@ -10,7 +10,7 @@ Authorization: Bearer <token>
 Content-Type: application/json
 ```
 
-Only notes whose `contentFormat` is `tiptap-json` are accepted.
+Only `tiptap-json` notes are accepted.
 
 ## Request envelope
 
@@ -22,15 +22,15 @@ Only notes whose `contentFormat` is `tiptap-json` are accepted.
 }
 ```
 
-- `expectedNoteVersion` is required. A mismatch returns `409 VERSION_CONFLICT` before persistence.
-- `operationId` is a user-level idempotency key, 8–128 characters.
-- An uncertain retry must reuse the same operation ID for the same note.
-- Reusing one operation ID on another note returns `409 OPERATION_ID_CONFLICT`.
-- `operations` contains 1–100 ordered operations. The request is limited to approximately 2 MB.
+- `expectedNoteVersion` is required and checked again inside the write transaction.
+- `operationId` is a per-user idempotency key, 8–128 characters.
+- An uncertain retry must reuse the same operation ID.
+- `operations` contains 1–100 ordered operations and the request is limited to approximately 2 MB.
+- One successful request increments the note version exactly once.
 
-## Operations
+## Normal Block operations
 
-### Create a normal Block
+### Create
 
 ```json
 {
@@ -43,59 +43,7 @@ Only notes whose `contentFormat` is `tiptap-json` are accepted.
 }
 ```
 
-Supported types are `paragraph`, `heading`, `codeBlock`, `blockquote`, `listItem` and `taskItem`. Heading creation defaults to H2.
-
-When `blockId` is omitted, the server generates one and returns the client/server mapping in `createdBlocks`. Only top-level paragraph, heading and code-block creation is currently eligible for normal structural or mixed incremental indexing.
-
-### Create one leaf list item
-
-```json
-{
-  "type": "create",
-  "scope": "listItem",
-  "clientId": "blk_item_new",
-  "blockId": "blk_item_new",
-  "targetBlockId": "blk_existing_item",
-  "position": "after",
-  "node": {
-    "type": "listItem",
-    "attrs": {
-      "blockId": "blk_item_new"
-    },
-    "content": [
-      {
-        "type": "paragraph",
-        "attrs": {
-          "blockId": "blk_paragraph_new",
-          "textAlign": null,
-          "lineHeight": null
-        },
-        "content": [
-          {
-            "type": "text",
-            "text": "New item",
-            "marks": [{ "type": "bold" }]
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-V2-I accepts exactly one scoped list-item create operation per request.
-
-Requirements:
-
-- `position` is `before` or `after` an existing sibling;
-- item and paragraph Block IDs are valid, distinct and globally unused;
-- `listItem` targets a bullet/ordered list;
-- `taskItem` targets a task list and includes boolean `checked`;
-- the item contains exactly one safe paragraph;
-- no nested list, table, media, formula, Mermaid or second paragraph is accepted;
-- the item node is limited to 256 KB.
-
-See `docs/block-patch-list-structure.md` for the complete replay proof and fallback contract.
+Supported indexed types are `paragraph`, `heading`, `codeBlock`, `blockquote`, `listItem` and `taskItem`. The normal structural incremental path is restricted to proven-safe top-level paragraph, heading and code-block changes.
 
 ### Plain-text update
 
@@ -107,38 +55,82 @@ See `docs/block-patch-list-structure.md` for the complete replay proof and fallb
 }
 ```
 
-This keeps the existing Block type and attributes while replacing its editable text payload.
+The existing Block type and attrs are preserved while its editable text payload is replaced.
 
-### Safe rich Block replacement
+### Safe rich replacement
 
 ```json
 {
   "type": "replace",
   "blockId": "blk_alpha000",
   "node": {
-    "type": "heading",
+    "type": "paragraph",
     "attrs": {
       "blockId": "blk_alpha000",
-      "level": 3,
-      "textAlign": "center",
-      "lineHeight": "1.6"
+      "textAlign": null,
+      "lineHeight": null
     },
     "content": [
+      { "type": "text", "text": "Before " },
       {
-        "type": "text",
-        "text": "Nowen",
-        "marks": [{ "type": "bold" }]
-      }
+        "type": "image",
+        "attrs": {
+          "src": "/api/attachments/11111111-1111-4111-8111-111111111111/content",
+          "alt": "Diagram",
+          "title": "Rotated diagram",
+          "width": 640,
+          "height": 360,
+          "rotation": 90,
+          "flipX": true
+        }
+      },
+      { "type": "text", "text": " after" }
     ]
   }
 }
 ```
 
-The API does not accept arbitrary ProseMirror JSON. Allowed Block nodes are `paragraph`, `heading` and `codeBlock`; allowed inline nodes are `text` and paragraph/heading `hardBreak`.
+Allowed replacement Block nodes:
 
-Allowed marks include bold, italic, underline, strike, inline code, safe links, highlight and text style. Unknown nodes, marks, attrs, fields, dangerous URL schemes, mismatched Block IDs and oversized replacement nodes return `INVALID_BLOCK_NODE` before persistence.
+- `paragraph`;
+- `heading`;
+- `codeBlock`.
 
-### Delete a normal Block
+Allowed inline nodes:
+
+- `text`;
+- paragraph/heading `hardBreak`;
+- paragraph/heading `image`.
+
+Allowed marks on text are bold, italic, underline, strike, inline code, safe links, highlight and text style.
+
+### Inline image contract
+
+An image is part of its identified parent paragraph or heading; it is not an independently versioned Block. Therefore adding, removing, replacing or changing an inline image is committed as one parent-Block `replace` operation.
+
+Image attrs are limited to:
+
+```text
+src, alt, title, width, height, rotation, flipX
+```
+
+Validation rules:
+
+- `src` accepts HTTP(S), `/`, `./`, `../`, or bounded raster data URLs;
+- raster data URLs are limited to PNG, JPEG, GIF and WebP;
+- SVG data URLs, `javascript:`, `vbscript:`, `file:` and `blob:` are rejected;
+- `alt` and `title` are limited to 512 characters and cannot contain control characters;
+- `width` and `height` are integers from 1 to 10000;
+- `rotation` is one of `0`, `90`, `180`, `270`;
+- `flipX` is boolean;
+- images cannot carry marks and cannot appear in a code block;
+- one normalized replacement node cannot exceed 256 KB.
+
+Unknown fields, nodes, attrs, marks, unsafe protocols, mismatched Block IDs and oversized payloads return `INVALID_BLOCK_NODE` before persistence.
+
+Attachment ownership is not changed by this operation. Existing attachment upload/ownership rules still apply, and the complete authoritative JSON returned by the server becomes the next Patch baseline.
+
+### Delete
 
 ```json
 {
@@ -147,9 +139,49 @@ Allowed marks include bold, italic, underline, strike, inline code, safe links, 
 }
 ```
 
-The server repairs empty list and quote containers. Deleting every top-level identified Block creates one canonical empty paragraph with a fresh stable Block ID. Delete-all uses full index synchronization because the replacement Block did not exist in the pre-patch index.
+Deleting all identified top-level Blocks creates one canonical empty paragraph with a new stable Block ID. The client reconciles that identity without adding an Undo history entry.
 
-### Delete one leaf list item
+### Move
+
+```json
+{
+  "type": "move",
+  "blockId": "blk_beta000",
+  "targetBlockId": "blk_alpha000",
+  "position": "after"
+}
+```
+
+Normal moves remain same-parent operations. Unsupported cross-parent changes fail closed.
+
+## Scoped list operations
+
+### Create or delete a leaf item
+
+```json
+{
+  "type": "create",
+  "scope": "listItem",
+  "clientId": "blk_item_new",
+  "blockId": "blk_item_new",
+  "targetBlockId": "blk_item_old",
+  "position": "after",
+  "node": {
+    "type": "listItem",
+    "attrs": { "blockId": "blk_item_new" },
+    "content": [
+      {
+        "type": "paragraph",
+        "attrs": {
+          "blockId": "blk_paragraph_new",
+          "textAlign": null,
+          "lineHeight": null
+        }
+      }
+    ]
+  }
+}
+```
 
 ```json
 {
@@ -159,24 +191,9 @@ The server repairs empty list and quote containers. Deleting every top-level ide
 }
 ```
 
-The target must contain exactly one paragraph and no nested list or subtree. The item and paragraph Block rows are deleted together. An empty list wrapper is removed.
+A created item contains one identified safe paragraph. Task items require boolean `checked`. Nested subtree creation/deletion is not accepted by this leaf operation.
 
-Deleting the only list item when it would make the complete Tiptap document empty returns `LIST_STRUCTURE_INVALID`. The editor then uses the established whole-note empty-document save path and Block ID reconciliation.
-
-### Move a normal Block
-
-```json
-{
-  "type": "move",
-  "blockId": "blk_beta0000",
-  "targetBlockId": "blk_alpha000",
-  "position": "after"
-}
-```
-
-Legacy Block moves are supported inside the same parent. Cross-parent moves return `BLOCK_MOVE_PARENT_MISMATCH`. Incremental indexing currently requires top-level paragraph, heading or code-block identities.
-
-### Move a list item
+### Move, sink or lift inside list structure
 
 ```json
 {
@@ -188,96 +205,67 @@ Legacy Block moves are supported inside the same parent. Cross-parent moves retu
 }
 ```
 
-Supported positions:
+- `inside` sinks under the immediate previous compatible item;
+- `before` and `after` perform a proven same-depth or controlled cross-parent move;
+- bullet, ordered and task list types are not implicitly converted.
 
-- `inside`: sink the source under its immediate previous sibling;
-- `after`: lift a nested item after its direct parent, or move at the same depth after another item;
-- `before`: move at the same depth before another item.
+### Lift a root list item to a paragraph
 
-The source and target item/list types must match. Other cross-depth moves, non-adjacent sink, conflicting nested-list types and self moves return `LIST_MOVE_INVALID`. The complete item subtree moves unchanged. See `docs/block-patch-list-hierarchy.md` for the full proof contract.
+```json
+{
+  "type": "lift",
+  "scope": "listItem",
+  "blockId": "blk_root_item",
+  "position": "after"
+}
+```
+
+The list-item wrapper is removed while its paragraph Block ID, text and marks are preserved. Empty list wrappers are cleaned up.
+
+### Ordered list batches
+
+The endpoint accepts up to 100 ordered operations. The editor can use one atomic batch for:
+
+- Enter split: replace/update the original paragraph plus create the new item;
+- multi-line paste creating several items;
+- batch delete;
+- consecutive compatible moves;
+- controlled content/format plus list-structure changes.
+
+The frontend sends a batch only when applying the generated operations reproduces the complete target JSON. The server maintains temporary identities across the batch and rejects references to missing, deleted or conflicting Blocks.
 
 ## Atomic semantics
 
-Operations are evaluated in request order. Inside one SQLite transaction, the server:
+Inside one SQLite transaction the server:
 
-1. Rechecks existence, permissions, lock state and version.
-2. Verifies whether the persisted Block index mirrors the current Tiptap document.
-3. Materializes missing stable IDs when full normalization is required.
-4. Validates and applies every operation in memory.
-5. Records the pre-edit version using the same five-minute merge window as whole-note save.
-6. Updates `notes.content`, `contentText`, version and timestamp with optimistic locking.
-7. Applies a leaf, structural, mixed, list-subtree, list-structural or full index synchronization plan.
-8. Stores the idempotent authoritative response.
+1. rechecks existence, permission, lock state and note version;
+2. validates the full operation sequence before persistence;
+3. applies operations in order to an in-memory document;
+4. records the pre-edit version using the existing merge window;
+5. updates canonical content, searchable text, version and timestamp;
+6. updates Block/link indexes incrementally when correctness is proven, otherwise performs a full rebuild;
+7. stores the authoritative idempotent response;
+8. emits note and list realtime updates after commit.
 
-Any failure rolls back the document, indexes, history row and idempotency record. One successful request increments the note version exactly once. Idempotent replay returns the same authoritative content and generated IDs.
+Any failure rolls back content, indexes, history and the idempotency record.
 
 ## Index update modes
 
-Before any incremental mode is enabled, the server compares row count, Block IDs, types, parents, order, paths, plain text and content hashes. Any mismatch fails closed to full synchronization.
+`indexUpdateMode` is `incremental` or `full`.
 
-### `leaf`
+`indexUpdateKind` currently reports:
 
-Used for safe `update` and `replace` batches.
+- `leaf`: safe update/replace, including identified paragraphs containing inline images;
+- `structural`: top-level create/delete/move;
+- `mixed`: normal leaf plus top-level structure;
+- `list-subtree`: controlled list hierarchy movement;
+- `list-structural`: list-item create/delete/lift and compatible structure batches;
+- `list-mixed`: list structure plus paragraph content/format changes;
+- `full`: correctness could not be proven.
 
-- Changed leaf rows are upserted.
-- Indexed ancestors are refreshed when aggregate text/hash changes.
-- Links are recreated only for changed source leaves.
-- Unrelated rows and links keep their IDs and timestamps.
+Before an incremental path is used, the persisted Block index must mirror the current document. Any missing/duplicate ID, stale row, unexpected parent/path/content difference or unsupported node fails closed to full synchronization.
 
-### `structural`
-
-Used for top-level create, delete and move batches.
-
-- New and deleted rows are inserted or removed.
-- Only shifted `blockOrder/path` rows are updated.
-- Pure moves preserve link rows.
-- New and deleted source links are updated locally.
-
-### `mixed`
-
-Used when safe leaf and top-level structural operations occur together.
-
-- Leaf changes and indexed ancestors are refreshed.
-- Created/deleted rows are inserted or removed.
-- Shifted top-level rows are updated.
-- Links are recreated only for changed/new sources and removed for deleted sources.
-
-### `list-subtree`
-
-Used for one controlled scoped list-item move when the old index is an exact mirror of the source document.
-
-- The moved root may change `parentBlockId`.
-- The moved subtree and intervening rows may change `blockOrder/path`.
-- Old/new parent items and their indexed ancestors may change aggregate `plainText/contentHash`.
-- Paragraph, heading and code-block content/hash must remain unchanged.
-- Only proven-different rows are upserted.
-- No `note_links` rows are deleted or recreated.
-
-### `list-structural`
-
-Used for one controlled leaf list-item create or delete.
-
-For create:
-
-- exactly the new item and its paragraph are inserted;
-- nested parent/ancestor aggregate text and hash are refreshed when needed;
-- only shifted `blockOrder/path` rows are updated;
-- links are extracted only from the new paragraph.
-
-For delete:
-
-- exactly the item and its paragraph are removed;
-- nested parent/ancestor aggregate text and hash are refreshed when needed;
-- only shifted `blockOrder/path` rows are updated;
-- links sourced from the removed item/paragraph are deleted.
-
-Existing leaf content must remain unchanged. Any extra added/deleted Block, unexpected parent change or unproved structural difference disables this mode.
-
-### `full`
-
-Used whenever incremental correctness cannot be proven, including stale indexes, missing or duplicate IDs, unsupported nested mutations, identity ambiguity, complex nodes, delete-all replacement, multi-item list edits, or a list difference exceeding a controlled operation contract.
-
-All fallback decisions happen inside the same transaction.
+Only affected link sources are recreated. Pure structural moves preserve existing link row IDs and timestamps.
 
 ## Authoritative response
 
@@ -287,76 +275,54 @@ All fallback decisions happen inside the same transaction.
   "noteId": "note-id",
   "title": "Note title",
   "version": 8,
-  "updatedAt": "2026-07-23T10:00:00.000Z",
+  "updatedAt": "2026-07-24T10:00:00.000Z",
   "content": "{\"type\":\"doc\",\"content\":[]}",
   "contentText": "Searchable plain text",
   "contentFormat": "tiptap-json",
   "notebookId": "notebook-id",
   "operationCount": 1,
-  "affectedBlockIds": ["blk_item_new", "blk_paragraph_new"],
+  "affectedBlockIds": ["blk_alpha000"],
   "deletedBlockIds": [],
-  "createdBlocks": [
-    {
-      "operationIndex": 0,
-      "clientId": "blk_item_new",
-      "blockId": "blk_item_new"
-    }
-  ],
+  "createdBlocks": [],
   "blocks": [],
   "indexUpdateMode": "incremental",
-  "indexUpdateKind": "list-structural",
-  "indexedBlockIds": ["blk_item_new", "blk_paragraph_new"],
+  "indexUpdateKind": "leaf",
+  "indexedBlockIds": ["blk_alpha000"],
   "contentChangedByNormalization": false
 }
 ```
 
-The client must use the returned content and version as the base for the next dependent patch. Successful writes emit `note:updated` and `note:list-updated`.
+The returned `content` and `version` are the only valid base for a dependent Patch. Only one request may be in flight per editor. A timeout or other uncertain result retries with the same operation ID and never triggers a blind whole-note overwrite.
 
 ## Editor rollout
 
-The Tiptap Runtime enables Block Patch by default only for the active note in `viewport-optimized` or `lightweight-edit` mode.
-
-A session override remains available:
+Block Patch is enabled by default for the active authenticated Tiptap note in `viewport-optimized` and `lightweight-edit` modes. A session override remains available:
 
 ```js
 localStorage.setItem("nowen.tiptap_block_patch_v1", "on")
 localStorage.setItem("nowen.tiptap_block_patch_v1", "off")
 ```
 
-The runtime planner currently sends:
+Public, guest and presentation routes do not mount the authenticated Patch bridge.
 
-- plain-text changes as `update`;
-- safe formatting and attrs as `replace`;
-- top-level create/delete/reorder operations;
-- safe content and structure changes as one mixed transaction;
-- final-Block deletion as an empty-document delete batch;
-- one proven-safe list sink, lift or same-depth move;
-- one proven-safe leaf list-item create or delete.
+## Whole-save fallback boundaries
 
-List-item create/delete planning requires an exact full-JSON replay and a globally unique Block identity delta. The following continue through whole-note save:
+The following remain on the whole-document path:
 
-- item split where the original paragraph also changes;
-- nested list-subtree creation or deletion;
-- multiple list-item create/delete operations;
-- mixed list structure plus content/formatting changes;
-- deleting the only list item when the whole document becomes empty;
-- tables and table structure changes;
-- images, videos, attachments, Mermaid, math and other atom nodes;
-- top-level lift out of a list;
-- conversion between bullet, ordered and task lists;
-- arbitrary cross-depth or cross-type reparenting;
-- unsupported complex paste operations;
-- unknown extension nodes or attributes;
-- title/meta changes.
+- tables and table structure;
+- Block Embed, video/iframe, Mermaid and math nodes;
+- unsupported image attrs or unsafe image sources;
+- arbitrary unknown extensions;
+- bullet/ordered/task type conversion;
+- list changes that cannot be reproduced by a bounded deterministic batch;
+- title and other note metadata changes;
+- any result whose identity or structure cannot be proven.
 
-Only one patch may be in flight per editor. Uncertain outcomes retry with the same idempotency key and never trigger a blind whole-note overwrite. Public, guest and presentation routes never mount the authenticated Block Patch AppContext bridge.
+## Remaining architecture boundaries
 
-## Remaining boundaries
-
-- `notes.content` remains the canonical complete document.
-- A successful patch still serializes a full JSON snapshot.
-- Multi-item and mixed list-structure transactions remain deferred.
-- Arbitrary nested structural operations remain deferred.
-- Table, media, attachment, formula and Mermaid node patches are deferred.
-- There is no independent Block-authoritative content table yet.
-- Markdown uses its separate CodeMirror/Y.Text incremental path.
+- `notes.content` is still the canonical complete document.
+- Every successful Patch still serializes a complete JSON snapshot.
+- Images do not yet have independent Block identity or Block-level version history.
+- There is no independent Block-authoritative table or Block-to-attachment reference table.
+- Markdown uses its separate editor path; a format-aware Markdown Block Patch protocol is not implemented yet.
+- Table/media/embedding node families require separate schema-specific Patch contracts.

--- a/frontend/src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx
+++ b/frontend/src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  baseProps: null as any,
+  snapshot: null as { content: string; contentText: string } | null,
+  acknowledgeSave: vi.fn(),
+  actions: {
+    setActiveNote: vi.fn(),
+    updateNoteInList: vi.fn(),
+    updateNoteTab: vi.fn(),
+    setSyncStatus: vi.fn(),
+    setLastSynced: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/AppContext", () => ({
+  useAppActions: () => fixture.actions,
+}));
+
+vi.mock("@/lib/draftStorage", () => ({
+  saveDraft: vi.fn(),
+  clearDraft: vi.fn(),
+}));
+
+vi.mock("@/lib/api.impl", () => ({
+  getBaseUrl: () => "/api",
+}));
+
+vi.mock("../TiptapEditor", async () => {
+  const ReactModule = await import("react");
+  const Base = ReactModule.forwardRef((props: any, ref) => {
+    fixture.baseProps = props;
+    ReactModule.useImperativeHandle(ref, () => ({
+      flushSave: vi.fn(),
+      discardPending: vi.fn(),
+      getSnapshot: () => fixture.snapshot,
+      acknowledgeSave: fixture.acknowledgeSave,
+      isReady: () => true,
+      appendMarkdown: () => false,
+    }));
+    return ReactModule.createElement("div", { "data-base-tiptap-image": "" });
+  });
+  Base.displayName = "MockBaseTiptapImageRuntime";
+  return { default: Base };
+});
+
+import TiptapEditorRuntime from "../TiptapEditorRuntime";
+import { resolveEditorRuntimeDecision } from "@/lib/editorRuntimePolicy";
+import {
+  clearActiveEditorRuntimeDecision,
+  setActiveEditorRuntimeDecision,
+} from "@/lib/editorRuntimeStore";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const blockId = "blk_image_runtime";
+const src = "/api/attachments/11111111-1111-4111-8111-111111111111/content";
+
+function paragraph(imageAttrs: Record<string, unknown>) {
+  return {
+    type: "paragraph",
+    attrs: { blockId, textAlign: null, lineHeight: null },
+    content: [
+      { type: "text", text: "Before " },
+      { type: "image", attrs: imageAttrs },
+      { type: "text", text: " after" },
+    ],
+  };
+}
+
+function documentWith(node: unknown): string {
+  return JSON.stringify({ type: "doc", content: [node] });
+}
+
+function note(id: string, content: string) {
+  return {
+    id,
+    title: "Image note",
+    content,
+    contentText: "Before  after",
+    contentFormat: "tiptap-json",
+    version: 1,
+    updatedAt: "2026-07-24T09:00:00.000Z",
+    notebookId: "notebook-1",
+    workspaceId: null,
+    isLocked: false,
+    isTrashed: false,
+    isPinned: false,
+    isFavorite: false,
+  } as any;
+}
+
+function optimizedDecision() {
+  return resolveEditorRuntimeDecision({
+    content: JSON.stringify({
+      type: "doc",
+      content: [{
+        type: "paragraph",
+        attrs: { blockId: "blk_runtime_seed" },
+        content: [{ type: "text", text: "x".repeat(220_000) }],
+      }],
+    }),
+    contentFormat: "tiptap-json",
+  });
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let host: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  fixture.baseProps = null;
+  fixture.snapshot = null;
+  fixture.acknowledgeSave.mockClear();
+  Object.values(fixture.actions).forEach((mock) => mock.mockClear());
+  clearActiveEditorRuntimeDecision();
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  clearActiveEditorRuntimeDecision();
+  vi.restoreAllMocks();
+});
+
+describe("Tiptap inline image Block Patch runtime", () => {
+  it("sends safe image presentation changes as one replace operation", async () => {
+    const baseNode = paragraph({
+      src,
+      alt: "Diagram",
+      title: null,
+      width: 320,
+      height: 180,
+      rotation: 0,
+      flipX: false,
+    });
+    const nextNode = paragraph({
+      src,
+      alt: "Diagram",
+      title: "Rotated diagram",
+      width: 640,
+      height: 360,
+      rotation: 90,
+      flipX: true,
+    });
+    const current = note("runtime-image-safe", documentWith(baseNode));
+    const nextContent = documentWith(nextNode);
+    fixture.snapshot = { content: nextContent, contentText: "Before  after" };
+    setActiveEditorRuntimeDecision(current.id, optimizedDecision());
+    const wholeSave = vi.fn();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      noteId: current.id,
+      title: current.title,
+      version: 2,
+      updatedAt: "2026-07-24T10:00:00.000Z",
+      content: nextContent,
+      contentText: "Before  after",
+      contentFormat: "tiptap-json",
+      notebookId: current.notebookId,
+      operationCount: 1,
+      affectedBlockIds: [blockId],
+      deletedBlockIds: [],
+      createdBlocks: [],
+      blocks: [],
+      indexUpdateMode: "incremental",
+      indexUpdateKind: "leaf",
+      indexedBlockIds: [blockId],
+      contentChangedByNormalization: false,
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await act(async () => {
+      root.render(<TiptapEditorRuntime note={current} onUpdate={wholeSave} />);
+    });
+    await act(async () => {
+      fixture.baseProps.onUpdate({
+        title: current.title,
+        content: nextContent,
+        contentText: "Before  after",
+        _noteId: current.id,
+        _saveGeneration: 1,
+      });
+      await flushAsync();
+    });
+
+    expect(wholeSave).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(request.operations).toEqual([{
+      type: "replace",
+      blockId,
+      node: nextNode,
+    }]);
+    expect(fixture.acknowledgeSave).toHaveBeenCalledWith(expect.objectContaining({
+      noteId: current.id,
+      version: 2,
+      content: nextContent,
+    }));
+  });
+});


### PR DESCRIPTION
同步 `main@170c8be91601cbdd795250ad65d3d379f66f87c1` 的 Block Patch 图片路由/运行时测试到 `pg-migration-unified`。共享 workflow 已预先对齐。