### PR TITLE
feat(settings): 支持隐藏空间入口

### DIFF
--- a/backend/src/routes/user-preferences-sync.ts
+++ b/backend/src/routes/user-preferences-sync.ts
@@ -18,6 +18,7 @@ export interface SyncedUserPreferences {
   outlineDefaultOpen: boolean;
   lockOnOpen: boolean;
   showNotesInNotebookTree: boolean;
+  showSpaceActions: boolean;
   readingDensity: ReadingDensity;
   showNoteListUpdatedTime: boolean;
   enableNoteTabs: boolean;
@@ -54,6 +55,7 @@ export const DEFAULT_SYNCED_USER_PREFERENCES: SyncedUserPreferences = {
   outlineDefaultOpen: false,
   lockOnOpen: false,
   showNotesInNotebookTree: false,
+  showSpaceActions: true,
   readingDensity: "cozy",
   showNoteListUpdatedTime: true,
   enableNoteTabs: false,
@@ -89,6 +91,7 @@ function normalizePreferenceValue<K extends PreferenceKey>(
     case "outlineDefaultOpen":
     case "lockOnOpen":
     case "showNotesInNotebookTree":
+    case "showSpaceActions":
     case "showNoteListUpdatedTime":
     case "enableNoteTabs":
     case "noteListTitleOnly":

--- a/backend/tests/user-preferences-sync.test.ts
+++ b/backend/tests/user-preferences-sync.test.ts
@@ -161,3 +161,16 @@ test("rejects invalid values for known preference fields", async () => {
   assert.equal(result.status, 400);
   assert.equal(result.json.code, "INVALID_USER_PREFERENCE");
 });
+
+
+test("syncs the space entry visibility as an account preference", async () => {
+  const defaults = await requestJson("GET");
+  assert.equal(defaults.status, 200);
+  assert.equal(defaults.json.showSpaceActions, true);
+  const updated = await requestJson("PATCH", { showSpaceActions: false, _baseRevision: 0 });
+  assert.equal(updated.status, 200);
+  assert.equal(updated.json.showSpaceActions, false);
+  assert.ok(updated.json.fieldUpdatedAt.showSpaceActions);
+  const other = await requestJson("GET", undefined, OTHER_ID);
+  assert.equal(other.json.showSpaceActions, true);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import OfflineIndicator from "@/components/common/OfflineIndicator";
 import UpdateNotifier from "@/components/common/UpdateNotifier";
 import FolderSyncScheduler from "@/components/FolderSyncScheduler";
 import { PhaseAPerfProfiler } from "@/components/PhaseAPerfProfiler";
+import SpaceActionsPreferenceGate from "@/components/SpaceActionsPreferenceGate";
 
 const AUTH_USER_CACHE_PREFIX = "nowen-auth-user:";
 
@@ -1252,6 +1253,7 @@ function App() {
     <ThemeProvider>
       <SiteSettingsProvider>
         <UserPreferencesProvider>
+          <SpaceActionsPreferenceGate />
           <ConfirmProvider>
             <AuthGate />
             <Toaster />

--- a/frontend/src/components/PublicSpaceLauncher.tsx
+++ b/frontend/src/components/PublicSpaceLauncher.tsx
@@ -91,7 +91,11 @@ function railMountsEqual(previous: RailMount[], next: RailMount[]): boolean {
  * 侧栏、底部安全区及软键盘争抢位置。旧版 NoteTransferCenter 仍持有弹窗状态，
  * 这里隐藏其旧悬浮触发器并复用 click 行为，确保迁移过程不改变转移业务逻辑。
  */
-export default function PublicSpaceLauncher() {
+interface PublicSpaceLauncherProps {
+  visible?: boolean;
+}
+
+export default function PublicSpaceLauncher({ visible = true }: PublicSpaceLauncherProps) {
   const [railMounts, setRailMounts] = useState<RailMount[]>([]);
   const [panel, setPanel] = useState<OpenPanel | null>(null);
   const legacyTransferTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -108,6 +112,12 @@ export default function PublicSpaceLauncher() {
         legacyTransferTriggerRef.current = trigger;
         trigger.hidden = true;
         trigger.dataset.spaceActionsManaged = "true";
+      }
+
+      if (!visible) {
+        document.querySelectorAll<HTMLElement>("[" + RAIL_MOUNT_ATTRIBUTE + "]").forEach((mount) => mount.remove());
+        setRailMounts((previous) => previous.length === 0 ? previous : []);
+        return;
       }
 
       const mounts: RailMount[] = [];
@@ -153,13 +163,20 @@ export default function PublicSpaceLauncher() {
       if (frame) window.cancelAnimationFrame(frame);
       document.querySelectorAll<HTMLElement>(`[${RAIL_MOUNT_ATTRIBUTE}]`).forEach((mount) => mount.remove());
 
-      const trigger = legacyTransferTriggerRef.current;
-      if (trigger?.dataset.spaceActionsManaged === "true") {
-        trigger.hidden = false;
-        delete trigger.dataset.spaceActionsManaged;
-      }
     };
+  }, [visible]);
+
+  useEffect(() => () => {
+    const trigger = legacyTransferTriggerRef.current;
+    if (trigger?.dataset.spaceActionsManaged === "true") {
+      trigger.hidden = false;
+      delete trigger.dataset.spaceActionsManaged;
+    }
   }, []);
+
+  useEffect(() => {
+    if (!visible) setPanel(null);
+  }, [visible]);
 
   useEffect(() => {
     if (!panel) return;

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -771,6 +771,11 @@ function SwitchesPanel() {
       hint: t('settings.prefShowNotesInNotebookTreeHint'),
     },
     {
+      key: "showSpaceActions" as const,
+      label: t('settings.prefShowSpaceActions'),
+      hint: t('settings.prefShowSpaceActionsHint'),
+    },
+    {
       key: "showNoteListUpdatedTime" as const,
       label: t('settings.prefShowNoteListUpdatedTime'),
       hint: t('settings.prefShowNoteListUpdatedTimeHint'),

--- a/frontend/src/components/SpaceActionsPreferenceGate.tsx
+++ b/frontend/src/components/SpaceActionsPreferenceGate.tsx
@@ -1,0 +1,8 @@
+import PublicSpaceLauncher from "@/components/PublicSpaceLauncher";
+import { useUserPreferences } from "@/hooks/useUserPreferences";
+
+/** Keeps the Spaces launcher account-scoped and immediately reactive. */
+export default function SpaceActionsPreferenceGate() {
+  const { prefs } = useUserPreferences();
+  return <PublicSpaceLauncher visible={prefs.showSpaceActions} />;
+}

--- a/frontend/src/components/__tests__/PublicSpaceLauncher.visibility.test.tsx
+++ b/frontend/src/components/__tests__/PublicSpaceLauncher.visibility.test.tsx
@@ -1,0 +1,43 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import PublicSpaceLauncher from "@/components/PublicSpaceLauncher";
+
+describe("PublicSpaceLauncher visibility", () => {
+  let root: Root;
+  let host: HTMLDivElement;
+  let legacyTrigger: HTMLButtonElement;
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = `
+      <aside class="nav-rail"><div class="flex-1 overflow-y-auto"></div></aside>
+      <button aria-label="跨空间转移笔记">legacy</button>
+    `;
+    legacyTrigger = document.querySelector("button")!;
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = "";
+  });
+  const settle = async () => {
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 30));
+    });
+  };
+  it("hides the nav entry without restoring the legacy floating trigger", async () => {
+    act(() => root.render(<PublicSpaceLauncher visible={false} />));
+    await settle();
+    expect(legacyTrigger.hidden).toBe(true);
+    expect(document.querySelector("[data-nowen-space-actions-mount]")).toBeNull();
+    act(() => root.render(<PublicSpaceLauncher visible />));
+    await settle();
+    expect(document.querySelector("[data-nowen-space-actions-mount]")).not.toBeNull();
+    act(() => root.render(<PublicSpaceLauncher visible={false} />));
+    await settle();
+    expect(legacyTrigger.hidden).toBe(true);
+    expect(document.querySelector("[data-nowen-space-actions-mount]")).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/SpaceActionsPreferenceGate.test.tsx
+++ b/frontend/src/components/__tests__/SpaceActionsPreferenceGate.test.tsx
@@ -1,0 +1,37 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SpaceActionsPreferenceGate from "@/components/SpaceActionsPreferenceGate";
+
+const preferenceState = vi.hoisted(() => ({ showSpaceActions: true }));
+vi.mock("@/hooks/useUserPreferences", () => ({
+  useUserPreferences: () => ({ prefs: preferenceState, setPref: vi.fn() }),
+}));
+vi.mock("@/components/PublicSpaceLauncher", () => ({
+  default: ({ visible }: { visible?: boolean }) => (
+    <div data-space-actions-launcher="true" data-visible={String(visible)} />
+  ),
+}));
+
+describe("SpaceActionsPreferenceGate", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    preferenceState.showSpaceActions = true;
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+  it("passes visibility without unmounting the legacy-trigger guard", () => {
+    act(() => root.render(<SpaceActionsPreferenceGate />));
+    expect(host.querySelector('[data-visible="true"]')).not.toBeNull();
+    preferenceState.showSpaceActions = false;
+    act(() => root.render(<SpaceActionsPreferenceGate />));
+    expect(host.querySelector('[data-visible="false"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -628,7 +628,9 @@
     "fontUploadSuccess": "Successfully imported {{count}} fonts",
     "fontUploadFailed": "Upload failed",
     "interDefault": "Inter (Default)",
-    "download": "Downloads"
+    "download": "Downloads",
+    "prefShowSpaceActions": "Show space entry",
+    "prefShowSpaceActionsHint": "Show the Spaces entry in the navigation rail. Public-space links remain accessible when hidden."
   },
   "editorTabs": {
     "close": "Close tab",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -645,7 +645,9 @@
     "fontUploadSuccess": "成功导入 {{count}} 个字体",
     "fontUploadFailed": "上传失败",
     "interDefault": "Inter (默认)",
-    "download": "下载客户端"
+    "download": "下载客户端",
+    "prefShowSpaceActions": "显示空间入口",
+    "prefShowSpaceActionsHint": "在左侧导航栏显示“空间”入口；关闭后仍可直接访问公共空间链接。"
   },
   "editorTabs": {
     "close": "关闭标签",

--- a/frontend/src/lib/__tests__/userPreferenceAccountCache.test.ts
+++ b/frontend/src/lib/__tests__/userPreferenceAccountCache.test.ts
@@ -126,3 +126,22 @@ describe("user preference account cache", () => {
     expect(JSON.stringify(patch)).not.toContain("secret");
   });
 });
+
+
+describe("space actions account preference", () => {
+  it("defaults to visible and persists an explicit hidden value", () => {
+    const storage = new MemoryStorage();
+    expect(DEFAULT_USER_PREFERENCES.showSpaceActions).toBe(true);
+    writeAccountPreferenceCache(storage, {
+      version: 2,
+      userId: "space-user",
+      prefs: { ...DEFAULT_USER_PREFERENCES, showSpaceActions: false },
+      revision: 2,
+      pending: { showSpaceActions: false },
+    });
+    const cached = readAccountPreferenceCache(storage, "space-user");
+    expect(cached?.prefs.showSpaceActions).toBe(false);
+    expect(sanitizeUserPreferencePatch({ showSpaceActions: false, token: "secret" }))
+      .toEqual({ showSpaceActions: false });
+  });
+});

--- a/frontend/src/lib/userPreferenceAccountCache.ts
+++ b/frontend/src/lib/userPreferenceAccountCache.ts
@@ -15,6 +15,7 @@ export interface UserPreferences {
   outlineDefaultOpen: boolean;
   lockOnOpen: boolean;
   showNotesInNotebookTree: boolean;
+  showSpaceActions: boolean;
   readingDensity: ReadingDensity;
   showNoteListUpdatedTime: boolean;
   enableNoteTabs: boolean;
@@ -45,6 +46,7 @@ export const DEFAULT_USER_PREFERENCES: UserPreferences = {
   outlineDefaultOpen: false,
   lockOnOpen: false,
   showNotesInNotebookTree: false,
+  showSpaceActions: true,
   readingDensity: "cozy",
   showNoteListUpdatedTime: true,
   enableNoteTabs: false,
@@ -96,6 +98,9 @@ export function normalizeUserPreferences(
     showNotesInNotebookTree: typeof raw.showNotesInNotebookTree === "boolean"
       ? raw.showNotesInNotebookTree
       : fallback.showNotesInNotebookTree,
+    showSpaceActions: typeof raw.showSpaceActions === "boolean"
+      ? raw.showSpaceActions
+      : fallback.showSpaceActions,
     readingDensity: raw.readingDensity === "compact" || raw.readingDensity === "cozy"
       ? raw.readingDensity
       : fallback.readingDensity,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,7 +9,6 @@ import "./i18n";
 import "./lib/imageNodeTransformBootstrap";
 import App from "./App";
 import PublicNotebookView from "./components/PublicNotebookView";
-import PublicSpaceLauncher from "./components/PublicSpaceLauncher";
 import { ThemeProvider } from "./components/ThemeProvider";
 import Toaster from "./components/Toaster";
 import NoteIconBridge from "./components/NoteIconBridge";
@@ -154,7 +153,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <AndroidShareImportCenter />
         <NoteImageExportCenter />
         <DocxImportCenter />
-        <PublicSpaceLauncher />
         <NoteTransferCenter />
         <RoundTripImportBatchCenter />
         <RoundTripPermissionMappingCenter />


### PR DESCRIPTION
Closes #353

## 实现概览

补齐 Issue #353 剩余需求：用户可以在「设置 → 功能开关」中控制左侧导航栏“空间”入口是否显示。

## 实现内容

- 新增账号级偏好 `showSpaceActions`，默认值为 `true`，保持升级兼容；
- 偏好复用现有 UserPreferences 同步、账号隔离、离线缓存和字段级合并体系；
- 在设置页增加“显示空间入口”开关，修改后立即生效；
- 将 `PublicSpaceLauncher` 移到 `UserPreferencesProvider` 内，由偏好门控；
- 关闭时只移除 NavRail 中的“空间”入口；
- 组件继续常驻并压制旧版右下角“跨空间转移”悬浮触发器，避免重新遮挡大纲；
- 隐藏入口不影响直接访问 `/public` 或已有公共空间链接；
- 增加中英文文案。

## 验证

最终 Head：`679261a9783b8bee1f48e41bd98ca77e05cd0fc4`

专项验证运行：`30101380443`

- [x] Backend TypeScript
- [x] 用户偏好默认值、PATCH 持久化、账号隔离测试
- [x] 前端账号缓存与未知敏感字段过滤测试
- [x] 设置偏好即时传递测试
- [x] 真实 DOM：隐藏入口时 NavRail 挂载点被移除
- [x] 真实 DOM：隐藏入口时旧悬浮触发器仍保持隐藏
- [x] 重新开启后入口即时恢复
- [x] Frontend project TypeScript

分支已压缩为 1 个提交，与最新 `main` 同步：`ahead_by=1`、`behind_by=0`，PR `mergeable: true`。