### PR TITLE
fix(tags): make AI tag creation idempotent by scope

### DIFF
--- a/.github/workflows/tag-idempotency-ci.yml
+++ b/.github/workflows/tag-idempotency-ci.yml
@@ -1,0 +1,49 @@
+name: Tag Idempotency CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/src/routes/tags.ts"
+      - "backend/src/services/tagScope.ts"
+      - "backend/src/db/tagScopeUniquenessMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/tests/tag-idempotency.test.ts"
+      - "backend/tests/tag-scope-uniqueness-migration.test.ts"
+      - ".github/workflows/tag-idempotency-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/routes/tags.ts"
+      - "backend/src/services/tagScope.ts"
+      - "backend/src/db/tagScopeUniquenessMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/tests/tag-idempotency.test.ts"
+      - "backend/tests/tag-scope-uniqueness-migration.test.ts"
+      - ".github/workflows/tag-idempotency-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tag-idempotency:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Type-check backend
+        run: npm run build:tsc
+      - name: Run tag idempotency regression tests
+        run: >-
+          node --import tsx --test
+          tests/tag-idempotency.test.ts
+          tests/tag-scope-uniqueness-migration.test.ts

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -18,6 +18,7 @@ import { blockAuthorityMigration } from "./blockAuthorityMigration.js";
 import { yjsSubdocumentsMigration } from "./yjsSubdocumentsMigration.js";
 import { blockAuthorityStaleGuardMigration } from "./blockAuthorityStaleGuardMigration.js";
 import { yjsSubdocumentGenerationMigration } from "./yjsSubdocumentGenerationMigration.js";
+import { tagScopeUniquenessMigration } from "./tagScopeUniquenessMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -268,6 +269,7 @@ export const MIGRATIONS: Migration[] = [
   yjsSubdocumentsMigration,
   blockAuthorityStaleGuardMigration,
   yjsSubdocumentGenerationMigration,
+  tagScopeUniquenessMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/db/tagScopeUniquenessMigration.ts
+++ b/backend/src/db/tagScopeUniquenessMigration.ts
@@ -1,0 +1,111 @@
+import type Database from "better-sqlite3";
+import type { Migration } from "./migrations.impl.js";
+
+/**
+ * v59: 标签名称从“账号全局唯一”调整为真正的空间唯一。
+ *
+ * 最终规则：
+ * - 个人空间：userId + normalizedName 唯一；
+ * - 工作区：workspaceId + normalizedName 唯一，创建者 userId 不参与唯一性。
+ *
+ * 历史库可能已存在大小写/空格差异的重复标签，或同一工作区由不同成员创建
+ * 的同名标签。迁移保留最早创建的记录，并把 note_tags 关系合并到该记录。
+ */
+export const tagScopeUniquenessMigration: Migration = {
+  version: 59,
+  name: "tag-scope-unique-names",
+  up: (db: Database.Database) => {
+    db.exec(`
+      CREATE TABLE tags_v59 (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        name TEXT NOT NULL,
+        color TEXT DEFAULT '#58a6ff',
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        workspaceId TEXT,
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+      );
+
+      INSERT INTO tags_v59 (id, userId, name, color, createdAt, workspaceId)
+      SELECT
+        t.id,
+        t.userId,
+        trim(t.name),
+        t.color,
+        t.createdAt,
+        t.workspaceId
+      FROM tags t
+      WHERE t.id = (
+        SELECT t2.id
+        FROM tags t2
+        WHERE lower(trim(t2.name)) = lower(trim(t.name))
+          AND (
+            (
+              t.workspaceId IS NULL
+              AND t2.workspaceId IS NULL
+              AND t2.userId = t.userId
+            )
+            OR (
+              t.workspaceId IS NOT NULL
+              AND t2.workspaceId = t.workspaceId
+            )
+          )
+        ORDER BY t2.createdAt ASC, t2.id ASC
+        LIMIT 1
+      );
+
+      CREATE TABLE note_tags_v59 (
+        noteId TEXT NOT NULL,
+        tagId TEXT NOT NULL,
+        PRIMARY KEY (noteId, tagId),
+        FOREIGN KEY (noteId) REFERENCES notes(id) ON DELETE CASCADE,
+        FOREIGN KEY (tagId) REFERENCES tags_v59(id) ON DELETE CASCADE
+      );
+
+      INSERT OR IGNORE INTO note_tags_v59 (noteId, tagId)
+      SELECT
+        nt.noteId,
+        (
+          SELECT t2.id
+          FROM tags t2
+          WHERE lower(trim(t2.name)) = lower(trim(t.name))
+            AND (
+              (
+                t.workspaceId IS NULL
+                AND t2.workspaceId IS NULL
+                AND t2.userId = t.userId
+              )
+              OR (
+                t.workspaceId IS NOT NULL
+                AND t2.workspaceId = t.workspaceId
+              )
+            )
+          ORDER BY t2.createdAt ASC, t2.id ASC
+          LIMIT 1
+        ) AS canonicalTagId
+      FROM note_tags nt
+      JOIN tags t ON t.id = nt.tagId;
+
+      DROP TABLE note_tags;
+      DROP TABLE tags;
+      ALTER TABLE tags_v59 RENAME TO tags;
+      ALTER TABLE note_tags_v59 RENAME TO note_tags;
+
+      CREATE INDEX IF NOT EXISTS idx_tags_workspace
+        ON tags(workspaceId);
+      CREATE INDEX IF NOT EXISTS idx_tags_user_workspace
+        ON tags(userId, workspaceId);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_personal_name_unique
+        ON tags(userId, lower(trim(name)))
+        WHERE workspaceId IS NULL;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_workspace_name_unique
+        ON tags(workspaceId, lower(trim(name)))
+        WHERE workspaceId IS NOT NULL;
+    `);
+
+    const fkErrors = db.prepare("PRAGMA foreign_key_check").all();
+    if (fkErrors.length > 0) {
+      throw new Error(`tag scope migration foreign key check failed: ${JSON.stringify(fkErrors)}`);
+    }
+  },
+};

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -3,6 +3,11 @@ import { getDb } from "../db/schema";
 import { v4 as uuid } from "uuid";
 import { getUserWorkspaceRole, hasRole } from "../middleware/acl";
 import { tagsRepository, noteTagsRepository } from "../repositories";
