### PR TITLE
fix(mobile): 补回触屏端笔记全文搜索入口

### DIFF
--- a/frontend/src/components/NavRail.tsx
+++ b/frontend/src/components/NavRail.tsx
@@ -12,6 +12,7 @@ import {
   NotebookPen,
   PanelLeft,
   PanelLeftClose,
+  Search,
   Settings,
   Sparkles,
   Star,
@@ -36,6 +37,7 @@ import {
 } from "@/lib/desktopBridge";
 import { clearLocalIdMap, clearQueue, getQueueLength } from "@/lib/offlineQueue";
 import { clearRememberedCredentials } from "@/lib/rememberLogin";
+import { openMobileNoteSearch } from "@/lib/mobileNoteSearch";
 
 type NavGroup = "workspace" | "modules" | "tools";
 
@@ -149,6 +151,10 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
     [actions, isMobile],
   );
 
+  const handleMobileSearch = useCallback(() => {
+    openMobileNoteSearch(() => actions.setMobileSidebar(false));
+  }, [actions]);
+
   const handleDesktopCloudButton = useCallback(async () => {
     if (!canSwitchBackToLocal) return;
 
@@ -227,6 +233,7 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
   const groups: NavGroup[] = ["workspace", "modules", "tools"];
   const mobileNextMode: RailMode = effectiveMode === "label" ? "icon" : "label";
   const MobileSwitchIcon = effectiveMode === "label" ? Columns2 : Columns3;
+  const mobileSearchLabel = t("sidebar.searchPlaceholder", "搜索笔记").replace(/[.…]+$/, "");
 
   return (
     <div
@@ -270,6 +277,27 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
       <div className={cn("my-2 border-t border-app-border/60", showLabel ? "w-8" : "w-6")} aria-hidden />
 
       <div className="flex-1 min-h-0 w-full overflow-y-auto no-scrollbar flex flex-col items-center gap-1 px-1">
+        {isMobile && (
+          <>
+            <button
+              type="button"
+              onClick={handleMobileSearch}
+              title={showLabel ? undefined : mobileSearchLabel}
+              aria-label={mobileSearchLabel}
+              className={cn(itemBaseClass, "text-tx-tertiary hover:bg-app-hover hover:text-tx-primary")}
+              data-mobile-note-search=""
+            >
+              <Search size={RAIL_ICON_SIZE} />
+              {showLabel && (
+                <span className="text-[10px] leading-none mt-0.5 max-w-full truncate px-1">
+                  {mobileSearchLabel}
+                </span>
+              )}
+            </button>
+            <div className={cn("my-1 border-t border-app-border/60", showLabel ? "w-8" : "w-6")} aria-hidden />
+          </>
+        )}
+
         {groups.map((group, index) => {
           const groupItems = items.filter((item) => item.group === group);
           if (groupItems.length === 0) return null;

--- a/frontend/src/lib/__tests__/mobileNoteSearch.test.ts
+++ b/frontend/src/lib/__tests__/mobileNoteSearch.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  OPEN_COMMAND_PALETTE_EVENT,
+  openMobileNoteSearch,
+} from "@/lib/mobileNoteSearch";
+
+describe("openMobileNoteSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("closes the mobile drawer before opening global note search", () => {
+    const closeSidebar = vi.fn();
+    const openSearch = vi.fn();
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, openSearch);
+
+    openMobileNoteSearch(closeSidebar);
+
+    expect(closeSidebar).toHaveBeenCalledTimes(1);
+    expect(openSearch).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(openSearch).toHaveBeenCalledTimes(1);
+    window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, openSearch);
+  });
+});

--- a/frontend/src/lib/__tests__/mobileNoteSearch.test.ts
+++ b/frontend/src/lib/__tests__/mobileNoteSearch.test.ts
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/frontend/src/lib/mobileNoteSearch.ts
+++ b/frontend/src/lib/mobileNoteSearch.ts
@@ -1,0 +1,16 @@
+export const OPEN_COMMAND_PALETTE_EVENT = "nowen:open-command-palette";
+
+/**
+ * Close the mobile navigation drawer before opening global note search.
+ * Deferring the event to the next task lets the drawer unmount first, avoiding
+ * focus and soft-keyboard contention on Android while the palette input mounts.
+ */
+export function openMobileNoteSearch(
+  closeSidebar: () => void,
+  target: Window = window,
+): void {
+  closeSidebar();
+  target.setTimeout(() => {
+    target.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
+  }, 0);
+}


### PR DESCRIPTION
## 背景

#478 移除侧栏顶部常驻全文搜索框后，桌面端仍可通过 `Cmd/Ctrl + K` 和原生菜单打开全局搜索，但纯触屏移动端失去了可见入口。「筛选目录与文档」只过滤当前内容树标题，不能替代标题和正文全文搜索。

## 本次修复

- 在移动端 NavRail 顶部增加独立的「搜索笔记」按钮；
- 入口位于导航模式切换区下方、所有笔记等业务入口之前；
- 仅在 `variant="mobile"` 时渲染，不改变桌面端布局；
- 点击后先关闭移动端抽屉，再打开现有 CommandPalette；
- 延迟到下一任务派发打开事件，避免 Android 上抽屉卸载、输入框聚焦和软键盘同时竞争；
- 搜索继续复用现有 `api.search()`、结果高亮、中文输入和笔记跳转逻辑，不引入第二套搜索状态；
- 图标模式显示放大镜，图标+文字模式显示「搜索笔记」。

## 交互结果

```text
移动导航
├── 关闭
├── 切换导航显示模式
├── 搜索笔记
├── 所有笔记
├── 收藏
└── ...
```

点击「搜索笔记」后：

1. 移动抽屉关闭；
2. 全局搜索面板打开并自动聚焦；
3. 输入关键词搜索笔记标题和正文；
4. 点击结果直接打开对应笔记。

## 测试

新增 `mobileNoteSearch.test.ts`，验证抽屉关闭发生在搜索面板打开事件之前，防止焦点和 Android 软键盘回归。

## 影响范围

仅前端移动导航入口；不修改后端、数据库、备份、目录树或桌面端搜索入口。