### PR TITLE
优化分享管理的公开地址风险提示

### DIFF
--- a/frontend/src/components/ShareManagementPage.tsx
+++ b/frontend/src/components/ShareManagementPage.tsx
@@ -14,6 +14,7 @@ import {
   RotateCcw,
   Search,
   Trash2,
+  X,
 } from "lucide-react";
 import ShareModal from "@/components/ShareModal";
 import { Button } from "@/components/ui/button";
@@ -25,6 +26,7 @@ import {
   buildPublicWebUrl,
   getPublicWebOriginSourceLabel,
   resolvePublicWebOrigin,
+  type PublicWebOriginResolution,
 } from "@/lib/publicWebOrigin";
 import {
   compactShareToken,
@@ -75,9 +77,241 @@ function IconAction({ label, onClick, danger = false, children }: {
   );
 }
 
+function getOriginRiskCopy(publicOrigin: PublicWebOriginResolution) {
+  switch (publicOrigin.risk) {
+    case "localhost":
+      return {
+        label: "分享地址仅本机可访问",
+        message: "当前分享地址为 localhost，仅本机可访问。",
+      };
+    case "private-network":
+      return {
+        label: "分享地址可能仅限内网",
+        message: "当前分享地址可能仅限局域网或 VPN 内访问，外部访客可能无法打开。",
+      };
+    case "protected-gateway":
+      return {
+        label: "分享地址可能需要登录",
+        message: "当前分享地址可能经过登录网关，未登录访客可能无法打开。",
+      };
+    default:
+      return {
+        label: "公开地址待验证",
+        message: "公开分享地址尚未验证，建议使用无痕窗口或未登录设备测试。",
+      };
+  }
+}
+
+function PublicOriginRiskControl({
+  publicOrigin,
+  configuredOrigin,
+  updatePublicWebOrigin,
+  variant,
+}: {
+  publicOrigin: PublicWebOriginResolution;
+  configuredOrigin: string;
+  updatePublicWebOrigin: (origin: string) => Promise<void>;
+  variant: "banner" | "badge";
+}) {
+  const [open, setOpen] = useState(false);
+  const [canManage, setCanManage] = useState<boolean | null>(null);
+  const [originDraft, setOriginDraft] = useState(configuredOrigin);
+  const [saving, setSaving] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const copy = getOriginRiskCopy(publicOrigin);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getMe()
+      .then((user) => {
+        if (!cancelled) setCanManage(user.role === "admin");
+      })
+      .catch(() => {
+        if (!cancelled) setCanManage(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    setOriginDraft(configuredOrigin);
+  }, [configuredOrigin]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown, { passive: true });
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const saveOrigin = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await updatePublicWebOrigin(originDraft.trim());
+      toast.success(originDraft.trim() ? "公开分享地址已保存" : "已恢复容器环境变量或当前访问域名");
+      setOpen(false);
+    } catch (error: any) {
+      toast.error(error?.message || "公开分享地址保存失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const copyOrigin = async () => {
+    if (!publicOrigin.origin) return;
+    try {
+      await navigator.clipboard.writeText(publicOrigin.origin);
+      toast.success("公开分享地址已复制");
+    } catch {
+      toast.error("复制失败，请手动复制");
+    }
+  };
+
+  const panel = open && (
+    <div
+      role="dialog"
+      aria-label="公开分享地址详情"
+      className={cn(
+        "absolute z-40 mt-2 w-[min(360px,calc(100vw-2rem))] rounded-xl border border-app-border bg-app-elevated p-4 text-left shadow-xl",
+        variant === "banner" ? "left-0 sm:left-auto sm:right-0" : "right-0",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-tx-primary">{copy.label}</p>
+          <p className="mt-1 text-xs leading-5 text-tx-secondary">{copy.message}</p>
+        </div>
+        <button
+          type="button"
+          aria-label="关闭公开地址详情"
+          onClick={() => setOpen(false)}
+          className="rounded-md p-1 text-tx-tertiary transition-colors hover:bg-app-hover hover:text-tx-primary"
+        >
+          <X size={15} />
+        </button>
+      </div>
+
+      <div className="mt-3 rounded-lg bg-app-hover/60 p-3">
+        <div className="flex items-center justify-between gap-3 text-[11px] text-tx-tertiary">
+          <span>地址来源</span>
+          <span>{getPublicWebOriginSourceLabel(publicOrigin.source)}</span>
+        </div>
+        <div className="mt-2 flex items-start gap-2">
+          <code className="min-w-0 flex-1 break-all text-xs text-tx-secondary">
+            {publicOrigin.origin || "相对地址"}
+          </code>
+          {publicOrigin.origin && (
+            <button
+              type="button"
+              aria-label="复制公开分享地址"
+              title="复制公开分享地址"
+              onClick={() => void copyOrigin()}
+              className="shrink-0 rounded-md p-1 text-tx-tertiary transition-colors hover:bg-app-surface hover:text-tx-primary"
+            >
+              <Copy size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {canManage ? (
+        <div className="mt-3">
+          <label className="text-xs font-medium text-tx-secondary" htmlFor="share-public-origin">
+            独立公开地址
+          </label>
+          <div className="mt-1.5 flex gap-2">
+            <Input
+              id="share-public-origin"
+              value={originDraft}
+              onChange={(event) => setOriginDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void saveOrigin();
+              }}
+              placeholder="https://note.example.com"
+              className="h-9 min-w-0 flex-1 text-xs"
+            />
+            <Button size="sm" disabled={saving} onClick={() => void saveOrigin()} className="h-9 shrink-0">
+              {saving && <Loader2 size={13} className="mr-1 animate-spin" />}
+              保存
+            </Button>
+          </div>
+          <p className="mt-1.5 text-[11px] leading-4 text-tx-tertiary">
+            留空后优先恢复容器 PUBLIC_WEB_ORIGIN；仍未配置时使用当前访问域名。
+          </p>
+        </div>
+      ) : canManage === false ? (
+        <p className="mt-3 text-xs leading-5 text-tx-tertiary">
+          当前账号无权修改，请让管理员配置独立公开地址或 PUBLIC_WEB_ORIGIN。
+        </p>
+      ) : (
+        <div className="mt-3 flex items-center text-xs text-tx-tertiary">
+          <Loader2 size={13} className="mr-1.5 animate-spin" />
+          正在检查配置权限…
+        </div>
+      )}
+
+      <p className="mt-3 border-t border-app-border pt-3 text-[11px] leading-4 text-tx-tertiary">
+        配置完成后，仍建议使用无痕窗口或未登录设备验证一次。
+      </p>
+    </div>
+  );
+
+  if (variant === "banner") {
+    return (
+      <div ref={rootRef} className="relative">
+        <div className="flex min-h-10 flex-col gap-2 rounded-lg border border-amber-500/25 bg-amber-500/[0.07] px-3 py-2 text-sm text-amber-800 sm:flex-row sm:items-center sm:justify-between dark:text-amber-200">
+          <div className="flex min-w-0 items-center gap-2">
+            <AlertTriangle size={16} className="shrink-0" />
+            <span className="leading-5">{copy.message}</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen((value) => !value)}
+            aria-expanded={open}
+            className="shrink-0 self-start rounded-md px-1.5 py-0.5 text-xs font-medium underline-offset-4 transition-colors hover:bg-amber-500/10 hover:underline sm:self-auto"
+          >
+            配置公开地址
+          </button>
+        </div>
+        {panel}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] px-3 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-200"
+      >
+        <AlertTriangle size={14} />
+        {copy.label}
+      </button>
+      {panel}
+    </div>
+  );
+}
+
 export default function ShareManagementPage() {
   const actions = useAppActions();
-  const { siteConfig } = useSiteSettings();
+  const { siteConfig, updatePublicWebOrigin } = useSiteSettings();
   const [data, setData] = useState<ShareManagementResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -260,6 +494,9 @@ export default function ShareManagementPage() {
     </div>
   );
 
+  const showLocalhostBanner = publicOrigin.risk === "localhost";
+  const showHeaderRisk = publicOrigin.risk !== "none" && !showLocalhostBanner;
+
   return (
     <div className="min-h-0 flex-1 overflow-y-auto bg-app-bg">
       <div className="mx-auto w-full max-w-[1500px] space-y-5 px-4 py-5 sm:px-6 lg:px-8">
@@ -268,20 +505,29 @@ export default function ShareManagementPage() {
             <div className="flex items-center gap-2"><Link2 size={22} className="text-accent-primary" /><h1 className="text-xl font-semibold text-tx-primary">分享管理</h1></div>
             <p className="mt-1 text-sm text-tx-secondary">集中查看、修改、停用和清理当前账号可管理的分享链接。</p>
           </div>
-          <Button variant="outline" onClick={() => void load(true)} disabled={refreshing}>
-            {refreshing ? <Loader2 size={15} className="mr-2 animate-spin" /> : <RefreshCw size={15} className="mr-2" />}
-            刷新
-          </Button>
+          <div className="flex flex-wrap items-center gap-2 self-start sm:self-auto">
+            {showHeaderRisk && (
+              <PublicOriginRiskControl
+                publicOrigin={publicOrigin}
+                configuredOrigin={siteConfig.publicWebOrigin}
+                updatePublicWebOrigin={updatePublicWebOrigin}
+                variant="badge"
+              />
+            )}
+            <Button variant="outline" onClick={() => void load(true)} disabled={refreshing}>
+              {refreshing ? <Loader2 size={15} className="mr-2 animate-spin" /> : <RefreshCw size={15} className="mr-2" />}
+              刷新
+            </Button>
+          </div>
         </header>
 
-        {publicOrigin.requiresAnonymousCheck && (
-          <div className="flex items-start gap-2 rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
-            <AlertTriangle size={17} className="mt-0.5 shrink-0" />
-            <div>
-              <p>当前公开分享地址可能依赖内网、VPN 或登录网关，请用无痕窗口或未登录设备验证。</p>
-              <p className="mt-1 break-all text-xs opacity-80">地址来源：{getPublicWebOriginSourceLabel(publicOrigin.source)} · {publicOrigin.origin || "相对地址"}</p>
-            </div>
-          </div>
+        {showLocalhostBanner && (
+          <PublicOriginRiskControl
+            publicOrigin={publicOrigin}
+            configuredOrigin={siteConfig.publicWebOrigin}
+            updatePublicWebOrigin={updatePublicWebOrigin}
+            variant="banner"
+          />
         )}
 
         <section className="grid grid-cols-2 gap-3 lg:grid-cols-4">

--- a/frontend/src/components/__tests__/ShareManagementPage.test.tsx
+++ b/frontend/src/components/__tests__/ShareManagementPage.test.tsx
@@ -7,18 +7,30 @@ import ShareManagementPage from "@/components/ShareManagementPage";
 
 const mocks = vi.hoisted(() => ({
   getShareManagement: vi.fn(),
+  getMe: vi.fn(),
+  updatePublicWebOrigin: vi.fn(),
+  siteConfig: {
+    publicWebOrigin: "https://note.example.com",
+    publicWebOriginSource: "settings",
+  },
 }));
 
 vi.mock("@/lib/api", () => ({
   api: {
     getShareManagement: mocks.getShareManagement,
+    getMe: mocks.getMe,
     updateShare: vi.fn(),
     deleteShare: vi.fn(),
     getNote: vi.fn(),
   },
 }));
 vi.mock("@/store/AppContext", () => ({ useAppActions: () => ({ setActiveNote: vi.fn(), setViewMode: vi.fn(), setMobileView: vi.fn() }) }));
-vi.mock("@/hooks/useSiteSettings", () => ({ useSiteSettings: () => ({ siteConfig: { publicWebOrigin: "https://note.example.com", publicWebOriginSource: "runtime" } }) }));
+vi.mock("@/hooks/useSiteSettings", () => ({
+  useSiteSettings: () => ({
+    siteConfig: mocks.siteConfig,
+    updatePublicWebOrigin: mocks.updatePublicWebOrigin,
+  }),
+}));
 vi.mock("@/components/ShareModal", () => ({ default: () => null }));
 vi.mock("@/components/ui/confirm", () => ({ confirm: vi.fn().mockResolvedValue(true) }));
 vi.mock("@/lib/toast", () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
@@ -48,6 +60,12 @@ describe("ShareManagementPage", () => {
   beforeEach(() => {
     mocks.getShareManagement.mockReset();
     mocks.getShareManagement.mockResolvedValue(response);
+    mocks.getMe.mockReset();
+    mocks.getMe.mockResolvedValue({ role: "admin" });
+    mocks.updatePublicWebOrigin.mockReset();
+    mocks.updatePublicWebOrigin.mockResolvedValue(undefined);
+    mocks.siteConfig.publicWebOrigin = "https://note.example.com";
+    mocks.siteConfig.publicWebOriginSource = "settings";
     host = document.createElement("div");
     document.body.appendChild(host);
     root = createRoot(host);
@@ -91,5 +109,28 @@ describe("ShareManagementPage", () => {
     await flushEffects();
 
     expect(host.textContent).toContain("还没有符合条件的分享链接");
+  });
+
+  it("uses a compact localhost banner and reveals details on demand", async () => {
+    mocks.siteConfig.publicWebOrigin = "http://localhost:5173";
+
+    await act(async () => { root.render(<ShareManagementPage />); });
+    await flushEffects();
+
+    expect(host.textContent).toContain("当前分享地址为 localhost，仅本机可访问。");
+    expect(host.textContent).toContain("配置公开地址");
+    expect(host.textContent).not.toContain("地址来源");
+
+    const configureButton = Array.from(host.querySelectorAll("button")).find((button) => button.textContent?.includes("配置公开地址"));
+    expect(configureButton).toBeTruthy();
+    await act(async () => {
+      configureButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    expect(host.textContent).toContain("地址来源");
+    expect(host.textContent).toContain("管理员设置");
+    expect(host.textContent).toContain("独立公开地址");
   });
 });

--- a/frontend/src/lib/__tests__/publicWebOrigin.test.ts
+++ b/frontend/src/lib/__tests__/publicWebOrigin.test.ts
@@ -32,6 +32,7 @@ describe("publicWebOrigin", () => {
       source: "settings",
       usesCurrentOrigin: false,
       requiresAnonymousCheck: false,
+      risk: "none",
     });
     expect(buildPublicWebUrl("share/token", {
       runtimeOrigin: resolved.origin,
@@ -51,6 +52,7 @@ describe("publicWebOrigin", () => {
       origin: "https://runtime.example.com",
       source: "environment",
       requiresAnonymousCheck: false,
+      risk: "none",
     });
   });
 
@@ -75,6 +77,7 @@ describe("publicWebOrigin", () => {
       origin: "https://build.example.com",
       source: "build",
       usesCurrentOrigin: false,
+      risk: "none",
     });
   });
 
@@ -87,6 +90,39 @@ describe("publicWebOrigin", () => {
       source: "current",
       usesCurrentOrigin: true,
       requiresAnonymousCheck: true,
+      risk: "verify",
+    });
+  });
+
+  it("classifies localhost as a definite device-local share address", () => {
+    expect(resolvePublicWebOrigin({
+      runtimeOrigin: "http://localhost:5173",
+      runtimeSource: "settings",
+      buildOrigin: "",
+      currentOrigin: "https://current.example.com",
+    })).toMatchObject({
+      origin: "http://localhost:5173",
+      requiresAnonymousCheck: true,
+      risk: "localhost",
+    });
+
+    expect(resolvePublicWebOrigin({
+      runtimeOrigin: "",
+      buildOrigin: "",
+      currentOrigin: "http://127.0.0.1:3000",
+    })).toMatchObject({
+      risk: "localhost",
+    });
+  });
+
+  it("classifies private IP addresses as private-network risk", () => {
+    expect(resolvePublicWebOrigin({
+      runtimeOrigin: "http://192.168.1.8:3000",
+      runtimeSource: "environment",
+      currentOrigin: "https://current.example.com",
+    })).toMatchObject({
+      requiresAnonymousCheck: true,
+      risk: "private-network",
     });
   });
 
@@ -99,6 +135,7 @@ describe("publicWebOrigin", () => {
     })).toMatchObject({
       isLikelyProtectedGateway: true,
       requiresAnonymousCheck: true,
+      risk: "protected-gateway",
     });
   });
 });

--- a/frontend/src/lib/publicWebOrigin.ts
+++ b/frontend/src/lib/publicWebOrigin.ts
@@ -1,4 +1,5 @@
 export type PublicWebOriginSource = "settings" | "environment" | "build" | "current" | "relative";
+export type PublicWebOriginRisk = "none" | "verify" | "private-network" | "localhost" | "protected-gateway";
 
 export interface PublicWebOriginOptions {
   runtimeOrigin?: string | null;
@@ -13,6 +14,7 @@ export interface PublicWebOriginResolution {
   usesCurrentOrigin: boolean;
   isLikelyProtectedGateway: boolean;
   requiresAnonymousCheck: boolean;
+  risk: PublicWebOriginRisk;
 }
 
 let runtimePublicWebOrigin = "";
@@ -44,21 +46,82 @@ export function setRuntimePublicWebOrigin(
   runtimePublicWebOriginSource = source || null;
 }
 
-export function isLikelyProtectedGatewayOrigin(value: string): boolean {
+function getOriginHostname(value: string): string {
   const normalized = normalizePublicWebOrigin(value);
-  if (!normalized) return false;
+  if (!normalized) return "";
   try {
-    const hostname = new URL(normalized).hostname.toLowerCase();
-    return hostname === "fnos.net" || hostname.endsWith(".fnos.net") || hostname.includes("fnconnect");
+    return new URL(normalized).hostname.toLowerCase().replace(/^\[|\]$/g, "");
   } catch {
+    return "";
+  }
+}
+
+export function isLikelyProtectedGatewayOrigin(value: string): boolean {
+  const hostname = getOriginHostname(value);
+  return hostname === "fnos.net" || hostname.endsWith(".fnos.net") || hostname.includes("fnconnect");
+}
+
+export function isLoopbackOrigin(value: string): boolean {
+  const hostname = getOriginHostname(value);
+  if (!hostname) return false;
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "::1") return true;
+  const parts = hostname.split(".").map(Number);
+  return parts.length === 4 && parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) && parts[0] === 127;
+}
+
+export function isPrivateNetworkOrigin(value: string): boolean {
+  const hostname = getOriginHostname(value);
+  if (!hostname || isLoopbackOrigin(value)) return false;
+
+  const isIpv6 = hostname.includes(":");
+  if (
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".lan") ||
+    hostname.endsWith(".internal") ||
+    (isIpv6 && (hostname.startsWith("fc") || hostname.startsWith("fd") || hostname.startsWith("fe80:")))
+  ) {
+    return true;
+  }
+
+  const parts = hostname.split(".").map(Number);
+  if (parts.length !== 4 || !parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) {
     return false;
   }
+
+  return parts[0] === 10 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    (parts[0] === 169 && parts[1] === 254);
+}
+
+function classifyPublicWebOriginRisk(origin: string, verifyFallback: boolean): PublicWebOriginRisk {
+  if (isLikelyProtectedGatewayOrigin(origin)) return "protected-gateway";
+  if (isLoopbackOrigin(origin)) return "localhost";
+  if (isPrivateNetworkOrigin(origin)) return "private-network";
+  return verifyFallback ? "verify" : "none";
 }
 
 function normalizeRuntimeSource(value: string | null | undefined): PublicWebOriginSource {
   if (value === "environment") return "environment";
   if (value === "settings") return "settings";
   return "settings";
+}
+
+function buildResolution(
+  origin: string,
+  source: PublicWebOriginSource,
+  usesCurrentOrigin: boolean,
+  verifyFallback: boolean,
+): PublicWebOriginResolution {
+  const risk = classifyPublicWebOriginRisk(origin, verifyFallback);
+  return {
+    origin,
+    source,
+    usesCurrentOrigin,
+    isLikelyProtectedGateway: risk === "protected-gateway",
+    requiresAnonymousCheck: risk !== "none",
+    risk,
+  };
 }
 
 /**
@@ -76,15 +139,7 @@ export function resolvePublicWebOrigin(options: PublicWebOriginOptions = {}): Pu
     : runtimePublicWebOriginSource;
   const runtime = normalizePublicWebOrigin(runtimeInput);
   if (runtime) {
-    const source = normalizeRuntimeSource(runtimeSourceInput);
-    const protectedGateway = isLikelyProtectedGatewayOrigin(runtime);
-    return {
-      origin: runtime,
-      source,
-      usesCurrentOrigin: false,
-      isLikelyProtectedGateway: protectedGateway,
-      requiresAnonymousCheck: protectedGateway,
-    };
+    return buildResolution(runtime, normalizeRuntimeSource(runtimeSourceInput), false, false);
   }
 
   const build = normalizePublicWebOrigin(
@@ -93,14 +148,7 @@ export function resolvePublicWebOrigin(options: PublicWebOriginOptions = {}): Pu
       import.meta.env.VITE_APP_PUBLIC_URL,
   );
   if (build) {
-    const protectedGateway = isLikelyProtectedGatewayOrigin(build);
-    return {
-      origin: build,
-      source: "build",
-      usesCurrentOrigin: false,
-      isLikelyProtectedGateway: protectedGateway,
-      requiresAnonymousCheck: protectedGateway,
-    };
+    return buildResolution(build, "build", false, false);
   }
 
   const current = normalizePublicWebOrigin(
@@ -108,24 +156,12 @@ export function resolvePublicWebOrigin(options: PublicWebOriginOptions = {}): Pu
       (typeof window !== "undefined" ? window.location.origin : ""),
   );
   if (current) {
-    return {
-      origin: current,
-      source: "current",
-      usesCurrentOrigin: true,
-      isLikelyProtectedGateway: isLikelyProtectedGatewayOrigin(current),
-      // A current-origin fallback may be an intranet, VPN or authenticated gateway even when the
-      // hostname is not recognizable. The creator's logged-in browser cannot prove anonymity.
-      requiresAnonymousCheck: true,
-    };
+    // A current-origin fallback may be an intranet, VPN or authenticated gateway even when the
+    // hostname is not recognizable. The creator's logged-in browser cannot prove anonymity.
+    return buildResolution(current, "current", true, true);
   }
 
-  return {
-    origin: "",
-    source: "relative",
-    usesCurrentOrigin: false,
-    isLikelyProtectedGateway: false,
-    requiresAnonymousCheck: true,
-  };
+  return buildResolution("", "relative", false, true);
 }
 
 export function getPublicWebOrigin(options: PublicWebOriginOptions = {}): string {


### PR DESCRIPTION
## 变更内容

- 将 `localhost` 场景从两行全宽警告卡改为紧凑单行提示，默认只保留核心结论和“配置公开地址”入口。
- 将普通待验证、内网地址和登录网关风险收进标题栏状态按钮，点击后再展开地址来源、完整地址和验证说明。
- 管理员可直接在详情浮层中配置独立公开地址；普通用户会看到联系管理员的说明。
- 为公开地址增加风险分级：`none`、`verify`、`private-network`、`localhost`、`protected-gateway`。
- 增加 localhost、内网 IP、当前域名回退和登录网关的单元测试，并补充分享管理页面交互测试。

## 设计目标

当前警告长期占据标题与统计卡片之间的大面积空间，且 localhost 与“可能需要验证”的场景使用相同文案。此次调整让高确定性风险仍然可见，但降低默认视觉权重；详细信息和配置操作按需展开。

## 验证

- 新增 `publicWebOrigin` 风险分级测试。
- 新增分享管理 localhost 紧凑提示与展开详情测试。
- 等待 Share Management CI 和前端 TypeScript 检查。