### PR TITLE
feat(tree): 新建内容改为树内行内创建

### DIFF
--- a/frontend/src/components/KnowledgeTreeNodeMenu.tsx
+++ b/frontend/src/components/KnowledgeTreeNodeMenu.tsx
@@ -14,6 +14,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  Plus,
   Printer,
   ShieldCheck,
   SplitSquareHorizontal,
@@ -22,6 +23,7 @@ import {
   StarOff,
   Trash2,
   Unlock,
+  Upload,
 } from "lucide-react";
 
 import ContextMenu, { type ContextMenuItem } from "@/components/ContextMenu";
@@ -36,7 +38,9 @@ import {
   exportSingleNoteAsPDF,
   exportNoteAsImage,
 } from "@/lib/exportService";
-import { knowledgeTreeApi, type KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
+import type { KnowledgeTreeInlineCreateKind } from "@/lib/knowledgeTreeInlineCreate";
+import type { KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
+import { knowledgeTreeApi } from "@/lib/knowledgeTreeApi";
 import { toast } from "@/lib/toast";
 import { useApp, useAppActions } from "@/store/AppContext";
 import type { Notebook } from "@/types";
@@ -51,6 +55,7 @@ export interface KnowledgeTreeNodeMenuProps {
   onClose: () => void;
   onOpen: (node: KnowledgeTreeNode) => void | Promise<void>;
   onSplit: (node: KnowledgeTreeNode, direction: "right" | "down") => void;
+  onCreate: (node: KnowledgeTreeNode, kind: KnowledgeTreeInlineCreateKind) => void;
   onRename: (node: KnowledgeTreeNode) => void | Promise<void>;
   onMove: (node: KnowledgeTreeNode) => void;
   onPermissions: (node: KnowledgeTreeNode) => void;
@@ -69,6 +74,21 @@ function exportChildren(): ContextMenuItem[] {
     { id: "export_note_png", label: "PNG", icon: <ImageIcon size={14} /> },
     { id: "export_note_jpg", label: "JPG", icon: <ImageIcon size={14} /> },
     { id: "export_note_word", label: "Word", icon: <FileType2 size={14} /> },
+  ];
+}
+
+function createChildren(): ContextMenuItem[] {
+  return [
+    { id: "new_note", label: "文档", icon: <FilePlus size={14} /> },
+    { id: "new_markdown", label: "Markdown 文档", icon: <FileCode size={14} /> },
+    { id: "new_folder", label: "文件夹", icon: <FolderPlus size={14} /> },
+  ];
+}
+
+function importChildren(): ContextMenuItem[] {
+  return [
+    { id: "import_word", label: "Word 文档", icon: <FileType2 size={14} /> },
+    { id: "import_url", label: "公众号文章", icon: <Link2 size={14} /> },
   ];
 }
 
@@ -94,11 +114,8 @@ export function buildKnowledgeTreeNodeMenuItems(
   if (capabilities.canCreate) {
     if (items.length) items.push(separator("sep-create"));
     items.push(
-      { id: "new_note", label: "新建富文本文档", icon: <FilePlus size={14} /> },
-      { id: "new_markdown", label: "新建 Markdown", icon: <FileCode size={14} /> },
-      { id: "import_word", label: "导入 Word 文档", icon: <FileType2 size={14} /> },
-      { id: "import_url", label: "导入公众号文章", icon: <Link2 size={14} /> },
-      { id: "new_folder", label: "新建子文件夹", icon: <FolderPlus size={14} /> },
+      { id: "create", label: "新建", icon: <Plus size={14} />, children: createChildren() },
+      { id: "import", label: "导入", icon: <Upload size={14} />, children: importChildren() },
     );
   }
 
@@ -201,6 +218,7 @@ export default function KnowledgeTreeNodeMenu({
   onClose,
   onOpen,
   onSplit,
+  onCreate,
   onRename,
   onMove,
   onPermissions,
@@ -246,6 +264,7 @@ export default function KnowledgeTreeNodeMenu({
       updatedAt: value.updatedAt,
     });
     actions.setMobileView("editor");
+    actions.setMobileSidebar(false);
   };
 
   const resolvePhysicalNotebookId = async (parent: KnowledgeTreeNode): Promise<string> => {
@@ -261,37 +280,6 @@ export default function KnowledgeTreeNodeMenu({
       return (await api.getNote(parent.resourceId)).notebookId;
     }
     throw new Error("找不到可用于导入的物理目录");
-  };
-
-  const finishCreatedNote = async (createdNode: KnowledgeTreeNode) => {
-    const value = await api.getNote(createdNode.resourceId);
-    openLoadedNote(value);
-    await onReload();
-    actions.refreshNotes();
-    actions.refreshNotebooks();
-  };
-
-  const createDirectChild = async (kind: "note" | "markdown" | "folder") => {
-    if (!node) return;
-    let title = kind === "note" ? "无标题笔记" : kind === "markdown" ? "无标题 Markdown" : "";
-    if (kind === "folder") {
-      const value = await appPrompt({
-        title: "新建子文件夹",
-        placeholder: "文件夹名称",
-        confirmText: "创建",
-        validate: (input) => input.trim() ? null : "名称不能为空",
-      });
-      if (value == null) return;
-      title = value.trim();
-    }
-    const created = await knowledgeTreeApi.create({ parentId: node.id, nodeType: kind, title });
-    if (kind === "folder") {
-      await onReload();
-      actions.refreshNotebooks();
-      toast.success("已创建文件夹");
-    } else {
-      await finishCreatedNote(created);
-    }
   };
 
   const importWord = async () => {
@@ -441,9 +429,9 @@ export default function KnowledgeTreeNodeMenu({
         case "open": await onOpen(node); break;
         case "split_right": onSplit(node, "right"); break;
         case "split_down": onSplit(node, "down"); break;
-        case "new_note": await createDirectChild("note"); break;
-        case "new_markdown": await createDirectChild("markdown"); break;
-        case "new_folder": await createDirectChild("folder"); break;
+        case "new_note": onCreate(node, "note"); break;
+        case "new_markdown": onCreate(node, "markdown"); break;
+        case "new_folder": onCreate(node, "folder"); break;
         case "import_word": await importWord(); break;
         case "import_url": await importUrl(); break;
         case "toggle_pin": await patchNote({ isPinned: note?.isPinned === 1 ? 0 : 1 }); break;

--- a/frontend/src/components/KnowledgeTreePanel.tsx
+++ b/frontend/src/components/KnowledgeTreePanel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Check,
   ChevronDown,
   ChevronRight,
   FileCode,
@@ -23,6 +24,12 @@ import KnowledgeTreeNodeMenu from "@/components/KnowledgeTreeNodeMenu";
 import { choose, confirm, prompt } from "@/components/ui/confirm";
 import { useContextMenu } from "@/hooks/useContextMenu";
 import { api } from "@/lib/api";
+import {
+  defaultInlineCreateTitle,
+  normalizeInlineCreateTitle,
+  type KnowledgeTreeInlineCreateKind,
+  type KnowledgeTreeInlineDraft,
+} from "@/lib/knowledgeTreeInlineCreate";
 import {
   knowledgeTreeApi,
   type KnowledgePermissionRow,
@@ -68,6 +75,12 @@ function nodeIcon(node: KnowledgeTreeNode) {
       : <Folder size={15} className="text-amber-500" />;
   }
   if (node.nodeType === "markdown") return <FileCode size={15} className="text-emerald-500" />;
+  return <FileText size={15} className="text-accent-primary" />;
+}
+
+function draftIcon(kind: KnowledgeTreeInlineCreateKind) {
+  if (kind === "folder") return <Folder size={15} className="text-amber-500" />;
+  if (kind === "markdown") return <FileCode size={15} className="text-emerald-500" />;
   return <FileText size={15} className="text-accent-primary" />;
 }
 
@@ -319,12 +332,14 @@ export function KnowledgeTreePanel({
   const actions = useAppActions();
   const surfaceActive = useActiveSidebarSurface(variant);
   const searchRef = useRef<HTMLInputElement>(null);
+  const draftInputRef = useRef<HTMLInputElement>(null);
   const [nodes, setNodes] = useState<KnowledgeTreeNode[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sharedLoadError, setSharedLoadError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [draft, setDraft] = useState<KnowledgeTreeInlineDraft | null>(null);
   const [permissionsNode, setPermissionsNode] = useState<KnowledgeTreeNode | null>(null);
   const [movingNode, setMovingNode] = useState<KnowledgeTreeNode | null>(null);
   const { menu, menuRef, openMenu, openMenuAt, closeMenu } = useContextMenu();
@@ -358,8 +373,7 @@ export function KnowledgeTreePanel({
         return new Set(Array.from(current).filter((id) => ids.has(id)));
       });
     } catch (requestError: any) {
-      const message = requestError?.message || "加载内容树失败";
-      setError(message);
+      setError(requestError?.message || "加载内容树失败");
     } finally {
       setLoading(false);
     }
@@ -382,17 +396,41 @@ export function KnowledgeTreePanel({
 
   useEffect(() => {
     if (!surfaceActive) return;
-    const focus = () => {
-      requestAnimationFrame(() => searchRef.current?.focus());
-    };
+    const focus = () => requestAnimationFrame(() => searchRef.current?.focus());
     window.addEventListener(FOCUS_KNOWLEDGE_TREE_EVENT, focus);
     return () => window.removeEventListener(FOCUS_KNOWLEDGE_TREE_EVENT, focus);
   }, [surfaceActive]);
+
+  useEffect(() => {
+    if (!draft) return;
+    requestAnimationFrame(() => {
+      draftInputRef.current?.focus({ preventScroll: true });
+      draftInputRef.current?.select();
+    });
+  }, [draft?.kind, draft?.parentId]);
 
   const allChildren = useMemo(() => buildChildren(nodes), [nodes]);
   const filteredNodes = useMemo(() => filterKnowledgeTreeNodes(nodes, query), [nodes, query]);
   const children = useMemo(() => buildChildren(filteredNodes), [filteredNodes]);
   const effectiveExpanded = query.trim() ? new Set(filteredNodes.map((node) => node.id)) : expanded;
+
+  const activateNote = useCallback((note: Awaited<ReturnType<typeof api.getNote>>) => {
+    actions.setActiveNote(note);
+    actions.setSelectedNotebook(note.notebookId);
+    actions.setViewMode("notebook");
+    actions.openNoteTab({
+      id: note.id,
+      title: note.title,
+      notebookId: note.notebookId,
+      workspaceId: note.workspaceId,
+      contentFormat: note.contentFormat,
+      isLocked: note.isLocked,
+      isTrashed: note.isTrashed,
+      updatedAt: note.updatedAt,
+    });
+    actions.setMobileView("editor");
+    if (variant === "mobile") actions.setMobileSidebar(false);
+  }, [actions, variant]);
 
   const toggle = async (node: KnowledgeTreeNode) => {
     const next = new Set(expanded);
@@ -412,21 +450,7 @@ export function KnowledgeTreePanel({
     }
     if (node.resourceType !== "note") return;
     try {
-      const note = await api.getNote(node.resourceId);
-      actions.setActiveNote(note);
-      actions.setSelectedNotebook(note.notebookId);
-      actions.setViewMode("notebook");
-      actions.openNoteTab({
-        id: note.id,
-        title: note.title,
-        notebookId: note.notebookId,
-        workspaceId: note.workspaceId,
-        contentFormat: note.contentFormat,
-        isLocked: note.isLocked,
-        isTrashed: note.isTrashed,
-        updatedAt: note.updatedAt,
-      });
-      actions.setMobileView("editor");
+      activateNote(await api.getNote(node.resourceId));
     } catch (requestError: any) {
       toast.error(requestError?.message || "打开文档失败");
     }
@@ -438,39 +462,69 @@ export function KnowledgeTreePanel({
     closeMenu();
   };
 
-  const createChild = async (parent: KnowledgeTreeNode | null) => {
+  const startInlineCreate = useCallback((parent: KnowledgeTreeNode | null, kind: KnowledgeTreeInlineCreateKind) => {
+    if (parent && !parent.access.capabilities.canCreate) return;
+    if (!parent && kind !== "folder") return;
     closeMenu();
-    const choice = await choose({
-      title: parent ? `在“${parent.title}”下新建` : "新建根内容",
-      choices: parent
-        ? [
-            { value: "folder", label: "子文件夹" },
-            { value: "note", label: "子文档" },
-            { value: "markdown", label: "Markdown 文档" },
-            { value: "word", label: "Word 文档" },
-          ]
-        : [{ value: "folder", label: "根文件夹" }],
+    setQuery("");
+    if (parent) {
+      setExpanded((current) => new Set(current).add(parent.id));
+      if (!parent.sharedRootId) void knowledgeTreeApi.update(parent.id, { isExpanded: true }).catch(() => {});
+    }
+    setDraft({
+      parentId: parent?.id || null,
+      kind,
+      title: defaultInlineCreateTitle(kind),
+      saving: false,
+      error: null,
     });
-    if (!choice || !["folder", "note", "markdown", "word"].includes(choice)) return;
-    const title = await prompt({
-      title: "输入名称",
-      confirmText: "创建",
-      validate: (value) => value.trim() ? null : "名称不能为空",
-    });
-    if (title == null) return;
+  }, [closeMenu]);
+
+  const commitDraft = async () => {
+    if (!draft || draft.saving) return;
+    const title = normalizeInlineCreateTitle(draft.title);
+    if (!title) {
+      setDraft((current) => current ? { ...current, error: "名称不能为空" } : null);
+      requestAnimationFrame(() => draftInputRef.current?.focus());
+      return;
+    }
+
+    const snapshot = { ...draft, title };
+    setDraft((current) => current ? { ...current, title, saving: true, error: null } : null);
+
+    let created: KnowledgeTreeNode;
     try {
-      await knowledgeTreeApi.create({
-        parentId: parent?.id || null,
-        nodeType: choice as "folder" | "note" | "markdown" | "word",
-        title: title.trim(),
+      created = await knowledgeTreeApi.create({
+        parentId: snapshot.parentId,
+        nodeType: snapshot.kind,
+        title,
       });
-      if (parent) setExpanded((current) => new Set(current).add(parent.id));
-      emitTreeChanged("node-created");
-      await reload();
-      actions.refreshNotebooks();
-      toast.success("已创建");
     } catch (requestError: any) {
-      toast.error(requestError?.message || "创建失败");
+      setDraft((current) => current ? {
+        ...current,
+        saving: false,
+        error: requestError?.message || "创建失败，请重试",
+      } : null);
+      requestAnimationFrame(() => draftInputRef.current?.focus());
+      return;
+    }
+
+    setDraft(null);
+    if (snapshot.parentId) setExpanded((current) => new Set(current).add(snapshot.parentId!));
+    emitTreeChanged("node-created-inline");
+    await reload();
+    actions.refreshNotebooks();
+    actions.refreshNotes();
+
+    if (snapshot.kind === "folder") {
+      toast.success("已创建文件夹");
+      return;
+    }
+
+    try {
+      activateNote(await api.getNote(created.resourceId));
+    } catch (requestError: any) {
+      toast.error(requestError?.message || "文档已创建，但自动打开失败");
     }
   };
 
@@ -579,9 +633,74 @@ export function KnowledgeTreePanel({
     if (dx * dx + dy * dy > 100) cancelLongPress();
   };
 
+  const renderDraft = (depth: number) => {
+    if (!draft) return null;
+    return (
+      <div
+        key={`inline-create:${draft.parentId ?? "root"}`}
+        className={cn(
+          "rounded-md bg-accent-primary/5",
+          draft.error && "bg-red-500/5",
+        )}
+        style={{ paddingLeft: `${depth * 16 + 2}px` }}
+        data-knowledge-tree-inline-create=""
+      >
+        <div className="flex min-w-0 items-center py-0.5">
+          <span className="flex h-7 w-5 shrink-0 items-center justify-center" />
+          <span className="mr-1.5 shrink-0">{draftIcon(draft.kind)}</span>
+          <input
+            ref={draftInputRef}
+            value={draft.title}
+            disabled={draft.saving}
+            onChange={(event) => setDraft((current) => current ? { ...current, title: event.target.value, error: null } : null)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && !draft.saving) {
+                event.preventDefault();
+                setDraft(null);
+                return;
+              }
+              if (event.key === "Enter" && !event.nativeEvent.isComposing && event.nativeEvent.keyCode !== 229) {
+                event.preventDefault();
+                void commitDraft();
+              }
+            }}
+            className={cn(
+              "min-w-0 flex-1 rounded border bg-app-bg px-1.5 py-1 text-xs text-tx-primary outline-none",
+              draft.error ? "border-red-500" : "border-accent-primary/60 focus:border-accent-primary",
+            )}
+            aria-label="新内容名称"
+          />
+          <button
+            type="button"
+            disabled={draft.saving}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => void commitDraft()}
+            className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded text-accent-primary hover:bg-accent-primary/10 disabled:opacity-50"
+            title="确认创建"
+            aria-label="确认创建"
+          >
+            {draft.saving ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+          </button>
+          <button
+            type="button"
+            disabled={draft.saving}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => setDraft(null)}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-tx-tertiary hover:bg-app-hover hover:text-tx-primary disabled:opacity-50"
+            title="取消创建"
+            aria-label="取消创建"
+          >
+            <X size={13} />
+          </button>
+        </div>
+        {draft.error && <p className="pb-1 pl-7 pr-2 text-[10px] text-red-500">{draft.error}</p>}
+      </div>
+    );
+  };
+
   const renderNode = (node: KnowledgeTreeNode, depth: number): React.ReactNode => {
     const childNodes = children.get(node.id) || [];
-    const hasChildren = childNodes.length > 0 || node.childCount > 0;
+    const hasChildren = childNodes.length > 0 || node.childCount > 0 || draft?.parentId === node.id;
     const isExpanded = effectiveExpanded.has(node.id);
     const active = node.resourceType === "note" && state.activeNote?.id === node.resourceId;
     const actionVisibility = variant === "mobile" ? "flex" : "hidden group-hover:flex";
@@ -593,7 +712,7 @@ export function KnowledgeTreePanel({
             active && "bg-app-active text-tx-primary",
           )}
           style={{ paddingLeft: `${depth * 16 + 2}px` }}
-           draggable={node.access.capabilities.canMove && !isSharedRoot(node)}
+          draggable={node.access.capabilities.canMove && !isSharedRoot(node)}
           onDragStart={(event) => {
             event.dataTransfer.effectAllowed = "move";
             event.dataTransfer.setData("application/x-nowen-tree-node", node.id);
@@ -613,6 +732,7 @@ export function KnowledgeTreePanel({
           onTouchMove={moveLongPress}
           onTouchEnd={cancelLongPress}
           onTouchCancel={cancelLongPress}
+          data-knowledge-tree-node-id={node.id}
         >
           <button type="button" onClick={() => hasChildren && void toggle(node)} className="flex h-7 w-5 shrink-0 items-center justify-center text-tx-tertiary" aria-label={isExpanded ? "折叠" : "展开"}>
             {hasChildren ? (isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />) : null}
@@ -628,11 +748,22 @@ export function KnowledgeTreePanel({
           >
             {nodeIcon(node)}
             <span className="min-w-0 flex-1 truncate">{node.title}</span>
-             {isSharedRoot(node) && <span className="rounded bg-accent-primary/10 px-1 text-[9px] text-accent-primary">共享</span>}
-             {node.access.source === "inherited" && <span className="rounded bg-app-active px-1 text-[9px] text-tx-tertiary">继承</span>}
+            {isSharedRoot(node) && <span className="rounded bg-accent-primary/10 px-1 text-[9px] text-accent-primary">共享</span>}
+            {node.access.source === "inherited" && <span className="rounded bg-app-active px-1 text-[9px] text-tx-tertiary">继承</span>}
           </button>
           {node.access.capabilities.canCreate && (
-            <button type="button" onClick={() => void createChild(node)} className={cn("h-6 w-6 items-center justify-center rounded text-tx-tertiary hover:bg-app-active", actionVisibility)} title="新建子内容"><Plus size={13} /></button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                startInlineCreate(node, "note");
+              }}
+              className={cn("h-6 w-6 items-center justify-center rounded text-tx-tertiary hover:bg-app-active", actionVisibility)}
+              title="新建文档"
+              aria-label={`在“${node.title}”下新建文档`}
+            >
+              <Plus size={13} />
+            </button>
           )}
           <button
             type="button"
@@ -644,9 +775,13 @@ export function KnowledgeTreePanel({
             className={cn("h-6 w-6 items-center justify-center rounded text-tx-tertiary hover:bg-app-active", actionVisibility)}
             title="更多"
           ><MoreHorizontal size={14} /></button>
-
         </div>
-        {isExpanded && childNodes.map((child) => renderNode(child, depth + 1))}
+        {isExpanded && (
+          <>
+            {childNodes.map((child) => renderNode(child, depth + 1))}
+            {draft?.parentId === node.id && renderDraft(depth + 1)}
+          </>
+        )}
       </div>
     );
   };
@@ -654,6 +789,7 @@ export function KnowledgeTreePanel({
   const rootNodes = children.get(null) || [];
   const ownedRoots = rootNodes.filter((node) => !node.sharedRootId);
   const sharedRoots = rootNodes.filter((node) => Boolean(node.sharedRootId));
+  const hasRootDraft = draft?.parentId === null;
 
   return (
     <section className={cn("relative flex min-h-0 flex-1 flex-col", className)} data-nowen-knowledge-tree="embedded" data-sidebar-surface-active={surfaceActive ? "true" : "false"}>
@@ -670,7 +806,12 @@ export function KnowledgeTreePanel({
           />
           {query && <button type="button" onClick={() => setQuery("")} className="text-tx-tertiary hover:text-tx-primary" aria-label="清空筛选"><X size={12} /></button>}
         </div>
-        <button type="button" onClick={() => void createChild(null)} className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary" title="新建根文件夹"><Plus size={14} /></button>
+        <button
+          type="button"
+          onClick={() => startInlineCreate(null, "folder")}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+          title="新建根文件夹"
+        ><Plus size={14} /></button>
         <button type="button" onClick={() => void reload()} disabled={loading} className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tx-tertiary hover:bg-app-hover hover:text-tx-primary disabled:opacity-50" title="刷新内容树"><RefreshCw size={13} className={loading ? "animate-spin" : undefined} /></button>
       </div>
 
@@ -685,22 +826,23 @@ export function KnowledgeTreePanel({
               <button type="button" onClick={() => void reload()} className="rounded-md bg-accent-primary px-2.5 py-1 text-[10px] font-medium text-white">重试</button>
             </div>
           </div>
-        ) : filteredNodes.length === 0 && !sharedLoadError ? (
+        ) : filteredNodes.length === 0 && !sharedLoadError && !draft ? (
           <div className="flex flex-col items-center py-14 text-center">
             <TreePine size={28} className="mb-2 text-tx-tertiary/40" />
             <p className="text-xs text-tx-secondary">{query ? "没有匹配内容" : "暂无内容"}</p>
-            {!query && <p className="mt-1 max-w-[230px] text-[10px] leading-relaxed text-tx-tertiary">先创建根文件夹，再在文件夹或文档下继续创建子内容。</p>}
+            {!query && <p className="mt-1 max-w-[230px] text-[10px] leading-relaxed text-tx-tertiary">点击上方加号创建根文件夹，再在树中直接创建文档。</p>}
           </div>
         ) : (
           <>
-            {ownedRoots.length > 0 && (
+            {(ownedRoots.length > 0 || hasRootDraft) && (
               <div data-knowledge-tree-section="owned">
                 <div className="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-tx-tertiary">当前空间</div>
                 {ownedRoots.map((node) => renderNode(node, 0))}
+                {hasRootDraft && renderDraft(0)}
               </div>
             )}
             {sharedRoots.length > 0 && (
-              <div className={cn("mt-2 border-t border-app-border pt-2", ownedRoots.length === 0 && "mt-0 border-t-0 pt-0")} data-knowledge-tree-section="shared">
+              <div className={cn("mt-2 border-t border-app-border pt-2", ownedRoots.length === 0 && !hasRootDraft && "mt-0 border-t-0 pt-0")} data-knowledge-tree-section="shared">
                 <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-tx-tertiary">共享给我</div>
                 {sharedRoots.map((node) => renderNode(node, 0))}
               </div>
@@ -724,6 +866,7 @@ export function KnowledgeTreePanel({
         onClose={closeMenu}
         onOpen={openDocument}
         onSplit={openSplit}
+        onCreate={startInlineCreate}
         onRename={rename}
         onMove={setMovingNode}
         onPermissions={setPermissionsNode}

--- a/frontend/src/lib/__tests__/knowledgeTreeInlineCreate.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeInlineCreate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultInlineCreateTitle,
+  normalizeInlineCreateTitle,
+} from "@/lib/knowledgeTreeInlineCreate";
+
+describe("knowledge tree inline create", () => {
+  it("provides selected starter titles for every inline type", () => {
+    expect(defaultInlineCreateTitle("note")).toBe("未命名文档");
+    expect(defaultInlineCreateTitle("markdown")).toBe("未命名 Markdown");
+    expect(defaultInlineCreateTitle("folder")).toBe("未命名文件夹");
+  });
+
+  it("normalizes valid titles and rejects whitespace-only drafts", () => {
+    expect(normalizeInlineCreateTitle("  项目计划  ")).toBe("项目计划");
+    expect(normalizeInlineCreateTitle("   ")).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/knowledgeTreeInlineCreateContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeInlineCreateContract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(relativeUrl: string) {
+  return readFileSync(new URL(relativeUrl, import.meta.url), "utf8");
+}
+
+describe("knowledge tree inline create contract", () => {
+  it("uses the row plus button for direct document creation", () => {
+    const panel = source("../../components/KnowledgeTreePanel.tsx");
+    expect(panel).toContain('startInlineCreate(node, "note")');
+    expect(panel).toContain('data-knowledge-tree-inline-create=""');
+    expect(panel).toContain('title="新建文档"');
+    expect(panel).not.toContain('title: parent ? `在“${parent.title}”下新建`');
+  });
+
+  it("keeps secondary creation and imports in compact submenus", () => {
+    const menu = source("../../components/KnowledgeTreeNodeMenu.tsx");
+    expect(menu).toContain('id: "create", label: "新建"');
+    expect(menu).toContain('id: "import", label: "导入"');
+    expect(menu).toContain('id: "import_word"');
+    expect(menu).toContain('onCreate(node, "markdown")');
+    expect(menu).not.toContain('title: "新建子文件夹"');
+  });
+});

--- a/frontend/src/lib/knowledgeTreeInlineCreate.ts
+++ b/frontend/src/lib/knowledgeTreeInlineCreate.ts
@@ -1,0 +1,20 @@
+export type KnowledgeTreeInlineCreateKind = "folder" | "note" | "markdown";
+
+export interface KnowledgeTreeInlineDraft {
+  parentId: string | null;
+  kind: KnowledgeTreeInlineCreateKind;
+  title: string;
+  saving: boolean;
+  error: string | null;
+}
+
+export function defaultInlineCreateTitle(kind: KnowledgeTreeInlineCreateKind): string {
+  if (kind === "folder") return "未命名文件夹";
+  if (kind === "markdown") return "未命名 Markdown";
+  return "未命名文档";
+}
+
+export function normalizeInlineCreateTitle(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}


### PR DESCRIPTION
## 背景

统一内容树已经成为唯一笔记导航，但节点 `+` 仍使用居中选择弹窗，再弹一次名称输入框。该流程会打断目录上下文，也把“新建 Word”与实际文件导入混在一起。

## 本次改造

### 树行主操作

- 单击节点行尾 `+`：直接在该节点子级末尾插入“未命名文档”草稿；
- 自动展开父节点并聚焦、全选标题；
- `Enter` 或 `✓` 确认创建；
- `Esc` 或 `×` 取消，不产生数据库残留；
- 创建失败时草稿和用户输入保留，并显示行内错误；
- 创建普通文档或 Markdown 后自动打开编辑器；
- 移动端创建成功后关闭抽屉并进入编辑器。

### 根目录

- 顶部 `+` 直接插入根文件夹草稿并行内命名；
- 空树状态也能正常显示根草稿。

### 更多菜单

原来平铺的创建项收敛为两个二级菜单：

```text
新建
├─ 文档
├─ Markdown 文档
└─ 文件夹

导入
├─ Word 文档
└─ 公众号文章
```

Word 明确归入导入，不再作为空白文档类型创建。右键、移动端长按和行尾更多按钮复用同一菜单。

## 交互细节

- 开始新建时自动清空内容树筛选，避免草稿因过滤条件不可见；
- 中文输入法组合阶段不会误触 Enter 创建；
- 保存期间禁用取消与重复提交；
- 同一时间只保留一个新建草稿，启动另一项会自然切换目标；
- 新建不再调用居中 `choose/prompt` 弹窗。

## 测试

新增：

- 行内草稿默认标题与名称标准化单测；
- 源码契约测试，锁定行尾 `+` 直接创建、行内输入和“新建/导入”二级菜单；
- 既有统一树菜单、共享树、侧栏和类型检查继续由 CI 覆盖。

## 影响范围

仅前端统一内容树的新建交互。不修改后端 API、数据库 schema、目录树数据结构、同步、备份或恢复格式。