### PR TITLE
fix(share): 修复 Edge 分享链接复制失败

### DIFF
--- a/.github/edge-share-copy-trigger
+++ b/.github/edge-share-copy-trigger
@@ -1,0 +1,1 @@
+Trigger the one-shot Edge share clipboard fallback implementation.

--- a/.github/edge-share-copy-trigger
+++ b/.github/edge-share-copy-trigger
@@ -1,1 +1,0 @@
-Trigger the one-shot Edge share clipboard fallback implementation.

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { confirm } from "@/components/ui/confirm";
 import { api } from "@/lib/api";
+import { copyText } from "@/lib/clipboard";
 import {
   buildPublicWebUrl,
   getPublicWebOriginSourceLabel,
@@ -180,17 +181,18 @@ export default function ShareModal({ noteId, noteTitle, initialShareId, onClose 
 
   const shareUrl = (token: string) => buildPublicWebUrl(`/share/${token}`, publicOriginOptions);
   const copy = async (value: string, id: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(id);
-      window.setTimeout(() => setCopied(null), 1600);
-      if (publicOrigin.requiresAnonymousCheck) {
-        toast.warning("链接已复制，请在无痕窗口、微信或未登录设备中验证");
-      } else {
-        toast.success("分享链接已复制");
-      }
-    } catch {
+    const ok = await copyText(value);
+    if (!ok) {
       toast.error("复制失败，请手动复制");
+      return;
+    }
+
+    setCopied(id);
+    window.setTimeout(() => setCopied((current) => current === id ? null : current), 1600);
+    if (publicOrigin.requiresAnonymousCheck) {
+      toast.warning("链接已复制，请在无痕窗口、微信或未登录设备中验证");
+    } else {
+      toast.success("分享链接已复制");
     }
   };
 

--- a/frontend/src/components/__tests__/ShareModalClipboard.test.ts
+++ b/frontend/src/components/__tests__/ShareModalClipboard.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(resolve(process.cwd(), "src/components/ShareModal.tsx"), "utf8");
+
+describe("ShareModal clipboard fallback", () => {
+  it("uses the shared clipboard helper instead of the Edge-sensitive direct API", () => {
+    expect(source).toContain('import { copyText } from "@/lib/clipboard";');
+    expect(source).toContain("const ok = await copyText(value);");
+    expect(source).toContain('toast.error("复制失败，请手动复制")');
+    expect(source).not.toContain("navigator.clipboard.writeText(value)");
+  });
+
+  it("only clears the copied indicator for the same share", () => {
+    expect(source).toContain("setCopied((current) => current === id ? null : current)");
+  });
+});


### PR DESCRIPTION
## 问题

分享弹窗直接调用 `navigator.clipboard.writeText`。Edge 在剪贴板权限受限、HTTP 自部署或非安全上下文下会直接失败，未走项目已有的降级复制逻辑。

## 修改

- 分享弹窗改用统一 `copyText` 工具。
- 异步 Clipboard API 失败时自动降级到 `textarea + execCommand('copy')`。
- 复制状态定时器只清理当前分享项，避免快速连续复制时状态串扰。
- 增加回归测试并执行前端构建。
