### PR TITLE
refactor(frontend): 收敛侧栏重复搜索入口

### DIFF
--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+import { applySidebarSearchExperience } from "@/lib/sidebarSearchExperience";
+
+/**
+ * 统一内容树上线后的搜索入口兼容桥。
+ *
+ * Sidebar 目前仍包含旧笔记本树的大量兼容代码，直接在本次 UI 收敛中整体拆除风险较高。
+ * 此桥只负责搜索入口语义，不参与任何业务查询：全文搜索仍由命令面板负责，
+ * 内容树输入框继续调用 KnowledgeTreePanel 自己的本地过滤逻辑。
+ */
+export default function SidebarSearchExperienceBridge() {
+  useEffect(() => {
+    const apply = () => applySidebarSearchExperience(document);
+
+    apply();
+
+    const observer = new MutationObserver(() => apply());
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // 工作区切换时移动端/桌面端 Sidebar 可能重新挂载，主动再收敛一次。
+    window.addEventListener("nowen:workspace-changed", apply);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("nowen:workspace-changed", apply);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 
-import { applySidebarSearchExperience } from "@/lib/sidebarSearchExperience";
+import {
+  applySidebarSearchExperience,
+  SIDEBAR_SEARCH_SURFACE_SELECTOR,
+} from "@/lib/sidebarSearchExperience";
 
 /**
  * 统一内容树上线后的搜索入口兼容桥。
@@ -11,19 +14,31 @@ import { applySidebarSearchExperience } from "@/lib/sidebarSearchExperience";
  */
 export default function SidebarSearchExperienceBridge() {
   useEffect(() => {
-    const apply = () => applySidebarSearchExperience(document);
+    const applyDocument = () => applySidebarSearchExperience(document);
 
-    apply();
+    applyDocument();
 
-    const observer = new MutationObserver(() => apply());
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const addedNode of record.addedNodes) {
+          if (!(addedNode instanceof Element)) continue;
+          if (
+            addedNode.matches(SIDEBAR_SEARCH_SURFACE_SELECTOR)
+            || addedNode.querySelector(SIDEBAR_SEARCH_SURFACE_SELECTOR)
+          ) {
+            applySidebarSearchExperience(addedNode);
+          }
+        }
+      }
+    });
     observer.observe(document.body, { childList: true, subtree: true });
 
     // 工作区切换时移动端/桌面端 Sidebar 可能重新挂载，主动再收敛一次。
-    window.addEventListener("nowen:workspace-changed", apply);
+    window.addEventListener("nowen:workspace-changed", applyDocument);
 
     return () => {
       observer.disconnect();
-      window.removeEventListener("nowen:workspace-changed", apply);
+      window.removeEventListener("nowen:workspace-changed", applyDocument);
     };
   }, []);
 

