### PR TITLE
fix(electron): 修复 Windows Markdown 打开保存乱码 (#474)

### DIFF
--- a/electron/__tests__/textEncoding.test.js
+++ b/electron/__tests__/textEncoding.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { decodeTextBuffer } = require("../textEncoding");
+
+test("decodes UTF-8 markdown without changing Chinese content", () => {
+  const result = decodeTextBuffer(Buffer.from("# 中文\n保存后不乱码", "utf8"));
+  assert.deepEqual(result, {
+    content: "# 中文\n保存后不乱码",
+    encoding: "utf-8",
+    hadBom: false,
+  });
+});
+
+test("strips UTF-8 BOM", () => {
+  const result = decodeTextBuffer(Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from("# 标题", "utf8"),
+  ]));
+  assert.equal(result.content, "# 标题");
+  assert.equal(result.encoding, "utf-8");
+  assert.equal(result.hadBom, true);
+});
+
+test("decodes UTF-16LE markdown with BOM", () => {
+  const result = decodeTextBuffer(Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from("# 中文", "utf16le"),
+  ]));
+  assert.equal(result.content, "# 中文");
+  assert.equal(result.encoding, "utf-16le");
+  assert.equal(result.hadBom, true);
+});
+
+test("decodes UTF-16BE markdown with BOM", () => {
+  const littleEndian = Buffer.from("# 中文", "utf16le");
+  const bigEndian = Buffer.from(littleEndian);
+  bigEndian.swap16();
+  const result = decodeTextBuffer(Buffer.concat([
+    Buffer.from([0xfe, 0xff]),
+    bigEndian,
+  ]));
+  assert.equal(result.content, "# 中文");
+  assert.equal(result.encoding, "utf-16be");
+  assert.equal(result.hadBom, true);
+});
+
+test("detects UTF-16LE markdown without BOM when null-byte pattern is clear", () => {
+  const result = decodeTextBuffer(Buffer.from("# title\r\nbody", "utf16le"));
+  assert.equal(result.content, "# title\r\nbody");
+  assert.equal(result.encoding, "utf-16le");
+  assert.equal(result.hadBom, false);
+});
+
+test("decodes Windows GBK/GB18030 markdown instead of replacement characters", () => {
+  const gbk = Buffer.from([
+    0x23, 0x20,
+    0xd6, 0xd0,
+    0xce, 0xc4,
+    0x20,
+    0x4d, 0x61, 0x72, 0x6b, 0x64, 0x6f, 0x77, 0x6e,
+  ]);
+  const result = decodeTextBuffer(gbk);
+  assert.equal(result.content, "# 中文 Markdown");
+  assert.equal(result.encoding, "gb18030");
+  assert.equal(result.hadBom, false);
+  assert.equal(result.content.includes("�"), false);
+});
+
+test("falls back to Windows-1252 for Western ANSI text", () => {
+  const result = decodeTextBuffer(Buffer.from([0x63, 0x61, 0x66, 0xe9]));
+  assert.equal(result.content, "café");
+  assert.equal(result.encoding, "windows-1252");
+  assert.equal(result.hadBom, false);
+});

--- a/electron/fileAssoc.js
+++ b/electron/fileAssoc.js
@@ -9,6 +9,7 @@
 const fs = require("fs");
 const path = require("path");
 const { app, BrowserWindow } = require("electron");
+const { decodeTextBuffer } = require("./textEncoding");
 
 const MAX_BYTES = 10 * 1024 * 1024; // 10MB 安全上限
 const VALID_EXT = new Set([".md", ".markdown", ".txt"]);
@@ -42,11 +43,24 @@ function readFileSafe(filePath) {
       console.warn("[fileAssoc] file too large, skipped:", abs, stat.size);
       return null;
     }
