### PR TITLE
fix(editor): downgrade normal editors after initialization timeout

### DIFF
--- a/.github/workflows/editor-init-timeout-ci.yml
+++ b/.github/workflows/editor-init-timeout-ci.yml
@@ -1,0 +1,52 @@
+name: Editor Initialization Timeout CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/vite.config.ts"
+      - "frontend/src/lib/editorInitializationRuntime.ts"
+      - "frontend/src/hooks/useEditorInitializationTimeout.ts"
+      - "frontend/src/components/MarkdownEditorInitializationRuntime.tsx"
+      - "frontend/src/components/TiptapEditorInitializationRuntime.tsx"
+      - "frontend/src/hooks/__tests__/useEditorInitializationTimeout.test.tsx"
+      - "frontend/src/lib/editorRuntimePolicy.ts"
+      - "frontend/src/lib/editorRuntimeStore.ts"
+      - ".github/workflows/editor-init-timeout-ci.yml"
+  pull_request:
+    paths:
+      - "frontend/vite.config.ts"
+      - "frontend/src/lib/editorInitializationRuntime.ts"
+      - "frontend/src/hooks/useEditorInitializationTimeout.ts"
+      - "frontend/src/components/MarkdownEditorInitializationRuntime.tsx"
+      - "frontend/src/components/TiptapEditorInitializationRuntime.tsx"
+      - "frontend/src/hooks/__tests__/useEditorInitializationTimeout.test.tsx"
+      - "frontend/src/lib/editorRuntimePolicy.ts"
+      - "frontend/src/lib/editorRuntimeStore.ts"
+      - ".github/workflows/editor-init-timeout-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Initialization timeout tests
+        run: npm run test:run -- src/hooks/__tests__/useEditorInitializationTimeout.test.tsx
+      - name: Frontend typecheck
+        if: always()
+        run: npx tsc -b

--- a/frontend/src/components/MarkdownEditorInitializationRuntime.tsx
+++ b/frontend/src/components/MarkdownEditorInitializationRuntime.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef } from "react";
+
+import type { NoteEditorHandle } from "@/components/editors/types";
+import { useEditorInitializationTimeout } from "@/hooks/useEditorInitializationTimeout";
+import MarkdownEditor from "./MarkdownEditor";
+
+type MarkdownEditorInitializationRuntimeProps = React.ComponentPropsWithoutRef<typeof MarkdownEditor>;
+
+/** Adds the shared initialization watchdog without changing the public Markdown editor contract. */
+const MarkdownEditorInitializationRuntime = forwardRef<
+  NoteEditorHandle,
+  MarkdownEditorInitializationRuntimeProps
+>(function MarkdownEditorInitializationRuntime(props, ref) {
+  const onEditorReady = useEditorInitializationTimeout({
+    noteId: props.note.id,
+    engine: "markdown",
+    onEditorReady: props.onEditorReady,
+  });
+
+  return (
+    <MarkdownEditor
+      {...props}
+      ref={ref}
+      onEditorReady={onEditorReady}
+    />
+  );
+});
+
+MarkdownEditorInitializationRuntime.displayName = "MarkdownEditorInitializationRuntime";
+
+export default MarkdownEditorInitializationRuntime;

--- a/frontend/src/components/TiptapEditorInitializationRuntime.tsx
+++ b/frontend/src/components/TiptapEditorInitializationRuntime.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef } from "react";
+
+import type { NoteEditorHandle } from "@/components/editors/types";
+import { useEditorInitializationTimeout } from "@/hooks/useEditorInitializationTimeout";
+import TiptapEditorRuntime from "./TiptapEditorRuntime";
+
+type TiptapEditorInitializationRuntimeProps = React.ComponentPropsWithoutRef<typeof TiptapEditorRuntime>;
+
+/** Adds the shared initialization watchdog around the existing Tiptap runtime shell. */
+const TiptapEditorInitializationRuntime = forwardRef<
+  NoteEditorHandle,
+  TiptapEditorInitializationRuntimeProps
+>(function TiptapEditorInitializationRuntime(props, ref) {
+  const onEditorReady = useEditorInitializationTimeout({
+    noteId: props.note.id,
+    engine: "tiptap",
+    onEditorReady: props.onEditorReady,
+  });
+
+  return (
+    <TiptapEditorRuntime
+      {...props}
+      ref={ref}
+      onEditorReady={onEditorReady}
+    />
+  );
+});
+
+TiptapEditorInitializationRuntime.displayName = "TiptapEditorInitializationRuntime";
+
+export default TiptapEditorInitializationRuntime;

