### PR TITLE
refactor(ai): 将“任务队列”改为易懂的“索引任务”

### DIFF
--- a/.github/workflows/embedding-index-copy-ci.yml
+++ b/.github/workflows/embedding-index-copy-ci.yml
@@ -1,0 +1,39 @@
+name: Embedding Index Copy CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx"
+      - "frontend/src/components/__tests__/EmbeddingIndexTaskCopyBridge.test.ts"
+      - "frontend/src/main.tsx"
+      - ".github/workflows/embedding-index-copy-ci.yml"
+  pull_request:
+    paths:
+      - "frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx"
+      - "frontend/src/components/__tests__/EmbeddingIndexTaskCopyBridge.test.ts"
+      - "frontend/src/main.tsx"
+      - ".github/workflows/embedding-index-copy-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Embedding index copy tests
+        run: npm run test:run -- src/components/__tests__/EmbeddingIndexTaskCopyBridge.test.ts
+      - name: Frontend typecheck
+        run: npx tsc -b

--- a/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
+++ b/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
@@ -119,12 +119,15 @@ export default function EmbeddingIndexTaskCopyBridge() {
       if (nextSection !== observedSection) {
         sectionObserver?.disconnect();
         observedSection = nextSection;
-        sectionObserver = nextSection ? new MutationObserver(schedule) : null;
-        sectionObserver?.observe(nextSection, {
-          childList: true,
-          subtree: true,
-          characterData: true,
-        });
+        sectionObserver = null;
+        if (nextSection) {
+          sectionObserver = new MutationObserver(schedule);
+          sectionObserver.observe(nextSection, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+          });
+        }
       }
 
       if (nextSection) applyEmbeddingIndexTaskCopy(nextSection);

