### PR TITLE
feat(issue-370): 产品化创作布局与双编辑区分屏

### DIFF
--- a/.github/workflows/knowledge-tree-p0-ci.yml
+++ b/.github/workflows/knowledge-tree-p0-ci.yml
@@ -1,0 +1,42 @@
+name: Knowledge Tree P0 CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/src/components/EditorSplitView.tsx"
+      - "frontend/src/components/common/CommandPalette.tsx"
+      - "frontend/src/lib/editorWorkspaceLayout.ts"
+      - "frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts"
+      - ".github/workflows/knowledge-tree-p0-ci.yml"
+  pull_request:
+    paths:
+      - "frontend/src/components/EditorSplitView.tsx"
+      - "frontend/src/components/common/CommandPalette.tsx"
+      - "frontend/src/lib/editorWorkspaceLayout.ts"
+      - "frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts"
+      - ".github/workflows/knowledge-tree-p0-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Workspace layout tests
+        run: npm run test:run -- src/lib/__tests__/editorWorkspaceLayout.test.ts
+      - name: Frontend typecheck
+        if: always()
+        run: npx tsc -b

--- a/frontend/src/components/EditorSplitView.tsx
+++ b/frontend/src/components/EditorSplitView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Loader2, X } from "lucide-react";
+import { ArrowLeftRight, Eye, Loader2, PanelLeftClose, Pencil, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import FormatAwareEditorPane from "@/components/FormatAwareEditorPane";
 import NoteTabsBar from "@/components/NoteTabsBar";
@@ -18,21 +18,34 @@ import { useNoteLoader } from "@/hooks/useNoteLoader";
 import { NoteLoadCoordinator, type NoteLoadSink } from "@/lib/noteLoadCoordinator";
 import { canApplyRevalidatedNote, loadNoteCacheFirst } from "@/lib/noteLoadSource";
 import { loadDraft } from "@/lib/draftStorage";
+import {
+  clampEditorSplitRatio,
+  loadEditorSplitRatio,
+  saveEditorSplitRatio,
+} from "@/lib/editorWorkspaceLayout";
 
 export default function EditorSplitView() {
   const { state } = useApp();
+  const actions = useAppActions();
   const { prefs } = useUserPreferences();
   const split = state.editorSplit;
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const dragCleanupRef = useRef<(() => void) | null>(null);
   const dragRafRef = useRef<number | null>(null);
-  const pendingRatioRef = useRef(0.5);
-  const [splitRatio, setSplitRatio] = useState(0.5);
+  const pendingRatioRef = useRef(loadEditorSplitRatio(split?.direction || "right"));
+  const [splitRatio, setSplitRatio] = useState(pendingRatioRef.current);
+  const [secondaryReadOnly, setSecondaryReadOnly] = useState(false);
 
   useEffect(() => {
-    setSplitRatio(0.5);
-    pendingRatioRef.current = 0.5;
-  }, [split?.direction, split?.noteId]);
+    if (!split) return;
+    const savedRatio = loadEditorSplitRatio(split.direction);
+    pendingRatioRef.current = savedRatio;
+    setSplitRatio(savedRatio);
+  }, [split?.direction]);
+
+  useEffect(() => {
+    setSecondaryReadOnly(false);
+  }, [split?.noteId, split?.direction]);
 
   useEffect(() => {
     return () => {
@@ -44,7 +57,7 @@ export default function EditorSplitView() {
   }, []);
 
   const applySplitRatio = useCallback((ratio: number) => {
-    pendingRatioRef.current = ratio;
+    pendingRatioRef.current = clampEditorSplitRatio(ratio);
     if (dragRafRef.current !== null) return;
     dragRafRef.current = requestAnimationFrame(() => {
       dragRafRef.current = null;
@@ -65,7 +78,7 @@ export default function EditorSplitView() {
       const raw = split.direction === "down"
         ? (clientY - rect.top) / rect.height
         : (clientX - rect.left) / rect.width;
-      applySplitRatio(Math.max(0.2, Math.min(0.8, raw)));
+      applySplitRatio(raw);
     };
 
     applyRatio(event.clientX, event.clientY);
@@ -83,7 +96,7 @@ export default function EditorSplitView() {
         cancelAnimationFrame(dragRafRef.current);
         dragRafRef.current = null;
       }
-      const finalRatio = pendingRatioRef.current;
+      const finalRatio = saveEditorSplitRatio(split.direction, pendingRatioRef.current);
       splitContainerRef.current?.style.setProperty("--split-primary", `${finalRatio * 100}%`);
       splitContainerRef.current?.style.setProperty("--split-secondary", `${(1 - finalRatio) * 100}%`);
       setSplitRatio(finalRatio);
@@ -100,7 +113,48 @@ export default function EditorSplitView() {
     window.addEventListener("mouseup", cleanup);
   }, [applySplitRatio, split]);
 
+  const promoteSecondary = useCallback((secondaryNote: Note) => {
+    if (!split || !state.activeNote) return;
+    const previousPrimary = state.activeNote;
+
+    actions.setActiveNote(secondaryNote);
+    actions.openNoteTab({
+      id: secondaryNote.id,
+      title: secondaryNote.title,
+      notebookId: secondaryNote.notebookId,
+      workspaceId: secondaryNote.workspaceId,
+      contentFormat: secondaryNote.contentFormat,
+      isLocked: secondaryNote.isLocked,
+      isTrashed: secondaryNote.isTrashed,
+      updatedAt: secondaryNote.updatedAt,
+    });
+
+    if (previousPrimary.id === secondaryNote.id) {
+      actions.closeEditorSplit();
+      return;
+    }
+
+    actions.openNoteTab({
+      id: previousPrimary.id,
+      title: previousPrimary.title,
+      notebookId: previousPrimary.notebookId,
+      workspaceId: previousPrimary.workspaceId,
+      contentFormat: previousPrimary.contentFormat,
+      isLocked: previousPrimary.isLocked,
+      isTrashed: previousPrimary.isTrashed,
+      updatedAt: previousPrimary.updatedAt,
+    });
+    actions.splitEditor({ noteId: previousPrimary.id, direction: split.direction });
+  }, [actions, split, state.activeNote]);
+
+  const hideNoteList = useCallback(() => {
+    if (!state.noteListCollapsed) actions.toggleNoteListCollapsed();
+  }, [actions, state.noteListCollapsed]);
+
   if (!split || !state.activeNote) return <FormatAwareEditorPane />;
+
+  const duplicateDocument = split.noteId === state.activeNote.id;
+  const effectiveReadOnly = duplicateDocument || secondaryReadOnly;
 
   return (
     <div className="flex-1 flex flex-col min-w-0 overflow-hidden bg-app-bg">
@@ -145,7 +199,15 @@ export default function EditorSplitView() {
           className="min-h-0 min-w-0 flex-none overflow-hidden"
           style={{ flexBasis: "var(--split-secondary)" }}
         >
-          <SplitEditorPane noteId={split.noteId} />
+          <SplitEditorPane
+            noteId={split.noteId}
+            readOnly={effectiveReadOnly}
+            duplicateDocument={duplicateDocument}
+            onToggleReadOnly={() => setSecondaryReadOnly((value) => !value)}
+            onPromote={promoteSecondary}
+            showHideNoteList={!state.noteListCollapsed}
+            onHideNoteList={hideNoteList}
+          />
         </div>
       </div>
     </div>
@@ -164,7 +226,25 @@ function createSplitLoadingState(): NoteLoadingState {
   };
 }
 
-function SplitEditorPane({ noteId }: { noteId: string }) {
+interface SplitEditorPaneProps {
+  noteId: string;
+  readOnly: boolean;
+  duplicateDocument: boolean;
+  onToggleReadOnly: () => void;
+  onPromote: (note: Note) => void;
+  showHideNoteList: boolean;
+  onHideNoteList: () => void;
+}
+
+function SplitEditorPane({
+  noteId,
+  readOnly,
+  duplicateDocument,
+  onToggleReadOnly,
+  onPromote,
+  showHideNoteList,
+  onHideNoteList,
+}: SplitEditorPaneProps) {
   const { state } = useApp();
   const actions = useAppActions();
   const { loadNote: loadPrimaryNote } = useNoteLoader();
@@ -272,7 +352,13 @@ function SplitEditorPane({ noteId }: { noteId: string }) {
 
   const handleUpdate = useCallback(async (data: NoteEditorUpdatePayload) => {
     const current = noteRef.current;
-    if (!current || !canWriteNote(current) || (data._noteId && data._noteId !== current.id)) return;
+    if (
+      readOnly ||
+      !current ||
+      state.activeNote?.id === current.id ||
+      !canWriteNote(current) ||
+      (data._noteId && data._noteId !== current.id)
+    ) return;
     setSyncing(true);
     try {
       const updated = await api.updateNote(current.id, {
@@ -305,7 +391,7 @@ function SplitEditorPane({ noteId }: { noteId: string }) {
     } finally {
       setSyncing(false);
     }
-  }, [actions, state.activeNote?.id, t]);
+  }, [actions, readOnly, state.activeNote?.id, t]);
 
   const handleOpenNote = useCallback(async (targetNoteId: string) => {
     await loadPrimaryNote({
@@ -329,13 +415,67 @@ function SplitEditorPane({ noteId }: { noteId: string }) {
   }, [actions, loadPrimaryNote, t]);
 
   const title = note?.id === noteId ? note.title : tabMeta?.title || t("editorTabs.noTitle");
-  const editable = !!note && note.id === noteId && canWriteNote(note) && !note.isLocked && !note.isTrashed && !loadingState.pendingNoteId;
+  const editable = !!note
+    && note.id === noteId
+    && !readOnly
+    && state.activeNote?.id !== noteId
+    && canWriteNote(note)
+    && !note.isLocked
+    && !note.isTrashed
+    && !loadingState.pendingNoteId;
 
   return (
     <section className="flex h-full min-h-0 min-w-0 flex-col bg-app-bg">
-      <header className="flex h-10 shrink-0 items-center gap-2 border-b border-app-border bg-app-surface/60 px-3">
+      <header className="flex h-10 shrink-0 items-center gap-1.5 border-b border-app-border bg-app-surface/60 px-2.5">
         <div className="min-w-0 flex-1 truncate text-sm font-medium text-tx-primary">{title}</div>
+        {readOnly && (
+          <span
+            className="hidden shrink-0 rounded border border-app-border bg-app-hover px-1.5 py-0.5 text-[10px] text-tx-tertiary sm:inline-flex"
+            title={duplicateDocument
+              ? t("editorTabs.sameDocumentMirror", { defaultValue: "同文档只读镜像，避免两个编辑器重复保存" })
+              : t("editorTabs.readOnlyReference", { defaultValue: "只读参考" })}
+          >
+            {duplicateDocument
+              ? t("editorTabs.mirror", { defaultValue: "镜像" })
+              : t("editorTabs.readOnly", { defaultValue: "只读" })}
+          </span>
+        )}
         {syncing && <Loader2 size={14} className="shrink-0 animate-spin text-tx-tertiary" />}
+        {showHideNoteList && (
+          <button
+            type="button"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+            onClick={onHideNoteList}
+            title={t("editorTabs.hideNoteListForSplit", { defaultValue: "隐藏中间笔记列表，扩大分屏空间" })}
+            aria-label={t("editorTabs.hideNoteListForSplit", { defaultValue: "隐藏中间笔记列表，扩大分屏空间" })}
+          >
+            <PanelLeftClose size={14} />
+          </button>
+        )}
+        <button
+          type="button"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onToggleReadOnly}
+          disabled={duplicateDocument}
+          aria-pressed={readOnly}
+          title={duplicateDocument
+            ? t("editorTabs.sameDocumentMirror", { defaultValue: "同文档分屏固定为只读镜像" })
+            : readOnly
+              ? t("editorTabs.enableSplitEditing", { defaultValue: "允许副屏编辑" })
+              : t("editorTabs.useAsReference", { defaultValue: "切换为只读参考" })}
+        >
+          {readOnly ? <Eye size={14} /> : <Pencil size={14} />}
+        </button>
+        <button
+          type="button"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={() => note && onPromote(note)}
+          disabled={!note || duplicateDocument}
+          title={t("editorTabs.promoteSplit", { defaultValue: "设为主编辑文档并交换主副屏" })}
+          aria-label={t("editorTabs.promoteSplit", { defaultValue: "设为主编辑文档并交换主副屏" })}
+        >
+          <ArrowLeftRight size={14} />
+        </button>
         <button
           type="button"
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"

--- a/frontend/src/components/common/CommandPalette.tsx
+++ b/frontend/src/components/common/CommandPalette.tsx
@@ -1,13 +1,23 @@
 /**
- * CommandPalette —— Cmd-K 全局搜索弹窗
+ * CommandPalette —— Cmd-K 全局搜索与工作台命令
  * ----------------------------------------------------------------------------
  * Sidebar 搜索负责持久化浏览，并由 SearchCenter 展示完整结果页；Cmd-K 仍然保持
- * “即用即走”的快速跳转语义。两套入口共用同一个后端搜索接口，但互不改变对方状态。
+ * “即用即走”的快速跳转语义。布局命令与搜索结果共用入口，但不会污染搜索状态。
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Search as SearchIcon, FileText, Loader2 } from "lucide-react";
+import {
+  Columns2,
+  FileText,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Search as SearchIcon,
+  X,
+} from "lucide-react";
 import { useApp, useAppActions } from "@/store/AppContext";
 import { api } from "@/lib/api";
 import { highlightTextNode, sanitizeSearchHtml } from "@/lib/searchHighlight";
@@ -16,6 +26,10 @@ import {
   normalizeSidebarSearchValue,
   SIDEBAR_SEARCH_CHANGE_EVENT,
 } from "@/lib/sidebarSearchBridge";
+import {
+  EDITOR_LAYOUT_TOGGLE_SHORTCUT_LABEL,
+  isEditorLayoutToggleShortcut,
+} from "@/lib/editorWorkspaceLayout";
 import type { SearchResult } from "@/types";
 import SearchCenter from "@/components/SearchCenter";
 import MobileDrawerUxBridge from "@/components/MobileDrawerUxBridge";
@@ -24,6 +38,22 @@ export interface CommandPaletteProps {
   /** 由外部控制开合；App 层一个 useState 即可 */
   open: boolean;
   onClose: () => void;
+}
+
+interface WorkspaceCommand {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  shortcut?: string;
+  icon: React.ReactNode;
+  run: () => void;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  return tagName === "input" || tagName === "textarea" || target.isContentEditable;
 }
 
 /**
@@ -114,6 +144,7 @@ function SearchNavigationGuard() {
 }
 
 export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
+  const { state } = useApp();
   const actions = useAppActions();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -124,6 +155,87 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const workspaceCommands = useMemo<WorkspaceCommand[]>(() => {
+    const commands: WorkspaceCommand[] = [
+      {
+        id: "toggle-note-list",
+        label: state.noteListCollapsed ? "显示笔记列表" : "隐藏笔记列表",
+        description: state.noteListCollapsed
+          ? "恢复管理模式的中间笔记列表"
+          : "进入创作模式，让编辑器占满剩余空间",
+        keywords: ["布局", "笔记列表", "创作模式", "管理模式", "sidebar", "list"],
+        shortcut: EDITOR_LAYOUT_TOGGLE_SHORTCUT_LABEL,
+        icon: state.noteListCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />,
+        run: actions.toggleNoteListCollapsed,
+      },
+    ];
+
+    if (state.activeNote) {
+      commands.push({
+        id: "toggle-editor-fullscreen",
+        label: state.editorFullscreen ? "退出编辑器全屏" : "进入编辑器全屏",
+        description: state.editorFullscreen
+          ? "恢复目录树和笔记列表"
+          : "临时隐藏全部外侧导航，不修改面板折叠偏好",
+        keywords: ["全屏", "专注", "编辑器", "fullscreen"],
+        icon: state.editorFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />,
+        run: actions.toggleEditorFullscreen,
+      });
+
+      commands.push(
+        {
+          id: "split-right",
+          label: "在右侧分屏参考当前文档",
+          description: "创建左右双编辑区；同一文档会自动以只读镜像打开",
+          keywords: ["分屏", "右侧", "左右", "split"],
+          icon: <Columns2 size={16} />,
+          run: () => actions.splitEditor({ noteId: state.activeNote!.id, direction: "right" }),
+        },
+        {
+          id: "split-down",
+          label: "在下方分屏参考当前文档",
+          description: "创建上下双编辑区；同一文档会自动以只读镜像打开",
+          keywords: ["分屏", "下方", "上下", "split"],
+          icon: <Columns2 size={16} className="rotate-90" />,
+          run: () => actions.splitEditor({ noteId: state.activeNote!.id, direction: "down" }),
+        },
+      );
+    }
+
+    if (state.editorSplit) {
+      commands.push({
+        id: "close-split",
+        label: "关闭分屏",
+        description: "副屏文档仍保留在已打开标签页中",
+        keywords: ["分屏", "关闭", "split"],
+        icon: <X size={16} />,
+        run: actions.closeEditorSplit,
+      });
+    }
+
+    return commands;
+  }, [
+    actions,
+    state.activeNote,
+    state.editorFullscreen,
+    state.editorSplit,
+    state.noteListCollapsed,
+  ]);
+
+  const normalizedQuery = query.trim();
+  const commandQuery = normalizedQuery.startsWith(">")
+    ? normalizedQuery.slice(1).trim().toLowerCase()
+    : normalizedQuery.toLowerCase();
+  const commandOnly = normalizedQuery.startsWith(">");
+
+  const visibleCommands = useMemo(() => {
+    if (!commandQuery) return workspaceCommands;
+    return workspaceCommands.filter((command) => {
+      const haystack = [command.label, command.description, ...command.keywords].join(" ").toLowerCase();
+      return haystack.includes(commandQuery);
+    });
+  }, [commandQuery, workspaceCommands]);
 
   useEffect(() => {
     if (!open) return;
@@ -147,8 +259,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
     if (!open) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
-    const normalized = query.trim();
-    if (!normalized) {
+    if (!normalizedQuery || commandOnly) {
       setResults([]);
       setLoading(false);
       return;
@@ -161,7 +272,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
       abortRef.current?.abort();
       abortRef.current = request;
       try {
-        const rows = await api.search(normalized);
+        const rows = await api.search(normalizedQuery);
         if (request.signal.aborted) return;
         setResults(rows);
         setActiveIdx(0);
@@ -173,10 +284,15 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
         if (!request.signal.aborted) setLoading(false);
       }
     }, 200);
-  }, [open, query]);
+  }, [commandOnly, normalizedQuery, open]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditorLayoutToggleShortcut(event) && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        actions.toggleNoteListCollapsed();
+        return;
+      }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();
         if (!open) window.dispatchEvent(new CustomEvent("nowen:open-command-palette"));
@@ -187,7 +303,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, open]);
+  }, [actions, onClose, open]);
 
   const jumpTo = useCallback(async (id: string) => {
     try {
@@ -203,7 +319,17 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
     }
   }, [actions, onClose]);
 
+  const runCommand = useCallback((command: WorkspaceCommand) => {
+    command.run();
+    onClose();
+  }, [onClose]);
+
   const onInputKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && commandOnly && visibleCommands[0]) {
+      event.preventDefault();
+      runCommand(visibleCommands[0]);
+      return;
+    }
     if (!results.length) return;
     if (event.key === "ArrowDown") {
       event.preventDefault();
@@ -216,7 +342,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
       const result = results[activeIdx];
       if (result) void jumpTo(result.id);
     }
-  }, [activeIdx, jumpTo, results]);
+  }, [activeIdx, commandOnly, jumpTo, results, runCommand, visibleCommands]);
 
   useEffect(() => {
     const element = listRef.current?.querySelector<HTMLElement>(`[data-idx="${activeIdx}"]`);
@@ -225,6 +351,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
 
   const paletteBody = useMemo(() => {
     if (!open) return null;
+    const showEmptySearch = normalizedQuery && !commandOnly && results.length === 0 && !loading;
     return (
       <div
         className="fixed inset-0 z-[200] flex items-start justify-center px-4 pt-[15vh]"
@@ -237,7 +364,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
           className="relative w-full max-w-[640px] overflow-hidden rounded-xl border border-app-border bg-app-elevated shadow-2xl"
           role="dialog"
           aria-modal="true"
-          aria-label="全局搜索"
+          aria-label="全局搜索与工作台命令"
           onClick={(event) => event.stopPropagation()}
         >
           <div className="flex items-center gap-2 border-b border-app-border px-4 py-3">
@@ -248,7 +375,7 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               onKeyDown={onInputKeyDown}
-              placeholder="搜索笔记标题与内容…"
+              placeholder="搜索笔记，或输入 > 执行布局命令…"
               className="flex-1 bg-transparent text-sm text-tx-primary outline-none placeholder:text-tx-tertiary"
               autoComplete="off"
               spellCheck={false}
@@ -259,17 +386,54 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
             </kbd>
           </div>
 
-          <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-1">
-            {results.length === 0 && query.trim() && !loading && (
-              <div className="px-4 py-6 text-center text-sm text-tx-tertiary">
-                未找到与 &ldquo;{query}&rdquo; 匹配的笔记
+          <div ref={listRef} className="max-h-[56vh] overflow-y-auto py-1">
+            {visibleCommands.length > 0 && (
+              <section aria-label="工作台命令">
+                <div className="px-4 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wide text-tx-tertiary">
+                  工作台命令
+                </div>
+                {visibleCommands.map((command) => (
+                  <button
+                    key={command.id}
+                    type="button"
+                    onClick={() => runCommand(command)}
+                    className="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-app-hover"
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-app-hover text-tx-secondary">
+                      {command.icon}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm text-tx-primary">{command.label}</span>
+                      <span className="block truncate text-xs text-tx-tertiary">{command.description}</span>
+                    </span>
+                    {command.shortcut && (
+                      <kbd className="hidden shrink-0 rounded border border-app-border px-1.5 py-0.5 text-[10px] text-tx-tertiary sm:inline-flex">
+                        {command.shortcut}
+                      </kbd>
+                    )}
+                  </button>
+                ))}
+              </section>
+            )}
+
+            {!commandOnly && results.length > 0 && (
+              <div className="mt-1 border-t border-app-border px-4 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wide text-tx-tertiary">
+                笔记搜索结果
               </div>
             )}
-            {!query.trim() && (
+
+            {showEmptySearch && visibleCommands.length === 0 && (
               <div className="px-4 py-6 text-center text-sm text-tx-tertiary">
-                输入关键词开始搜索（↑↓ 选择，Enter 打开，Esc 关闭）
+                未找到与 &ldquo;{query}&rdquo; 匹配的笔记或命令
               </div>
             )}
+
+            {!normalizedQuery && (
+              <div className="border-t border-app-border px-4 py-3 text-center text-xs text-tx-tertiary">
+                输入关键词搜索笔记；输入 &gt; 只筛选命令
+              </div>
+            )}
+
             {results.map((result, index) => {
               const active = index === activeIdx;
               const snippetHtml = result.snippetHtml || result.snippet;
@@ -308,7 +472,20 @@ export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
         </div>
       </div>
     );
-  }, [activeIdx, jumpTo, loading, onClose, onInputKeyDown, open, query, results]);
+  }, [
+    activeIdx,
+    commandOnly,
+    jumpTo,
+    loading,
+    normalizedQuery,
+    onClose,
+    onInputKeyDown,
+    open,
+    query,
+    results,
+    runCommand,
+    visibleCommands,
+  ]);
 
   return (
     <>

--- a/frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts
+++ b/frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampEditorSplitRatio,
+  getEditorSplitRatioStorageKey,
+  isEditorLayoutToggleShortcut,
+  loadEditorSplitRatio,
+  resolveEditorWorkspaceMode,
+  saveEditorSplitRatio,
+  type StorageLike,
+} from "@/lib/editorWorkspaceLayout";
+
+function createMemoryStorage(initial: Record<string, string> = {}): StorageLike {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+  };
+}
+
+describe("editorWorkspaceLayout", () => {
+  it("recognizes the cross-platform note-list shortcut", () => {
+    expect(isEditorLayoutToggleShortcut({ key: "B", ctrlKey: true, shiftKey: true })).toBe(true);
+    expect(isEditorLayoutToggleShortcut({ key: "b", metaKey: true, shiftKey: true })).toBe(true);
+    expect(isEditorLayoutToggleShortcut({ key: "b", ctrlKey: true })).toBe(false);
+    expect(isEditorLayoutToggleShortcut({ key: "b", ctrlKey: true, shiftKey: true, altKey: true })).toBe(false);
+  });
+
+  it("resolves the four product layout modes in priority order", () => {
+    expect(resolveEditorWorkspaceMode({ editorFullscreen: false, noteListCollapsed: false, hasSplit: false })).toBe("manage");
+    expect(resolveEditorWorkspaceMode({ editorFullscreen: false, noteListCollapsed: true, hasSplit: false })).toBe("focus");
+    expect(resolveEditorWorkspaceMode({ editorFullscreen: false, noteListCollapsed: false, hasSplit: true })).toBe("split");
+    expect(resolveEditorWorkspaceMode({ editorFullscreen: true, noteListCollapsed: false, hasSplit: true })).toBe("fullscreen");
+  });
+
+  it("clamps and persists a ratio per split direction", () => {
+    const storage = createMemoryStorage();
+    expect(saveEditorSplitRatio("right", 0.73, storage)).toBe(0.73);
+    expect(loadEditorSplitRatio("right", storage)).toBe(0.73);
+    expect(loadEditorSplitRatio("down", storage)).toBe(0.5);
+
+    saveEditorSplitRatio("down", 2, storage);
+    expect(loadEditorSplitRatio("down", storage)).toBe(0.8);
+    expect(getEditorSplitRatioStorageKey("right")).not.toBe(getEditorSplitRatioStorageKey("down"));
+  });
+
+  it("falls back safely for invalid stored ratios", () => {
+    const storage = createMemoryStorage({
+      [getEditorSplitRatioStorageKey("right")]: "not-a-number",
+    });
+    expect(loadEditorSplitRatio("right", storage)).toBe(0.5);
+    expect(clampEditorSplitRatio(-1)).toBe(0.2);
+    expect(clampEditorSplitRatio(10)).toBe(0.8);
+  });
+});

--- a/frontend/src/lib/editorWorkspaceLayout.ts
+++ b/frontend/src/lib/editorWorkspaceLayout.ts
@@ -1,0 +1,76 @@
+export type EditorWorkspaceMode = "manage" | "focus" | "split" | "fullscreen";
+export type EditorSplitDirection = "right" | "down";
+
+export const EDITOR_LAYOUT_TOGGLE_SHORTCUT_LABEL = "Ctrl/Cmd + Shift + B";
+const SPLIT_RATIO_STORAGE_PREFIX = "nowen.editorSplit.ratio";
+
+export interface ShortcutLikeEvent {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function isEditorLayoutToggleShortcut(event: ShortcutLikeEvent): boolean {
+  return (
+    (event.metaKey || event.ctrlKey) === true &&
+    event.shiftKey === true &&
+    event.altKey !== true &&
+    event.key.toLowerCase() === "b"
+  );
+}
+
+export function resolveEditorWorkspaceMode(input: {
+  editorFullscreen: boolean;
+  noteListCollapsed: boolean;
+  hasSplit: boolean;
+}): EditorWorkspaceMode {
+  if (input.editorFullscreen) return "fullscreen";
+  if (input.hasSplit) return "split";
+  if (input.noteListCollapsed) return "focus";
+  return "manage";
+}
+
+export function clampEditorSplitRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.max(0.2, Math.min(0.8, value));
+}
+
+export function getEditorSplitRatioStorageKey(direction: EditorSplitDirection): string {
+  return `${SPLIT_RATIO_STORAGE_PREFIX}.${direction}`;
+}
+
+export function loadEditorSplitRatio(
+  direction: EditorSplitDirection,
+  storage: StorageLike | null | undefined = typeof window === "undefined" ? null : window.localStorage,
+): number {
+  if (!storage) return 0.5;
+  try {
+    const value = storage.getItem(getEditorSplitRatioStorageKey(direction));
+    if (value == null || value.trim() === "") return 0.5;
+    return clampEditorSplitRatio(Number(value));
+  } catch {
+    return 0.5;
+  }
+}
+
+export function saveEditorSplitRatio(
+  direction: EditorSplitDirection,
+  value: number,
+  storage: StorageLike | null | undefined = typeof window === "undefined" ? null : window.localStorage,
+): number {
+  const normalized = clampEditorSplitRatio(value);
+  if (!storage) return normalized;
+  try {
+    storage.setItem(getEditorSplitRatioStorageKey(direction), String(normalized));
+  } catch {
+    // Storage can be unavailable in privacy mode; the in-memory ratio still works.
+  }
+  return normalized;
+}


### PR DESCRIPTION
## 背景

推进 #370 的首个可合并里程碑，先收口 P0-A 创作布局入口与 P0-B 分屏安全/管理能力，不在本 PR 中提前引入统一内容树数据库迁移。

## 本次实现

### 创作布局
- 在 Cmd/Ctrl + K 中加入“工作台命令”，可搜索和执行：
  - 显示/隐藏中间笔记列表；
  - 进入/退出编辑器全屏；
  - 右侧/下方分屏；
  - 关闭分屏。
- 增加 `Ctrl/Cmd + Shift + B` 全局快捷键切换中间笔记列表，并避开输入框、文本域和 contenteditable。
- 显式定义管理、创作、分屏、全屏四种布局模式的纯函数协议。

### 分屏产品化
- 左右、上下分屏比例分别持久化，重启和切换文档后保持。
- 副屏支持“只读参考 / 可编辑”切换。
- 同一文档在主、副屏同时打开时强制只读镜像，阻止双实例重复保存。
- 支持将副屏设为主编辑文档并交换主、副屏。
- 分屏头部提供一键隐藏中间笔记列表入口。
- 关闭分屏时仍保留现有标签页语义。

### 测试
- 新增布局模式、快捷键识别、分屏比例边界与持久化单元测试。

## 范围说明

本 PR 完成 #370 的 P0-A/P0-B 第一阶段。P0-C 细粒度 capability、P1 统一内容树与 P2 钉钉迁移仍在该 Epic 中继续推进，因此本 PR 使用 `Refs #370`，不会自动关闭 Issue。

Refs #370