### PR TITLE
fix(import): support SingleFile saved HTML documents

### DIFF
--- a/frontend/src/lib/__tests__/singleFileHtmlImport.test.ts
+++ b/frontend/src/lib/__tests__/singleFileHtmlImport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { normalizeImportedHtmlContent } from "@/lib/singleFileHtmlImport";
+
+describe("normalizeImportedHtmlContent", () => {
+  it("extracts the article root even when the source omits an explicit body tag", () => {
+    const html = `<!doctype html>
+      <head><title>Saved page</title><style>.hidden{display:none}</style></head>
+      <div class="toolbar">not article</div>
+      <div id="js_content" class="rich_media_content" style="color:red">
+        <h2 id="heading">Article heading</h2>
+        <p onclick="alert(1)">Article body</p>
+      </div>
+      <div class="footer">not article either</div>`;
+
+    const normalized = normalizeImportedHtmlContent(html);
+
+    expect(normalized).toContain("Article heading");
+    expect(normalized).toContain("Article body");
+    expect(normalized).not.toContain("not article");
+    expect(normalized).not.toContain("style=");
+    expect(normalized).not.toContain("onclick=");
+  });
+
+  it("replaces SingleFile data images with their retained remote source", () => {
+    const embedded = `data:image/png;base64,${"A".repeat(20_000)}`;
+    const html = `<main><p>正文</p><img src="${embedded}" data-src="https://mmbiz.qpic.cn/example.png" class="rich_pages wxw-img"></main>`;
+
+    const normalized = normalizeImportedHtmlContent(html);
+
+    expect(normalized).toContain('src="https://mmbiz.qpic.cn/example.png"');
+    expect(normalized).toContain('loading="lazy"');
+    expect(normalized).not.toContain("data:image/png;base64");
+    expect(normalized.length).toBeLessThan(500);
+  });
+
+  it("keeps an embedded image when no recoverable remote source exists", () => {
+    const embedded = "data:image/png;base64,QUJD";
+    const normalized = normalizeImportedHtmlContent(`<article><img src="${embedded}" alt="cover"></article>`);
+
+    expect(normalized).toContain(embedded);
+    expect(normalized).toContain('alt="cover"');
+  });
+
+  it("removes scripts and javascript links from the selected content", () => {
+    const normalized = normalizeImportedHtmlContent(`
+      <article>
+        <script>window.bad = true</script>
+        <a href="javascript:alert(1)" title="unsafe">Click</a>
+        <a href="https://example.com">Safe</a>
+      </article>
+    `);
+
+    expect(normalized).not.toContain("window.bad");
+    expect(normalized).not.toContain("javascript:");
+    expect(normalized).toContain('href="https://example.com"');
+  });
+});

