### PR TITLE
chore(knowledge-tree): sync latest main into issue-464 branch

### DIFF
--- a/backend/src/db/knowledgeTreeMigrationCore.ts
+++ b/backend/src/db/knowledgeTreeMigrationCore.ts
@@ -87,21 +87,10 @@ export function ensureKnowledgeTreeTables(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_knowledge_tree_history_actor
       ON knowledge_tree_history(actorUserId, createdAt DESC);
 
+    -- 回填阶段暂不创建 INSERT 守卫触发器：历史数据里父节点可能尚未插入
+    -- （行序不确定），或父节点已删除/跨 scope，直接建守卫会让整批 INSERT 被
+    -- ABORT 而中断迁移。INSERT 守卫在回填全部完成后单独创建（见下方）。
     DROP TRIGGER IF EXISTS knowledge_tree_parent_scope_guard_insert;
-    CREATE TRIGGER knowledge_tree_parent_scope_guard_insert
-    BEFORE INSERT ON knowledge_tree_nodes
-    WHEN NEW.parentId IS NOT NULL
-    BEGIN
-      SELECT RAISE(ABORT, 'KNOWLEDGE_TREE_PARENT_SCOPE_MISMATCH')
-      WHERE NOT EXISTS (
-        SELECT 1 FROM knowledge_tree_nodes parent
-        WHERE parent.id = NEW.parentId
-          AND parent.scopeKey = NEW.scopeKey
-          AND parent.isDeleted = 0
-      );
-      SELECT RAISE(ABORT, 'KNOWLEDGE_TREE_SELF_PARENT')
-      WHERE NEW.parentId = NEW.id;
-    END;
 
     DROP TRIGGER IF EXISTS knowledge_tree_parent_scope_guard_update;
     CREATE TRIGGER knowledge_tree_parent_scope_guard_update
@@ -237,7 +226,16 @@ export function ensureKnowledgeTreeTables(db: Database.Database): void {
       nb.userId,
       nb.workspaceId,
       CASE WHEN nb.workspaceId IS NULL THEN 'personal:' || nb.userId ELSE 'workspace:' || nb.workspaceId END,
-      CASE WHEN nb.parentId IS NULL THEN NULL ELSE 'notebook:' || nb.parentId END,
+      CASE
+        WHEN nb.parentId IS NULL OR nb.parentId = '' THEN NULL
+        WHEN EXISTS (
+          SELECT 1 FROM notebooks p
+          WHERE p.id = nb.parentId
+            AND COALESCE(p.workspaceId, '') = COALESCE(nb.workspaceId, '')
+            AND (nb.workspaceId IS NOT NULL OR p.userId = nb.userId)
+        ) THEN 'notebook:' || nb.parentId
+        ELSE NULL
+      END,
       'folder', 'notebook', nb.id, COALESCE(nb.sortOrder, 0), COALESCE(nb.isExpanded, 1),
       COALESCE(nb.isDeleted, 0), nb.deletedAt, nb.createdAt, nb.updatedAt
     FROM notebooks nb;
@@ -251,7 +249,16 @@ export function ensureKnowledgeTreeTables(db: Database.Database): void {
       n.userId,
       n.workspaceId,
       CASE WHEN n.workspaceId IS NULL THEN 'personal:' || n.userId ELSE 'workspace:' || n.workspaceId END,
-      'notebook:' || n.notebookId,
+      CASE
+        WHEN n.notebookId IS NULL OR n.notebookId = '' THEN NULL
+        WHEN EXISTS (
+          SELECT 1 FROM notebooks p
+          WHERE p.id = n.notebookId
+            AND COALESCE(p.workspaceId, '') = COALESCE(n.workspaceId, '')
+            AND (n.workspaceId IS NOT NULL OR p.userId = n.userId)
+        ) THEN 'notebook:' || n.notebookId
+        ELSE NULL
+      END,
       CASE
         WHEN n.note_type = 'word' THEN 'word'
         WHEN n.contentFormat = 'markdown' THEN 'markdown'
@@ -260,6 +267,25 @@ export function ensureKnowledgeTreeTables(db: Database.Database): void {
       'note', n.id, COALESCE(n.sortOrder, 0), 1,
       COALESCE(n.isTrashed, 0), n.trashedAt, n.createdAt, n.updatedAt
     FROM notes n;
+  `);
+
+  // 回填全部完成后，再创建 INSERT 守卫触发器，保证运行期写入仍受结构约束保护。
+  db.exec(`
+    DROP TRIGGER IF EXISTS knowledge_tree_parent_scope_guard_insert;
+    CREATE TRIGGER knowledge_tree_parent_scope_guard_insert
+    BEFORE INSERT ON knowledge_tree_nodes
+    WHEN NEW.parentId IS NOT NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'KNOWLEDGE_TREE_PARENT_SCOPE_MISMATCH')
+      WHERE NOT EXISTS (
+        SELECT 1 FROM knowledge_tree_nodes parent
+        WHERE parent.id = NEW.parentId
+          AND parent.scopeKey = NEW.scopeKey
+          AND parent.isDeleted = 0
+      );
+      SELECT RAISE(ABORT, 'KNOWLEDGE_TREE_SELF_PARENT')
+      WHERE NEW.parentId = NEW.id;
+    END;
   `);
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "@hono/node-server";
+import "./runtime/knowledge-tree-migration-bootstrap";
 import "./runtime/task-stats-hardening";
 import "./runtime/notebook-publication";
+import "./runtime/knowledge-tree";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
@@ -8,6 +10,7 @@ import { compress } from "hono/compress";
 import path from "path";
 import fs from "fs";
 import { verifyLoginToken, getCachedAuthUser, setCachedAuthUser } from "./lib/auth-security";
+import knowledgeTreeRouter from "./routes/knowledge-tree";
 import notebooksRouter from "./routes/notebooks";
 import notesRouter from "./routes/notes";
 import blocksRouter from "./routes/blocks";
@@ -467,6 +470,7 @@ app.use("/api/*", async (c, next) => {
 app.use("/api/*", enforceApiTokenAccess);
 
 // API 路由（受 JWT 保护）
+app.route("/api/knowledge-tree/", knowledgeTreeRouter);
 app.route("/api/notebooks", notebooksRouter);
 app.route("/api/notes", notesRouter);
 app.route("/api/blocks", blocksRouter);

--- a/backend/src/runtime/knowledge-tree.ts
+++ b/backend/src/runtime/knowledge-tree.ts
@@ -7,10 +7,8 @@ import {
   enforceKnowledgeNoteCapabilities,
   enforceKnowledgeNotebookCapabilities,
 } from "../middleware/knowledgeCapabilityGuard.js";
-import knowledgeTreeRouter from "../routes/knowledge-tree.js";
 
 const INSTALL_KEY = Symbol.for("nowen.knowledgeTree.runtimeInstalled");
-const ROUTE_KEY = Symbol.for("nowen.knowledgeTree.routeMounted");
 const globals = globalThis as typeof globalThis & Record<symbol, boolean>;
 
 // Ensure optional resource tables/views exist before the first tree query. The file manager is
@@ -40,12 +38,7 @@ if (!globals[INSTALL_KEY]) {
       const wrapper = new Hono<any>();
       wrapper.use("*", enforceKnowledgeNotebookCapabilities);
       wrapper.route("/", subApp);
-      const mounted = nativeRoute.call(this, path, wrapper);
-      if (!globals[ROUTE_KEY]) {
-        globals[ROUTE_KEY] = true;
-        nativeRoute.call(this, "/api/knowledge-tree", knowledgeTreeRouter);
-      }
-      return mounted;
+      return nativeRoute.call(this, path, wrapper);
     }
 
     return nativeRoute.call(this, path, subApp);

--- a/backend/tests/knowledge-tree-existing-data-migration.test.ts
+++ b/backend/tests/knowledge-tree-existing-data-migration.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+
+import { ensureKnowledgeTreeTables } from "../src/db/knowledgeTreeMigrationCore.js";
+
+test("knowledge tree migration preserves existing deleted subtrees", () => {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE users (id TEXT PRIMARY KEY);
+    CREATE TABLE notebooks (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      parentId TEXT,
+      name TEXT NOT NULL,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      isExpanded INTEGER NOT NULL DEFAULT 1,
+      isDeleted INTEGER NOT NULL DEFAULT 0,
+      deletedAt TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+    CREATE TABLE notes (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      notebookId TEXT,
+      title TEXT NOT NULL,
+      contentFormat TEXT,
+      note_type TEXT,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      isTrashed INTEGER NOT NULL DEFAULT 0,
+      trashedAt TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+
+    INSERT INTO users (id) VALUES ('user-1');
+    INSERT INTO notebooks
+      (id, userId, parentId, name, isDeleted, deletedAt, createdAt, updatedAt)
+    VALUES
+      ('deleted-child', 'user-1', 'deleted-parent', 'Child', 1, '2026-01-01', '2026-01-01', '2026-01-01'),
+      ('deleted-parent', 'user-1', NULL, 'Parent', 1, '2026-01-01', '2026-01-01', '2026-01-01');
+    INSERT INTO notes
+      (id, userId, notebookId, title, contentFormat, note_type, isTrashed, trashedAt, createdAt, updatedAt)
+    VALUES
+      ('deleted-note', 'user-1', 'deleted-child', 'Note', 'markdown', 'note', 1, '2026-01-01', '2026-01-01', '2026-01-01');
+  `);
+
+  try {
+    ensureKnowledgeTreeTables(db);
+
+    const child = db.prepare("SELECT parentId, isDeleted FROM knowledge_tree_nodes WHERE id = ?")
+      .get("notebook:deleted-child") as { parentId: string | null; isDeleted: number };
+    const note = db.prepare("SELECT parentId, isDeleted FROM knowledge_tree_nodes WHERE id = ?")
+      .get("note:deleted-note") as { parentId: string | null; isDeleted: number };
+    assert.deepEqual(child, { parentId: "notebook:deleted-parent", isDeleted: 1 });
+    assert.deepEqual(note, { parentId: "notebook:deleted-child", isDeleted: 1 });
+  } finally {
+    db.close();
+  }
+});