--- a/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
+++ b/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
@@ -1,0 +1,131 @@
+import { useEffect } from "react";
+
+const HEADING_COPY = {
+  zh: "向量检索（Embedding）",
+  en: "Vector search (Embedding)",
+};
+
+const COPY = {
+  zh: {
+    oldQueue: "任务队列",
+    queue: "索引任务",
+    pendingPattern: /待处理\s+(\d+)/,
+    pendingReplacement: "等待 $1",
+    oldHint: "索引在后台异步执行；失败任务可通过重新构建索引再次处理。",
+    help: "AI 助手会在后台为笔记和附件建立搜索索引，不是待办事项或聊天排队，也不会修改笔记原文。",
+    blocked: "向量引擎不可用，等待中的索引任务暂时不会开始处理。配置并测试可用的 Embedding 模型后，可重新构建索引。",
+    unavailable: "不可用",
+  },
+  en: {
+    oldQueue: "Queue",
+    queue: "Index jobs",
+    pendingPattern: /pending\s+(\d+)/i,
+    pendingReplacement: "waiting $1",
+    oldHint: "Indexing runs in the background. Failed jobs can be retried by rebuilding the index.",
+    help: "The AI assistant builds search indexes for notes and attachments in the background. These are not to-dos or chat requests, and original note content is not changed.",
+    blocked: "The vector engine is unavailable, so waiting index jobs will not start yet. Configure and test a working embedding model, then rebuild the index.",
+    unavailable: "Unavailable",
+  },
+};
+
+type LocaleKey = keyof typeof COPY;
+
+function exactTextElement(root: ParentNode, text: string): HTMLElement | null {
+  return Array.from(root.querySelectorAll<HTMLElement>("*")).find((element) => {
+    if (element.children.length > 0) return false;
+    return (element.textContent || "").trim() === text;
+  }) || null;
+}
+
+function resolveEmbeddingSection(root: ParentNode): { section: HTMLElement; locale: LocaleKey } | null {
+  const headings = Array.from(root.querySelectorAll<HTMLElement>("h1,h2,h3,h4"));
+  for (const heading of headings) {
+    const text = (heading.textContent || "").trim();
+    const locale: LocaleKey | null = text === HEADING_COPY.zh ? "zh" : text === HEADING_COPY.en ? "en" : null;
+    if (!locale) continue;
+    const section = heading.closest<HTMLElement>("section");
+    if (section) return { section, locale };
+  }
+  return null;
+}
+
+function extractWaitingCount(text: string, locale: LocaleKey): number {
+  const match = text.match(locale === "zh" ? /(?:待处理|等待)\s+(\d+)/ : /(?:pending|waiting)\s+(\d+)/i);
+  return match ? Number(match[1]) || 0 : 0;
+}
+
+export function applyEmbeddingIndexTaskCopy(root: ParentNode = document): boolean {
+  const resolved = resolveEmbeddingSection(root);
+  if (!resolved) return false;
+
+  const { section, locale } = resolved;
+  const copy = COPY[locale];
+  const queueLabel = exactTextElement(section, copy.oldQueue) || exactTextElement(section, copy.queue);
+  if (!queueLabel) return false;
+
+  queueLabel.textContent = copy.queue;
+  const queueCard = queueLabel.parentElement;
+  if (!queueCard) return false;
+
+  const queueValue = Array.from(queueCard.querySelectorAll<HTMLElement>("div")).find((element) => {
+    const text = (element.textContent || "").trim();
+    return element !== queueLabel && copy.pendingPattern.test(text);
+  }) || null;
+
+  if (queueValue) {
+    queueValue.textContent = (queueValue.textContent || "").replace(copy.pendingPattern, copy.pendingReplacement);
+  }
+
+  queueCard.title = copy.help;
+  queueCard.setAttribute("aria-label", `${copy.queue}。${copy.help}`);
+  queueCard.dataset.embeddingIndexTaskCard = "";
+
+  const vectorUnavailable = Array.from(section.querySelectorAll<HTMLElement>("*")).some((element) => {
+    if (element.children.length > 0) return false;
+    return (element.textContent || "").trim() === copy.unavailable;
+  });
+  const waiting = extractWaitingCount(queueValue?.textContent || "", locale);
+  const helpText = vectorUnavailable && waiting > 0 ? copy.blocked : copy.help;
+
+  const existingHelp = section.querySelector<HTMLElement>("[data-embedding-index-task-help]");
+  const oldHint = exactTextElement(section, copy.oldHint);
+  const help = existingHelp || oldHint;
+  if (help) {
+    help.textContent = helpText;
+    help.dataset.embeddingIndexTaskHelp = "";
+    help.id = help.id || "embedding-index-task-help";
+    queueCard.setAttribute("aria-describedby", help.id);
+  }
+
+  return true;
+}
+
+export default function EmbeddingIndexTaskCopyBridge() {
+  useEffect(() => {
+    let frame = 0;
+    const schedule = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        applyEmbeddingIndexTaskCopy();
+      });
+    };
+
+    schedule();
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    window.addEventListener("nowen:ai-settings-changed", schedule);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener("nowen:ai-settings-changed", schedule);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
+++ b/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
@@ -10,6 +10,7 @@ const COPY = {
     oldQueue: "任务队列",
     queue: "索引任务",
     pendingPattern: /待处理\s+(\d+)/,
+    statusPattern: /(?:待处理|等待)\s+\d+/,
     pendingReplacement: "等待 $1",
     oldHint: "索引在后台异步执行；失败任务可通过重新构建索引再次处理。",
     help: "AI 助手会在后台为笔记和附件建立搜索索引，不是待办事项或聊天排队，也不会修改笔记原文。",
@@ -20,6 +21,7 @@ const COPY = {
     oldQueue: "Queue",
     queue: "Index jobs",
     pendingPattern: /pending\s+(\d+)/i,
+    statusPattern: /(?:pending|waiting)\s+\d+/i,
     pendingReplacement: "waiting $1",
     oldHint: "Indexing runs in the background. Failed jobs can be retried by rebuilding the index.",
     help: "The AI assistant builds search indexes for notes and attachments in the background. These are not to-dos or chat requests, and original note content is not changed.",
@@ -63,22 +65,26 @@ export function applyEmbeddingIndexTaskCopy(root: ParentNode = document): boolea
   const queueLabel = exactTextElement(section, copy.oldQueue) || exactTextElement(section, copy.queue);
   if (!queueLabel) return false;
 
-  queueLabel.textContent = copy.queue;
+  if ((queueLabel.textContent || "").trim() !== copy.queue) queueLabel.textContent = copy.queue;
   const queueCard = queueLabel.parentElement;
   if (!queueCard) return false;
 
   const queueValue = Array.from(queueCard.querySelectorAll<HTMLElement>("div")).find((element) => {
     const text = (element.textContent || "").trim();
-    return element !== queueLabel && copy.pendingPattern.test(text);
+    return element !== queueLabel && copy.statusPattern.test(text);
   }) || null;
 
   if (queueValue) {
-    queueValue.textContent = (queueValue.textContent || "").replace(copy.pendingPattern, copy.pendingReplacement);
+    const current = queueValue.textContent || "";
+    const next = current.replace(copy.pendingPattern, copy.pendingReplacement);
+    if (next !== current) queueValue.textContent = next;
   }
 
-  queueCard.title = copy.help;
-  queueCard.setAttribute("aria-label", `${copy.queue}。${copy.help}`);
-  queueCard.dataset.embeddingIndexTaskCard = "";
+  const separator = locale === "zh" ? "。" : ". ";
+  const ariaLabel = `${copy.queue}${separator}${copy.help}`;
+  if (queueCard.title !== copy.help) queueCard.title = copy.help;
+  if (queueCard.getAttribute("aria-label") !== ariaLabel) queueCard.setAttribute("aria-label", ariaLabel);
+  if (!queueCard.hasAttribute("data-embedding-index-task-card")) queueCard.dataset.embeddingIndexTaskCard = "";
 
   const vectorUnavailable = Array.from(section.querySelectorAll<HTMLElement>("*")).some((element) => {
     if (element.children.length > 0) return false;
@@ -91,10 +97,10 @@ export function applyEmbeddingIndexTaskCopy(root: ParentNode = document): boolea
   const oldHint = exactTextElement(section, copy.oldHint);
   const help = existingHelp || oldHint;
   if (help) {
-    help.textContent = helpText;
-    help.dataset.embeddingIndexTaskHelp = "";
-    help.id = help.id || "embedding-index-task-help";
-    queueCard.setAttribute("aria-describedby", help.id);
+    if ((help.textContent || "").trim() !== helpText) help.textContent = helpText;
+    if (!help.hasAttribute("data-embedding-index-task-help")) help.dataset.embeddingIndexTaskHelp = "";
+    if (!help.id) help.id = "embedding-index-task-help";
+    if (queueCard.getAttribute("aria-describedby") !== help.id) queueCard.setAttribute("aria-describedby", help.id);
   }
 
   return true;

--- a/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
+++ b/frontend/src/components/EmbeddingIndexTaskCopyBridge.tsx
@@ -109,26 +109,47 @@ export function applyEmbeddingIndexTaskCopy(root: ParentNode = document): boolea
 export default function EmbeddingIndexTaskCopyBridge() {
   useEffect(() => {
     let frame = 0;
-    const schedule = () => {
+    let observedSection: HTMLElement | null = null;
+    let sectionObserver: MutationObserver | null = null;
+
+    function refresh() {
+      const resolved = resolveEmbeddingSection(document);
+      const nextSection = resolved?.section || null;
+
+      if (nextSection !== observedSection) {
+        sectionObserver?.disconnect();
+        observedSection = nextSection;
+        sectionObserver = nextSection ? new MutationObserver(schedule) : null;
+        sectionObserver?.observe(nextSection, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+      }
+
+      if (nextSection) applyEmbeddingIndexTaskCopy(nextSection);
+    }
+
+    function schedule() {
       if (frame) return;
       frame = window.requestAnimationFrame(() => {
         frame = 0;
-        applyEmbeddingIndexTaskCopy();
+        refresh();
       });
-    };
+    }
 
     schedule();
-    const observer = new MutationObserver(schedule);
-    observer.observe(document.body, {
+    const rootObserver = new MutationObserver(schedule);
+    rootObserver.observe(document.body, {
       childList: true,
       subtree: true,
-      characterData: true,
     });
     window.addEventListener("nowen:ai-settings-changed", schedule);
 
     return () => {
       if (frame) window.cancelAnimationFrame(frame);
-      observer.disconnect();
+      rootObserver.disconnect();
+      sectionObserver?.disconnect();
       window.removeEventListener("nowen:ai-settings-changed", schedule);
     };
   }, []);

--- a/frontend/src/components/__tests__/EmbeddingIndexTaskCopyBridge.test.ts
+++ b/frontend/src/components/__tests__/EmbeddingIndexTaskCopyBridge.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { applyEmbeddingIndexTaskCopy } from "@/components/EmbeddingIndexTaskCopyBridge";
+
+function renderChineseStatus(vectorState = "不可用") {
+  document.body.innerHTML = `
+    <section>
+      <h3>向量检索（Embedding）</h3>
+      <div id="queue-card">
+        <div>任务队列</div>
+        <div>待处理 34 · 处理中 0 · 失败 0</div>
+      </div>
+      <div>
+        <div>向量引擎</div>
+        <div>${vectorState}</div>
+      </div>
+      <p>索引在后台异步执行；失败任务可通过重新构建索引再次处理。</p>
+    </section>
+  `;
+}
+
+describe("EmbeddingIndexTaskCopyBridge", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("clarifies Chinese queue copy and explains blocked waiting jobs", () => {
+    renderChineseStatus();
+
+    expect(applyEmbeddingIndexTaskCopy()).toBe(true);
+    expect(document.body.textContent).toContain("索引任务");
+    expect(document.body.textContent).toContain("等待 34 · 处理中 0 · 失败 0");
+    expect(document.body.textContent).toContain("向量引擎不可用，等待中的索引任务暂时不会开始处理");
+
+    const card = document.querySelector<HTMLElement>("#queue-card");
+    expect(card?.dataset.embeddingIndexTaskCard).toBe("");
+    expect(card?.getAttribute("aria-describedby")).toBe("embedding-index-task-help");
+  });
+
+  it("uses the general explanation when the vector engine is available", () => {
+    renderChineseStatus("可用");
+
+    applyEmbeddingIndexTaskCopy();
+
+    expect(document.body.textContent).toContain("不是待办事项或聊天排队");
+    expect(document.body.textContent).not.toContain("暂时不会开始处理");
+  });
+
+  it("is idempotent and supports English copy", () => {
+    document.body.innerHTML = `
+      <section>
+        <h3>Vector search (Embedding)</h3>
+        <div id="queue-card"><div>Queue</div><div>pending 2 · processing 1 · failed 0</div></div>
+        <div><div>Vector engine</div><div>Ready</div></div>
+        <p>Indexing runs in the background. Failed jobs can be retried by rebuilding the index.</p>
+      </section>
+    `;
+
+    applyEmbeddingIndexTaskCopy();
+    const once = document.body.innerHTML;
+    applyEmbeddingIndexTaskCopy();
+
+    expect(document.body.innerHTML).toBe(once);
+    expect(document.body.textContent).toContain("Index jobs");
+    expect(document.body.textContent).toContain("waiting 2 · processing 1 · failed 0");
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import { SiteSettingsProvider } from "./hooks/useSiteSettings";
 import Toaster from "./components/Toaster";
 import NoteIconBridge from "./components/NoteIconBridge";
 import AIProfileSwitcherBridge from "./components/AIProfileSwitcherBridge";
+import EmbeddingIndexTaskCopyBridge from "./components/EmbeddingIndexTaskCopyBridge";
 import MarkdownExperienceBridge from "./components/MarkdownExperienceBridge";
 import SidebarSearchExperienceBridge from "./components/SidebarSearchExperienceBridge";
 import MindMapAppearanceBridge from "./components/MindMapAppearanceBridge";
@@ -148,6 +149,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <>
           <NoteIconBridge />
           <AIProfileSwitcherBridge />
+          <EmbeddingIndexTaskCopyBridge />
           <MarkdownExperienceBridge />
           <SidebarSearchExperienceBridge />
           <MindMapAppearanceBridge />


### PR DESCRIPTION
## 背景

AI 助手的向量检索设置页使用“任务队列”展示后台索引状态，普通用户容易将其理解成待办事项、聊天请求排队或通用后台任务。

## 本次改造

### 状态卡文案

```text
旧：任务队列
新：索引任务

旧：待处理 34 · 处理中 0 · 失败 0
新：等待 34 · 处理中 0 · 失败 0
```

英文同步调整为：

```text
Queue → Index jobs
pending → waiting
```

### 用户解释

状态区现在明确说明：

- 这些任务用于 AI 助手后台为笔记和附件建立搜索索引；
- 不是待办事项，也不是聊天请求排队；
- 建立索引不会修改笔记原文；
- 失败任务可以通过重新构建索引重试。

### 阻塞状态

当同时满足：

- 向量引擎显示“不可用”；
- 存在等待中的索引任务；

说明会自动改成：

> 向量引擎不可用，等待中的索引任务暂时不会开始处理。配置并测试可用的 Embedding 模型后，可重新构建索引。

### 可访问性

- 索引任务状态卡增加 `title`；
- 增加 `aria-label` 和 `aria-describedby`；
- 中文和英文均覆盖。

## 测试

新增 jsdom 回归测试，覆盖：

- 中文状态名称和“等待”文案；
- 向量引擎不可用时的阻塞解释；
- 向量引擎可用时的一般解释；
- 英文文案；
- 重复刷新时保持幂等，不发生反复覆盖。

## 影响范围

仅修改 AI 向量索引状态区的展示文案与帮助说明，不修改索引任务、Embedding Worker、数据库、AI 搜索或笔记内容。