--- a/frontend/src/lib/__tests__/sidebarSearchExperience.test.ts
+++ b/frontend/src/lib/__tests__/sidebarSearchExperience.test.ts
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applySidebarSearchExperience } from "@/lib/sidebarSearchExperience";
+
+describe("applySidebarSearchExperience", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("retires the duplicated global search row and clears an active legacy query", () => {
+    document.body.innerHTML = `
+      <div id="legacy-row">
+        <div>
+          <svg aria-hidden="true"></svg>
+          <input data-sidebar-search value="React" />
+        </div>
+      </div>
+    `;
+
+    const input = document.querySelector<HTMLInputElement>("[data-sidebar-search]")!;
+    const inputEvent = vi.fn();
+    input.addEventListener("input", inputEvent);
+
+    expect(applySidebarSearchExperience(document)).toBe(true);
+
+    const row = document.querySelector<HTMLElement>("#legacy-row")!;
+    expect(row.dataset.retiredSidebarSearchRow).toBe("true");
+    expect(row.getAttribute("aria-hidden")).toBe("true");
+    expect(input.value).toBe("");
+    expect(input.tabIndex).toBe(-1);
+    expect(inputEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes the knowledge tree field clearly local to folders and documents", () => {
+    document.body.innerHTML = `
+      <div id="tree-filter">
+        <svg aria-hidden="true"></svg>
+        <input data-knowledge-tree-search placeholder="筛选内容树…" />
+      </div>
+    `;
+
+    applySidebarSearchExperience(document);
+
+    const surface = document.querySelector<HTMLElement>("#tree-filter")!;
+    const input = document.querySelector<HTMLInputElement>("[data-knowledge-tree-search]")!;
+
+    expect(surface.dataset.treeFilterSurface).toBe("true");
+    expect(input.placeholder).toBe("筛选目录与文档…");
+    expect(input.getAttribute("aria-label")).toBe("筛选当前目录中的文件夹与文档");
+    expect(input.title).toBe("仅筛选当前内容树，不搜索笔记正文");
+    expect(input.dataset.searchScope).toBe("tree");
+  });
+
+  it("does not dispatch duplicate clear events when applied repeatedly", () => {
+    document.body.innerHTML = `
+      <div><div><input data-sidebar-search value="query" /></div></div>
+    `;
+
+    const input = document.querySelector<HTMLInputElement>("[data-sidebar-search]")!;
+    const inputEvent = vi.fn();
+    input.addEventListener("input", inputEvent);
+
+    applySidebarSearchExperience(document);
+    applySidebarSearchExperience(document);
+
+    expect(inputEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/sidebarSearchExperience.ts
+++ b/frontend/src/lib/sidebarSearchExperience.ts
@@ -1,0 +1,66 @@
+export const LEGACY_GLOBAL_SEARCH_SELECTOR = "[data-sidebar-search]";
+export const KNOWLEDGE_TREE_FILTER_SELECTOR = "[data-knowledge-tree-search]";
+
+const RETIRED_MARKER = "sidebarSearchRetired";
+
+function setNativeInputValue(input: HTMLInputElement, value: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+  if (descriptor?.set) {
+    descriptor.set.call(input, value);
+    return;
+  }
+  input.value = value;
+}
+
+/**
+ * 收敛侧栏搜索入口：
+ *
+ * - 旧的“搜索笔记”输入框会切换全文搜索视图，与统一内容树筛选框紧邻后语义冲突；
+ * - 全文搜索继续由 Cmd/Ctrl+K 命令面板和桌面端原生菜单承载；
+ * - 内容树输入框只负责当前树节点过滤，并显式标注作用范围。
+ *
+ * 这里暂时保留旧输入节点供旧版 Sidebar 代码兼容，但从可见 UI 和键盘导航中退休。
+ * Sidebar 后续拆除旧目录代码时，可以连同该兼容层一起删除。
+ */
+export function applySidebarSearchExperience(root: ParentNode = document): boolean {
+  let changed = false;
+
+  const legacyInput = root.querySelector<HTMLInputElement>(LEGACY_GLOBAL_SEARCH_SELECTOR);
+  if (legacyInput) {
+    const row = legacyInput.parentElement?.parentElement;
+    if (row instanceof HTMLElement && row.dataset.retiredSidebarSearchRow !== "true") {
+      row.dataset.retiredSidebarSearchRow = "true";
+      row.setAttribute("aria-hidden", "true");
+      changed = true;
+    }
+
+    legacyInput.tabIndex = -1;
+    legacyInput.setAttribute("aria-hidden", "true");
+
+    if (legacyInput.dataset[RETIRED_MARKER] !== "true") {
+      // 若升级发生在旧搜索仍有关键词的会话中，触发原有 React onChange，
+      // 让 viewMode/searchQuery 一并回到默认状态，避免隐藏输入后无法退出搜索。
+      if (legacyInput.value) {
+        setNativeInputValue(legacyInput, "");
+        legacyInput.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      legacyInput.dataset[RETIRED_MARKER] = "true";
+      changed = true;
+    }
+  }
+
+  const treeFilter = root.querySelector<HTMLInputElement>(KNOWLEDGE_TREE_FILTER_SELECTOR);
+  if (treeFilter) {
+    const filterSurface = treeFilter.parentElement;
+    if (filterSurface instanceof HTMLElement) {
+      filterSurface.dataset.treeFilterSurface = "true";
+    }
+    treeFilter.placeholder = "筛选目录与文档…";
+    treeFilter.setAttribute("aria-label", "筛选当前目录中的文件夹与文档");
+    treeFilter.title = "仅筛选当前内容树，不搜索笔记正文";
+    treeFilter.dataset.searchScope = "tree";
+    changed = true;
+  }
+
+  return changed;
+}

--- a/frontend/src/lib/sidebarSearchExperience.ts
+++ b/frontend/src/lib/sidebarSearchExperience.ts
@@ -1,5 +1,7 @@
 export const LEGACY_GLOBAL_SEARCH_SELECTOR = "[data-sidebar-search]";
 export const KNOWLEDGE_TREE_FILTER_SELECTOR = "[data-knowledge-tree-search]";
+export const SIDEBAR_SEARCH_SURFACE_SELECTOR =
+  `${LEGACY_GLOBAL_SEARCH_SELECTOR},${KNOWLEDGE_TREE_FILTER_SELECTOR}`;
 
 const RETIRED_MARKER = "sidebarSearchRetired";
 
@@ -10,6 +12,14 @@ function setNativeInputValue(input: HTMLInputElement, value: string): void {
     return;
   }
   input.value = value;
+}
+
+function findInputs(root: ParentNode, selector: string): HTMLInputElement[] {
+  const inputs = Array.from(root.querySelectorAll<HTMLInputElement>(selector));
+  if (root instanceof HTMLInputElement && root.matches(selector)) {
+    inputs.unshift(root);
+  }
+  return inputs;
 }
 
 /**
@@ -25,8 +35,7 @@ function setNativeInputValue(input: HTMLInputElement, value: string): void {
 export function applySidebarSearchExperience(root: ParentNode = document): boolean {
   let changed = false;
 
-  const legacyInput = root.querySelector<HTMLInputElement>(LEGACY_GLOBAL_SEARCH_SELECTOR);
-  if (legacyInput) {
+  for (const legacyInput of findInputs(root, LEGACY_GLOBAL_SEARCH_SELECTOR)) {
     const row = legacyInput.parentElement?.parentElement;
     if (row instanceof HTMLElement && row.dataset.retiredSidebarSearchRow !== "true") {
       row.dataset.retiredSidebarSearchRow = "true";
@@ -49,17 +58,31 @@ export function applySidebarSearchExperience(root: ParentNode = document): boole
     }
   }
 
-  const treeFilter = root.querySelector<HTMLInputElement>(KNOWLEDGE_TREE_FILTER_SELECTOR);
-  if (treeFilter) {
+  for (const treeFilter of findInputs(root, KNOWLEDGE_TREE_FILTER_SELECTOR)) {
     const filterSurface = treeFilter.parentElement;
-    if (filterSurface instanceof HTMLElement) {
+    if (
+      filterSurface instanceof HTMLElement
+      && filterSurface.dataset.treeFilterSurface !== "true"
+    ) {
       filterSurface.dataset.treeFilterSurface = "true";
+      changed = true;
     }
-    treeFilter.placeholder = "筛选目录与文档…";
-    treeFilter.setAttribute("aria-label", "筛选当前目录中的文件夹与文档");
-    treeFilter.title = "仅筛选当前内容树，不搜索笔记正文";
-    treeFilter.dataset.searchScope = "tree";
-    changed = true;
+    if (treeFilter.placeholder !== "筛选目录与文档…") {
+      treeFilter.placeholder = "筛选目录与文档…";
+      changed = true;
+    }
+    if (treeFilter.getAttribute("aria-label") !== "筛选当前目录中的文件夹与文档") {
+      treeFilter.setAttribute("aria-label", "筛选当前目录中的文件夹与文档");
+      changed = true;
+    }
+    if (treeFilter.title !== "仅筛选当前内容树，不搜索笔记正文") {
+      treeFilter.title = "仅筛选当前内容树，不搜索笔记正文";
+      changed = true;
+    }
+    if (treeFilter.dataset.searchScope !== "tree") {
+      treeFilter.dataset.searchScope = "tree";
+      changed = true;
+    }
   }
 
   return changed;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,6 +16,7 @@ import Toaster from "./components/Toaster";
 import NoteIconBridge from "./components/NoteIconBridge";
 import AIProfileSwitcherBridge from "./components/AIProfileSwitcherBridge";
 import MarkdownExperienceBridge from "./components/MarkdownExperienceBridge";
+import SidebarSearchExperienceBridge from "./components/SidebarSearchExperienceBridge";
 import MindMapAppearanceBridge from "./components/MindMapAppearanceBridge";
 import EmbedPasswordBridge from "./components/EmbedPasswordBridge";
 import ImageExperienceBridge from "./components/ImageExperienceBridge";
@@ -39,6 +40,7 @@ import "./code-block-wrap.css";
 import "./overlay-layers.css";
 import "./space-actions.css";
 import "./settings-switches.css";
+import "./sidebar-search-experience.css";
 import { initCodeBlockTheme } from "./lib/codeBlockTheme";
 import { installAndroidNativeHttpBridge } from "./lib/androidNativeHttpBridge";
 import { installMobileStartupBridge } from "./lib/mobileStartupBridge";
@@ -145,6 +147,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <NoteIconBridge />
           <AIProfileSwitcherBridge />
           <MarkdownExperienceBridge />
+          <SidebarSearchExperienceBridge />
           <MindMapAppearanceBridge />
           <EmbedPasswordBridge />
           <ImageExperienceBridge />

--- a/frontend/src/sidebar-search-experience.css
+++ b/frontend/src/sidebar-search-experience.css
@@ -1,0 +1,31 @@
+/*
+ * 统一内容树上线后，Sidebar 旧的全文搜索输入框与树筛选框紧邻，
+ * 视觉和语义重复。旧节点暂时由兼容桥标记，避免在本次改动中冒险拆除
+ * Sidebar 内尚未完全退场的旧目录代码。
+ */
+[data-retired-sidebar-search-row="true"] {
+  display: none !important;
+}
+
+/* 内容树过滤使用“逐级收窄”的图形，不再与全文搜索共用放大镜。 */
+[data-tree-filter-surface="true"] > svg:first-child {
+  display: none;
+}
+
+[data-tree-filter-surface="true"]::before {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  content: "";
+  background-color: currentColor;
+  color: var(--tx-tertiary, currentColor);
+  opacity: 0.65;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M3 5h18v2H3V5Zm3 6h12v2H6v-2Zm3 6h6v2H9v-2Z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M3 5h18v2H3V5Zm3 6h12v2H6v-2Zm3 6h6v2H9v-2Z'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}


### PR DESCRIPTION
## 背景

统一内容树上线后，侧栏同时出现两个外观和位置高度相似的搜索框：

- 顶部「搜索笔记」会进入全文搜索结果；
- 内容区「筛选内容树」只过滤当前目录节点。

二者紧邻且都使用放大镜，用户无法快速判断搜索范围，形成明显的交互语义冲突。

## 本次改动

- 退休侧栏顶部常驻全文搜索输入框；
- 全文搜索继续由 `Cmd/Ctrl + K` 命令面板和桌面端原生搜索菜单承载；
- 将内容树输入框明确为「筛选目录与文档…」；
- 为目录筛选换成逐级收窄的过滤图形，避免与全文搜索使用同一视觉符号；
- 增加 `aria-label` 和作用域提示，明确“不搜索笔记正文”；
- 升级时若旧搜索框仍保留关键词，会主动触发原有清空逻辑，避免隐藏入口后停留在无法退出的搜索视图；
- 同时处理桌面端和移动端可能并存/重挂载的侧栏实例；
- MutationObserver 只检查新增且包含搜索入口的节点，不扫描编辑器的普通 DOM 变化。

## 兼容策略

当前 `Sidebar.tsx` 仍保留较多旧笔记本树兼容代码。本次先通过独立兼容桥退休旧搜索节点，不删除全文搜索业务能力，也不改变后端接口和用户数据。后续彻底拆除旧目录代码时，可一并移除该桥。

## 测试

新增 Vitest/jsdom 测试，覆盖：

1. 旧全文搜索行隐藏并清空活动关键词；
2. 内容树筛选的文案、无障碍标签和作用域；
3. 重复应用不会重复派发清空事件。