--- a/frontend/src/lib/importService.ts
+++ b/frontend/src/lib/importService.ts
@@ -1,5 +1,6 @@
 import {
   readMarkdownFromZipWithMeta as readMarkdownFromZipWithMetaBase,
+  readMarkdownFiles as readMarkdownFilesBase,
   importNotes as importNotesBase,
 } from "./importService.base";
 import type {
@@ -14,6 +15,7 @@ import {
   type RoundTripImportStrategy,
 } from "./roundTripImportReview";
 import { requestRoundTripPermissionReview } from "./roundTripPermissionReview";
+import { normalizeImportedHtmlContent } from "./singleFileHtmlImport";
 
 export {
   tiptapExtensions,
@@ -21,7 +23,6 @@ export {
   PDF_NO_TEXT_LAYER_FLAG,
   PDF_TOO_LARGE_FLAG,
   deriveNotebookNameFromFile,
-  readMarkdownFiles,
   markdownToSimpleHtml,
   convertToTiptapJson,
   extractPlainText,
@@ -54,6 +55,8 @@ interface PackageManifestPreview {
   };
 }
 
+const HTML_IMPORT_SOURCES = new Set(["html", "xiaomi", "oppo", "vivo", "oneplus"]);
+
 async function readRoundTripManifest(file: File): Promise<PackageManifestPreview | null> {
   try {
     const JSZip = (await import("jszip")).default;
@@ -70,6 +73,22 @@ async function readRoundTripManifest(file: File): Promise<PackageManifestPreview
   } catch {
     return null;
   }
+}
+
+/**
+ * Browser-saved HTML (especially SingleFile) needs a DOM-aware preprocessing pass before the
+ * generic importer sees it. The base reader still owns file validation/title/source detection;
+ * this wrapper only narrows the document to its article root and de-duplicates embedded images.
+ */
+export async function readMarkdownFiles(files: FileList | File[]): Promise<ImportFileInfo[]> {
+  const fileInfos = await readMarkdownFilesBase(files);
+  return fileInfos.map((fileInfo) => {
+    if (!HTML_IMPORT_SOURCES.has(String(fileInfo.source || ""))) return fileInfo;
+    return {
+      ...fileInfo,
+      content: normalizeImportedHtmlContent(fileInfo.content),
+    };
+  });
 }
 
 /**

--- a/frontend/src/lib/singleFileHtmlImport.ts
+++ b/frontend/src/lib/singleFileHtmlImport.ts
@@ -1,0 +1,130 @@
+const HTML_CONTENT_ROOT_SELECTORS = [
+  "#js_content",
+  ".rich_media_content",
+  "article",
+  "main",
+  "[role=main]",
+  "body",
+];
+
+const REMOTE_IMAGE_SOURCE_ATTRIBUTES = [
+  "data-src",
+  "data-original",
+  "data-lazy-src",
+  "data-actualsrc",
+];
+
+const REMOVABLE_ELEMENTS = [
+  "script",
+  "style",
+  "noscript",
+  "iframe",
+  "frame",
+  "form",
+  "button",
+  "input",
+  "textarea",
+  "select",
+  "option",
+  "canvas",
+  "template",
+  "meta",
+  "link",
+].join(",");
+
+const ALLOWED_ATTRIBUTES: Record<string, ReadonlySet<string>> = {
+  a: new Set(["href", "title"]),
+  img: new Set(["src", "alt", "title", "width", "height", "loading"]),
+  video: new Set(["src", "poster", "controls", "width", "height"]),
+  audio: new Set(["src", "controls"]),
+  source: new Set(["src", "type"]),
+  td: new Set(["colspan", "rowspan"]),
+  th: new Set(["colspan", "rowspan"]),
+  ol: new Set(["start"]),
+  li: new Set(["data-type", "data-checked", "data-block-id"]),
+  p: new Set(["data-block-id"]),
+  h1: new Set(["data-block-id"]),
+  h2: new Set(["data-block-id"]),
+  h3: new Set(["data-block-id"]),
+  h4: new Set(["data-block-id"]),
+  h5: new Set(["data-block-id"]),
+  h6: new Set(["data-block-id"]),
+  blockquote: new Set(["data-block-id"]),
+  pre: new Set(["data-language", "data-block-id"]),
+  code: new Set(["data-language"]),
+};
+
+function normalizeRemoteUrl(value: string | null): string | null {
+  const candidate = String(value || "").trim();
+  if (/^https?:\/\//i.test(candidate)) return candidate;
+  if (candidate.startsWith("//")) return `https:${candidate}`;
+  return null;
+}
+
+function preferRemoteSingleFileImages(root: ParentNode): void {
+  root.querySelectorAll("img").forEach((image) => {
+    const currentSrc = String(image.getAttribute("src") || "").trim();
+    if (!/^data:image\//i.test(currentSrc)) return;
+
+    for (const attribute of REMOTE_IMAGE_SOURCE_ATTRIBUTES) {
+      const remoteUrl = normalizeRemoteUrl(image.getAttribute(attribute));
+      if (!remoteUrl) continue;
+      image.setAttribute("src", remoteUrl);
+      image.setAttribute("loading", "lazy");
+      break;
+    }
+  });
+}
+
+function stripUnsafeAndLayoutAttributes(root: ParentNode): void {
+  root.querySelectorAll<HTMLElement>("*").forEach((element) => {
+    const allowed = ALLOWED_ATTRIBUTES[element.tagName.toLowerCase()] || new Set<string>();
+    for (const attribute of Array.from(element.attributes)) {
+      if (!allowed.has(attribute.name.toLowerCase())) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+
+    if (element.tagName === "A") {
+      const href = String(element.getAttribute("href") || "").trim();
+      if (/^javascript:/i.test(href)) element.removeAttribute("href");
+    }
+  });
+}
+
+function hasMeaningfulContent(root: ParentNode): boolean {
+  const text = String(root.textContent || "").replace(/\s+/g, "").trim();
+  return text.length > 0 || Boolean(root.querySelector("img,video,audio,table,pre,blockquote"));
+}
+
+/**
+ * Normalize browser-saved HTML before the existing import pipeline converts it to Tiptap JSON.
+ *
+ * SingleFile pages often omit an explicit <body>, wrap the article in a site-specific root, and
+ * duplicate every remote image as a multi-megabyte data URI while retaining the original URL in
+ * data-src. Feeding that whole document into the generic importer inflates the JSON request and can
+ * hit the normal write timeout. DOMParser gives us a standards-compliant body even when the source
+ * omitted one, and the content-root preference keeps navigation/toolbar/sidebar markup out.
+ */
+export function normalizeImportedHtmlContent(html: string): string {
+  if (!html || typeof DOMParser === "undefined") return html;
+
+  try {
+    const document = new DOMParser().parseFromString(html, "text/html");
+    const sourceRoot = HTML_CONTENT_ROOT_SELECTORS
+      .map((selector) => document.querySelector(selector))
+      .find((candidate): candidate is Element => Boolean(candidate));
+    if (!sourceRoot) return html;
+
+    const container = document.createElement("div");
+    container.append(...Array.from(sourceRoot.childNodes).map((node) => node.cloneNode(true)));
+    container.querySelectorAll(REMOVABLE_ELEMENTS).forEach((element) => element.remove());
+    preferRemoteSingleFileImages(container);
+    stripUnsafeAndLayoutAttributes(container);
+
+    return hasMeaningfulContent(container) ? container.innerHTML.trim() : html;
+  } catch (error) {
+    console.warn("[import] failed to normalize saved HTML; using original source", error);
+    return html;
+  }
+}


### PR DESCRIPTION
## 问题

使用 SingleFile 保存的网页 HTML（本次样本为微信公众号文章）导入时，会把完整页面及多张 Base64 内嵌图片直接送入 Tiptap/JSON 导入链路。单篇内容膨胀到数 MB 后容易触发普通写请求超时，界面只显示 `signal is aborted without reason`。

## 修复

- 新增 DOMParser 驱动的 HTML 预处理器，不再依赖源文件必须显式包含 `<body>`。
- 按优先级提取正文根节点：`#js_content`、`.rich_media_content`、`article`、`main`、`[role=main]`、`body`。
- 删除脚本、样式、表单、iframe 等非正文/危险节点，并清理布局和事件属性。
- 对 SingleFile 的 `data:image/...` 图片，若存在 `data-src` / `data-original` / `data-lazy-src` / `data-actualsrc` 原始网络地址，则恢复为远程图片，避免重复携带多 MB Base64。
- 保留没有可恢复远程地址的内嵌图片，避免静默丢图。
- 在公共 `readMarkdownFiles` 入口统一处理 HTML 及手机笔记 HTML 来源，不影响 Markdown、TXT、PDF 和 Nowen 无损包导入。

## 测试

新增 4 组回归测试：

- 源码缺少显式 `<body>` 时仍能提取微信公众号正文。
- SingleFile Base64 图片恢复为原始远程地址并显著缩小内容。
- 无远程备份地址时保留 Data URI。
- 删除脚本及 `javascript:` 链接，同时保留正常链接。

## 设计说明

本次优先消除超时根因，而不是直接放大全局 POST 超时时间。普通导入请求继续保持现有超时保护；经过正文提取和图片去重后，本次 11.65 MB 样本会降到约 50 KB 量级，避免大请求长期占用前后端资源。后续如需真正离线保存图片，可再把 Data URI/远程图片迁移为 Nowen 附件。