### PR TITLE
fix(tree): 恢复桌面端内容树可见滚动条

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -31,6 +31,40 @@ interface TagColorTarget {
 }
 
 /**
+ * Keep the desktop tree scrollbar discoverable even when Chromium/Windows uses
+ * auto-hiding overlay scrollbars. Mobile keeps its native touch-scrolling UI.
+ */
+export const KNOWLEDGE_TREE_SCROLLBAR_CSS = `
+[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"] {
+  overflow-y: scroll !important;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--pm-scrollbar) transparent;
+}
+
+[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]::-webkit-scrollbar {
+  width: 9px;
+}
+
+[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]::-webkit-scrollbar-thumb {
+  min-height: 36px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: var(--pm-scrollbar);
+  background-clip: content-box;
+}
+
+[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]::-webkit-scrollbar-thumb:hover {
+  background: var(--pm-scrollbar-hover);
+  background-clip: content-box;
+}
+`;
+
+/**
  * Unified sidebar.
  *
  * The legacy notebook-directory renderer, direct-note caches, notebook DnD,
@@ -157,6 +191,10 @@ export default function Sidebar({ variant = "mobile" }: { variant?: "desktop" | 
       data-unified-sidebar=""
       data-sidebar-variant={variant}
     >
+      {variant === "desktop" && (
+        <style data-knowledge-tree-scrollbar="">{KNOWLEDGE_TREE_SCROLLBAR_CSS}</style>
+      )}
+
       <header
         className="flex shrink-0 items-center justify-between border-b border-app-border px-4 py-3"
         style={{ paddingTop: "calc(var(--safe-area-top) + 12px)" }}

--- a/frontend/src/lib/__tests__/knowledgeTreeScrollbarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeScrollbarContract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const sidebarSource = readFileSync(
+  new URL("../../components/Sidebar.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("knowledge tree scrollbar contract", () => {
+  it("keeps a stable visible scrollbar on the desktop tree only", () => {
+    expect(sidebarSource).toContain('[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]');
+    expect(sidebarSource).toContain("overflow-y: scroll !important");
+    expect(sidebarSource).toContain("scrollbar-gutter: stable");
+    expect(sidebarSource).toContain("scrollbar-color: var(--pm-scrollbar) transparent");
+    expect(sidebarSource).toContain('variant === "desktop"');
+    expect(sidebarSource).not.toContain('[data-sidebar-variant="mobile"] [data-swipe-blocker="knowledge-tree-scroll"]');
+  });
+});


### PR DESCRIPTION
## 问题

统一内容树使用 `overflow-y-auto`，滚动条只在内容明确溢出时生成；Windows/Chromium 还可能自动隐藏细滚动条。用户在目录较长或接近容器高度时，很容易误以为树列表无法继续滚动或内容被截断。

## 修复

- 桌面端内容树强制使用稳定的纵向滚动槽；
- 增加 `scrollbar-gutter: stable`，避免滚动条出现/消失导致内容横向跳动；
- 针对 Firefox 设置 `scrollbar-width` / `scrollbar-color`；
- 针对 Chromium/Electron 设置 9px 滚动区域、圆角可见滑块和悬停反馈；
- 滑块颜色继续复用现有明暗主题变量；
- 仅作用于统一内容树，不影响标签、编辑器和其他列表；
- 移动端继续使用原生触摸滚动，不常驻占用侧栏宽度。

## 验收

- 桌面端树内容未溢出时也保留稳定滚动槽；
- 内容溢出时滑块清晰可见并可拖动；
- 明暗主题对比度正常；
- 展开/收起标签区域后，树宽度不跳动；
- 移动端布局和触摸滚动不变。

## 测试

新增源码契约测试，锁定桌面端选择器、`overflow-y: scroll`、稳定 gutter 和移动端隔离。

## 影响范围

仅前端侧栏滚动条展示，不修改目录树数据、后端、同步、数据库、备份或恢复。