### PR TITLE
fix(android): 默认打开移动端目录树并修复导航文字裁切

### DIFF
--- a/frontend/src/components/MobileDrawerUxBridge.tsx
+++ b/frontend/src/components/MobileDrawerUxBridge.tsx
@@ -10,6 +10,10 @@ import {
 
 export const MOBILE_DRAWER_SEARCH_BLUR_DELAY_MS = 160;
 
+export function isMobileDrawerViewport(width: number): boolean {
+  return Number.isFinite(width) && width < 768;
+}
+
 export function getSidebarSearchInput(target: EventTarget | null): HTMLInputElement | null {
   if (!(target instanceof HTMLInputElement)) return null;
   return target.matches("[data-sidebar-search]") ? target : null;
@@ -68,7 +72,7 @@ export function annotateMobileDrawerControls(root: ParentNode = document): void 
   });
 }
 
-const ANDROID_DRAWER_SAFE_AREA_CSS = `
+export const ANDROID_DRAWER_SAFE_AREA_CSS = `
 @media (max-width: 767px) {
   html[data-native="android"] [data-mobile-safe-topbar] {
     padding-top: max(calc(var(--safe-area-top) + 8px), 44px) !important;
@@ -87,6 +91,31 @@ const ANDROID_DRAWER_SAFE_AREA_CSS = `
 
   html[data-native="android"] [data-mobile-drawer-rail] {
     padding-top: max(calc(var(--safe-area-top) + 8px), 44px) !important;
+  }
+
+  /* Android WebView may enlarge tiny CJK text and clip it against the 64px label rail.
+     Give label mode a little more room and use a non-clipping line box. Icon mode keeps
+     its compact width, so switching modes still behaves as expected. */
+  html[data-native="android"] [data-mobile-drawer-rail].w-16 {
+    width: 72px !important;
+    min-width: 72px !important;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  html[data-native="android"] [data-mobile-drawer-rail].w-16 button {
+    width: 64px !important;
+    max-width: 64px !important;
+  }
+
+  html[data-native="android"] [data-mobile-drawer-rail].w-16 button > span:last-child {
+    max-width: 64px !important;
+    padding-left: 2px !important;
+    padding-right: 2px !important;
+    line-height: 1.35 !important;
+    white-space: nowrap !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
   }
 }
 `;
@@ -111,7 +140,6 @@ export default function MobileDrawerUxBridge() {
   const actions = useAppActions();
   const mobileSidebarOpenRef = useRef(state.mobileSidebarOpen);
   const blurTimerRef = useRef<number | null>(null);
-  const layoutInitializedRef = useRef(false);
   const previousViewModeRef = useRef(state.viewMode);
 
   useEffect(() => {
@@ -137,14 +165,16 @@ export default function MobileDrawerUxBridge() {
     if (functionalList) {
       if (viewChanged && state.mobileView !== "list") actions.setMobileView("list");
     } else if (state.mobileView !== "editor") {
-      // First boot goes directly to the editor empty state. A later Android back
-      // action previously targeting the retired list now opens the unified tree.
+      // The retired note-list route now maps to the editor shell. On phones, open the
+      // unified tree immediately on first boot as well as after a later Android-back
+      // navigation, so users never have to press Back once just to reach their notebooks.
       actions.setMobileView("editor");
-      if (layoutInitializedRef.current) actions.setMobileSidebar(true);
+      if (typeof window !== "undefined" && isMobileDrawerViewport(window.innerWidth)) {
+        actions.setMobileSidebar(true);
+      }
     }
 
     previousViewModeRef.current = state.viewMode;
-    layoutInitializedRef.current = true;
   }, [actions, state.mobileView, state.noteListCollapsed, state.viewMode]);
 
   useEffect(() => {

--- a/frontend/src/components/__tests__/MobileDrawerUxBridge.test.ts
+++ b/frontend/src/components/__tests__/MobileDrawerUxBridge.test.ts
@@ -2,8 +2,10 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  ANDROID_DRAWER_SAFE_AREA_CSS,
   annotateMobileDrawerControls,
   getSidebarSearchInput,
+  isMobileDrawerViewport,
   shouldCloseDrawerAfterSearchBlur,
   shouldCloseDrawerOnSearchEnter,
 } from "@/components/MobileDrawerUxBridge";
@@ -11,6 +13,19 @@ import {
 describe("MobileDrawerUxBridge helpers", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+  });
+
+  it("treats phone widths as the default-open drawer surface", () => {
+    expect(isMobileDrawerViewport(360)).toBe(true);
+    expect(isMobileDrawerViewport(767)).toBe(true);
+    expect(isMobileDrawerViewport(768)).toBe(false);
+    expect(isMobileDrawerViewport(Number.NaN)).toBe(false);
+  });
+
+  it("keeps Android label mode wide enough without clipping CJK glyphs", () => {
+    expect(ANDROID_DRAWER_SAFE_AREA_CSS).toContain("width: 72px !important");
+    expect(ANDROID_DRAWER_SAFE_AREA_CSS).toContain("line-height: 1.35 !important");
+    expect(ANDROID_DRAWER_SAFE_AREA_CSS).toContain("text-overflow: clip !important");
   });
 
   it("closes on a committed Enter but not while an IME is composing", () => {


### PR DESCRIPTION
## 用户反馈

1. 手机端打开应用后没有直接展示抽屉目录树，需要先按一次返回键才能看到。
2. Android 导航栏开启“图标 + 文字”模式后，部分中文文字被裁切或显示不完整。

## 修复

- 统一内容树模式首次进入手机端时，直接打开现有的 `NavRail + Sidebar` 抽屉。
- 保留桌面端行为不变，仅在 `< 768px` 的手机视口自动打开。
- Android 标签模式下将导航 Rail 从 64px 放宽到 72px，按钮内容区放宽到 64px。
- 修正 Android WebView 小字号 CJK 文本的自动缩放与 `line-height: 1` 裁切问题。
- 覆盖原来的 `truncate` 溢出规则，标签使用完整文字，不再出现省略或缺笔画。

## 测试

- 新增手机视口边界测试：767px 自动打开，768px 不自动打开。
- 新增 Android 导航宽度、行高和取消文字裁切的样式契约测试。
- 原有搜索提交、失焦关闭抽屉和安全区标记测试保持不变。

## 影响范围

仅影响移动端统一目录树抽屉和 Android 导航 Rail；桌面布局、笔记内容和同步逻辑不受影响。