--- a/frontend/src/hooks/__tests__/useEditorInitializationTimeout.test.tsx
+++ b/frontend/src/hooks/__tests__/useEditorInitializationTimeout.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorInitializationTimeout } from "@/hooks/useEditorInitializationTimeout";
+import { resolveEditorRuntimeDecision } from "@/lib/editorRuntimePolicy";
+import {
+  clearActiveEditorRuntimeDecision,
+  getActiveEditorRuntimeState,
+  setActiveEditorRuntimeDecision,
+} from "@/lib/editorRuntimeStore";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+let currentReady: ((scrollTo: (pos: number) => void) => void) | null = null;
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function richText(length: number): string {
+  return `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"${"x".repeat(length)}"}]}]}`;
+}
+
+function setDecision(noteId: string, length = 1_000): void {
+  setActiveEditorRuntimeDecision(noteId, resolveEditorRuntimeDecision({
+    content: richText(length),
+    contentFormat: "tiptap-json",
+  }));
+}
+
+function Harness({
+  noteId,
+  onEditorReady,
+}: {
+  noteId: string;
+  onEditorReady?: (scrollTo: (pos: number) => void) => void;
+}) {
+  currentReady = useEditorInitializationTimeout({
+    noteId,
+    engine: "tiptap",
+    onEditorReady,
+    timeoutMs: 100,
+  });
+  return null;
+}
+
+async function renderHarness(
+  noteId: string,
+  onEditorReady?: (scrollTo: (pos: number) => void) => void,
+): Promise<void> {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => root?.render(
+    <Harness noteId={noteId} onEditorReady={onEditorReady} />,
+  ));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  clearActiveEditorRuntimeDecision();
+  currentReady = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+  currentReady = null;
+  clearActiveEditorRuntimeDecision();
+  vi.useRealTimers();
+});
+
+describe("useEditorInitializationTimeout", () => {
+  it("downgrades an active normal editor to viewport optimization after the budget", async () => {
+    setDecision("note-timeout");
+    await renderHarness("note-timeout");
+
+    await act(async () => vi.advanceTimersByTime(101));
+
+    const decision = getActiveEditorRuntimeState().decision;
+    expect(decision.mode).toBe("viewport-optimized");
+    expect(decision.reasons).toContain("initialization-timeout");
+    expect(decision.capabilities.editable).toBe(true);
+  });
+
+  it("cancels the downgrade when the editor reports ready first", async () => {
+    const onEditorReady = vi.fn();
+    setDecision("note-ready");
+    await renderHarness("note-ready", onEditorReady);
+
+    const scrollTo = vi.fn();
+    await act(async () => currentReady?.(scrollTo));
+    await act(async () => vi.advanceTimersByTime(101));
+
+    expect(onEditorReady).toHaveBeenCalledWith(scrollTo);
+    expect(getActiveEditorRuntimeState().decision.mode).toBe("normal");
+  });
+
+  it("does not let a stale timer downgrade the next active note", async () => {
+    setDecision("note-old");
+    await renderHarness("note-old");
+    setDecision("note-new");
+
+    await act(async () => vi.advanceTimersByTime(101));
+
+    const current = getActiveEditorRuntimeState();
+    expect(current.noteId).toBe("note-new");
+    expect(current.decision.mode).toBe("normal");
+    expect(current.decision.reasons).not.toContain("initialization-timeout");
+  });
+
+  it("does not further downgrade a document already classified for viewport optimization", async () => {
+    setDecision("note-viewport", 120_000);
+    await renderHarness("note-viewport");
+
+    await act(async () => vi.advanceTimersByTime(101));
+
+    const decision = getActiveEditorRuntimeState().decision;
+    expect(decision.mode).toBe("viewport-optimized");
+    expect(decision.reasons).not.toContain("initialization-timeout");
+  });
+});