+import {
+  ensureScopedTag,
+  isTagUniqueConstraintError,
+  normalizeTagName,
+} from "../services/tagScope.js";
 
 /**
  * Tags 路由 —— 支持工作区隔离
@@ -16,10 +21,10 @@ import { tagsRepository, noteTagsRepository } from "../repositories";
  *       <workspaceUuid>           → 落到该工作区（要求 editor 以上角色）
  *   - 更新 / 删除 / 给笔记打标签：通过 tag.id 反查 owner & workspace 后再做 ACL 校验
  *
- * 注意：
- *   - 标签的 UNIQUE(userId, name) 约束未变，仍然是"同用户名全局唯一"；
- *     workspaceId 只是限定可见范围，不参与唯一性。这是为了避免重建表
- *     （详见 schema.ts 中的注释），同时保持标签作为用户分类体系的语义简单。
+ * 标签名称唯一性：
+ *   - 个人空间：同一 userId 内唯一；
+ *   - 工作区：同一 workspaceId 内唯一，与创建者 userId 无关；
+ *   - 创建接口是幂等的：同名标签已存在时直接返回已有记录，不向调用方暴露 409。
  */
 
 const app = new Hono();
@@ -79,14 +84,15 @@ app.get("/", (c) => {
  * POST /tags
  * body: { name, color?, workspaceId? }
  *   workspaceId 为 'personal'/缺省 → 个人空间；为 uuid → 工作区（要求 editor+）
+ *
+ * 同一作用域重复创建时返回已有标签（200）；首次创建返回 201。
  */
 app.post("/", async (c) => {
   const db = getDb();
   const userId = c.req.header("X-User-Id") || "demo";
   const body = await c.req.json();
 
-  // 标签名称校验
-  const name = (body.name || "").trim();
+  const name = normalizeTagName(body.name);
   if (!name) {
     return c.json({ error: "标签名称不能为空" }, 400);
   }
@@ -102,42 +108,25 @@ app.post("/", async (c) => {
     }
   }
 
-  const id = uuid();
-  try {
-    tagsRepository.create({
-      id,
-      userId,
-      workspaceId: ws,
-      name,
-      color: body.color || "#58a6ff",
-    });
-  } catch (err: any) {
-    // UNIQUE(userId, name) 冲突 → 当前账号已有同名标签（可能在其他空间）
-    if (String(err?.message || err).includes("UNIQUE")) {
-      return c.json(
-        {
-          error:
-            "您已经有一个同名标签（标签名在账号内全局唯一），请换一个名字",
-        },
-        409,
-      );
-    }
-    throw err;
-  }
-  const tag = tagsRepository.getById(id);
-  return c.json(tag, 201);
+  const result = ensureScopedTag(db, {
+    id: uuid(),
+    userId,
+    workspaceId: ws,
+    name,
+    color: body.color || "#58a6ff",
+  });
+
+  return c.json(result.tag, result.created ? 201 : 200);
 });
 
 // 更新标签（名称/颜色）
 app.put("/:id", async (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id") || "";
   const id = c.req.param("id");
   const body = await c.req.json();
 
-  // 标签名称校验
   if (body.name !== undefined) {
-    const name = (body.name || "").trim();
+    const name = normalizeTagName(body.name);
     if (!name) {
       return c.json({ error: "标签名称不能为空" }, 400);
     }
@@ -160,13 +149,20 @@ app.put("/:id", async (c) => {
   }
   if (Object.keys(patch).length === 0) return c.json({ error: "No fields to update" }, 400);
 
-  tagsRepository.updateById(id, patch);
+  try {
+    tagsRepository.updateById(id, patch);
+  } catch (error) {
+    if (isTagUniqueConstraintError(error)) {
+      return c.json({ error: "当前空间已存在同名标签，请直接使用该标签" }, 409);
+    }
+    throw error;
+  }
+
   const tag = tagsRepository.getByIdWithCount(id);
   return c.json(tag);
 });
 
 app.delete("/:id", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id") || "";
   const id = c.req.param("id");
 
@@ -205,7 +201,6 @@ app.post("/note/:noteId/tag/:tagId", (c) => {
 
 // 移除笔记标签
 app.delete("/note/:noteId/tag/:tagId", (c) => {
-  const db = getDb();
   const userId = c.req.header("X-User-Id") || "";
   const { noteId, tagId } = c.req.param();
 

--- a/backend/src/services/tagScope.ts
+++ b/backend/src/services/tagScope.ts
@@ -1,0 +1,110 @@
+import type Database from "better-sqlite3";
+
+export interface ScopedTagRecord {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  color: string;
+  createdAt: string;
+}
+
+export interface EnsureScopedTagInput {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  color: string;
+}
+
+export interface EnsureScopedTagResult {
+  tag: ScopedTagRecord;
+  created: boolean;
+}
+
+export function normalizeTagName(raw: unknown): string {
+  return String(raw ?? "").trim();
+}
+
+/**
+ * 标签作用域：
+ * - 个人空间：同一 userId 内名称唯一；
+ * - 工作区：同一 workspaceId 内名称唯一，创建者 userId 不参与查重。
+ *
+ * 名称查找与数据库唯一索引保持一致，使用 trim + lower 处理前后空格和
+ * ASCII 大小写差异，避免 React/react 被当成两个标签。
+ */
+export function findTagByScopedName(
+  db: Database.Database,
+  userId: string,
+  workspaceId: string | null,
+  name: string,
+): ScopedTagRecord | undefined {
+  const normalizedName = normalizeTagName(name);
+  if (!normalizedName) return undefined;
+
+  if (workspaceId) {
+    return db.prepare(`
+      SELECT id, userId, workspaceId, name, color, createdAt
+      FROM tags
+      WHERE workspaceId = ?
+        AND lower(trim(name)) = lower(?)
+      ORDER BY createdAt ASC, id ASC
+      LIMIT 1
+    `).get(workspaceId, normalizedName) as ScopedTagRecord | undefined;
+  }
+
+  return db.prepare(`
+    SELECT id, userId, workspaceId, name, color, createdAt
+    FROM tags
+    WHERE userId = ?
+      AND workspaceId IS NULL
+      AND lower(trim(name)) = lower(?)
+    ORDER BY createdAt ASC, id ASC
+    LIMIT 1
+  `).get(userId, normalizedName) as ScopedTagRecord | undefined;
+}
+
+export function isTagUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /UNIQUE constraint failed|SQLITE_CONSTRAINT_UNIQUE|SQLITE_CONSTRAINT/i.test(message);
+}
+
+/**
+ * 幂等创建标签。
+ *
+ * 先查再插用于常规路径；唯一索引负责并发兜底。若两个请求同时创建同名标签，
+ * 后到请求捕获唯一冲突后重新查询并复用已创建记录，而不是向用户暴露 409。
+ */
+export function ensureScopedTag(
+  db: Database.Database,
+  input: EnsureScopedTagInput,
+): EnsureScopedTagResult {
+  const name = normalizeTagName(input.name);
+  const existing = findTagByScopedName(db, input.userId, input.workspaceId, name);
+  if (existing) return { tag: existing, created: false };
+
+  try {
+    db.prepare(`
+      INSERT INTO tags (id, userId, workspaceId, name, color)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(input.id, input.userId, input.workspaceId, name, input.color);
+  } catch (error) {
+    if (isTagUniqueConstraintError(error)) {
+      const raced = findTagByScopedName(db, input.userId, input.workspaceId, name);
+      if (raced) return { tag: raced, created: false };
+    }
+    throw error;
+  }
+
+  const created = db.prepare(`
+    SELECT id, userId, workspaceId, name, color, createdAt
+    FROM tags
+    WHERE id = ?
+  `).get(input.id) as ScopedTagRecord | undefined;
+
+  if (!created) {
+    throw new Error("标签创建后未能读取记录");
+  }
+  return { tag: created, created: true };
+}

--- a/backend/tests/tag-idempotency.test.ts
+++ b/backend/tests/tag-idempotency.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+import { ensureScopedTag } from "../src/services/tagScope";
+
+function createDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE tags (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL DEFAULT '#58a6ff',
+      createdAt TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX idx_tags_personal_name_unique
+      ON tags(userId, lower(trim(name)))
+      WHERE workspaceId IS NULL;
+    CREATE UNIQUE INDEX idx_tags_workspace_name_unique
+      ON tags(workspaceId, lower(trim(name)))
+      WHERE workspaceId IS NOT NULL;
+  `);
+  return db;
+}
+
+test("personal tag creation reuses an existing normalized name", () => {
+  const db = createDb();
+  try {
+    const first = ensureScopedTag(db, {
+      id: "tag-1",
+      userId: "u1",
+      workspaceId: null,
+      name: "React",
+      color: "#111",
+    });
+    const second = ensureScopedTag(db, {
+      id: "tag-2",
+      userId: "u1",
+      workspaceId: null,
+      name: " react ",
+      color: "#222",
+    });
+
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(second.tag.id, "tag-1");
+    assert.equal((db.prepare("SELECT COUNT(*) AS count FROM tags").get() as { count: number }).count, 1);
+  } finally {
+    db.close();
+  }
+});
+
+test("workspace tag creation is shared by all editors in that workspace", () => {
+  const db = createDb();
+  try {
+    const first = ensureScopedTag(db, {
+      id: "tag-ws-1",
+      userId: "u1",
+      workspaceId: "ws-a",
+      name: "开发",
+      color: "#111",
+    });
+    const second = ensureScopedTag(db, {
+      id: "tag-ws-2",
+      userId: "u2",
+      workspaceId: "ws-a",
+      name: "开发",
+      color: "#222",
+    });
+    const third = ensureScopedTag(db, {
+      id: "tag-ws-3",
+      userId: "u1",
+      workspaceId: "ws-b",
+      name: "开发",
+      color: "#333",
+    });
+
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(second.tag.id, "tag-ws-1");
+    assert.equal(third.created, true);
+    assert.equal(third.tag.id, "tag-ws-3");
+    assert.equal((db.prepare("SELECT COUNT(*) AS count FROM tags").get() as { count: number }).count, 2);
+  } finally {
+    db.close();
+  }
+});

--- a/backend/tests/tag-scope-uniqueness-migration.test.ts
+++ b/backend/tests/tag-scope-uniqueness-migration.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+import { tagScopeUniquenessMigration } from "../src/db/tagScopeUniquenessMigration";
+
+function createLegacyDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY
+    );
+    CREATE TABLE notes (
+      id TEXT PRIMARY KEY
+    );
+    CREATE TABLE tags (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      name TEXT NOT NULL,
+      color TEXT DEFAULT '#58a6ff',
+      createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+      workspaceId TEXT,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      UNIQUE(userId, name)
+    );
+    CREATE TABLE note_tags (
+      noteId TEXT NOT NULL,
+      tagId TEXT NOT NULL,
+      PRIMARY KEY (noteId, tagId),
+      FOREIGN KEY (noteId) REFERENCES notes(id) ON DELETE CASCADE,
+      FOREIGN KEY (tagId) REFERENCES tags(id) ON DELETE CASCADE
+    );
+  `);
+  db.prepare("INSERT INTO users (id) VALUES (?), (?)").run("u1", "u2");
+  db.prepare("INSERT INTO notes (id) VALUES (?), (?)").run("n1", "n2");
+  return db;
+}
+
+test("v59 merges historical duplicates and preserves note relations", () => {
+  const db = createLegacyDb();
+  try {
+    const insertTag = db.prepare(`
+      INSERT INTO tags (id, userId, workspaceId, name, color, createdAt)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    insertTag.run("personal-old", "u1", null, "React", "#111", "2026-01-01 00:00:00");
+    insertTag.run("personal-dup", "u1", null, " react ", "#222", "2026-01-02 00:00:00");
+    insertTag.run("workspace-old", "u1", "ws-a", "Shared", "#333", "2026-01-01 00:00:00");
+    insertTag.run("workspace-dup", "u2", "ws-a", "shared", "#444", "2026-01-02 00:00:00");
+
+    const link = db.prepare("INSERT INTO note_tags (noteId, tagId) VALUES (?, ?)");
+    link.run("n1", "personal-old");
+    link.run("n1", "personal-dup");
+    link.run("n2", "workspace-old");
+    link.run("n2", "workspace-dup");
+
+    tagScopeUniquenessMigration.up(db);
+
+    const personal = db.prepare(`
+      SELECT id, name FROM tags
+      WHERE userId = 'u1' AND workspaceId IS NULL AND lower(trim(name)) = 'react'
+    `).all() as Array<{ id: string; name: string }>;
+    assert.deepEqual(personal, [{ id: "personal-old", name: "React" }]);
+
+    const workspace = db.prepare(`
+      SELECT id, name FROM tags
+      WHERE workspaceId = 'ws-a' AND lower(trim(name)) = 'shared'
+    `).all() as Array<{ id: string; name: string }>;
+    assert.deepEqual(workspace, [{ id: "workspace-old", name: "Shared" }]);
+
+    assert.deepEqual(
+      db.prepare("SELECT noteId, tagId FROM note_tags ORDER BY noteId").all(),
+      [
+        { noteId: "n1", tagId: "personal-old" },
+        { noteId: "n2", tagId: "workspace-old" },
+      ],
+    );
+    assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
+  } finally {
+    db.close();
+  }
+});
+
+test("v59 enforces personal and workspace scoped names", () => {
+  const db = createLegacyDb();
+  try {
+    db.prepare(`
+      INSERT INTO tags (id, userId, workspaceId, name, color, createdAt)
+      VALUES ('personal', 'u1', NULL, 'React', '#111', '2026-01-01 00:00:00')
+    `).run();
+    db.prepare(`
+      INSERT INTO tags (id, userId, workspaceId, name, color, createdAt)
+      VALUES ('workspace', 'u1', 'ws-a', 'Shared', '#222', '2026-01-01 00:00:00')
+    `).run();
+
+    tagScopeUniquenessMigration.up(db);
+
+    assert.throws(() => {
+      db.prepare("INSERT INTO tags (id, userId, workspaceId, name) VALUES (?, ?, ?, ?)")
+        .run("personal-dup", "u1", null, " react ");
+    }, /UNIQUE/);
+
+    assert.throws(() => {
+      db.prepare("INSERT INTO tags (id, userId, workspaceId, name) VALUES (?, ?, ?, ?)")
+        .run("workspace-dup", "u2", "ws-a", "shared");
+    }, /UNIQUE/);
+
+    db.prepare("INSERT INTO tags (id, userId, workspaceId, name) VALUES (?, ?, ?, ?)")
+      .run("workspace-other", "u1", "ws-b", "Shared");
+    db.prepare("INSERT INTO tags (id, userId, workspaceId, name) VALUES (?, ?, ?, ?)")
+      .run("personal-other", "u2", null, "React");
+
+    assert.equal((db.prepare("SELECT COUNT(*) AS count FROM tags").get() as { count: number }).count, 4);
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
## 问题

AI 推荐标签会依赖前端缓存判断标签是否存在。缓存过期、同一次 AI 输出包含重复标签、批量任务并发创建相同标签，或数据库存在未关联的空标签时，前端会重复调用 `POST /tags`，最终向用户暴露“账号内已有同名标签”的 409。

旧的 `UNIQUE(userId, name)` 还与工作区隔离冲突：其他工作区已经使用某个名称后，当前工作区无法创建同名标签。

## 修复

- 将 `POST /tags` 改为幂等创建：同一作用域已有同名标签时直接返回已有记录；
- 并发创建由唯一索引兜底，唯一冲突后重新查询并复用标签；
- 标签名称按 `trim + lower` 归一化，避免 `React` / ` react ` 重复；
- 新增 SQLite v59 迁移：
  - 个人空间按 `userId + normalizedName` 唯一；
  - 工作区按 `workspaceId + normalizedName` 唯一，与创建者无关；
  - 合并历史重复标签并重写 `note_tags` 关系，不丢失笔记关联；
- 标签重命名冲突返回明确的空间级 409；
- 增加迁移、幂等创建和跨工作区同名标签回归测试；
- 增加长期保留的 Tag Idempotency CI。

## 验收

- 相同 AI 标签重复生成不会报错；
- 多篇笔记同时生成相同标签只产生一条工作区标签；
- 历史空标签可直接复用；
- 个人空间和不同工作区允许使用相同名称；
- 同一工作区由不同成员创建同名标签时复用已有记录；
- 历史 `note_tags` 关系在迁移后保持完整。

Closes #347