### PR TITLE
feat(sync): 自动使用最新写入解决版本冲突

### DIFF
--- a/frontend/src/lib/__tests__/conflictResolution.test.ts
+++ b/frontend/src/lib/__tests__/conflictResolution.test.ts
@@ -21,7 +21,10 @@ vi.mock("@/lib/noteSyncSafety", () => ({ clearNoteSyncConflict }));
 
 import {
   getConflictCopyId,
+  getConflictResolutionStrategy,
   resolveNoteConflict,
+  resolveQueuedNoteConflicts,
+  setConflictResolutionStrategy,
 } from "@/lib/conflictResolution";
 
 function remoteNote(overrides: Partial<Note> = {}): Note {
@@ -48,7 +51,7 @@ function remoteNote(overrides: Partial<Note> = {}): Note {
   } as Note;
 }
 
-function conflictItem(): OfflineQueueItem {
+function conflictItem(overrides: Partial<OfflineQueueItem> = {}): OfflineQueueItem {
   return {
     id: "queue-1",
     type: "updateNote",
@@ -76,14 +79,24 @@ function conflictItem(): OfflineQueueItem {
     retryable: false,
     errorCode: "VERSION_CONFLICT",
     serverVersion: 8,
+    ...overrides,
   };
 }
 
 describe("resolveNoteConflict", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     loadDraft.mockReturnValue(null);
     apiMock.getNote.mockResolvedValue(remoteNote());
+  });
+
+  it("defaults to latest-write-wins and allows opting back into manual handling", () => {
+    expect(getConflictResolutionStrategy()).toBe("latest-wins");
+    setConflictResolutionStrategy("ask");
+    expect(getConflictResolutionStrategy()).toBe("ask");
+    setConflictResolutionStrategy("latest-wins");
+    expect(getConflictResolutionStrategy()).toBe("latest-wins");
   });
 
   it("keeps the local version using a non-queued confirmed write and clears only after ACK", async () => {
@@ -112,6 +125,60 @@ describe("resolveNoteConflict", () => {
 
     await expect(resolveNoteConflict(conflictItem(), "keep-local")).rejects.toThrow("服务器尚未确认");
     expect(discardNoteQueueItems).not.toHaveBeenCalled();
+  });
+
+  it("automatically rebases only the newest queued write for each conflicted note", async () => {
+    const older = conflictItem({ id: "queue-old", enqueuedAt: 100 });
+    const newer = conflictItem({
+      id: "queue-new",
+      enqueuedAt: 200,
+      body: {
+        title: "最后提交的标题",
+        content: "最后提交的正文",
+        contentText: "最后提交的正文",
+        contentFormat: "markdown",
+        version: 4,
+      },
+      localPayload: {
+        title: "最后提交的标题",
+        content: "最后提交的正文",
+        contentText: "最后提交的正文",
+        contentFormat: "markdown",
+        version: 4,
+      },
+    });
+    const updated = remoteNote({
+      title: "最后提交的标题",
+      content: "最后提交的正文",
+      contentText: "最后提交的正文",
+      version: 9,
+    });
+    apiMock.updateNoteConfirmed.mockResolvedValue(updated);
+
+    await expect(resolveQueuedNoteConflicts([older, newer], "latest-wins")).resolves.toEqual({
+      attempted: 1,
+      resolved: 1,
+      failed: 0,
+      failures: [],
+    });
+
+    expect(apiMock.getNote).toHaveBeenCalledTimes(1);
+    expect(apiMock.updateNoteConfirmed).toHaveBeenCalledWith("note-1", expect.objectContaining({
+      title: "最后提交的标题",
+      content: "最后提交的正文",
+      version: 8,
+    }));
+  });
+
+  it("leaves conflicts untouched when manual handling is selected", async () => {
+    await expect(resolveQueuedNoteConflicts([conflictItem()], "ask")).resolves.toEqual({
+      attempted: 0,
+      resolved: 0,
+      failed: 0,
+      failures: [],
+    });
+    expect(apiMock.getNote).not.toHaveBeenCalled();
+    expect(apiMock.updateNoteConfirmed).not.toHaveBeenCalled();
   });
 
   it("creates a recoverable conflict copy with a stable id before accepting the server version", async () => {

--- a/frontend/src/lib/conflictResolution.ts
+++ b/frontend/src/lib/conflictResolution.ts
@@ -9,10 +9,23 @@ import { clearOfflineNoteSnapshot } from "@/lib/offlineRead";
 import { clearNoteSyncConflict } from "@/lib/noteSyncSafety";
 
 export type ConflictResolutionChoice = "keep-local" | "use-server";
+export type ConflictResolutionStrategy = "ask" | "latest-wins";
+
+export const DEFAULT_CONFLICT_RESOLUTION_STRATEGY: ConflictResolutionStrategy = "latest-wins";
+export const CONFLICT_RESOLUTION_STRATEGY_CHANGED_EVENT = "nowen:conflict-resolution-strategy-changed";
+
+const CONFLICT_RESOLUTION_STRATEGY_STORAGE_KEY = "nowen.sync.conflict-resolution-strategy.v1";
 
 export interface ConflictResolutionResult {
   note: Note;
   conflictCopy?: Note;
+}
+
+export interface AutoConflictResolutionResult {
+  attempted: number;
+  resolved: number;
+  failed: number;
+  failures: Array<{ noteId: string; message: string }>;
 }
 
 type ConflictPayload = {
@@ -21,6 +34,30 @@ type ConflictPayload = {
   contentText: string;
   contentFormat?: Note["contentFormat"];
 };
+
+export function getConflictResolutionStrategy(): ConflictResolutionStrategy {
+  try {
+    return localStorage.getItem(CONFLICT_RESOLUTION_STRATEGY_STORAGE_KEY) === "ask"
+      ? "ask"
+      : DEFAULT_CONFLICT_RESOLUTION_STRATEGY;
+  } catch {
+    return DEFAULT_CONFLICT_RESOLUTION_STRATEGY;
+  }
+}
+
+export function setConflictResolutionStrategy(strategy: ConflictResolutionStrategy): void {
+  try {
+    localStorage.setItem(CONFLICT_RESOLUTION_STRATEGY_STORAGE_KEY, strategy);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent<ConflictResolutionStrategy>(
+        CONFLICT_RESOLUTION_STRATEGY_CHANGED_EVENT,
+        { detail: strategy },
+      ));
+    }
+  } catch {
+    // 隐私模式或只读存储下仍保留本次调用语义；下次启动回到默认策略。
+  }
+}
 
 function payloadFromQueue(item: OfflineQueueItem): Partial<ConflictPayload> {
   const payload = item.localPayload || item.body || {};
@@ -164,4 +201,48 @@ export async function resolveNoteConflict(
     return keepLocalVersion(item, remote, local);
   }
   return useServerVersion(item, remote, local);
+}
+
+/**
+ * “最新版本优先”采用最后写入获胜语义：队列里的本地修改是刚刚提交到服务器的写入，
+ * 冲突发生后先读取服务器最新 revision，再用该 revision 重放本地修改。判断过程不依赖
+ * 客户端时钟；服务器旧内容仍由既有版本历史机制保留。
+ */
+export async function resolveQueuedNoteConflicts(
+  items: ReadonlyArray<OfflineQueueItem>,
+  strategy: ConflictResolutionStrategy = getConflictResolutionStrategy(),
+): Promise<AutoConflictResolutionResult> {
+  if (strategy === "ask") {
+    return { attempted: 0, resolved: 0, failed: 0, failures: [] };
+  }
+
+  const latestByNote = new Map<string, OfflineQueueItem>();
+  for (const item of items) {
+    if (item.type !== "updateNote" || !(item.conflict || item.errorCode === "VERSION_CONFLICT")) continue;
+    const previous = latestByNote.get(item.noteId);
+    if (!previous || item.enqueuedAt >= previous.enqueuedAt) latestByNote.set(item.noteId, item);
+  }
+
+  const conflicts = [...latestByNote.values()].sort((left, right) => left.enqueuedAt - right.enqueuedAt);
+  const failures: AutoConflictResolutionResult["failures"] = [];
+  let resolved = 0;
+
+  for (const item of conflicts) {
+    try {
+      await resolveNoteConflict(item, "keep-local");
+      resolved += 1;
+    } catch (error) {
+      failures.push({
+        noteId: item.noteId,
+        message: error instanceof Error ? error.message : String(error || "自动处理失败"),
+      });
+    }
+  }
+
+  return {
+    attempted: conflicts.length,
+    resolved,
+    failed: failures.length,
+    failures,
+  };
 }

--- a/frontend/src/lib/syncEngine.ts
+++ b/frontend/src/lib/syncEngine.ts
@@ -25,6 +25,7 @@ import {
   type OfflineQueueItem,
 } from "@/lib/offlineQueue";
 import { offlineQueueFetch } from "@/lib/offlineQueueFetch";
+import { resolveQueuedNoteConflicts } from "@/lib/conflictResolution";
 import type { Note, User } from "@/types";
 
 type SyncState = "idle" | "bootstrapping" | "ready" | "error";
@@ -90,6 +91,17 @@ export function countVersionConflicts(
   items: ReadonlyArray<Pick<OfflineQueueItem, "conflict" | "errorCode">>,
 ): number {
   return items.filter((item) => item.conflict || item.errorCode === "VERSION_CONFLICT").length;
+}
+
+async function resolveConfiguredVersionConflicts(): Promise<void> {
+  const result = await resolveQueuedNoteConflicts(getOfflineQueue());
+  if (result.failed > 0) {
+    console.warn("[syncEngine] automatic latest-write conflict resolution incomplete", {
+      attempted: result.attempted,
+      resolved: result.resolved,
+      failures: result.failures,
+    });
+  }
 }
 
 export function findLocallyDeletedQueuedNoteIds(
@@ -243,6 +255,7 @@ export async function bootstrap(user: User): Promise<void> {
         console.warn("[syncEngine] flush offline queue before pull failed:", error);
       });
     }
+    if (getOfflineQueue().length > 0) await resolveConfiguredVersionConflicts();
     await pullServerSnapshot();
     const pending = getQueueLength();
     const versionConflicts = countVersionConflicts(getFailedQueueItems());
@@ -276,6 +289,7 @@ export async function syncNow(): Promise<{
   setState("bootstrapping");
   try {
     if (getQueueLength() > 0) await flushQueue(offlineQueueFetch);
+    if (getQueueLength() > 0) await resolveConfiguredVersionConflicts();
     await pullServerSnapshot();
 
     const pending = getQueueLength();


### PR DESCRIPTION
## 背景

用户不希望版本冲突横幅持续打扰，并明确接受冲突时由最后一次写入覆盖旧版本。

## 变更

- 默认启用 `latest-wins` 冲突策略，成功自动处理后不再展示常驻冲突提醒
- 冲突发生后先读取服务器当前 revision，再重放最后提交的本地修改
- 同一篇笔记存在多条冲突队列时，只采用 `enqueuedAt` 最新的一条
- 判断过程不依赖客户端系统时间，避免多设备时钟偏差
- 服务器被覆盖内容继续由现有版本历史机制保留
- 自动处理失败时不清除队列，仍保留原有手动处理入口
- 保留 `ask` 策略，后续设置入口可直接切回逐条确认

## 测试

新增覆盖：

- 默认采用 `latest-wins`
- 可切换为手动 `ask`
- 同一笔记仅重放最新队列内容
- 手动策略不触发自动覆盖
- 原有服务器版本、本地版本与冲突副本保护流程继续通过既有测试覆盖

## 说明

本次只修改冲突策略与同步流程，不移除底层冲突保护。自动覆盖必须收到服务器版本递增确认后才会清理本地队列；失败时内容不会静默丢失。