--- a/frontend/src/hooks/useEditorInitializationTimeout.ts
+++ b/frontend/src/hooks/useEditorInitializationTimeout.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { NoteEditorProps } from "@/components/editors/types";
+import {
+  EDITOR_INITIALIZATION_TIMEOUT_MS,
+  escalateEditorInitializationTimeout,
+  shouldWatchEditorInitialization,
+  type EditorInitializationEngine,
+} from "@/lib/editorInitializationRuntime";
+
+type EditorReadyCallback = NonNullable<NoteEditorProps["onEditorReady"]>;
+
+interface UseEditorInitializationTimeoutOptions {
+  noteId: string;
+  engine: EditorInitializationEngine;
+  onEditorReady?: NoteEditorProps["onEditorReady"];
+  timeoutMs?: number;
+}
+
+interface InitializationLifecycle {
+  noteId: string;
+  ready: boolean;
+  startedAt: number;
+}
+
+function clock(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+/**
+ * Wrap an editor's existing ready callback with a session-only initialization watchdog.
+ *
+ * Ready may be reported before this hook's effect runs. The lifecycle ref is therefore updated in
+ * render and checked before scheduling, preventing a fast editor from being downgraded by a timer
+ * that was armed after it had already become interactive.
+ */
+export function useEditorInitializationTimeout({
+  noteId,
+  engine,
+  onEditorReady,
+  timeoutMs = EDITOR_INITIALIZATION_TIMEOUT_MS,
+}: UseEditorInitializationTimeoutOptions): EditorReadyCallback {
+  const lifecycleRef = useRef<InitializationLifecycle>({
+    noteId,
+    ready: false,
+    startedAt: clock(),
+  });
+  const timerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+
+  if (lifecycleRef.current.noteId !== noteId) {
+    lifecycleRef.current = { noteId, ready: false, startedAt: clock() };
+  }
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current === null) return;
+    globalThis.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    clearTimer();
+    const lifecycle = lifecycleRef.current;
+    if (
+      lifecycle.noteId !== noteId
+      || lifecycle.ready
+      || !shouldWatchEditorInitialization(noteId)
+    ) {
+      return;
+    }
+
+    lifecycle.startedAt = clock();
+    timerRef.current = globalThis.setTimeout(() => {
+      timerRef.current = null;
+      const current = lifecycleRef.current;
+      if (current.noteId !== noteId || current.ready) return;
+
+      const decision = escalateEditorInitializationTimeout(noteId);
+      if (decision && import.meta.env.DEV) {
+        console.warn("[EditorRuntime] initialization timeout", {
+          noteId,
+          engine,
+          elapsedMs: Math.round(clock() - current.startedAt),
+          mode: decision.mode,
+          reasons: decision.reasons,
+        });
+      }
+    }, Math.max(0, timeoutMs));
+
+    return clearTimer;
+  }, [clearTimer, engine, noteId, timeoutMs]);
+
+  return useCallback<EditorReadyCallback>((scrollTo) => {
+    const lifecycle = lifecycleRef.current;
+    if (lifecycle.noteId === noteId) lifecycle.ready = true;
+    clearTimer();
+    onEditorReady?.(scrollTo);
+  }, [clearTimer, noteId, onEditorReady]);
+}

