### PR TITLE
fix(mobile): 继续压缩内容树箭头与图标间距

### DIFF
--- a/.github/workflows/knowledge-tree-sidebar-ci.yml
+++ b/.github/workflows/knowledge-tree-sidebar-ci.yml
@@ -46,6 +46,9 @@ jobs:
           grep -q "mobile-knowledge-tree-compact.css" frontend/src/main.tsx
           grep -q -- "--nowen-mobile-tree-row-height: 26px" frontend/src/mobile-knowledge-tree-compact.css
           grep -q -- "--nowen-mobile-tree-indent: 10px" frontend/src/mobile-knowledge-tree-compact.css
+          grep -q -- "--nowen-mobile-tree-expander-width: 8px" frontend/src/mobile-knowledge-tree-compact.css
+          grep -q -- "--nowen-mobile-tree-content-gap: 3px" frontend/src/mobile-knowledge-tree-compact.css
+          grep -q -- "flex: 0 0 var(--nowen-mobile-tree-expander-width) !important" frontend/src/mobile-knowledge-tree-compact.css
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -71,6 +71,12 @@ describe("knowledge tree sidebar contract", () => {
     expect(compactCss).toContain("@media (max-width: 767px)");
     expect(compactCss).toContain("--nowen-mobile-tree-row-height: 26px");
     expect(compactCss).toContain("--nowen-mobile-tree-indent: 10px");
+    expect(compactCss).toContain("--nowen-mobile-tree-expander-width: 8px");
+    expect(compactCss).toContain("--nowen-mobile-tree-content-gap: 3px");
+    expect(compactCss).toContain("min-width: var(--nowen-mobile-tree-expander-width) !important");
+    expect(compactCss).toContain("max-width: var(--nowen-mobile-tree-expander-width) !important");
+    expect(compactCss).toContain("flex: 0 0 var(--nowen-mobile-tree-expander-width) !important");
+    expect(compactCss).toContain("padding-left: 0 !important");
     expect(compactCss).toContain('button[aria-label$="下新建文档"]');
     expect(compactCss).toMatch(/button\[aria-label\$="下新建文档"\][\s\S]*display:\s*none\s*!important/);
     expect(compactCss).toContain('button[title="更多"]');

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -11,6 +11,8 @@
   [data-nowen-knowledge-tree="embedded"] {
     --nowen-mobile-tree-row-height: 26px;
     --nowen-mobile-tree-indent: 10px;
+    --nowen-mobile-tree-expander-width: 8px;
+    --nowen-mobile-tree-content-gap: 3px;
   }
 
   [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] {
@@ -18,21 +20,36 @@
     border-radius: 6px;
   }
 
+  /*
+   * Lock every part of the flex item, not only width. Some Android WebViews kept
+   * the original w-5 flex footprint even after width was overridden, leaving a
+   * visibly large gap between the chevron and the node icon.
+   */
   [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child {
-    width: 14px !important;
+    width: var(--nowen-mobile-tree-expander-width) !important;
+    min-width: var(--nowen-mobile-tree-expander-width) !important;
+    max-width: var(--nowen-mobile-tree-expander-width) !important;
     height: var(--nowen-mobile-tree-row-height) !important;
+    flex: 0 0 var(--nowen-mobile-tree-expander-width) !important;
+    margin-right: -1px !important;
+    padding: 0 !important;
   }
 
   [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child > svg {
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
+    flex: 0 0 10px;
   }
 
   [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) {
     min-height: var(--nowen-mobile-tree-row-height);
-    gap: 4px !important;
+    justify-content: flex-start;
+    gap: var(--nowen-mobile-tree-content-gap) !important;
+    margin-left: 0 !important;
     padding-top: 2px !important;
+    padding-right: 0 !important;
     padding-bottom: 2px !important;
+    padding-left: 0 !important;
     font-size: 12px !important;
     line-height: 18px !important;
   }


### PR DESCRIPTION
## 问题

PR #509 已压缩移动端内容树整体密度，但实际 Android 截图中，展开箭头与目录图标之间仍存在明显空白。

## 根因

上一版只覆盖了展开按钮的 `width: 14px`。在部分 Android WebView 的 Flex 布局中，原 Tailwind `w-5 shrink-0` 仍可能保留旧的最小宽度或 Flex 占位，因此视觉间距没有按预期收紧。

## 修复

- 展开区从 14px 进一步压缩为 **8px**；
- 同时锁定 `width / min-width / max-width / flex-basis`，彻底清除残留 Flex 占位；
- 展开按钮清零 padding，并回收 1px 右侧空间；
- 箭头图标收敛到 10px；
- 箭头后的内容间距统一为 **3px**；
- 文档/文件夹内容按钮清零左侧 padding，避免 WebView 默认样式造成额外空白；
- 行高、层级缩进、右侧更多按钮及桌面端布局保持不变。

## 交互保障

文件夹标题区域本身仍可点击展开/折叠，因此缩小箭头视觉占位不会降低主要触控可用性。

## 回归

- 合约测试锁定 8px 展开区、3px 内容间距及完整 Flex 约束；
- Knowledge Tree Sidebar CI 增加静态检查；
- 原内容树、上下文菜单、共享树测试与 TypeScript 检查继续运行。

## CI

以下工作流全部通过：

- Knowledge Tree CI
- Knowledge Tree Sidebar CI
- Shared Knowledge Tree CI
- 内容树合约及菜单测试
- 前端 TypeScript 检查

Follow-up to #509