### PR TITLE
feat(mobile): 紧凑化安卓与移动端内容树

### DIFF
--- a/.github/workflows/knowledge-tree-sidebar-ci.yml
+++ b/.github/workflows/knowledge-tree-sidebar-ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'frontend/src/main.tsx'
+      - 'frontend/src/mobile-knowledge-tree-compact.css'
       - 'frontend/src/components/Sidebar.tsx'
       - 'frontend/src/components/KnowledgeTreeDrawer.tsx'
       - 'frontend/src/components/KnowledgeTreePanel.tsx'
@@ -41,6 +43,9 @@ jobs:
           grep -q "onContextMenu" frontend/src/components/KnowledgeTreePanel.tsx
           grep -q "onTouchStart" frontend/src/components/KnowledgeTreePanel.tsx
           grep -q "KnowledgeTreeNodeMenu" frontend/src/components/KnowledgeTreePanel.tsx
+          grep -q "mobile-knowledge-tree-compact.css" frontend/src/main.tsx
+          grep -q -- "--nowen-mobile-tree-row-height: 26px" frontend/src/mobile-knowledge-tree-compact.css
+          grep -q -- "--nowen-mobile-tree-indent: 10px" frontend/src/mobile-knowledge-tree-compact.css
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -61,4 +61,24 @@ describe("knowledge tree sidebar contract", () => {
     expect(panel).toContain("onNotePatched={patchNoteStatus}");
     expect(menu).toContain("onNotePatched(node.id, patch)");
   });
+
+  it("uses a mobile-only compact tree without changing desktop density", () => {
+    const main = source("../../main.tsx");
+    const compactCss = source("../../mobile-knowledge-tree-compact.css");
+    const menu = source("../../components/KnowledgeTreeNodeMenu.tsx");
+
+    expect(main).toContain('import "./mobile-knowledge-tree-compact.css"');
+    expect(compactCss).toContain("@media (max-width: 767px)");
+    expect(compactCss).toContain("--nowen-mobile-tree-row-height: 26px");
+    expect(compactCss).toContain("--nowen-mobile-tree-indent: 10px");
+    expect(compactCss).toContain('button[aria-label$="下新建文档"]');
+    expect(compactCss).toMatch(/button\[aria-label\$="下新建文档"\][\s\S]*display:\s*none\s*!important/);
+    expect(compactCss).toContain('button[title="更多"]');
+    expect(compactCss).toContain("width: 22px !important");
+    expect(compactCss).not.toContain("@media (min-width: 768px)");
+
+    // Hiding the duplicated inline plus must not remove mobile creation access.
+    expect(menu).toContain("mobile long-press");
+    expect(menu).toContain('{ id: "create", label: "新建"');
+  });
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -44,6 +44,7 @@ import "./overlay-layers.css";
 import "./space-actions.css";
 import "./settings-switches.css";
 import "./sidebar-search-experience.css";
+import "./mobile-knowledge-tree-compact.css";
 import "./siyuan-rich-text-callout.css";
 import "./knowledge-tree-markdown-drop.css";
 import { initCodeBlockTheme } from "./lib/codeBlockTheme";

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -1,0 +1,124 @@
+/*
+ * Mobile / Android knowledge-tree density.
+ *
+ * The desktop tree intentionally keeps its current comfortable spacing. On a
+ * narrow sidebar every horizontal pixel matters, so the mobile surface uses a
+ * compact 26px row, a 10px hierarchy step and one visible row action. Creating
+ * children remains available from the More / long-press menu, so the repeated
+ * inline plus button is redundant on touch devices.
+ */
+@media (max-width: 767px) {
+  [data-nowen-knowledge-tree="embedded"] {
+    --nowen-mobile-tree-row-height: 26px;
+    --nowen-mobile-tree-indent: 10px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] {
+    min-height: var(--nowen-mobile-tree-row-height);
+    border-radius: 6px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child {
+    width: 14px !important;
+    height: var(--nowen-mobile-tree-row-height) !important;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child > svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) {
+    min-height: var(--nowen-mobile-tree-row-height);
+    gap: 4px !important;
+    padding-top: 2px !important;
+    padding-bottom: 2px !important;
+    font-size: 12px !important;
+    line-height: 18px !important;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) > svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) > span:first-child {
+    width: 14px !important;
+    font-size: 13px !important;
+  }
+
+  /* The same Create command exists in the More / long-press menu on mobile. */
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[aria-label$="下新建文档"] {
+    display: none !important;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[title="更多"] {
+    display: flex !important;
+    width: 22px !important;
+    height: var(--nowen-mobile-tree-row-height) !important;
+    flex: 0 0 22px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[title="更多"] > svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  /*
+   * KnowledgeTreePanel currently writes desktop indentation inline. Override it
+   * only on the mobile breakpoint and derive compact depth from the recursive
+   * wrapper structure. Eight levels covers the supported practical depth while
+   * keeping the document data untouched.
+   */
+  [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id] {
+    padding-left: 0 !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 1) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 2) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 3) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 4) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 5) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 6) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 7) !important;
+  }
+
+  [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
+    padding-left: calc(var(--nowen-mobile-tree-indent) * 8) !important;
+  }
+
+  [data-knowledge-tree-section] > div:first-child {
+    padding-top: 2px !important;
+    padding-bottom: 2px !important;
+    line-height: 14px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-inline-create] > div {
+    min-height: 28px;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-swipe-blocker="knowledge-tree-scroll"] {
+    padding-bottom: 8px !important;
+  }
+}


### PR DESCRIPTION
## 目标

针对安卓端与移动 Web 的内容树进行紧凑化，减少截图中展开箭头、层级缩进以及每行右侧操作区造成的空间浪费。桌面端布局保持不变。

## 设计调整

- 移动端树节点行高统一为 **26px**；
- 每级缩进由 **16px** 压缩为 **10px**；
- 展开箭头占位由 **20px** 压缩为 **14px**；
- 图标与标题间距由 6px 压缩为 4px；
- 图标统一收敛到约 14px；
- 移动端隐藏每一行重复的 `+` 按钮，只保留紧凑的 `…`；
- “新建”能力仍完整保留在 `…` 菜单和长按菜单中；
- 右侧更多按钮宽度压缩为 **22px**；
- 压缩“当前空间 / 共享给我”分区标题的上下留白；
- 内联新建行同步采用紧凑高度。

## 作用范围

所有样式均限制在：

```css
@media (max-width: 767px)
```

因此同时覆盖 Android WebView 与移动浏览器，不影响桌面端内容树密度。

## 产品交互

移动端删除重复的行内 `+` 不是删除功能：

- 点击 `…` 可进入“新建”子菜单；
- 长按任意节点也可打开同一个完整菜单；
- 顶部 `+` 继续负责创建根文件夹。

## 回归保障

- 校验紧凑样式已在入口加载；
- 锁定 26px 行高、10px 缩进和 22px 操作区；
- 校验移动端重复 `+` 被隐藏；
- 校验长按/更多菜单仍包含“新建”；
- Knowledge Tree Sidebar CI 增加样式文件触发路径与静态检查；
- 保留原有内容树、上下文菜单、共享树测试与 TypeScript 检查。

## CI

以下 7 条工作流全部通过：

- Knowledge Tree CI
- Knowledge Tree Sidebar CI
- Shared Knowledge Tree CI
- Round-trip Import Batch CI
- Round-trip Permission Transfer V2 CI
- Siyuan Import Feedback CI
- Embedding Index Copy CI