### PR TITLE
ci(search): add regression gate for issue #340

### DIFF
--- a/.github/workflows/search-regression.yml
+++ b/.github/workflows/search-regression.yml
@@ -1,0 +1,98 @@
+name: Search Regression
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/search-regression.yml"
+      - "backend/src/routes/search.ts"
+      - "backend/src/lib/searchQuery.ts"
+      - "backend/src/lib/searchIndex.ts"
+      - "backend/src/db/**"
+      - "backend/tests/search-*.test.ts"
+      - "backend/package.json"
+      - "backend/package-lock.json"
+      - "frontend/src/components/SearchCenter.tsx"
+      - "frontend/src/lib/api.ts"
+      - "frontend/src/lib/api.impl.ts"
+      - "frontend/src/lib/searchRequestPolicy.ts"
+      - "frontend/src/lib/__tests__/searchRequestPolicy.test.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/search-regression.yml"
+      - "backend/src/routes/search.ts"
+      - "backend/src/lib/searchQuery.ts"
+      - "backend/src/lib/searchIndex.ts"
+      - "backend/src/db/**"
+      - "backend/tests/search-*.test.ts"
+      - "backend/package.json"
+      - "backend/package-lock.json"
+      - "frontend/src/components/SearchCenter.tsx"
+      - "frontend/src/lib/api.ts"
+      - "frontend/src/lib/api.impl.ts"
+      - "frontend/src/lib/searchRequestPolicy.ts"
+      - "frontend/src/lib/__tests__/searchRequestPolicy.test.ts"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: search-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-search:
+    name: Backend search and index
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run search regression tests
+        run: >-
+          node --import tsx --import ./tests/setup-db-isolation.ts
+          --test tests/search-index.test.ts tests/search-experience.test.ts
+      - name: Type-check backend
+        run: npm run build:tsc
+      - name: Build backend bundle
+        run: npm run build
+
+  frontend-search:
+    name: Frontend progressive search
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run progressive-search policy tests
+        run: npm run test:run -- src/lib/__tests__/searchRequestPolicy.test.ts
+      - name: Type-check frontend
+        run: npx tsc -b


### PR DESCRIPTION
## 目的

为 #340 增加长期保留的搜索回归门禁，并在最新 `main` 组合状态上重新执行搜索专项验证。

## 覆盖范围

### 后端

- `search-index.test.ts`
- `search-experience.test.ts`
- 后端 TypeScript 检查
- 后端生产 bundle

重点覆盖索引候选召回、历史 `contentText` 修复、中文/英文/全半角/特殊标点、附件与标签召回、权限隔离、幽灵结果，以及 160 篇长正文规模回归。

### 前端

- 逐字输入短词策略测试
- 前端 TypeScript 检查

重点覆盖 `M → MT → MTU` 场景中的短词延迟策略和最新请求优先逻辑。

## 触发范围

工作流会在搜索后端、索引、数据库、SearchCenter、搜索 API、渐进式请求策略及相关依赖发生变化时运行；同时支持手动触发。

## 关闭边界

本 PR 只补齐自动化组合验证，不会自动关闭 #340。Issue 仍需原反馈环境或同等级低功耗 NAS 完成：

1. `M → MT → MTU` 从最终输入到结果展示不再出现秒级等待；
2. 历史正文关键词无需重新保存即可召回；
3. 记录冷查询和连续查询耗时。

Refs #340