### PR TITLE
fix(tree): Web 端使用应用级可见滚动条

### DIFF
--- a/frontend/src/lib/__tests__/knowledgeTreeScrollbarBridge.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeScrollbarBridge.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateKnowledgeTreeScrollbarMetrics } from "@/lib/knowledgeTreeScrollbarBridge";
+
+describe("knowledge tree custom scrollbar geometry", () => {
+  it("stays hidden when the tree does not overflow", () => {
+    expect(calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: 0,
+      scrollHeight: 500,
+      clientHeight: 500,
+    })).toEqual({
+      visible: false,
+      thumbHeight: 500,
+      thumbTop: 0,
+      maxScrollTop: 0,
+      maxThumbTop: 0,
+    });
+  });
+
+  it("uses a discoverable minimum thumb for long trees", () => {
+    const metrics = calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: 400,
+      scrollHeight: 2400,
+      clientHeight: 400,
+    });
+
+    expect(metrics.visible).toBe(true);
+    expect(metrics.thumbHeight).toBeGreaterThanOrEqual(36);
+    expect(metrics.thumbTop).toBeGreaterThan(0);
+    expect(metrics.thumbTop).toBeLessThan(metrics.maxThumbTop);
+  });
+
+  it("aligns the thumb with the bottom at maximum scroll", () => {
+    const metrics = calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: 1600,
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+
+    expect(metrics.visible).toBe(true);
+    expect(metrics.maxScrollTop).toBe(1600);
+    expect(metrics.thumbTop).toBe(metrics.maxThumbTop);
+  });
+
+  it("clamps out-of-range scroll positions", () => {
+    const beforeStart = calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: -100,
+      scrollHeight: 1000,
+      clientHeight: 250,
+    });
+    const afterEnd = calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: 9999,
+      scrollHeight: 1000,
+      clientHeight: 250,
+    });
+
+    expect(beforeStart.thumbTop).toBe(0);
+    expect(afterEnd.thumbTop).toBe(afterEnd.maxThumbTop);
+  });
+});

--- a/frontend/src/lib/__tests__/knowledgeTreeScrollbarRuntimeContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeScrollbarRuntimeContract.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(relativeUrl: string): string {
+  return readFileSync(new URL(relativeUrl, import.meta.url), "utf8");
+}
+
+describe("knowledge tree scrollbar runtime contract", () => {
+  it("installs the bridge before the application renders", () => {
+    const main = source("../../main.tsx");
+    expect(main).toContain('import { installKnowledgeTreeScrollbarBridge } from "./lib/knowledgeTreeScrollbarBridge"');
+    expect(main).toContain("installKnowledgeTreeScrollbarBridge();");
+  });
+
+  it("targets the real desktop tree scroll element and hides the unreliable native overlay", () => {
+    const bridge = source("../knowledgeTreeScrollbarBridge.ts");
+    expect(bridge).toContain('[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]');
+    expect(bridge).toContain("nowen-knowledge-tree-custom-scroll-track");
+    expect(bridge).toContain("scrollbar-width: none !important");
+    expect(bridge).toContain("setPointerCapture");
+    expect(bridge).toContain('role", "scrollbar"');
+  });
+
+  it("keeps the custom track out of the mobile layout", () => {
+    const bridge = source("../knowledgeTreeScrollbarBridge.ts");
+    expect(bridge).toContain("@media (max-width: 767px)");
+    expect(bridge).toContain("display: none !important");
+  });
+});

