### PR TITLE
fix(frontend): 恢复统一内容树排序按钮

### DIFF
--- a/frontend/src/components/KnowledgeTreeSortButton.tsx
+++ b/frontend/src/components/KnowledgeTreeSortButton.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { ArrowUpDown, Check } from "lucide-react";
+
+import {
+  KNOWLEDGE_TREE_SORT_CHANGED_EVENT,
+  KNOWLEDGE_TREE_SORT_OPTIONS,
+  loadKnowledgeTreeSortMode,
+  saveKnowledgeTreeSortMode,
+  type KnowledgeTreeSortMode,
+} from "@/lib/knowledgeTreeSort";
+import { cn } from "@/lib/utils";
+
+export default function KnowledgeTreeSortButton() {
+  const [mode, setMode] = useState<KnowledgeTreeSortMode>(() => loadKnowledgeTreeSortMode());
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const activeOption = KNOWLEDGE_TREE_SORT_OPTIONS.find((option) => option.value === mode)
+    || KNOWLEDGE_TREE_SORT_OPTIONS[0];
+
+  useEffect(() => {
+    const sync = (event: Event) => {
+      const next = (event as CustomEvent<{ mode?: KnowledgeTreeSortMode }>).detail?.mode;
+      setMode(next || loadKnowledgeTreeSortMode());
+    };
+    window.addEventListener(KNOWLEDGE_TREE_SORT_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(KNOWLEDGE_TREE_SORT_CHANGED_EVENT, sync);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("pointerdown", closeOutside, true);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("pointerdown", closeOutside, true);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const chooseMode = (nextMode: KnowledgeTreeSortMode) => {
+    setMode(nextMode);
+    saveKnowledgeTreeSortMode(nextMode);
+    setOpen(false);
+  };
+
+  return (
+    <span ref={rootRef} className="relative flex h-7 w-7 shrink-0 items-center justify-center">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className={cn(
+          "flex h-7 w-7 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary",
+          open && "bg-app-active text-tx-primary",
+          mode !== "manual" && "text-accent-primary",
+        )}
+        title={`排序：${activeOption.label}`}
+        aria-label={`内容树排序，当前为${activeOption.label}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-knowledge-tree-sort-button=""
+      >
+        <ArrowUpDown size={13} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-8 z-[240] w-36 overflow-hidden rounded-lg border border-app-border bg-app-elevated py-1 shadow-xl"
+          data-knowledge-tree-sort-menu=""
+        >
+          {KNOWLEDGE_TREE_SORT_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={mode === option.value}
+              onClick={() => chooseMode(option.value)}
+              className={cn(
+                "flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-tx-secondary hover:bg-app-hover hover:text-tx-primary",
+                mode === option.value && "text-accent-primary",
+              )}
+            >
+              <span className="flex h-4 w-4 items-center justify-center">
+                {mode === option.value && <Check size={12} />}
+              </span>
+              <span className="truncate">{option.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -1,24 +1,66 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
+import KnowledgeTreeSortButton from "@/components/KnowledgeTreeSortButton";
 import {
   applySidebarSearchExperience,
+  KNOWLEDGE_TREE_FILTER_SELECTOR,
   SIDEBAR_SEARCH_SURFACE_SELECTOR,
 } from "@/lib/sidebarSearchExperience";
 
+const SORT_SLOT_ATTRIBUTE = "data-knowledge-tree-sort-slot";
+let sortSlotSequence = 0;
+
+function collectSortSlots(): HTMLElement[] {
+  const slots: HTMLElement[] = [];
+  const inputs = Array.from(document.querySelectorAll<HTMLInputElement>(KNOWLEDGE_TREE_FILTER_SELECTOR));
+
+  for (const input of inputs) {
+    const filterSurface = input.parentElement;
+    const toolbar = filterSurface?.parentElement;
+    if (!(filterSurface instanceof HTMLElement) || !(toolbar instanceof HTMLElement)) continue;
+
+    let slot = Array.from(toolbar.children).find(
+      (child): child is HTMLElement => child instanceof HTMLElement && child.hasAttribute(SORT_SLOT_ATTRIBUTE),
+    );
+    if (!slot) {
+      slot = document.createElement("span");
+      slot.setAttribute(SORT_SLOT_ATTRIBUTE, "");
+      slot.dataset.knowledgeTreeSortSlotId = `sort-slot-${++sortSlotSequence}`;
+      slot.className = "contents";
+      toolbar.insertBefore(slot, filterSurface.nextSibling);
+    }
+    slots.push(slot);
+  }
+
+  return slots;
+}
+
+function sameSlots(current: HTMLElement[], next: HTMLElement[]): boolean {
+  return current.length === next.length && current.every((slot, index) => slot === next[index]);
+}
+
 /**
- * 统一内容树上线后的搜索入口兼容桥。
+ * 统一内容树上线后的侧栏入口兼容桥。
  *
- * Sidebar 目前仍包含旧笔记本树的大量兼容代码，直接在本次 UI 收敛中整体拆除风险较高。
- * 此桥只负责搜索入口语义，不参与任何业务查询：全文搜索仍由命令面板负责，
- * 内容树输入框继续调用 KnowledgeTreePanel 自己的本地过滤逻辑。
+ * - 退休与树筛选语义冲突的旧全文搜索框；
+ * - 在统一树工具栏恢复排序入口；
+ * - 同时兼容桌面与移动 Sidebar 的挂载和工作区切换。
  */
 export default function SidebarSearchExperienceBridge() {
+  const [sortSlots, setSortSlots] = useState<HTMLElement[]>([]);
+
   useEffect(() => {
-    const applyDocument = () => applySidebarSearchExperience(document);
+    const applyDocument = () => {
+      applySidebarSearchExperience(document);
+      const next = collectSortSlots();
+      setSortSlots((current) => sameSlots(current, next) ? current : next);
+    };
 
     applyDocument();
 
     const observer = new MutationObserver((records) => {
+      let relevant = false;
       for (const record of records) {
         for (const addedNode of record.addedNodes) {
           if (!(addedNode instanceof Element)) continue;
@@ -26,14 +68,27 @@ export default function SidebarSearchExperienceBridge() {
             addedNode.matches(SIDEBAR_SEARCH_SURFACE_SELECTOR)
             || addedNode.querySelector(SIDEBAR_SEARCH_SURFACE_SELECTOR)
           ) {
-            applySidebarSearchExperience(addedNode);
+            relevant = true;
+            break;
           }
         }
+        if (relevant) break;
+        for (const removedNode of record.removedNodes) {
+          if (!(removedNode instanceof Element)) continue;
+          if (
+            removedNode.hasAttribute(SORT_SLOT_ATTRIBUTE)
+            || removedNode.querySelector(`[${SORT_SLOT_ATTRIBUTE}]`)
+          ) {
+            relevant = true;
+            break;
+          }
+        }
+        if (relevant) break;
       }
+      if (relevant) applyDocument();
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
-    // 工作区切换时移动端/桌面端 Sidebar 可能重新挂载，主动再收敛一次。
     window.addEventListener("nowen:workspace-changed", applyDocument);
 
     return () => {
@@ -42,5 +97,13 @@ export default function SidebarSearchExperienceBridge() {
     };
   }, []);
 
-  return null;
+  return (
+    <>
+      {sortSlots.map((slot) => createPortal(
+        <KnowledgeTreeSortButton />,
+        slot,
+        slot.dataset.knowledgeTreeSortSlotId,
+      ))}
+    </>
+  );
 }

--- a/frontend/src/lib/__tests__/knowledgeTreeSort.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSort.test.ts
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/frontend/src/lib/__tests__/knowledgeTreeSort.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSort.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  KNOWLEDGE_TREE_SORT_CHANGED_EVENT,
+  applyKnowledgeTreeSort,
+  loadKnowledgeTreeSortMode,
+  saveKnowledgeTreeSortMode,
+} from "@/lib/knowledgeTreeSort";
+import type { KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
+
+function node(
+  id: string,
+  title: string,
+  sortOrder: number,
+  options: Partial<KnowledgeTreeNode> = {},
+): KnowledgeTreeNode {
+  return {
+    id,
+    userId: "u1",
+    workspaceId: null,
+    scopeKey: "personal:u1",
+    parentId: null,
+    nodeType: "folder",
+    resourceType: "notebook",
+    resourceId: id,
+    title,
+    sortOrder,
+    isExpanded: 0,
+    isDeleted: 0,
+    childCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    access: {
+      nodeId: id,
+      rolePreset: "admin",
+      source: "owner",
+      sourceNodeId: id,
+      capabilities: {
+        canView: true,
+        canComment: true,
+        canCreate: true,
+        canEdit: true,
+        canDelete: true,
+        canMove: true,
+        canDownload: true,
+        canReshare: true,
+        canManageMembers: true,
+      },
+    },
+    ...options,
+  };
+}
+
+function orderedTitles(nodes: KnowledgeTreeNode[], parentId: string | null): string[] {
+  return nodes
+    .filter((item) => item.parentId === parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((item) => item.title);
+}
+
+describe("knowledgeTreeSort", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("keeps persisted manual order as the default", () => {
+    const nodes = [node("b", "Beta", 0), node("a", "Alpha", 1)];
+    expect(applyKnowledgeTreeSort(nodes)).toBe(nodes);
+    expect(orderedTitles(nodes, null)).toEqual(["Beta", "Alpha"]);
+  });
+
+  it("sorts every sibling group by title without flattening hierarchy", () => {
+    const nodes = [
+      node("root-b", "Beta", 0),
+      node("root-a", "Alpha", 1),
+      node("child-z", "Zulu", 0, { parentId: "root-a" }),
+      node("child-a", "Able", 1, { parentId: "root-a" }),
+    ];
+    const sorted = applyKnowledgeTreeSort(nodes, "title-asc");
+
+    expect(orderedTitles(sorted, null)).toEqual(["Alpha", "Beta"]);
+    expect(orderedTitles(sorted, "root-a")).toEqual(["Able", "Zulu"]);
+    expect(sorted.find((item) => item.id === "child-a")?.parentId).toBe("root-a");
+  });
+
+  it("supports recent update and recent creation ordering", () => {
+    const older = node("older", "Older", 0, {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+    const newer = node("newer", "Newer", 1, {
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    });
+
+    expect(orderedTitles(applyKnowledgeTreeSort([older, newer], "updated-desc"), null))
+      .toEqual(["Older", "Newer"]);
+    expect(orderedTitles(applyKnowledgeTreeSort([older, newer], "created-desc"), null))
+      .toEqual(["Newer", "Older"]);
+  });
+
+  it("persists the selected mode and broadcasts both UI and tree refresh events", () => {
+    const sortListener = vi.fn();
+    const treeListener = vi.fn();
+    window.addEventListener(KNOWLEDGE_TREE_SORT_CHANGED_EVENT, sortListener);
+    window.addEventListener("nowen:knowledge-tree-changed", treeListener);
+
+    saveKnowledgeTreeSortMode("title-desc");
+
+    expect(loadKnowledgeTreeSortMode()).toBe("title-desc");
+    expect(sortListener).toHaveBeenCalledTimes(1);
+    expect(treeListener).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener(KNOWLEDGE_TREE_SORT_CHANGED_EVENT, sortListener);
+    window.removeEventListener("nowen:knowledge-tree-changed", treeListener);
+  });
+});

--- a/frontend/src/lib/knowledgeTreeApi.ts
+++ b/frontend/src/lib/knowledgeTreeApi.ts
@@ -1,4 +1,5 @@
 import { getCurrentWorkspace, getServerUrl } from "@/lib/api";
+import { applyKnowledgeTreeSort } from "@/lib/knowledgeTreeSort";
 
 export type KnowledgeNodeType = "folder" | "note" | "markdown" | "word" | "mindmap" | "file";
 export type KnowledgeRolePreset = "readonly" | "editor" | "maintainer" | "admin";
@@ -108,13 +109,17 @@ function workspaceQuery(includeDeleted = false): string {
   return params.toString();
 }
 
+function withDisplaySort(result: { nodes: KnowledgeTreeNode[] }): { nodes: KnowledgeTreeNode[] } {
+  return { nodes: applyKnowledgeTreeSort(result.nodes) };
+}
+
 export const knowledgeTreeApi = {
   list(includeDeleted = false) {
-    return request<{ nodes: KnowledgeTreeNode[] }>(`/?${workspaceQuery(includeDeleted)}`);
+    return request<{ nodes: KnowledgeTreeNode[] }>(`/?${workspaceQuery(includeDeleted)}`).then(withDisplaySort);
   },
 
   listShared() {
-    return request<{ nodes: KnowledgeTreeNode[] }>(`/shared-with-me?${workspaceQuery()}`);
+    return request<{ nodes: KnowledgeTreeNode[] }>(`/shared-with-me?${workspaceQuery()}`).then(withDisplaySort);
   },
 
   create(input: { parentId: string | null; nodeType: "folder" | "note" | "markdown" | "word"; title: string }) {

--- a/frontend/src/lib/knowledgeTreeSort.ts
+++ b/frontend/src/lib/knowledgeTreeSort.ts
@@ -1,0 +1,115 @@
+import type { KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
+
+export const KNOWLEDGE_TREE_SORT_STORAGE_KEY = "nowen.knowledgeTree.sort";
+export const KNOWLEDGE_TREE_SORT_CHANGED_EVENT = "nowen:knowledge-tree-sort-changed";
+
+export type KnowledgeTreeSortMode =
+  | "manual"
+  | "title-asc"
+  | "title-desc"
+  | "updated-desc"
+  | "created-desc";
+
+export interface KnowledgeTreeSortOption {
+  value: KnowledgeTreeSortMode;
+  label: string;
+}
+
+export const KNOWLEDGE_TREE_SORT_OPTIONS: KnowledgeTreeSortOption[] = [
+  { value: "manual", label: "手动排序" },
+  { value: "title-asc", label: "名称 A–Z" },
+  { value: "title-desc", label: "名称 Z–A" },
+  { value: "updated-desc", label: "最近更新" },
+  { value: "created-desc", label: "最近创建" },
+];
+
+const VALID_SORT_MODES = new Set<KnowledgeTreeSortMode>(
+  KNOWLEDGE_TREE_SORT_OPTIONS.map((option) => option.value),
+);
+
+export function loadKnowledgeTreeSortMode(): KnowledgeTreeSortMode {
+  try {
+    const stored = localStorage.getItem(KNOWLEDGE_TREE_SORT_STORAGE_KEY) as KnowledgeTreeSortMode | null;
+    return stored && VALID_SORT_MODES.has(stored) ? stored : "manual";
+  } catch {
+    return "manual";
+  }
+}
+
+export function saveKnowledgeTreeSortMode(mode: KnowledgeTreeSortMode): void {
+  try {
+    localStorage.setItem(KNOWLEDGE_TREE_SORT_STORAGE_KEY, mode);
+  } catch {
+    // Current-session sorting still works when storage is unavailable.
+  }
+  window.dispatchEvent(new CustomEvent(KNOWLEDGE_TREE_SORT_CHANGED_EVENT, { detail: { mode } }));
+  window.dispatchEvent(new CustomEvent("nowen:knowledge-tree-changed", { detail: { reason: "sort-mode-changed" } }));
+}
+
+function compareText(a: KnowledgeTreeNode, b: KnowledgeTreeNode): number {
+  return a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function timestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function compareKnowledgeTreeNodes(
+  a: KnowledgeTreeNode,
+  b: KnowledgeTreeNode,
+  mode: KnowledgeTreeSortMode,
+): number {
+  let result = 0;
+  switch (mode) {
+    case "title-asc":
+      result = compareText(a, b);
+      break;
+    case "title-desc":
+      result = compareText(b, a);
+      break;
+    case "updated-desc":
+      result = timestamp(b.updatedAt) - timestamp(a.updatedAt);
+      break;
+    case "created-desc":
+      result = timestamp(b.createdAt) - timestamp(a.createdAt);
+      break;
+    case "manual":
+    default:
+      result = a.sortOrder - b.sortOrder;
+      break;
+  }
+  return result || a.sortOrder - b.sortOrder || compareText(a, b) || a.id.localeCompare(b.id);
+}
+
+/**
+ * KnowledgeTreePanel currently groups nodes by parent and sorts each sibling list
+ * by sortOrder. Non-manual modes therefore project a display-only sortOrder for
+ * each sibling group; no server hierarchy or manual order is mutated.
+ */
+export function applyKnowledgeTreeSort(
+  nodes: KnowledgeTreeNode[],
+  mode: KnowledgeTreeSortMode = loadKnowledgeTreeSortMode(),
+): KnowledgeTreeNode[] {
+  if (mode === "manual") return nodes;
+
+  const siblings = new Map<string | null, KnowledgeTreeNode[]>();
+  for (const node of nodes) {
+    const group = siblings.get(node.parentId) || [];
+    group.push(node);
+    siblings.set(node.parentId, group);
+  }
+
+  const displayOrder = new Map<string, number>();
+  for (const group of siblings.values()) {
+    group
+      .slice()
+      .sort((a, b) => compareKnowledgeTreeNodes(a, b, mode))
+      .forEach((node, index) => displayOrder.set(node.id, index));
+  }
+
+  return nodes.map((node) => ({
+    ...node,
+    sortOrder: displayOrder.get(node.id) ?? node.sortOrder,
+  }));
+}


### PR DESCRIPTION
## 问题

统一内容树成为唯一目录入口后，旧笔记本树的排序按钮没有迁移到新树工具栏。#478 收敛重复搜索框后，这个缺口更加明显：筛选、创建和刷新都在，但用户无法再选择目录排序方式。

## 修复

- 在「筛选目录与文档」右侧恢复排序按钮，位置为筛选框与新建按钮之间；
- 支持：
  - 手动排序；
  - 名称 A–Z；
  - 名称 Z–A；
  - 最近更新；
  - 最近创建；
- 当前非手动排序时，按钮使用强调色提示；
- 排序选择持久化到本地，重启后保持；
- 桌面端和移动端统一可用；
- 排序仅改变展示顺序，不写回服务端，不破坏目录父子关系和原始 `sortOrder`；
- 切换排序后通过现有知识树刷新事件重新加载；
- 保留当前筛选、创建、刷新和右键菜单能力。

## 实现边界

当前 `KnowledgeTreePanel` 按 `sortOrder` 排列每组同级节点。本次在 API 返回后按所选模式生成展示用 `sortOrder`，不修改数据库。手动模式直接使用服务端原始顺序。

## 测试

新增单元测试覆盖：

1. 默认手动顺序不变；
2. 每个父节点下独立按名称排序，不扁平化层级；
3. 最近更新和最近创建排序；
4. 本地持久化及 UI/树刷新事件广播。