--- a/frontend/src/lib/editorInitializationRuntime.ts
+++ b/frontend/src/lib/editorInitializationRuntime.ts
@@ -1,0 +1,36 @@
+import type { EditorRuntimeDecision } from "@/lib/editorRuntimePolicy";
+import {
+  escalateActiveEditorRuntimeMode,
+  getActiveEditorRuntimeState,
+} from "@/lib/editorRuntimeStore";
+
+/**
+ * Normal documents should become interactive quickly. When a normal editor has not reported ready
+ * within this budget, the current session drops expensive whole-document work and heavy-node eager
+ * rendering before the user is left staring at an unresponsive editor.
+ */
+export const EDITOR_INITIALIZATION_TIMEOUT_MS = 1_500;
+
+export type EditorInitializationEngine = "markdown" | "tiptap";
+
+/** Only the active normal-mode note may be downgraded by an initialization timeout. */
+export function shouldWatchEditorInitialization(noteId: string): boolean {
+  const current = getActiveEditorRuntimeState();
+  return current.noteId === noteId && current.decision.mode === "normal";
+}
+
+/**
+ * Escalate one active normal session to viewport optimization.
+ *
+ * The active-note and current-mode checks deliberately happen again at timeout time, so a stale
+ * timer from a previous note or a Long Task escalation cannot mutate the new editor session.
+ */
+export function escalateEditorInitializationTimeout(
+  noteId: string,
+): EditorRuntimeDecision | null {
+  if (!shouldWatchEditorInitialization(noteId)) return null;
+  return escalateActiveEditorRuntimeMode(
+    "viewport-optimized",
+    "initialization-timeout",
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,11 +50,17 @@ export default defineConfig({
         find: /^@\/components\/SearchReplacePanel$/,
         replacement: path.resolve(__dirname, "./src/components/SearchReplacePanelRuntime.tsx"),
       },
-      // Issue #369：Tiptap 派生数据只扫描一次；优化模式暂停实时全文大纲。
+      // Issue #369：统一监听 Markdown / Tiptap 首次可交互，普通模式超时后自动降级。
+      // 初始化壳再通过相对路径进入原运行时，避免精确别名递归。
+      {
+        find: /^@\/components\/MarkdownEditor$/,
+        replacement: path.resolve(__dirname, "./src/components/MarkdownEditorInitializationRuntime.tsx"),
+      },
       {
         find: /^@\/components\/TiptapEditor$/,
-        replacement: path.resolve(__dirname, "./src/components/TiptapEditorRuntime.tsx"),
+        replacement: path.resolve(__dirname, "./src/components/TiptapEditorInitializationRuntime.tsx"),
       },
+      // Issue #369：Tiptap 派生数据只扫描一次；优化模式暂停实时全文大纲。
       {
         find: /^@\/lib\/proseMirrorPlainText$/,
         replacement: path.resolve(__dirname, "./src/lib/proseMirrorPlainTextRuntime.ts"),


### PR DESCRIPTION
## 背景

#369 已进入灰度发布与多端性能签收阶段。现有运行时已经支持 `initialization-timeout` 原因和模式升级，但真实编辑器初始化路径没有接入超时触发。

## 实现

- 新增统一的 1.5 秒编辑器初始化预算；
- 仅对当前活动笔记且运行模式仍为 `normal` 的会话生效；
- Markdown 与 Tiptap 都通过轻量运行时包装器监听原有 `onEditorReady`；
- 超时后执行 `normal → viewport-optimized`，保留正文编辑能力；
- 编辑器及时就绪、切换笔记或已经处于优化模式时，不触发降级；
- stale timer 会在执行前再次核对活动笔记和模式，避免影响下一篇笔记；
- 新增 Vitest 回归测试和独立 CI 门禁。

## 安全边界

- 不会自动进入 `emergency-readonly`；
- 不修改正文、`contentFormat` 或服务端数据；
- 仅作用于当前前端会话；
- 现有编辑器组件和公共 props 契约保持不变。

关联 #369