--- a/backend/tests/knowledge-tree-standard-entry.test.ts
+++ b/backend/tests/knowledge-tree-standard-entry.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test("standard backend entry installs the knowledge tree routes", () => {
+  const source = readFileSync("src/index.ts", "utf8");
+  const migrationBootstrap = source.indexOf('import "./runtime/knowledge-tree-migration-bootstrap"');
+  const knowledgeTreeRuntime = source.indexOf('import "./runtime/knowledge-tree"');
+  const knowledgeTreeRoute = source.indexOf('app.route("/api/knowledge-tree/", knowledgeTreeRouter)');
+
+  assert.ok(migrationBootstrap >= 0);
+  assert.ok(knowledgeTreeRuntime >= 0);
+  assert.ok(knowledgeTreeRoute >= 0);
+  assert.ok(migrationBootstrap < knowledgeTreeRuntime);
+});
+
+test("standard backend entry serves both knowledge tree listings", async () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "nowen-knowledge-tree-entry-"));
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+  const address = probe.address();
+  assert.ok(address && typeof address !== "string");
+  const port = address.port;
+  await new Promise<void>((resolve, reject) => probe.close((error) => error ? reject(error) : resolve()));
+
+  const child = spawn(process.execPath, ["--import", "tsx", "src/index.ts"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DB_PATH: path.join(tempDir, "knowledge-tree-entry.db"),
+      NODE_ENV: "test",
+      PORT: String(port),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk: Buffer) => { output += chunk.toString(); });
+  child.stderr.on("data", (chunk: Buffer) => { output += chunk.toString(); });
+
+  try {
+    let ready = false;
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+        if (response.ok) {
+          ready = true;
+          break;
+        }
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+    assert.equal(ready, true, output);
+
+    const registration = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "routecheck", password: "routecheck-pass" }),
+    });
+    const registrationBody = await registration.text();
+    assert.equal(registration.status, 201, registrationBody);
+    const { token } = JSON.parse(registrationBody) as { token: string };
+
+    for (const requestPath of [
+      "/api/knowledge-tree/?workspaceId=personal",
+      "/api/knowledge-tree/shared-with-me?workspaceId=personal",
+    ]) {
+      const response = await fetch(`http://127.0.0.1:${port}${requestPath}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      assert.equal(response.status, 200, `${requestPath}: ${await response.text()}`);
+    }
+  } finally {
+    child.kill();
+    await Promise.race([
+      new Promise<void>((resolve) => child.once("exit", () => resolve())),
+      new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+    ]);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
将 `main@4cbb2446a6a35ba29e3b9a80da10deb56860fc61` 同步到 #464 实现分支。

主线新增内容包括知识树历史数据回填守卫、跨 scope 父节点映射和标准路由入口修复。与 #464 的旧 API 写入协调器属于同一领域，需要在最新迁移基线上重新执行完整 CI。

本 PR 仅用于分支同步，不关闭 Issue。