-    const content = fs.readFileSync(abs, "utf8");
+
+    // 不再固定按 UTF-8 读取：Windows 上的 Markdown 常见 GBK/GB18030、
+    // UTF-16LE/BE。错误地先解码成字符串会产生不可逆的 U+FFFD（�），
+    // 后续保存只是把乱码持久化。这里保留原始字节并在 IPC 前统一解码。
+    const decoded = decodeTextBuffer(fs.readFileSync(abs));
+    if (decoded.encoding !== "utf-8" || decoded.hadBom) {
+      console.log(
+        `[fileAssoc] decoded ${path.basename(abs)} as ${decoded.encoding}` +
+          (decoded.hadBom ? " (BOM)" : ""),
+      );
+    }
+
     return {
       name: path.basename(abs),
       size: stat.size,
-      content,
+      content: decoded.content,
+      encoding: decoded.encoding,
+      hadBom: decoded.hadBom,
     };
   } catch (e) {
     console.warn("[fileAssoc] read failed:", filePath, e?.message || e);

--- a/electron/textEncoding.js
+++ b/electron/textEncoding.js
@@ -1,0 +1,203 @@
+"use strict";
+
+const { TextDecoder } = require("node:util");
+
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+const UTF16LE_BOM = Buffer.from([0xff, 0xfe]);
+const UTF16BE_BOM = Buffer.from([0xfe, 0xff]);
+const UTF16_SNIFF_BYTES = 4096;
+
+function startsWith(buffer, prefix) {
+  return buffer.length >= prefix.length && buffer.subarray(0, prefix.length).equals(prefix);
+}
+
+function decodeStrict(buffer, encoding) {
+  return new TextDecoder(encoding, { fatal: true }).decode(buffer);
+}
+
+function stripLeadingBom(text) {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/**
+ * UTF-16 without BOM is common in files produced by Windows tools. Since those
+ * bytes can still be technically valid UTF-8 (because NUL is valid), sniff the
+ * alternating NUL-byte pattern before attempting strict UTF-8 decoding.
+ */
+function detectUtf16WithoutBom(buffer) {
+  const sampleLength = Math.min(buffer.length - (buffer.length % 2), UTF16_SNIFF_BYTES);
+  if (sampleLength < 4) return null;
+
+  let evenZeroes = 0;
+  let oddZeroes = 0;
+  const pairs = sampleLength / 2;
+  for (let i = 0; i < sampleLength; i += 2) {
+    if (buffer[i] === 0) evenZeroes += 1;
+    if (buffer[i + 1] === 0) oddZeroes += 1;
+  }
+
+  const evenRatio = evenZeroes / pairs;
+  const oddRatio = oddZeroes / pairs;
+  if (oddRatio >= 0.3 && evenRatio <= 0.05) return "utf-16le";
+  if (evenRatio >= 0.3 && oddRatio <= 0.05) return "utf-16be";
+  return null;
+}
+
+function scanGb18030(buffer) {
+  let sequences = 0;
+  let fourByteSequences = 0;
+  let invalidHighBytes = 0;
+
+  for (let i = 0; i < buffer.length;) {
+    const first = buffer[i];
+    if (first <= 0x7f) {
+      i += 1;
+      continue;
+    }
+    if (first === 0x80) {
+      sequences += 1;
+      i += 1;
+      continue;
+    }
+    if (first < 0x81 || first > 0xfe || i + 1 >= buffer.length) {
+      invalidHighBytes += 1;
+      i += 1;
+      continue;
+    }
+
+    const second = buffer[i + 1];
+    if (
+      second >= 0x30 && second <= 0x39 &&
+      i + 3 < buffer.length &&
+      buffer[i + 2] >= 0x81 && buffer[i + 2] <= 0xfe &&
+      buffer[i + 3] >= 0x30 && buffer[i + 3] <= 0x39
+    ) {
+      sequences += 1;
+      fourByteSequences += 1;
+      i += 4;
+      continue;
+    }
+
+    if (second >= 0x40 && second <= 0xfe && second !== 0x7f) {
+      sequences += 1;
+      i += 2;
+      continue;
+    }
+
+    invalidHighBytes += 1;
+    i += 1;
+  }
+
+  return { sequences, fourByteSequences, invalidHighBytes };
+}
+
+function countCjk(text) {
+  let count = 0;
+  for (const char of text) {
+    const codePoint = char.codePointAt(0);
+    if (
+      (codePoint >= 0x3400 && codePoint <= 0x4dbf) ||
+      (codePoint >= 0x4e00 && codePoint <= 0x9fff) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0x20000 && codePoint <= 0x2fa1f)
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function decodeLegacyWindowsText(buffer) {
+  let gb18030 = null;
+  try {
+    gb18030 = decodeStrict(buffer, "gb18030");
+  } catch {
+    // Not a valid GB18030 byte stream. Fall through to Windows-1252.
+  }
+
+  if (gb18030 !== null) {
+    const scan = scanGb18030(buffer);
+    const cjkCount = countCjk(gb18030);
+    if (
+      scan.invalidHighBytes === 0 &&
+      (scan.fourByteSequences > 0 || scan.sequences >= 2 || cjkCount >= 2)
+    ) {
+      return { content: stripLeadingBom(gb18030), encoding: "gb18030" };
+    }
+  }
+
+  return {
+    content: stripLeadingBom(new TextDecoder("windows-1252").decode(buffer)),
+    encoding: "windows-1252",
+  };
+}
+
+/**
+ * Decode a Markdown/text file without corrupting common Windows encodings.
+ *
+ * Priority:
+ *   1. Explicit UTF BOMs
+ *   2. UTF-16 alternating-NUL sniffing
+ *   3. Strict UTF-8
+ *   4. GB18030 (covers GBK/CP936)
+ *   5. Windows-1252 fallback
+ */
+function decodeTextBuffer(input) {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input || []);
+  if (buffer.length === 0) {
+    return { content: "", encoding: "utf-8", hadBom: false };
+  }
+
+  if (startsWith(buffer, UTF8_BOM)) {
+    return {
+      content: stripLeadingBom(decodeStrict(buffer.subarray(UTF8_BOM.length), "utf-8")),
+      encoding: "utf-8",
+      hadBom: true,
+    };
+  }
+  if (startsWith(buffer, UTF16LE_BOM)) {
+    return {
+      content: stripLeadingBom(decodeStrict(buffer.subarray(UTF16LE_BOM.length), "utf-16le")),
+      encoding: "utf-16le",
+      hadBom: true,
+    };
+  }
+  if (startsWith(buffer, UTF16BE_BOM)) {
+    return {
+      content: stripLeadingBom(decodeStrict(buffer.subarray(UTF16BE_BOM.length), "utf-16be")),
+      encoding: "utf-16be",
+      hadBom: true,
+    };
+  }
+
+  const utf16Encoding = detectUtf16WithoutBom(buffer);
+  if (utf16Encoding) {
+    try {
+      return {
+        content: stripLeadingBom(decodeStrict(buffer, utf16Encoding)),
+        encoding: utf16Encoding,
+        hadBom: false,
+      };
+    } catch {
+      // Continue with UTF-8 and legacy Windows encodings.
+    }
+  }
+
+  try {
+    return {
+      content: stripLeadingBom(decodeStrict(buffer, "utf-8")),
+      encoding: "utf-8",
+      hadBom: false,
+    };
+  } catch {
+    // Invalid UTF-8 is common for Windows ANSI/GBK markdown files.
+  }
+
+  return { ...decodeLegacyWindowsText(buffer), hadBom: false };
+}
+
+module.exports = {
+  decodeTextBuffer,
+  detectUtf16WithoutBom,
+  scanGb18030,
+};


### PR DESCRIPTION
## 问题分析

Issue #474 在 Windows 桌面端打开本地 Markdown 后，编辑、保存或重新打开会稳定出现乱码。

根因位于 Electron 文件关联读取链路：`electron/fileAssoc.js` 使用 `fs.readFileSync(path, "utf8")` 强制按 UTF-8 解码。Windows 上由记事本、旧编辑器或其它工具生成的 `.md/.txt` 文件可能是 GBK/GB18030、UTF-16LE/BE 或 Windows ANSI；强制 UTF-8 会先产生不可逆的 `�` 字符，随后应用把已经损坏的文本保存进笔记，因此表现为“保存后乱码”。

## 修复内容

- 文件关联入口改为读取原始 `Buffer`，避免提前错误解码
- 新增统一文本编码解码器，按以下顺序处理：
  1. UTF-8 / UTF-16 BOM
  2. 无 BOM UTF-16 字节特征
  3. 严格 UTF-8
  4. GB18030（兼容 GBK / CP936）
  5. Windows-1252 兜底
- 去除 BOM，不改写正文和换行
- IPC 负载附带实际识别到的 `encoding` / `hadBom`，便于日志诊断
- 增加 7 组编码回归测试

## 验证

```bash
node --test electron/__tests__/textEncoding.test.js
```

结果：7 passed，0 failed。

## 影响范围

仅影响 Electron 桌面端通过文件关联双击打开 `.md`、`.markdown`、`.txt` 的读取过程；网页端、数据库保存 API 和普通应用内笔记编辑链路不变。

Closes #474