--- a/frontend/src/lib/knowledgeTreeScrollbarBridge.ts
+++ b/frontend/src/lib/knowledgeTreeScrollbarBridge.ts
@@ -1,0 +1,397 @@
+const TREE_SCROLL_SELECTOR =
+  '[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]';
+const STYLE_ID = "nowen-knowledge-tree-custom-scrollbar-style";
+const SCROLL_CLASS = "nowen-knowledge-tree-custom-scroll-host";
+const PARENT_CLASS = "nowen-knowledge-tree-custom-scroll-parent";
+const TRACK_CLASS = "nowen-knowledge-tree-custom-scroll-track";
+const THUMB_CLASS = "nowen-knowledge-tree-custom-scroll-thumb";
+const MIN_THUMB_HEIGHT = 36;
+
+export interface KnowledgeTreeScrollbarMetricsInput {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  trackHeight?: number;
+  minThumbHeight?: number;
+}
+
+export interface KnowledgeTreeScrollbarMetrics {
+  visible: boolean;
+  thumbHeight: number;
+  thumbTop: number;
+  maxScrollTop: number;
+  maxThumbTop: number;
+}
+
+/** Pure geometry helper shared by runtime code and regression tests. */
+export function calculateKnowledgeTreeScrollbarMetrics({
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+  trackHeight = clientHeight,
+  minThumbHeight = MIN_THUMB_HEIGHT,
+}: KnowledgeTreeScrollbarMetricsInput): KnowledgeTreeScrollbarMetrics {
+  const safeClientHeight = Math.max(0, clientHeight);
+  const safeScrollHeight = Math.max(safeClientHeight, scrollHeight);
+  const safeTrackHeight = Math.max(0, trackHeight);
+  const maxScrollTop = Math.max(0, safeScrollHeight - safeClientHeight);
+  const visible = safeClientHeight > 0 && maxScrollTop > 1 && safeTrackHeight > 0;
+
+  if (!visible) {
+    return {
+      visible: false,
+      thumbHeight: safeTrackHeight,
+      thumbTop: 0,
+      maxScrollTop,
+      maxThumbTop: 0,
+    };
+  }
+
+  const proportionalHeight = safeTrackHeight * (safeClientHeight / safeScrollHeight);
+  const thumbHeight = Math.min(
+    safeTrackHeight,
+    Math.max(Math.min(minThumbHeight, safeTrackHeight), proportionalHeight),
+  );
+  const maxThumbTop = Math.max(0, safeTrackHeight - thumbHeight);
+  const clampedScrollTop = Math.min(maxScrollTop, Math.max(0, scrollTop));
+  const thumbTop = maxScrollTop > 0
+    ? (clampedScrollTop / maxScrollTop) * maxThumbTop
+    : 0;
+
+  return {
+    visible: true,
+    thumbHeight,
+    thumbTop,
+    maxScrollTop,
+    maxThumbTop,
+  };
+}
+
+function ensureScrollbarStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+.${PARENT_CLASS} {
+  position: relative !important;
+}
+
+html body .${SCROLL_CLASS} {
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
+  padding-right: 10px;
+}
+
+html body .${SCROLL_CLASS}::-webkit-scrollbar {
+  width: 0 !important;
+  height: 0 !important;
+  display: none !important;
+}
+
+.${TRACK_CLASS} {
+  position: absolute;
+  right: 2px;
+  z-index: 35;
+  width: 9px;
+  border-radius: 999px;
+  background: transparent;
+  cursor: default;
+  touch-action: none;
+  user-select: none;
+  opacity: 0.9;
+  transition: background-color 120ms ease, opacity 120ms ease;
+}
+
+.${TRACK_CLASS}:hover,
+.${TRACK_CLASS}:focus-visible,
+.${TRACK_CLASS}[data-dragging="true"] {
+  background: color-mix(in srgb, var(--pm-scrollbar) 18%, transparent);
+  opacity: 1;
+  outline: none;
+}
+
+.${THUMB_CLASS} {
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  top: 0;
+  min-height: ${MIN_THUMB_HEIGHT}px;
+  border-radius: 999px;
+  background: var(--pm-scrollbar);
+  cursor: grab;
+  transition: background-color 120ms ease;
+  will-change: transform, height;
+}
+
+.${TRACK_CLASS}:hover .${THUMB_CLASS},
+.${TRACK_CLASS}:focus-visible .${THUMB_CLASS},
+.${TRACK_CLASS}[data-dragging="true"] .${THUMB_CLASS} {
+  background: var(--pm-scrollbar-hover);
+}
+
+.${TRACK_CLASS}[data-dragging="true"] .${THUMB_CLASS} {
+  cursor: grabbing;
+}
+
+@media (max-width: 767px) {
+  .${TRACK_CLASS} {
+    display: none !important;
+  }
+  html body .${SCROLL_CLASS} {
+    padding-right: 0;
+  }
+}
+`;
+  document.head.appendChild(style);
+}
+
+interface ScrollController {
+  destroy: () => void;
+  update: () => void;
+}
+
+const controllers = new Map<HTMLElement, ScrollController>();
+let installed = false;
+let rootObserver: MutationObserver | null = null;
+let reconcileFrame = 0;
+let generatedId = 0;
+
+function attachScrollbar(scrollElement: HTMLElement): ScrollController | null {
+  const parent = scrollElement.parentElement;
+  if (!parent) return null;
+
+  scrollElement.classList.add(SCROLL_CLASS);
+  parent.classList.add(PARENT_CLASS);
+  if (!scrollElement.id) {
+    generatedId += 1;
+    scrollElement.id = `nowen-knowledge-tree-scroll-${generatedId}`;
+  }
+
+  const track = document.createElement("div");
+  track.className = TRACK_CLASS;
+  track.tabIndex = 0;
+  track.setAttribute("role", "scrollbar");
+  track.setAttribute("aria-orientation", "vertical");
+  track.setAttribute("aria-label", "内容树滚动条");
+  track.setAttribute("aria-controls", scrollElement.id);
+
+  const thumb = document.createElement("div");
+  thumb.className = THUMB_CLASS;
+  track.appendChild(thumb);
+  parent.appendChild(track);
+
+  let disposed = false;
+  let updateFrame = 0;
+  let latestMetrics = calculateKnowledgeTreeScrollbarMetrics({
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  });
+  let dragState: {
+    pointerId: number;
+    startY: number;
+    startScrollTop: number;
+  } | null = null;
+
+  const update = () => {
+    if (disposed) return;
+    const trackHeight = scrollElement.clientHeight;
+    latestMetrics = calculateKnowledgeTreeScrollbarMetrics({
+      scrollTop: scrollElement.scrollTop,
+      scrollHeight: scrollElement.scrollHeight,
+      clientHeight: scrollElement.clientHeight,
+      trackHeight,
+    });
+
+    track.hidden = !latestMetrics.visible;
+    track.style.top = `${scrollElement.offsetTop}px`;
+    track.style.height = `${trackHeight}px`;
+    thumb.style.height = `${latestMetrics.thumbHeight}px`;
+    thumb.style.transform = `translateY(${latestMetrics.thumbTop}px)`;
+    track.setAttribute("aria-valuemin", "0");
+    track.setAttribute("aria-valuemax", String(Math.round(latestMetrics.maxScrollTop)));
+    track.setAttribute("aria-valuenow", String(Math.round(scrollElement.scrollTop)));
+  };
+
+  const scheduleUpdate = () => {
+    if (disposed || updateFrame) return;
+    updateFrame = window.requestAnimationFrame(() => {
+      updateFrame = 0;
+      update();
+    });
+  };
+
+  const scrollToTrackPointer = (clientY: number) => {
+    const rect = track.getBoundingClientRect();
+    const targetThumbTop = clientY - rect.top - latestMetrics.thumbHeight / 2;
+    const clampedThumbTop = Math.min(
+      latestMetrics.maxThumbTop,
+      Math.max(0, targetThumbTop),
+    );
+    scrollElement.scrollTop = latestMetrics.maxThumbTop > 0
+      ? (clampedThumbTop / latestMetrics.maxThumbTop) * latestMetrics.maxScrollTop
+      : 0;
+  };
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (!latestMetrics.visible || event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    track.focus({ preventScroll: true });
+
+    if (event.target !== thumb) {
+      scrollToTrackPointer(event.clientY);
+      scheduleUpdate();
+    }
+
+    dragState = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startScrollTop: scrollElement.scrollTop,
+    };
+    track.dataset.dragging = "true";
+    track.setPointerCapture?.(event.pointerId);
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const scrollPerThumbPixel = latestMetrics.maxThumbTop > 0
+      ? latestMetrics.maxScrollTop / latestMetrics.maxThumbTop
+      : 0;
+    scrollElement.scrollTop = dragState.startScrollTop
+      + (event.clientY - dragState.startY) * scrollPerThumbPixel;
+  };
+
+  const finishPointerDrag = (event: PointerEvent) => {
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    dragState = null;
+    delete track.dataset.dragging;
+    if (track.hasPointerCapture?.(event.pointerId)) {
+      track.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    let nextScrollTop: number | null = null;
+    const page = Math.max(40, scrollElement.clientHeight * 0.85);
+    if (event.key === "ArrowDown") nextScrollTop = scrollElement.scrollTop + 40;
+    else if (event.key === "ArrowUp") nextScrollTop = scrollElement.scrollTop - 40;
+    else if (event.key === "PageDown") nextScrollTop = scrollElement.scrollTop + page;
+    else if (event.key === "PageUp") nextScrollTop = scrollElement.scrollTop - page;
+    else if (event.key === "Home") nextScrollTop = 0;
+    else if (event.key === "End") nextScrollTop = latestMetrics.maxScrollTop;
+    if (nextScrollTop == null) return;
+    event.preventDefault();
+    scrollElement.scrollTo({ top: nextScrollTop, behavior: "smooth" });
+  };
+
+  scrollElement.addEventListener("scroll", scheduleUpdate, { passive: true });
+  track.addEventListener("pointerdown", onPointerDown);
+  track.addEventListener("pointermove", onPointerMove);
+  track.addEventListener("pointerup", finishPointerDrag);
+  track.addEventListener("pointercancel", finishPointerDrag);
+  track.addEventListener("keydown", onKeyDown);
+
+  const ResizeObserverCtor = window.ResizeObserver;
+  const resizeObserver = ResizeObserverCtor
+    ? new ResizeObserverCtor(scheduleUpdate)
+    : null;
+  resizeObserver?.observe(scrollElement);
+  resizeObserver?.observe(parent);
+
+  const contentObserver = new MutationObserver(scheduleUpdate);
+  contentObserver.observe(scrollElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  });
+
+  update();
+
+  return {
+    update: scheduleUpdate,
+    destroy: () => {
+      if (disposed) return;
+      disposed = true;
+      if (updateFrame) window.cancelAnimationFrame(updateFrame);
+      resizeObserver?.disconnect();
+      contentObserver.disconnect();
+      scrollElement.removeEventListener("scroll", scheduleUpdate);
+      track.removeEventListener("pointerdown", onPointerDown);
+      track.removeEventListener("pointermove", onPointerMove);
+      track.removeEventListener("pointerup", finishPointerDrag);
+      track.removeEventListener("pointercancel", finishPointerDrag);
+      track.removeEventListener("keydown", onKeyDown);
+      scrollElement.classList.remove(SCROLL_CLASS);
+      track.remove();
+      if (!parent.querySelector(`.${TRACK_CLASS}`)) {
+        parent.classList.remove(PARENT_CLASS);
+      }
+    },
+  };
+}
+
+function reconcileScrollbars(): void {
+  for (const [element, controller] of controllers) {
+    if (!element.isConnected || !element.matches(TREE_SCROLL_SELECTOR)) {
+      controller.destroy();
+      controllers.delete(element);
+    }
+  }
+
+  document.querySelectorAll<HTMLElement>(TREE_SCROLL_SELECTOR).forEach((element) => {
+    if (controllers.has(element)) return;
+    const controller = attachScrollbar(element);
+    if (controller) controllers.set(element, controller);
+  });
+}
+
+function scheduleReconcile(): void {
+  if (reconcileFrame) return;
+  reconcileFrame = window.requestAnimationFrame(() => {
+    reconcileFrame = 0;
+    reconcileScrollbars();
+    controllers.forEach((controller) => controller.update());
+  });
+}
+
+/**
+ * Installs an OS-independent scrollbar for the desktop knowledge tree.
+ * Native overlay scrollbars can remain invisible in Chrome/Web regardless of
+ * CSS, so this bridge renders and synchronizes its own draggable thumb.
+ */
+export function installKnowledgeTreeScrollbarBridge(): () => void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return () => {};
+  }
+  if (installed) return () => {};
+  installed = true;
+  ensureScrollbarStyles();
+
+  const start = () => {
+    scheduleReconcile();
+    rootObserver = new MutationObserver(scheduleReconcile);
+    rootObserver.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", scheduleReconcile, { passive: true });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+
+  return () => {
+    document.removeEventListener("DOMContentLoaded", start);
+    window.removeEventListener("resize", scheduleReconcile);
+    rootObserver?.disconnect();
+    rootObserver = null;
+    if (reconcileFrame) window.cancelAnimationFrame(reconcileFrame);
+    reconcileFrame = 0;
+    controllers.forEach((controller) => controller.destroy());
+    controllers.clear();
+    installed = false;
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -62,6 +62,7 @@ import { installRoundTripPermissionExportBridge } from "./lib/roundTripPermissio
 import { installEditorPerformanceGlobal } from "./lib/editorPerformanceHarness";
 import { installIssue210SignoffRuntime } from "./lib/issue210Signoff";
 import { cleanupRemovedServerProfiles } from "./lib/removedServerProfileCleanup";
+import { installKnowledgeTreeScrollbarBridge } from "./lib/knowledgeTreeScrollbarBridge";
 
 void cleanupRemovedServerProfiles();
 
@@ -84,6 +85,7 @@ function BootSplashRemover() {
   return null;
 }
 
+installKnowledgeTreeScrollbarBridge();
 installNodeViewMutationGuard();
 installEditorMediaScopeGuard();
 installAndroidNativeHttpBridge();


### PR DESCRIPTION
## 问题复盘

#485 通过 `::-webkit-scrollbar`、`scrollbar-width` 和 `overflow-y: scroll` 加强了原生滚动条，但 Chrome/Web 在启用覆盖式滚动条或系统自动隐藏滚动条时，浏览器仍可完全不绘制原生滑块。因此 Electron 某些环境有效，Web 端仍可能看不到。

## 本次修复

不再依赖浏览器原生滚动条是否可见，新增应用级内容树滚动条桥：

- 启动时自动定位桌面端真实内容树滚动容器；
- 根据 `scrollTop / scrollHeight / clientHeight` 计算滑块高度和位置；
- 内容展开、折叠、新建、删除、标签区域高度变化和窗口缩放时自动重新计算；
- 支持鼠标点击轨道跳转；
- 支持拖动滑块；
- 支持键盘 `↑/↓`、`PageUp/PageDown`、`Home/End`；
- 使用 `role="scrollbar"` 和 ARIA 数值同步；
- 隐藏不可靠的原生覆盖式滚动条，避免双滚动条；
- Web 与 Electron 桌面端使用相同实现；
- 移动端不渲染自定义轨道，继续使用原生触摸滚动。

## 技术实现

新增 `knowledgeTreeScrollbarBridge.ts`：

- 通过 `MutationObserver` 处理 React 挂载/卸载和树内容变化；
- 通过 `ResizeObserver` 处理侧栏、标签区域和窗口尺寸变化；
- 使用 `requestAnimationFrame` 合并高频测量；
- 自定义滑块只挂载到 `[data-sidebar-variant="desktop"] [data-swipe-blocker="knowledge-tree-scroll"]`；
- 不修改统一树组件的数据和业务逻辑。

## 测试

新增：

- 滚动几何计算单测：无溢出、长树最小滑块、滚动到底部、越界钳制；
- 运行时契约测试：启动安装、真实滚动容器选择器、隐藏原生覆盖条、拖动支持、移动端隔离。

## 影响范围

仅前端内容树滚动展示和交互。不修改目录数据、后端、数据库、同步、备份或恢复格式。