### PR TITLE
feat(permissions): 参考钉钉重构目录权限管理

### DIFF
--- a/.github/permission-management-trigger.md
+++ b/.github/permission-management-trigger.md
@@ -1,1 +1,0 @@
-Collect Notebook Permission Management CI diagnostics for PR #513.

--- a/.github/permission-management-trigger.md
+++ b/.github/permission-management-trigger.md
@@ -1,1 +1,1 @@
-Temporary validation trigger for PR #513.
+Trigger Notebook Permission Management CI for PR #513.

--- a/.github/permission-management-trigger.md
+++ b/.github/permission-management-trigger.md
@@ -1,0 +1,1 @@
+Temporary validation trigger for PR #513.

--- a/.github/permission-management-trigger.md
+++ b/.github/permission-management-trigger.md
@@ -1,1 +1,1 @@
-Trigger Notebook Permission Management CI for PR #513.
+Collect Notebook Permission Management CI diagnostics for PR #513.

--- a/backend/src/runtime/knowledge-tree-migration-bootstrap.ts
+++ b/backend/src/runtime/knowledge-tree-migration-bootstrap.ts
@@ -1,3 +1,4 @@
+import "./notebook-permission-management.js";
 import { knowledgeTreeMigration } from "../db/knowledgeTreeMigration.js";
 import { knowledgeTreeResourceMigration } from "../db/knowledgeTreeResourceMigration.js";
 import { knowledgeTreeParentPreservationMigration } from "../db/knowledgeTreeParentPreservationMigration.js";
@@ -6,6 +7,8 @@ import { knowledgeTreeStructuralGuardMigration } from "../db/knowledgeTreeStruct
 import { MIGRATIONS as BASE_MIGRATIONS } from "../db/migrations.impl.js";
 
 // index.hardened imports this module before any runtime that can open the database.
+// Keep modular route installers here as well, so they are attached to their shared routers
+// before the application mounts those routers under /api.
 // Mutating the historical base list here lets migrations.ts compute CURRENT_SCHEMA_VERSION
 // with the feature migrations included, without coupling the main migration wrapper to them.
 for (const featureMigration of [

--- a/backend/src/runtime/notebook-permission-management.ts
+++ b/backend/src/runtime/notebook-permission-management.ts
@@ -1,0 +1,97 @@
+import notebooksRouter from "../routes/notebooks.js";
+import { getDb } from "../db/schema.js";
+import { hasPermission, resolveNotebookPermission } from "../middleware/acl.js";
+import { notebookMembersRepository } from "../repositories/index.js";
+import {
+  NotebookOwnershipTransferError,
+  transferNotebookOwnership,
+} from "../services/notebookOwnershipTransfer.js";
+
+const INSTALL_KEY = Symbol.for("nowen.notebookPermissionManagement.installed");
+const runtime = globalThis as typeof globalThis & { [INSTALL_KEY]?: boolean };
+
+function memberId(notebookId: string, userId: string): string {
+  return `${notebookId}:${userId}`;
+}
+
+if (!runtime[INSTALL_KEY]) {
+  runtime[INSTALL_KEY] = true;
+
+  notebooksRouter.get("/:id/permission-summary", (c) => {
+    const userId = c.req.header("X-User-Id") || "";
+    const notebookId = c.req.param("id");
+    const { permission } = resolveNotebookPermission(notebookId, userId);
+    if (!hasPermission(permission, "manage")) {
+      return c.json({ error: "无权管理该目录", code: "FORBIDDEN" }, 403);
+    }
+
+    const notebook = getDb().prepare(`
+      SELECT nb.id, nb.userId, nb.workspaceId, nb.createdAt, nb.updatedAt,
+             u.username, u.email, u.displayName, u.avatarUrl
+        FROM notebooks nb
+        JOIN users u ON u.id = nb.userId
+       WHERE nb.id = ? AND nb.isDeleted = 0
+    `).get(notebookId) as {
+      id: string;
+      userId: string;
+      workspaceId: string | null;
+      createdAt: string;
+      updatedAt: string;
+      username: string;
+      email: string | null;
+      displayName: string | null;
+      avatarUrl: string | null;
+    } | undefined;
+
+    if (!notebook) return c.json({ error: "目录不存在", code: "NOTEBOOK_NOT_FOUND" }, 404);
+
+    const directMembers = notebookMembersRepository
+      .listByNotebook(notebookId)
+      .filter((member) => member.userId !== notebook.userId);
+    const owner = {
+      id: memberId(notebookId, notebook.userId),
+      notebookId,
+      userId: notebook.userId,
+      role: "owner" as const,
+      status: "active" as const,
+      allowDownload: 1,
+      allowReshare: 1,
+      source: "manual" as const,
+      sourceId: null,
+      invitedBy: null,
+      createdAt: notebook.createdAt,
+      updatedAt: notebook.updatedAt,
+      username: notebook.username,
+      email: notebook.email,
+      displayName: notebook.displayName,
+      avatarUrl: notebook.avatarUrl,
+    };
+
+    return c.json({
+      notebookId,
+      workspaceId: notebook.workspaceId,
+      ownerId: notebook.userId,
+      members: [owner, ...directMembers],
+    });
+  });
+
+  notebooksRouter.post("/:id/transfer-owner", async (c) => {
+    const actorUserId = c.req.header("X-User-Id") || "";
+    const notebookId = c.req.param("id");
+    const body = await c.req.json().catch(() => ({}));
+
+    try {
+      return c.json(transferNotebookOwnership({
+        notebookId,
+        actorUserId,
+        targetUserId: String(body.targetUserId || ""),
+      }));
+    } catch (error) {
+      if (error instanceof NotebookOwnershipTransferError) {
+        return c.json({ error: error.message, code: error.code }, error.status as any);
+      }
+      console.error("[notebook-permission-management] transfer failed:", error);
+      return c.json({ error: "转交所有者失败", code: "TRANSFER_OWNER_FAILED" }, 500);
+    }
+  });
+}

--- a/backend/src/services/notebookOwnershipTransfer.ts
+++ b/backend/src/services/notebookOwnershipTransfer.ts
@@ -1,0 +1,209 @@
+import type Database from "better-sqlite3";
+import { v4 as uuid } from "uuid";
+import { getDb } from "../db/schema";
+
+export interface TransferNotebookOwnershipInput {
+  notebookId: string;
+  actorUserId: string;
+  targetUserId: string;
+}
+
+export interface TransferNotebookOwnershipResult {
+  notebookId: string;
+  previousOwnerId: string;
+  newOwnerId: string;
+  notebookCount: number;
+  noteCount: number;
+  attachmentCount: number;
+  detachedFromParent: boolean;
+}
+
+export class NotebookOwnershipTransferError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(code: string, message: string, status = 400) {
+    super(message);
+    this.name = "NotebookOwnershipTransferError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(",");
+}
+
+/**
+ * 将个人空间目录及完整子树转交给一个现有协作者。
+ *
+ * 约束：
+ * - 仅个人空间目录支持转交；团队空间的所有权由工作区角色管理。
+ * - 仅真实所有者可以发起，拥有 manage 权限的协作者不能代替所有者操作。
+ * - 接收人必须已经是该目录的直接协作者，避免误输账号导致不可逆转交。
+ * - 若目录原本位于另一个目录下，转交时自动提升为新所有者个人空间的根目录，
+ *   避免产生跨用户 parentId 链。
+ */
+export function transferNotebookOwnership(
+  input: TransferNotebookOwnershipInput,
+  db: Database.Database = getDb(),
+): TransferNotebookOwnershipResult {
+  const notebookId = String(input.notebookId || "").trim();
+  const actorUserId = String(input.actorUserId || "").trim();
+  const targetUserId = String(input.targetUserId || "").trim();
+
+  if (!actorUserId) throw new NotebookOwnershipTransferError("UNAUTHENTICATED", "未登录", 401);
+  if (!notebookId || !targetUserId) {
+    throw new NotebookOwnershipTransferError("INVALID_ARGUMENT", "notebookId 和 targetUserId 必填");
+  }
+
+  const root = db.prepare(
+    `SELECT id, userId, workspaceId, parentId, isDeleted
+       FROM notebooks
+      WHERE id = ?`,
+  ).get(notebookId) as {
+    id: string;
+    userId: string;
+    workspaceId: string | null;
+    parentId: string | null;
+    isDeleted: number;
+  } | undefined;
+
+  if (!root || root.isDeleted) {
+    throw new NotebookOwnershipTransferError("NOTEBOOK_NOT_FOUND", "目录不存在或已删除", 404);
+  }
+  if (root.workspaceId) {
+    throw new NotebookOwnershipTransferError(
+      "WORKSPACE_NOTEBOOK_TRANSFER_UNSUPPORTED",
+      "团队空间目录由工作区角色管理，暂不支持单独转交所有者",
+    );
+  }
+  if (root.userId !== actorUserId) {
+    throw new NotebookOwnershipTransferError("OWNER_REQUIRED", "只有目录所有者可以转交", 403);
+  }
+  if (targetUserId === actorUserId) {
+    throw new NotebookOwnershipTransferError("TARGET_IS_OWNER", "接收人已经是当前所有者");
+  }
+
+  const target = db.prepare(
+    "SELECT id FROM users WHERE id = ? AND isDisabled = 0",
+  ).get(targetUserId) as { id: string } | undefined;
+  if (!target) {
+    throw new NotebookOwnershipTransferError("TARGET_USER_NOT_FOUND", "接收用户不存在或已停用", 404);
+  }
+
+  const targetMembership = db.prepare(
+    `SELECT role, status
+       FROM notebook_members
+      WHERE notebookId = ? AND userId = ?`,
+  ).get(notebookId, targetUserId) as { role: string; status: string } | undefined;
+  if (!targetMembership || targetMembership.status !== "active") {
+    throw new NotebookOwnershipTransferError(
+      "TARGET_NOT_COLLABORATOR",
+      "请先将接收人添加为该目录的协作者",
+    );
+  }
+
+  const notebookIds = (db.prepare(
+    `WITH RECURSIVE subtree(id) AS (
+       SELECT id FROM notebooks WHERE id = ? AND isDeleted = 0
+       UNION ALL
+       SELECT child.id
+         FROM notebooks child
+         JOIN subtree parent ON child.parentId = parent.id
+        WHERE child.isDeleted = 0
+     )
+     SELECT id FROM subtree`,
+  ).all(notebookId) as Array<{ id: string }>).map((row) => row.id);
+
+  if (notebookIds.length === 0) {
+    throw new NotebookOwnershipTransferError("NOTEBOOK_NOT_FOUND", "目录不存在或已删除", 404);
+  }
+
+  const notebookMarks = placeholders(notebookIds.length);
+  const noteIds = (db.prepare(
+    `SELECT id FROM notes WHERE notebookId IN (${notebookMarks})`,
+  ).all(...notebookIds) as Array<{ id: string }>).map((row) => row.id);
+  const noteMarks = noteIds.length > 0 ? placeholders(noteIds.length) : "";
+
+  let attachmentCount = 0;
+  const detachedFromParent = Boolean(root.parentId);
+
+  const execute = db.transaction(() => {
+    if (root.parentId) {
+      db.prepare(
+        "UPDATE notebooks SET parentId = NULL, updatedAt = datetime('now') WHERE id = ?",
+      ).run(notebookId);
+    }
+
+    db.prepare(
+      `UPDATE notebooks
+          SET userId = ?, updatedAt = datetime('now')
+        WHERE id IN (${notebookMarks})`,
+    ).run(targetUserId, ...notebookIds);
+
+    if (noteIds.length > 0) {
+      db.prepare(
+        `UPDATE notes
+            SET userId = ?, updatedAt = datetime('now')
+          WHERE id IN (${noteMarks})`,
+      ).run(targetUserId, ...noteIds);
+
+      const attachmentResult = db.prepare(
+        `UPDATE attachments
+            SET userId = ?, workspaceId = NULL
+          WHERE noteId IN (${noteMarks})`,
+      ).run(targetUserId, ...noteIds);
+      attachmentCount = attachmentResult.changes;
+    }
+
+    // 清理旧所有者 / 新所有者在子树中的显式覆盖，避免 owner/editor 身份被 none 覆盖。
+    db.prepare(
+      `DELETE FROM notebook_acl_overrides
+        WHERE notebookId IN (${notebookMarks})
+          AND userId IN (?, ?)`,
+    ).run(...notebookIds, actorUserId, targetUserId);
+
+    // 子目录里可能存在历史 owner 成员行，统一降级为 editor；真正所有权以 notebooks.userId 为准。
+    db.prepare(
+      `UPDATE notebook_members
+          SET role = 'editor', status = 'active', updatedAt = datetime('now')
+        WHERE notebookId IN (${notebookMarks})
+          AND userId = ?`,
+    ).run(...notebookIds, actorUserId);
+
+    db.prepare(
+      `INSERT INTO notebook_members (
+         id, notebookId, userId, role, status, allowDownload, allowReshare,
+         source, sourceId, invitedBy
+       ) VALUES (?, ?, ?, 'editor', 'active', 1, 0, 'manual', NULL, ?)
+       ON CONFLICT(notebookId, userId) DO UPDATE SET
+         role = 'editor', status = 'active', allowDownload = 1, allowReshare = 0,
+         source = 'manual', sourceId = NULL, invitedBy = excluded.invitedBy,
+         updatedAt = datetime('now')`,
+    ).run(`${notebookId}:${actorUserId}`, notebookId, actorUserId, targetUserId);
+
+    db.prepare(
+      `INSERT INTO notebook_members (
+         id, notebookId, userId, role, status, allowDownload, allowReshare,
+         source, sourceId, invitedBy
+       ) VALUES (?, ?, ?, 'owner', 'active', 1, 1, 'manual', NULL, ?)
+       ON CONFLICT(notebookId, userId) DO UPDATE SET
+         role = 'owner', status = 'active', allowDownload = 1, allowReshare = 1,
+         source = 'manual', sourceId = NULL, invitedBy = excluded.invitedBy,
+         updatedAt = datetime('now')`,
+    ).run(`${notebookId}:${targetUserId}`, notebookId, targetUserId, actorUserId);
+  });
+
+  execute();
+
+  return {
+    notebookId,
+    previousOwnerId: actorUserId,
+    newOwnerId: targetUserId,
+    notebookCount: notebookIds.length,
+    noteCount: noteIds.length,
+    attachmentCount,
+    detachedFromParent,
+  };
+}

--- a/backend/src/services/notebookOwnershipTransfer.ts
+++ b/backend/src/services/notebookOwnershipTransfer.ts
@@ -104,22 +104,28 @@ export function transferNotebookOwnership(
     );
   }
 
-  const notebookIds = (db.prepare(
-    `WITH RECURSIVE subtree(id) AS (
-       SELECT id FROM notebooks WHERE id = ? AND isDeleted = 0
+  const treeRows = db.prepare(
+    `WITH RECURSIVE subtree(id, parentId) AS (
+       SELECT id, parentId FROM notebooks WHERE id = ? AND isDeleted = 0
        UNION ALL
-       SELECT child.id
+       SELECT child.id, child.parentId
          FROM notebooks child
          JOIN subtree parent ON child.parentId = parent.id
         WHERE child.isDeleted = 0
      )
-     SELECT id FROM subtree`,
-  ).all(notebookId) as Array<{ id: string }>).map((row) => row.id);
+     SELECT id, parentId FROM subtree`,
+  ).all(notebookId) as Array<{ id: string; parentId: string | null }>;
 
-  if (notebookIds.length === 0) {
+  if (treeRows.length === 0) {
     throw new NotebookOwnershipTransferError("NOTEBOOK_NOT_FOUND", "目录不存在或已删除", 404);
   }
 
+  const notebookIds = treeRows.map((row) => row.id);
+  const notebookIdSet = new Set(notebookIds);
+  const internalEdges = treeRows.filter(
+    (row): row is { id: string; parentId: string } =>
+      Boolean(row.parentId && notebookIdSet.has(row.parentId)),
+  );
   const notebookMarks = placeholders(notebookIds.length);
   const noteIds = (db.prepare(
     `SELECT id FROM notes WHERE notebookId IN (${notebookMarks})`,
@@ -131,17 +137,13 @@ export function transferNotebookOwnership(
   ensureNotebookAclOverridesTable();
 
   const execute = db.transaction(() => {
-    if (root.parentId) {
-      db.prepare(
-        "UPDATE notebooks SET parentId = NULL, updatedAt = datetime('now') WHERE id = ?",
-      ).run(notebookId);
-    }
-
+    // Tree guards intentionally reject a half-transferred tree. Temporarily detach the subtree,
+    // move resources and ownership while every node is a root, then restore only internal edges.
     db.prepare(
       `UPDATE notebooks
-          SET userId = ?, updatedAt = datetime('now')
-        WHERE id IN (${notebookMarks})`,
-    ).run(targetUserId, ...notebookIds);
+          SET parentId = NULL, updatedAt = datetime('now')
+        WHERE id IN (${notebookMarks}) AND parentId IS NOT NULL`,
+    ).run(...notebookIds);
 
     if (noteIds.length > 0) {
       db.prepare(
@@ -156,6 +158,19 @@ export function transferNotebookOwnership(
           WHERE noteId IN (${noteMarks})`,
       ).run(targetUserId, ...noteIds);
       attachmentCount = attachmentResult.changes;
+    }
+
+    db.prepare(
+      `UPDATE notebooks
+          SET userId = ?, updatedAt = datetime('now')
+        WHERE id IN (${notebookMarks})`,
+    ).run(targetUserId, ...notebookIds);
+
+    const restoreParent = db.prepare(
+      "UPDATE notebooks SET parentId = ?, updatedAt = datetime('now') WHERE id = ?",
+    );
+    for (const edge of internalEdges) {
+      restoreParent.run(edge.parentId, edge.id);
     }
 
     db.prepare(

--- a/backend/src/services/notebookOwnershipTransfer.ts
+++ b/backend/src/services/notebookOwnershipTransfer.ts
@@ -1,6 +1,6 @@
 import type Database from "better-sqlite3";
-import { v4 as uuid } from "uuid";
 import { getDb } from "../db/schema";
+import { ensureNotebookAclOverridesTable } from "../queries/memberQueryService";
 
 export interface TransferNotebookOwnershipInput {
   notebookId: string;
@@ -128,6 +128,7 @@ export function transferNotebookOwnership(
 
   let attachmentCount = 0;
   const detachedFromParent = Boolean(root.parentId);
+  ensureNotebookAclOverridesTable();
 
   const execute = db.transaction(() => {
     if (root.parentId) {
@@ -157,14 +158,12 @@ export function transferNotebookOwnership(
       attachmentCount = attachmentResult.changes;
     }
 
-    // 清理旧所有者 / 新所有者在子树中的显式覆盖，避免 owner/editor 身份被 none 覆盖。
     db.prepare(
       `DELETE FROM notebook_acl_overrides
         WHERE notebookId IN (${notebookMarks})
           AND userId IN (?, ?)`,
     ).run(...notebookIds, actorUserId, targetUserId);
 
-    // 子目录里可能存在历史 owner 成员行，统一降级为 editor；真正所有权以 notebooks.userId 为准。
     db.prepare(
       `UPDATE notebook_members
           SET role = 'editor', status = 'active', updatedAt = datetime('now')

--- a/backend/tests/notebook-owner-transfer.test.ts
+++ b/backend/tests/notebook-owner-transfer.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-notebook-owner-transfer-"));
+process.env.DB_PATH = path.join(dir, "test.db");
+process.env.ELECTRON_USER_DATA = dir;
+
+let closeDb: () => void;
+
+test("personal notebook owner can transfer the complete subtree to an existing collaborator", async () => {
+  const [{ default: notebooksRouter }, schema] = await Promise.all([
+    import("../src/routes/notebooks"),
+    import("../src/db/schema"),
+  ]);
+  closeDb = schema.closeDb;
+  const db = schema.getDb();
+
+  for (const id of ["owner", "target", "outsider"]) {
+    db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, 'hash')").run(id, id);
+  }
+  db.prepare("INSERT INTO notebooks (id, userId, parentId, name) VALUES ('root', 'owner', NULL, 'Root')").run();
+  db.prepare("INSERT INTO notebooks (id, userId, parentId, name) VALUES ('child', 'owner', 'root', 'Child')").run();
+  db.prepare("INSERT INTO notes (id, userId, notebookId, title) VALUES ('note', 'owner', 'child', 'Note')").run();
+  db.prepare(
+    `INSERT INTO notebook_members (id, notebookId, userId, role, status, invitedBy)
+     VALUES ('root:target', 'root', 'target', 'editor', 'active', 'owner')`,
+  ).run();
+
+  const app = new Hono();
+  app.route("/notebooks", notebooksRouter);
+
+  const membersBefore = await app.request("/notebooks/root/members", {
+    headers: { "X-User-Id": "owner" },
+  });
+  assert.equal(membersBefore.status, 200);
+  const rowsBefore = await membersBefore.json() as Array<{ userId: string; role: string }>;
+  assert.deepEqual(rowsBefore.map((row) => [row.userId, row.role]), [
+    ["owner", "owner"],
+    ["target", "editor"],
+  ]);
+
+  const outsider = await app.request("/notebooks/root/transfer-owner", {
+    method: "POST",
+    headers: { "X-User-Id": "owner", "Content-Type": "application/json" },
+    body: JSON.stringify({ targetUserId: "outsider" }),
+  });
+  assert.equal(outsider.status, 400);
+
+  const transferred = await app.request("/notebooks/root/transfer-owner", {
+    method: "POST",
+    headers: { "X-User-Id": "owner", "Content-Type": "application/json" },
+    body: JSON.stringify({ targetUserId: "target" }),
+  });
+  assert.equal(transferred.status, 200);
+  const result = await transferred.json() as {
+    previousOwnerId: string;
+    newOwnerId: string;
+    notebookCount: number;
+    noteCount: number;
+  };
+  assert.equal(result.previousOwnerId, "owner");
+  assert.equal(result.newOwnerId, "target");
+  assert.equal(result.notebookCount, 2);
+  assert.equal(result.noteCount, 1);
+
+  const notebooks = db.prepare("SELECT id, userId FROM notebooks ORDER BY id").all() as Array<{ id: string; userId: string }>;
+  assert.deepEqual(notebooks, [
+    { id: "child", userId: "target" },
+    { id: "root", userId: "target" },
+  ]);
+  const note = db.prepare("SELECT userId FROM notes WHERE id = 'note'").get() as { userId: string };
+  assert.equal(note.userId, "target");
+
+  const membersAfter = await app.request("/notebooks/root/members", {
+    headers: { "X-User-Id": "target" },
+  });
+  assert.equal(membersAfter.status, 200);
+  const rowsAfter = await membersAfter.json() as Array<{ userId: string; role: string }>;
+  assert.deepEqual(rowsAfter.map((row) => [row.userId, row.role]), [
+    ["target", "owner"],
+    ["owner", "editor"],
+  ]);
+});
+
+test.after(() => {
+  closeDb?.();
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/backend/tests/notebook-owner-transfer.test.ts
+++ b/backend/tests/notebook-owner-transfer.test.ts
@@ -16,6 +16,7 @@ test("personal notebook owner can transfer the complete subtree to an existing c
     import("../src/routes/notebooks"),
     import("../src/db/schema"),
   ]);
+  await import("../src/runtime/notebook-permission-management");
   closeDb = schema.closeDb;
   const db = schema.getDb();
 
@@ -33,12 +34,16 @@ test("personal notebook owner can transfer the complete subtree to an existing c
   const app = new Hono();
   app.route("/notebooks", notebooksRouter);
 
-  const membersBefore = await app.request("/notebooks/root/members", {
+  const summaryBefore = await app.request("/notebooks/root/permission-summary", {
     headers: { "X-User-Id": "owner" },
   });
-  assert.equal(membersBefore.status, 200);
-  const rowsBefore = await membersBefore.json() as Array<{ userId: string; role: string }>;
-  assert.deepEqual(rowsBefore.map((row) => [row.userId, row.role]), [
+  assert.equal(summaryBefore.status, 200);
+  const before = await summaryBefore.json() as {
+    ownerId: string;
+    members: Array<{ userId: string; role: string }>;
+  };
+  assert.equal(before.ownerId, "owner");
+  assert.deepEqual(before.members.map((row) => [row.userId, row.role]), [
     ["owner", "owner"],
     ["target", "editor"],
   ]);
@@ -75,12 +80,16 @@ test("personal notebook owner can transfer the complete subtree to an existing c
   const note = db.prepare("SELECT userId FROM notes WHERE id = 'note'").get() as { userId: string };
   assert.equal(note.userId, "target");
 
-  const membersAfter = await app.request("/notebooks/root/members", {
+  const summaryAfter = await app.request("/notebooks/root/permission-summary", {
     headers: { "X-User-Id": "target" },
   });
-  assert.equal(membersAfter.status, 200);
-  const rowsAfter = await membersAfter.json() as Array<{ userId: string; role: string }>;
-  assert.deepEqual(rowsAfter.map((row) => [row.userId, row.role]), [
+  assert.equal(summaryAfter.status, 200);
+  const after = await summaryAfter.json() as {
+    ownerId: string;
+    members: Array<{ userId: string; role: string }>;
+  };
+  assert.equal(after.ownerId, "target");
+  assert.deepEqual(after.members.map((row) => [row.userId, row.role]), [
     ["target", "owner"],
     ["owner", "editor"],
   ]);

--- a/backend/tests/notebook-owner-transfer.test.ts
+++ b/backend/tests/notebook-owner-transfer.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Hono } from "hono";
+import { fileURLToPath } from "node:url";
 
 const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-notebook-owner-transfer-"));
 process.env.DB_PATH = path.join(dir, "test.db");
@@ -12,11 +12,10 @@ process.env.ELECTRON_USER_DATA = dir;
 let closeDb: () => void;
 
 test("personal notebook owner can transfer the complete subtree to an existing collaborator", async () => {
-  // Match production startup: register feature migrations and modular notebook routes before getDb().
   await import("../src/runtime/knowledge-tree-migration-bootstrap");
-  const [{ default: notebooksRouter }, schema] = await Promise.all([
-    import("../src/routes/notebooks"),
+  const [schema, transferModule] = await Promise.all([
     import("../src/db/schema"),
+    import("../src/services/notebookOwnershipTransfer"),
   ]);
   closeDb = schema.closeDb;
   const db = schema.getDb();
@@ -32,42 +31,22 @@ test("personal notebook owner can transfer the complete subtree to an existing c
      VALUES ('root:target', 'root', 'target', 'editor', 'active', 'owner')`,
   ).run();
 
-  const app = new Hono();
-  app.route("/notebooks", notebooksRouter);
+  assert.throws(
+    () => transferModule.transferNotebookOwnership({
+      notebookId: "root",
+      actorUserId: "owner",
+      targetUserId: "outsider",
+    }, db),
+    (error: unknown) =>
+      error instanceof transferModule.NotebookOwnershipTransferError &&
+      error.code === "TARGET_NOT_COLLABORATOR",
+  );
 
-  const summaryBefore = await app.request("/notebooks/root/permission-summary", {
-    headers: { "X-User-Id": "owner" },
-  });
-  assert.equal(summaryBefore.status, 200);
-  const before = await summaryBefore.json() as {
-    ownerId: string;
-    members: Array<{ userId: string; role: string }>;
-  };
-  assert.equal(before.ownerId, "owner");
-  assert.deepEqual(before.members.map((row) => [row.userId, row.role]), [
-    ["owner", "owner"],
-    ["target", "editor"],
-  ]);
-
-  const outsider = await app.request("/notebooks/root/transfer-owner", {
-    method: "POST",
-    headers: { "X-User-Id": "owner", "Content-Type": "application/json" },
-    body: JSON.stringify({ targetUserId: "outsider" }),
-  });
-  assert.equal(outsider.status, 400);
-
-  const transferred = await app.request("/notebooks/root/transfer-owner", {
-    method: "POST",
-    headers: { "X-User-Id": "owner", "Content-Type": "application/json" },
-    body: JSON.stringify({ targetUserId: "target" }),
-  });
-  assert.equal(transferred.status, 200);
-  const result = await transferred.json() as {
-    previousOwnerId: string;
-    newOwnerId: string;
-    notebookCount: number;
-    noteCount: number;
-  };
+  const result = transferModule.transferNotebookOwnership({
+    notebookId: "root",
+    actorUserId: "owner",
+    targetUserId: "target",
+  }, db);
   assert.equal(result.previousOwnerId, "owner");
   assert.equal(result.newOwnerId, "target");
   assert.equal(result.notebookCount, 2);
@@ -81,19 +60,25 @@ test("personal notebook owner can transfer the complete subtree to an existing c
   const note = db.prepare("SELECT userId FROM notes WHERE id = 'note'").get() as { userId: string };
   assert.equal(note.userId, "target");
 
-  const summaryAfter = await app.request("/notebooks/root/permission-summary", {
-    headers: { "X-User-Id": "target" },
-  });
-  assert.equal(summaryAfter.status, 200);
-  const after = await summaryAfter.json() as {
-    ownerId: string;
-    members: Array<{ userId: string; role: string }>;
-  };
-  assert.equal(after.ownerId, "target");
-  assert.deepEqual(after.members.map((row) => [row.userId, row.role]), [
-    ["target", "owner"],
-    ["owner", "editor"],
+  const memberships = db.prepare(
+    "SELECT userId, role, status FROM notebook_members WHERE notebookId = 'root' ORDER BY role DESC, userId ASC",
+  ).all() as Array<{ userId: string; role: string; status: string }>;
+  assert.deepEqual(memberships, [
+    { userId: "target", role: "owner", status: "active" },
+    { userId: "owner", role: "editor", status: "active" },
   ]);
+});
+
+test("permission runtime registers summary and transfer endpoints", () => {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+  const source = fs.readFileSync(
+    path.resolve(currentDir, "../src/runtime/notebook-permission-management.ts"),
+    "utf8",
+  );
+  assert.match(source, /\/:id\/permission-summary/);
+  assert.match(source, /\/:id\/transfer-owner/);
+  assert.match(source, /resolveNotebookPermission/);
+  assert.match(source, /transferNotebookOwnership/);
 });
 
 test.after(() => {

--- a/backend/tests/notebook-owner-transfer.test.ts
+++ b/backend/tests/notebook-owner-transfer.test.ts
@@ -12,11 +12,12 @@ process.env.ELECTRON_USER_DATA = dir;
 let closeDb: () => void;
 
 test("personal notebook owner can transfer the complete subtree to an existing collaborator", async () => {
+  // Match production startup: register feature migrations and modular notebook routes before getDb().
+  await import("../src/runtime/knowledge-tree-migration-bootstrap");
   const [{ default: notebooksRouter }, schema] = await Promise.all([
     import("../src/routes/notebooks"),
     import("../src/db/schema"),
   ]);
-  await import("../src/runtime/notebook-permission-management");
   closeDb = schema.closeDb;
   const db = schema.getDb();
 

--- a/frontend/src/components/NotebookShareDialog.tsx
+++ b/frontend/src/components/NotebookShareDialog.tsx
@@ -1,13 +1,35 @@
 import { useEffect, useMemo, useState } from "react";
-import { Globe2, KeyRound, Link2, LockKeyhole, MessageCircle, RefreshCw, RotateCcw, ShieldCheck, Trash2, Unlink, UserRoundCog, Users, X } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Check,
+  ChevronRight,
+  Copy,
+  Crown,
+  Gear,
+  Link2,
+  LockKeyhole,
+  MessageCircle,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  ShieldCheck,
+  Trash2,
+  Unlink,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { confirm } from "@/components/ui/confirm";
 import { api } from "@/lib/api";
 import { copyText } from "@/lib/clipboard";
-import { toast } from "@/lib/toast";
-import { confirm } from "@/components/ui/confirm";
 import { buildPublicWebUrl } from "@/lib/publicWebOrigin";
-import type { Notebook, NotebookMember, NotebookShareLink, UserPublicInfo } from "@/types";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import type { Notebook, NotebookMember, NotebookShareLink, User, UserPublicInfo } from "@/types";
 import {
   notebookPublicationApi,
   type ManagedPublicationComment,
@@ -17,18 +39,94 @@ import {
   type NotebookPublicationAccessMode,
   type NotebookPublicationPermission,
 } from "@/lib/notebookPublicationApi";
-import { cn } from "@/lib/utils";
 
-interface Props { notebook: Notebook; onClose: () => void; }
-type Tab = "members" | "publish" | "permissions";
+interface Props {
+  notebook: Notebook;
+  onClose: () => void;
+}
+
+type View = "overview" | "scope" | "permissions";
+type MemberRole = "viewer" | "editor";
+
 const bool = (value: number | boolean | undefined) => value === true || value === 1;
-const localDateTime = (value: string | null | undefined) => value ? new Date(new Date(value).getTime() - new Date(value).getTimezoneOffset() * 60_000).toISOString().slice(0, 16) : "";
-const permissionLabel = (permission: NotebookDirectoryPermission) => ({ none: "不可见", read: "可查看", comment: "可评论", write: "可编辑", manage: "可管理" })[permission];
+const localDateTime = (value: string | null | undefined) =>
+  value
+    ? new Date(new Date(value).getTime() - new Date(value).getTimezoneOffset() * 60_000)
+        .toISOString()
+        .slice(0, 16)
+    : "";
+
+const permissionLabel = (permission: NotebookDirectoryPermission) =>
+  ({ none: "不可见", read: "可查看", comment: "可评论", write: "可编辑", manage: "可管理" })[
+    permission
+  ];
+
+const memberRoleLabel = (role: NotebookMember["role"]) =>
+  role === "owner" ? "所有者" : role === "editor" ? "可编辑" : "可查看";
+
+function displayName(member: Pick<NotebookMember, "displayName" | "username" | "userId">) {
+  return member.displayName || member.username || member.userId;
+}
+
+function sourceLabel(source: NotebookMember["source"]) {
+  if (source === "invite_link") return "通过邀请链接加入";
+  if (source === "publication") return "通过公开发布加入";
+  return "直接添加";
+}
+
+function Avatar({ member, size = 38 }: { member: NotebookMember; size?: number }) {
+  const name = displayName(member);
+  return member.avatarUrl ? (
+    <img
+      src={member.avatarUrl}
+      alt=""
+      className="shrink-0 rounded-md object-cover"
+      style={{ width: size, height: size }}
+    />
+  ) : (
+    <div
+      className="flex shrink-0 items-center justify-center rounded-md bg-accent-primary/10 text-sm font-semibold text-accent-primary"
+      style={{ width: size, height: size }}
+    >
+      {name.slice(0, 1).toUpperCase()}
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+  title,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  title: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-center gap-2 rounded-lg border border-app-border p-3 text-xs",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span>{title}</span>
+    </label>
+  );
+}
 
 export default function NotebookShareDialog({ notebook, onClose }: Props) {
-  const [tab, setTab] = useState<Tab>("members");
+  const [view, setView] = useState<View>("overview");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [me, setMe] = useState<User | null>(null);
   const [members, setMembers] = useState<NotebookMember[]>([]);
   const [link, setLink] = useState<NotebookShareLink | null>(null);
   const [publication, setPublication] = useState<NotebookPublication | null>(null);
@@ -36,9 +134,17 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
   const [inheritsFromParent, setInheritsFromParent] = useState<string | null>(null);
   const [comments, setComments] = useState<ManagedPublicationComment[]>([]);
 
+  const [memberSearch, setMemberSearch] = useState("");
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(new Set());
+  const [showAddMember, setShowAddMember] = useState(false);
   const [query, setQuery] = useState("");
   const [candidates, setCandidates] = useState<UserPublicInfo[]>([]);
-  const [role, setRole] = useState<"viewer" | "editor">("viewer");
+  const [role, setRole] = useState<MemberRole>("viewer");
+
+  const [transferOpen, setTransferOpen] = useState(false);
+  const [transferTargetId, setTransferTargetId] = useState("");
+  const [transferring, setTransferring] = useState(false);
+
   const [inviteExpiresAt, setInviteExpiresAt] = useState("");
   const [inviteMaxUses, setInviteMaxUses] = useState("");
 
@@ -57,98 +163,755 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
   const [aclAllowDownload, setAclAllowDownload] = useState(true);
   const [aclAllowReshare, setAclAllowReshare] = useState(false);
 
-  const shareUrl = useMemo(() => link?.token ? buildPublicWebUrl(`/notebook-share/${link.token}`) : "", [link?.token]);
-  const publicationUrl = useMemo(() => publication?.token && bool(publication.isActive) ? buildPublicWebUrl(`/public/${publication.token}`) : "", [publication?.token, publication?.isActive]);
+  const shareUrl = useMemo(
+    () => (link?.token ? buildPublicWebUrl(`/notebook-share/${link.token}`) : ""),
+    [link?.token],
+  );
+  const publicationUrl = useMemo(
+    () =>
+      publication?.token && bool(publication.isActive)
+        ? buildPublicWebUrl(`/public/${publication.token}`)
+        : "",
+    [publication?.token, publication?.isActive],
+  );
+
+  const owner = useMemo(() => members.find((member) => member.role === "owner") || null, [members]);
+  const collaborators = useMemo(
+    () => members.filter((member) => member.role !== "owner"),
+    [members],
+  );
+  const normalizedMemberSearch = memberSearch.trim().toLowerCase();
+  const filteredCollaborators = useMemo(
+    () =>
+      collaborators.filter((member) => {
+        if (!normalizedMemberSearch) return true;
+        return [member.displayName, member.username, member.email]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(normalizedMemberSearch));
+      }),
+    [collaborators, normalizedMemberSearch],
+  );
+
+  const activePublication = Boolean(publication && bool(publication.isActive));
+  const scopeMode = activePublication ? "public" : link ? "invite" : "private";
+  const scopeTitle =
+    scopeMode === "public"
+      ? "通过公开链接访问"
+      : scopeMode === "invite"
+        ? "登录后持链接加入"
+        : "仅文档协作者可访问";
+  const scopeDescription =
+    scopeMode === "public"
+      ? `公开权限：${publicPermission === "write" ? "登录后可编辑" : publicPermission === "comment" ? "可评论" : "仅查看"}`
+      : scopeMode === "invite"
+        ? `新成员加入后${role === "editor" ? "可编辑" : "仅查看"}`
+        : "未被添加的用户无法访问此目录";
+  const currentCopyUrl = publicationUrl || shareUrl;
+  const canTransferOwnership =
+    notebook.workspaceId === null && owner?.userId === me?.id && collaborators.length > 0;
 
   const applyPublication = (value: NotebookPublication | null) => {
     setPublication(value);
     if (!value) return;
-    setAccessMode(value.accessMode); setPublicPermission(value.permission);
-    setExpiresAt(localDateTime(value.expiresAt)); setAllowDownload(bool(value.allowDownload));
-    setAllowComment(bool(value.allowComment)); setAllowEdit(bool(value.allowEdit));
-    setAllowReshare(bool(value.allowReshare)); setPublicSecret("");
+    setAccessMode(value.accessMode);
+    setPublicPermission(value.permission);
+    setExpiresAt(localDateTime(value.expiresAt));
+    setAllowDownload(bool(value.allowDownload));
+    setAllowComment(bool(value.allowComment));
+    setAllowEdit(bool(value.allowEdit));
+    setAllowReshare(bool(value.allowReshare));
+    setPublicSecret("");
   };
+
   const applyLink = (value: NotebookShareLink | null) => {
     setLink(value);
     if (!value) return;
-    setRole(value.role); setInviteExpiresAt(localDateTime(value.expiresAt));
+    setRole(value.role);
+    setInviteExpiresAt(localDateTime(value.expiresAt));
     setInviteMaxUses(value.maxUses ? String(value.maxUses) : "");
   };
 
   const reload = async () => {
-    const [nextMembers, nextLink, nextPublication, nextOverrides] = await Promise.all([
-      api.getNotebookMembers(notebook.id), api.getNotebookShareLink(notebook.id),
-      notebookPublicationApi.getPublication(notebook.id), notebookPublicationApi.getPermissionOverrides(notebook.id),
+    const [nextMe, nextMembers, nextLink, nextPublication, nextOverrides] = await Promise.all([
+      api.getMe(),
+      api.getNotebookMembers(notebook.id),
+      api.getNotebookShareLink(notebook.id),
+      notebookPublicationApi.getPublication(notebook.id),
+      notebookPublicationApi.getPermissionOverrides(notebook.id),
     ]);
-    setMembers(nextMembers); applyLink(nextLink); applyPublication(nextPublication);
-    setOverrides(nextOverrides.direct); setInheritsFromParent(nextOverrides.inheritsFromParent);
-  };
-  const loadComments = async () => {
-    if (!publication || !bool(publication.isActive)) { setComments([]); return; }
-    try { setComments(await notebookPublicationApi.getManagedComments(notebook.id)); }
-    catch (error: any) { toast.error(error?.message || "加载公开评论失败"); }
+    setMe(nextMe);
+    setMembers(nextMembers);
+    applyLink(nextLink);
+    applyPublication(nextPublication);
+    setOverrides(nextOverrides.direct);
+    setInheritsFromParent(nextOverrides.inheritsFromParent);
+    setSelectedMemberIds(new Set());
   };
 
-  useEffect(() => { let cancelled = false; setLoading(true); reload().catch((e: any) => !cancelled && toast.error(e?.message || "加载分享设置失败")).finally(() => !cancelled && setLoading(false)); return () => { cancelled = true; }; }, [notebook.id]);
-  useEffect(() => { if (tab === "publish") void loadComments(); }, [tab, publication?.id, publication?.isActive]);
+  const loadComments = async () => {
+    if (!publication || !bool(publication.isActive)) {
+      setComments([]);
+      return;
+    }
+    try {
+      setComments(await notebookPublicationApi.getManagedComments(notebook.id));
+    } catch (error: any) {
+      toast.error(error?.message || "加载公开评论失败");
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    reload()
+      .catch((error: any) => !cancelled && toast.error(error?.message || "加载权限设置失败"))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [notebook.id]);
+
+  useEffect(() => {
+    if (view === "scope" && activePublication) void loadComments();
+  }, [view, publication?.id, publication?.isActive]);
 
   const copy = async (value: string) => {
+    if (!value) {
+      toast.warning("当前仅协作者可访问，请先在“分享范围”中开启链接访问");
+      return;
+    }
     const copied = await copyText(value);
-    toast[copied ? "success" : "error"](copied ? "链接已复制" : "复制失败");
+    if (copied) toast.success("链接已复制");
+    else toast.error("复制失败");
   };
+
   const searchUsers = async (kind: "member" | "acl") => {
-    const keyword = (kind === "member" ? query : aclQuery).trim(); if (!keyword) return;
-    const rows = await api.searchUsers(keyword);
-    if (kind === "member") setCandidates(rows.filter((u) => !members.some((m) => m.userId === u.id)));
-    else setAclCandidates(rows.filter((u) => !overrides.some((entry) => entry.userId === u.id)));
+    const keyword = (kind === "member" ? query : aclQuery).trim();
+    if (!keyword) return;
+    try {
+      const rows = await api.searchUsers(keyword);
+      if (kind === "member") {
+        setCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
+      } else {
+        setAclCandidates(rows.filter((user) => !overrides.some((entry) => entry.userId === user.id)));
+      }
+    } catch (error: any) {
+      toast.error(error?.message || "搜索用户失败");
+    }
   };
-  const addMember = async (userId: string) => { await api.addNotebookMember(notebook.id, { userId, role }); setQuery(""); setCandidates([]); toast.success("成员已添加"); await reload(); };
-  const changeMemberRole = async (member: NotebookMember, next: "viewer" | "editor") => { try { await api.updateNotebookMember(notebook.id, member.userId, { role: next }); toast.success("成员权限已更新"); await reload(); } catch (e: any) { toast.error(e?.message || "权限更新失败"); } };
-  const removeMember = async (userId: string) => { if (!await confirm({ title: "移除成员？", description: "该成员会立即失去共享目录访问权限。", danger: true })) return; await api.removeNotebookMember(notebook.id, userId); toast.success("成员已移除"); await reload(); };
+
+  const addMember = async (userId: string) => {
+    try {
+      await api.addNotebookMember(notebook.id, { userId, role });
+      setQuery("");
+      setCandidates([]);
+      setShowAddMember(false);
+      toast.success("协作者已添加");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "添加协作者失败");
+    }
+  };
+
+  const changeMemberRole = async (member: NotebookMember, next: MemberRole) => {
+    try {
+      await api.updateNotebookMember(notebook.id, member.userId, { role: next });
+      toast.success("协作者权限已更新");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "权限更新失败");
+    }
+  };
+
+  const removeMember = async (member: NotebookMember) => {
+    if (
+      !await confirm({
+        title: `移除 ${displayName(member)}？`,
+        description: "该协作者会立即失去当前目录及全部子目录的访问权限。",
+        danger: true,
+      })
+    ) return;
+    try {
+      await api.removeNotebookMember(notebook.id, member.userId);
+      toast.success("协作者已移除");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "移除协作者失败");
+    }
+  };
+
+  const toggleMemberSelection = (userId: string) => {
+    setSelectedMemberIds((current) => {
+      const next = new Set(current);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const toggleAllVisible = () => {
+    const visibleIds = filteredCollaborators.map((member) => member.userId);
+    const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedMemberIds.has(id));
+    setSelectedMemberIds((current) => {
+      const next = new Set(current);
+      visibleIds.forEach((id) => {
+        if (allSelected) next.delete(id);
+        else next.add(id);
+      });
+      return next;
+    });
+  };
+
+  const batchSetRole = async (nextRole: MemberRole) => {
+    const targets = collaborators.filter((member) => selectedMemberIds.has(member.userId));
+    if (targets.length === 0) return;
+    setSaving(true);
+    try {
+      await Promise.all(
+        targets.map((member) =>
+          api.updateNotebookMember(notebook.id, member.userId, { role: nextRole }),
+        ),
+      );
+      toast.success(`已将 ${targets.length} 位协作者设为${nextRole === "editor" ? "可编辑" : "可查看"}`);
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "批量更新失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const batchRemove = async () => {
+    const targets = collaborators.filter((member) => selectedMemberIds.has(member.userId));
+    if (targets.length === 0) return;
+    if (
+      !await confirm({
+        title: `移除 ${targets.length} 位协作者？`,
+        description: "这些用户会立即失去当前目录及全部子目录的访问权限。",
+        danger: true,
+      })
+    ) return;
+    setSaving(true);
+    try {
+      await Promise.all(targets.map((member) => api.removeNotebookMember(notebook.id, member.userId)));
+      toast.success("已批量移除协作者");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "批量移除失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openTransfer = () => {
+    const first = collaborators[0];
+    if (!first) return;
+    setTransferTargetId(first.userId);
+    setTransferOpen(true);
+  };
+
+  const transferOwnership = async () => {
+    if (!transferTargetId || transferring) return;
+    const target = collaborators.find((member) => member.userId === transferTargetId);
+    if (!target) return;
+    setTransferring(true);
+    try {
+      const result = await api.transferNotebookOwnership(notebook.id, transferTargetId);
+      setTransferOpen(false);
+      toast.success(`已将所有权转交给 ${displayName(target)}`);
+      await reload();
+      if (result.detachedFromParent) {
+        toast.info("该目录已从原父目录中分离，并成为新所有者个人空间的根目录");
+      }
+    } catch (error: any) {
+      toast.error(error?.message || "转交所有者失败");
+    } finally {
+      setTransferring(false);
+    }
+  };
 
   const saveInvite = async () => {
     const maxUses = inviteMaxUses.trim() ? Number(inviteMaxUses) : null;
-    if (maxUses !== null && (!Number.isInteger(maxUses) || maxUses < 1)) return toast.error("最大加入人数必须是正整数");
+    if (maxUses !== null && (!Number.isInteger(maxUses) || maxUses < 1)) {
+      toast.error("最大加入人数必须是正整数");
+      return;
+    }
     setSaving(true);
     try {
-      const input = { role, expiresAt: inviteExpiresAt ? new Date(inviteExpiresAt).toISOString() : null, maxUses };
-      const next = link ? await api.updateNotebookShareLink(notebook.id, input) : await api.createNotebookShareLink(notebook.id, input);
-      applyLink(next); toast.success(link ? "邀请设置已保存" : "邀请链接已生成");
-    } catch (e: any) { toast.error(e?.message || "邀请链接保存失败"); } finally { setSaving(false); }
+      const input = {
+        role,
+        expiresAt: inviteExpiresAt ? new Date(inviteExpiresAt).toISOString() : null,
+        maxUses,
+      };
+      const next = link
+        ? await api.updateNotebookShareLink(notebook.id, input)
+        : await api.createNotebookShareLink(notebook.id, input);
+      applyLink(next);
+      toast.success(link ? "邀请设置已保存" : "邀请链接已生成");
+    } catch (error: any) {
+      toast.error(error?.message || "邀请链接保存失败");
+    } finally {
+      setSaving(false);
+    }
   };
-  const rotateInvite = async () => { if (!await confirm({ title: "轮换邀请链接？", description: "旧链接立即失效，使用次数会清零；已加入成员不受影响。" })) return; const next = await api.updateNotebookShareLink(notebook.id, { rotateToken: true }); applyLink(next); toast.success("已生成新邀请链接"); };
-  const resetInviteUses = async () => { const next = await api.updateNotebookShareLink(notebook.id, { resetUses: true }); applyLink(next); toast.success("加入人数统计已清零"); };
-  const revokeInvite = async () => { if (!await confirm({ title: "撤销邀请链接？", description: "旧链接立即失效，并移除仅通过该链接加入的成员；手动成员不受影响。", danger: true })) return; await api.deleteNotebookShareLink(notebook.id); applyLink(null); toast.success("邀请链接已撤销"); await reload(); };
+
+  const rotateInvite = async () => {
+    if (
+      !await confirm({
+        title: "更换邀请链接？",
+        description: "旧链接立即失效，使用次数会清零；已加入的协作者不受影响。",
+      })
+    ) return;
+    const next = await api.updateNotebookShareLink(notebook.id, { rotateToken: true });
+    applyLink(next);
+    toast.success("已生成新邀请链接");
+  };
+
+  const resetInviteUses = async () => {
+    const next = await api.updateNotebookShareLink(notebook.id, { resetUses: true });
+    applyLink(next);
+    toast.success("加入人数统计已清零");
+  };
+
+  const revokeInvite = async () => {
+    if (
+      !await confirm({
+        title: "关闭邀请链接？",
+        description: "旧链接立即失效，仅通过该链接加入的成员会被移除；手动添加的协作者不受影响。",
+        danger: true,
+      })
+    ) return;
+    await api.deleteNotebookShareLink(notebook.id);
+    applyLink(null);
+    toast.success("邀请链接已关闭");
+    await reload();
+  };
 
   const savePublication = async () => {
-    if ((accessMode === "code" || accessMode === "password") && !publication?.hasSecret && !publicSecret.trim()) return toast.error("请设置访问凭证");
+    if (
+      (accessMode === "code" || accessMode === "password") &&
+      !publication?.hasSecret &&
+      !publicSecret.trim()
+    ) {
+      toast.error("请设置访问凭证");
+      return;
+    }
     setSaving(true);
-    try { const next = await notebookPublicationApi.savePublication(notebook.id, { accessMode, permission: publicPermission, secret: publicSecret.trim() || undefined, allowDownload, allowComment, allowEdit, allowReshare, expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null }); applyPublication(next); toast.success("公开发布设置已保存"); }
-    catch (e: any) { toast.error(e?.message || "发布失败"); } finally { setSaving(false); }
+    try {
+      const next = await notebookPublicationApi.savePublication(notebook.id, {
+        accessMode,
+        permission: publicPermission,
+        secret: publicSecret.trim() || undefined,
+        allowDownload,
+        allowComment,
+        allowEdit,
+        allowReshare,
+        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+      });
+      applyPublication(next);
+      toast.success("公开访问设置已保存");
+    } catch (error: any) {
+      toast.error(error?.message || "公开发布失败");
+    } finally {
+      setSaving(false);
+    }
   };
-  const revokePublication = async () => { if (!await confirm({ title: "撤销目录发布？", description: "公开链接、附件签名以及仅通过该发布加入的成员会立即失效。", danger: true })) return; await notebookPublicationApi.revokePublication(notebook.id); setPublication((p) => p ? { ...p, isActive: 0 } : p); setComments([]); toast.success("目录发布已撤销"); };
-  const moderate = async (comment: ManagedPublicationComment, input: { isResolved?: boolean; isHidden?: boolean }) => { await notebookPublicationApi.moderateComment(notebook.id, comment.id, input); await loadComments(); };
-  const deleteComment = async (comment: ManagedPublicationComment) => { if (!await confirm({ title: "删除评论？", description: "该操作不可恢复。", danger: true })) return; await notebookPublicationApi.deleteManagedComment(notebook.id, comment.id); await loadComments(); };
 
-  const addOverride = async (userId: string) => { await notebookPublicationApi.setPermissionOverride(notebook.id, userId, { permission: aclPermission, allowDownload: aclAllowDownload, allowReshare: aclAllowReshare }); setAclQuery(""); setAclCandidates([]); await reload(); };
-  const updateOverride = async (entry: NotebookPermissionOverride, permission: NotebookDirectoryPermission) => { await notebookPublicationApi.setPermissionOverride(notebook.id, entry.userId, { permission, allowDownload: bool(entry.allowDownload), allowReshare: bool(entry.allowReshare) }); await reload(); };
-  const removeOverride = async (userId: string) => { await notebookPublicationApi.removePermissionOverride(notebook.id, userId); await reload(); };
+  const revokePublication = async () => {
+    if (
+      !await confirm({
+        title: "关闭公开访问？",
+        description: "公开链接、附件签名以及仅通过公开发布加入的成员会立即失效。",
+        danger: true,
+      })
+    ) return;
+    await notebookPublicationApi.revokePublication(notebook.id);
+    setPublication((current) => current ? { ...current, isActive: 0 } : current);
+    setComments([]);
+    toast.success("公开访问已关闭");
+    await reload();
+  };
 
-  const tabs: Array<{ id: Tab; label: string; icon: typeof Users }> = [{ id: "members", label: "成员与邀请", icon: Users }, { id: "publish", label: "公开发布", icon: Globe2 }, { id: "permissions", label: "目录权限", icon: UserRoundCog }];
-  return <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 px-3 py-5 backdrop-blur-sm"><div className="flex max-h-[94vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-app-border bg-app-surface shadow-2xl">
-    <header className="flex items-center justify-between border-b border-app-border px-5 py-4"><div><h2 className="font-semibold">分享与发布</h2><p className="text-xs text-tx-tertiary">{notebook.icon} {notebook.name} · 包含全部子目录</p></div><button onClick={onClose} className="rounded-lg p-2 hover:bg-app-hover"><X size={17} /></button></header>
-    <nav className="flex gap-1 border-b border-app-border bg-app-hover/30 px-4 py-2">{tabs.map(({ id, label, icon: Icon }) => <button key={id} onClick={() => setTab(id)} className={cn("flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium", tab === id ? "bg-app-surface text-accent-primary shadow-sm" : "text-tx-secondary hover:bg-app-surface/70")}><Icon size={14} />{label}</button>)}</nav>
-    <main className="min-h-0 flex-1 overflow-y-auto p-5">{loading ? <div className="py-16 text-center text-sm text-tx-tertiary">正在加载...</div> : tab === "members" ? <div className="space-y-5">
-      <section><h3 className="mb-2 text-sm font-semibold">指定账号</h3><div className="flex gap-2"><select className="h-9 rounded-lg border border-app-border bg-app-bg px-2 text-sm" value={role} onChange={(e) => setRole(e.target.value as any)}><option value="viewer">只读</option><option value="editor">可编辑</option></select><Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="搜索用户名或邮箱" className="h-9" onKeyDown={(e) => { if (e.key === "Enter") void searchUsers("member"); }} /><Button variant="outline" onClick={() => searchUsers("member")}>搜索</Button></div>{candidates.length > 0 && <div className="mt-2 overflow-hidden rounded-lg border">{candidates.map((u) => <button key={u.id} onClick={() => addMember(u.id)} className="flex w-full justify-between px-3 py-2 text-sm hover:bg-app-hover"><span>{u.displayName || u.username}</span><span className="text-xs text-tx-tertiary">添加</span></button>)}</div>}</section>
-      <section><div className="mb-2 text-xs font-medium text-tx-tertiary">当前成员</div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{members.length === 0 ? <div className="p-5 text-center text-sm text-tx-tertiary">暂无指定成员</div> : members.map((m) => <div key={m.userId} className="flex items-center gap-3 px-3 py-2.5"><div className="min-w-0 flex-1"><div className="truncate text-sm">{m.displayName || m.username || m.userId}</div><div className="text-[11px] text-tx-tertiary">{m.source === "invite_link" ? "邀请链接加入" : m.source === "publication" ? "公开发布加入" : "手动成员"}</div></div>{m.role === "owner" ? <span className="text-xs text-tx-tertiary">拥有者</span> : <><select value={m.role} onChange={(e) => changeMemberRole(m, e.target.value as any)} className="h-8 rounded-md border bg-app-bg px-2 text-xs"><option value="viewer">只读</option><option value="editor">可编辑</option></select><button onClick={() => removeMember(m.userId)} className="rounded p-1.5 text-red-500 hover:bg-app-hover"><Trash2 size={14} /></button></>}</div>)}</div></section>
-      <section className="rounded-xl border border-app-border bg-app-hover/20 p-4"><div className="flex items-center gap-2"><Link2 size={16} /><h3 className="text-sm font-semibold">登录邀请链接</h3></div><div className="mt-3 grid gap-3 sm:grid-cols-3"><label className="space-y-1"><span className="text-xs">加入权限</span><select value={role} onChange={(e) => setRole(e.target.value as any)} className="h-9 w-full rounded-lg border bg-app-bg px-2 text-sm"><option value="viewer">只读</option><option value="editor">可编辑</option></select></label><label className="space-y-1"><span className="text-xs">最大加入人数</span><Input type="number" min={1} value={inviteMaxUses} onChange={(e) => setInviteMaxUses(e.target.value)} placeholder="不限" className="h-9" /></label><label className="space-y-1"><span className="text-xs">有效期</span><Input type="datetime-local" value={inviteExpiresAt} onChange={(e) => setInviteExpiresAt(e.target.value)} className="h-9" /></label></div>{link && <><div className="mt-3 flex gap-2"><Input readOnly value={shareUrl} className="h-9 text-xs" /><Button variant="outline" onClick={() => copy(shareUrl)}>复制</Button></div><p className="mt-1 text-[11px] text-tx-tertiary">已加入 {link.useCount || 0}{link.maxUses ? ` / ${link.maxUses}` : ""} 人</p></>}<div className="mt-3 flex flex-wrap justify-end gap-2">{link && <><Button variant="outline" onClick={resetInviteUses}><RotateCcw size={13} className="mr-1" />清零统计</Button><Button variant="outline" onClick={rotateInvite}><RefreshCw size={13} className="mr-1" />换链接</Button><Button variant="outline" className="text-red-500" onClick={revokeInvite}><Unlink size={13} className="mr-1" />撤销</Button></>}<Button onClick={saveInvite} disabled={saving}>{link ? "保存邀请设置" : "生成邀请链接"}</Button></div></section>
-    </div> : tab === "publish" ? <div className="space-y-5">
-      <section className="rounded-xl border border-app-border p-4"><div className="grid gap-3 sm:grid-cols-2"><label className="space-y-1"><span className="text-xs">访问方式</span><select value={accessMode} onChange={(e) => setAccessMode(e.target.value as any)} className="h-10 w-full rounded-lg border bg-app-bg px-3 text-sm"><option value="public">公共空间公开</option><option value="link">持链接访问</option><option value="code">访问码</option><option value="password">密码保护</option></select></label><label className="space-y-1"><span className="text-xs">基础权限</span><select value={publicPermission} onChange={(e) => { const next = e.target.value as NotebookPublicationPermission; setPublicPermission(next); if (next === "read") { setAllowComment(false); setAllowEdit(false); } else if (next === "comment") setAllowComment(true); }} className="h-10 w-full rounded-lg border bg-app-bg px-3 text-sm"><option value="read">查看</option><option value="comment">查看 + 评论</option><option value="write">登录后加入编辑</option></select></label></div>{(accessMode === "code" || accessMode === "password") && <label className="mt-3 block space-y-1"><span className="text-xs">{accessMode === "code" ? "访问码" : "密码"}</span><Input type={accessMode === "password" ? "password" : "text"} value={publicSecret} onChange={(e) => setPublicSecret(e.target.value)} placeholder={publication?.hasSecret ? "留空保持原凭证" : "设置访问凭证"} /></label>}<label className="mt-3 block space-y-1"><span className="text-xs">有效期</span><Input type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} /></label><div className="mt-3 grid gap-2 sm:grid-cols-2"><Toggle checked={allowDownload} onChange={setAllowDownload} title="允许附件下载" /><Toggle checked={allowComment} onChange={setAllowComment} title="允许游客评论" /><Toggle checked={allowEdit} onChange={setAllowEdit} disabled={publicPermission !== "write"} title="登录后加入编辑" /><Toggle checked={allowReshare} onChange={setAllowReshare} title="允许二次分享" /></div>{publicationUrl && <div className="mt-3 flex gap-2"><Input readOnly value={publicationUrl} className="text-xs" /><Button variant="outline" onClick={() => copy(publicationUrl)}>复制</Button></div>}<div className="mt-4 flex justify-end gap-2">{publication && bool(publication.isActive) && <Button variant="outline" className="text-red-500" onClick={revokePublication}>撤销发布</Button>}<Button onClick={savePublication} disabled={saving}>保存发布设置</Button></div></section>
-      <section><div className="mb-2 flex items-center justify-between"><div className="flex items-center gap-2 text-sm font-semibold"><MessageCircle size={15} />公开评论管理</div><Button size="sm" variant="ghost" onClick={loadComments}><RefreshCw size={13} /></Button></div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{comments.length === 0 ? <div className="p-6 text-center text-sm text-tx-tertiary">暂无公开评论</div> : comments.map((c) => <div key={c.id} className={cn("p-3", bool(c.isHidden) && "opacity-60")}><div className="flex items-center justify-between gap-3"><div className="text-xs font-medium">{c.nickname} · {c.noteTitle}</div><div className="text-[10px] text-tx-tertiary">{new Date(c.createdAt).toLocaleString()}</div></div><p className="mt-1 whitespace-pre-wrap text-sm">{c.content}</p><div className="mt-2 flex gap-2"><Button size="sm" variant="outline" onClick={() => moderate(c, { isResolved: !bool(c.isResolved) })}>{bool(c.isResolved) ? "取消解决" : "标记解决"}</Button><Button size="sm" variant="outline" onClick={() => moderate(c, { isHidden: !bool(c.isHidden) })}>{bool(c.isHidden) ? "恢复显示" : "隐藏"}</Button><Button size="sm" variant="outline" className="text-red-500" onClick={() => deleteComment(c)}><Trash2 size={13} /></Button></div></div>)}</div></section>
-    </div> : <div className="space-y-5"><section className="rounded-xl border border-app-border bg-app-hover/20 p-4"><h3 className="text-sm font-semibold">目录级权限继承</h3><p className="mt-1 text-xs text-tx-tertiary">最近的显式规则优先，并向子目录继承。{inheritsFromParent ? "当前目录可删除覆盖以恢复父级继承。" : "当前目录是权限树根节点。"}</p></section><section><div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]"><select value={aclPermission} onChange={(e) => setAclPermission(e.target.value as any)} className="h-9 rounded-lg border bg-app-bg px-2 text-sm"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><Input value={aclQuery} onChange={(e) => setAclQuery(e.target.value)} placeholder="搜索用户" className="h-9" /><Button variant="outline" onClick={() => searchUsers("acl")}>搜索</Button></div><div className="mt-2 flex gap-4 text-xs"><label><input type="checkbox" checked={aclAllowDownload} onChange={(e) => setAclAllowDownload(e.target.checked)} /> 允许下载</label><label><input type="checkbox" checked={aclAllowReshare} onChange={(e) => setAclAllowReshare(e.target.checked)} /> 允许二次分享</label></div>{aclCandidates.map((u) => <button key={u.id} onClick={() => addOverride(u.id)} className="mt-2 flex w-full justify-between rounded border px-3 py-2 text-sm hover:bg-app-hover"><span>{u.displayName || u.username}</span><span>设为{permissionLabel(aclPermission)}</span></button>)}</section><section><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{overrides.length === 0 ? <div className="p-6 text-center text-sm text-tx-tertiary">没有显式覆盖</div> : overrides.map((entry) => <div key={entry.userId} className="flex items-center gap-3 px-3 py-3"><div className="min-w-0 flex-1"><div className="truncate text-sm">{entry.displayName || entry.username}</div><div className="text-[11px] text-tx-tertiary">{bool(entry.allowDownload) ? "可下载" : "不可下载"} · {bool(entry.allowReshare) ? "可二次分享" : "不可二次分享"}</div></div><select value={entry.permission} onChange={(e) => updateOverride(entry, e.target.value as any)} className="h-8 rounded border bg-app-bg px-2 text-xs"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><button onClick={() => removeOverride(entry.userId)} className="rounded p-1.5 text-red-500"><Trash2 size={14} /></button></div>)}</div></section></div>}</main>
-  </div></div>;
-}
+  const setPrivateScope = async () => {
+    if (scopeMode === "private") return;
+    if (
+      !await confirm({
+        title: "改为仅协作者可访问？",
+        description: "邀请链接和公开链接将全部失效，仅保留当前协作者。",
+      })
+    ) return;
+    setSaving(true);
+    try {
+      if (link) await api.deleteNotebookShareLink(notebook.id);
+      if (activePublication) await notebookPublicationApi.revokePublication(notebook.id);
+      applyLink(null);
+      setPublication((current) => current ? { ...current, isActive: 0 } : null);
+      toast.success("已改为仅协作者可访问");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "更新分享范围失败");
+    } finally {
+      setSaving(false);
+    }
+  };
 
-function Toggle({ checked, onChange, title, disabled }: { checked: boolean; onChange: (value: boolean) => void; title: string; disabled?: boolean }) {
-  return <label className={cn("flex cursor-pointer items-center gap-2 rounded-lg border border-app-border p-3 text-xs", disabled && "cursor-not-allowed opacity-50")}><input type="checkbox" checked={checked} disabled={disabled} onChange={(e) => onChange(e.target.checked)} /><span>{title}</span></label>;
+  const moderate = async (
+    comment: ManagedPublicationComment,
+    input: { isResolved?: boolean; isHidden?: boolean },
+  ) => {
+    await notebookPublicationApi.moderateComment(notebook.id, comment.id, input);
+    await loadComments();
+  };
+
+  const deleteComment = async (comment: ManagedPublicationComment) => {
+    if (!await confirm({ title: "删除评论？", description: "该操作不可恢复。", danger: true })) return;
+    await notebookPublicationApi.deleteManagedComment(notebook.id, comment.id);
+    await loadComments();
+  };
+
+  const addOverride = async (userId: string) => {
+    await notebookPublicationApi.setPermissionOverride(notebook.id, userId, {
+      permission: aclPermission,
+      allowDownload: aclAllowDownload,
+      allowReshare: aclAllowReshare,
+    });
+    setAclQuery("");
+    setAclCandidates([]);
+    toast.success("目录权限已添加");
+    await reload();
+  };
+
+  const updateOverride = async (
+    entry: NotebookPermissionOverride,
+    permission: NotebookDirectoryPermission,
+  ) => {
+    await notebookPublicationApi.setPermissionOverride(notebook.id, entry.userId, {
+      permission,
+      allowDownload: bool(entry.allowDownload),
+      allowReshare: bool(entry.allowReshare),
+    });
+    await reload();
+  };
+
+  const removeOverride = async (userId: string) => {
+    await notebookPublicationApi.removePermissionOverride(notebook.id, userId);
+    await reload();
+  };
+
+  const headerTitle = view === "overview" ? "权限管理" : view === "scope" ? "分享范围" : "权限配置";
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/45 px-3 py-5 backdrop-blur-sm">
+      <div className="relative flex max-h-[94vh] w-full max-w-[760px] flex-col overflow-hidden rounded-2xl border border-app-border bg-app-surface shadow-2xl">
+        <header className="flex items-center justify-between px-6 py-5">
+          <div className="flex min-w-0 items-center gap-2.5">
+            {view !== "overview" && (
+              <button
+                onClick={() => setView("overview")}
+                className="rounded-lg p-1.5 text-tx-secondary hover:bg-app-hover"
+                aria-label="返回"
+              >
+                <ArrowLeft size={18} />
+              </button>
+            )}
+            <div className="min-w-0">
+              <h2 className="text-xl font-semibold text-tx-primary">{headerTitle}</h2>
+              <p className="mt-0.5 truncate text-xs text-tx-tertiary">
+                {notebook.icon} {notebook.name} · 权限包含全部子目录
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-tx-secondary hover:bg-app-hover"
+            aria-label="关闭"
+          >
+            <X size={20} />
+          </button>
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+          {loading ? (
+            <div className="py-24 text-center text-sm text-tx-tertiary">正在加载权限信息...</div>
+          ) : view === "overview" ? (
+            <div className="space-y-7">
+              <section>
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-base font-medium text-tx-secondary">分享范围</h3>
+                  <button
+                    onClick={() => copy(currentCopyUrl)}
+                    className={cn(
+                      "flex items-center gap-1.5 text-sm font-medium text-accent-primary",
+                      !currentCopyUrl && "opacity-60",
+                    )}
+                    title={currentCopyUrl ? "复制当前分享链接" : "请先开启链接访问"}
+                  >
+                    <Link2 size={17} />
+                    复制链接
+                  </button>
+                </div>
+                <button
+                  onClick={() => setView("scope")}
+                  className="flex w-full items-center gap-3 rounded-lg border border-app-border bg-app-hover/35 px-4 py-3 text-left transition-colors hover:bg-app-hover"
+                >
+                  <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-app-surface text-tx-secondary shadow-sm">
+                    {scopeMode === "private" ? <LockKeyhole size={18} /> : scopeMode === "invite" ? <Users size={18} /> : <ShieldCheck size={18} />}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-tx-primary">{scopeTitle}</div>
+                    <div className="mt-0.5 truncate text-xs text-tx-tertiary">{scopeDescription}</div>
+                  </div>
+                  <ChevronRight size={18} className="text-tx-tertiary" />
+                </button>
+              </section>
+
+              <section>
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-base font-medium text-tx-secondary">所有协作者</h3>
+                    <span className="rounded-full bg-app-hover px-2 py-0.5 text-[11px] text-tx-tertiary">
+                      {members.length}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => {
+                      setShowAddMember((current) => !current);
+                      setCandidates([]);
+                    }}
+                    className="flex items-center gap-1 text-sm font-medium text-accent-primary"
+                  >
+                    <Plus size={18} />
+                    添加协作者
+                  </button>
+                </div>
+
+                {showAddMember && (
+                  <div className="mb-3 rounded-xl border border-accent-primary/25 bg-accent-primary/[0.04] p-3">
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <select
+                        value={role}
+                        onChange={(event) => setRole(event.target.value as MemberRole)}
+                        className="h-9 rounded-lg border border-app-border bg-app-bg px-3 text-sm"
+                      >
+                        <option value="viewer">可查看</option>
+                        <option value="editor">可编辑</option>
+                      </select>
+                      <Input
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") void searchUsers("member");
+                        }}
+                        placeholder="搜索用户名或邮箱"
+                        className="h-9 flex-1"
+                        autoFocus
+                      />
+                      <Button variant="outline" onClick={() => searchUsers("member")}>
+                        <Search size={14} className="mr-1" />搜索
+                      </Button>
+                    </div>
+                    {candidates.length > 0 && (
+                      <div className="mt-2 overflow-hidden rounded-lg border border-app-border bg-app-surface">
+                        {candidates.map((user) => (
+                          <button
+                            key={user.id}
+                            onClick={() => addMember(user.id)}
+                            className="flex w-full items-center justify-between border-b border-app-border px-3 py-2.5 text-left last:border-b-0 hover:bg-app-hover"
+                          >
+                            <span className="text-sm">{user.displayName || user.username}</span>
+                            <span className="flex items-center gap-1 text-xs text-accent-primary">
+                              <UserPlus size={13} />添加
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <div className="overflow-hidden rounded-xl border border-app-border">
+                  <div className="flex h-12 items-center gap-3 border-b border-app-border px-4">
+                    <input
+                      type="checkbox"
+                      checked={
+                        filteredCollaborators.length > 0 &&
+                        filteredCollaborators.every((member) => selectedMemberIds.has(member.userId))
+                      }
+                      onChange={toggleAllVisible}
+                      aria-label="全选协作者"
+                    />
+                    <span className="text-sm font-medium text-tx-primary">全选</span>
+                    <div className="ml-auto flex w-52 items-center gap-2 rounded-lg bg-app-hover/50 px-2.5 py-1.5">
+                      <Search size={15} className="text-tx-tertiary" />
+                      <input
+                        value={memberSearch}
+                        onChange={(event) => setMemberSearch(event.target.value)}
+                        placeholder="搜索协作者"
+                        className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-tx-tertiary"
+                      />
+                    </div>
+                  </div>
+
+                  {selectedMemberIds.size > 0 && (
+                    <div className="flex flex-wrap items-center gap-2 border-b border-app-border bg-accent-primary/[0.04] px-4 py-2">
+                      <span className="mr-auto text-xs text-tx-secondary">
+                        已选择 {selectedMemberIds.size} 人
+                      </span>
+                      <Button size="sm" variant="outline" disabled={saving} onClick={() => batchSetRole("viewer")}>设为可查看</Button>
+                      <Button size="sm" variant="outline" disabled={saving} onClick={() => batchSetRole("editor")}>设为可编辑</Button>
+                      <Button size="sm" variant="outline" disabled={saving} className="text-red-500" onClick={batchRemove}>移除</Button>
+                    </div>
+                  )}
+
+                  {owner && (
+                    <div>
+                      <div className="px-4 pb-1 pt-4 text-xs text-tx-tertiary">所有者</div>
+                      <div className="flex items-center gap-3 px-4 py-3">
+                        <input type="checkbox" disabled aria-label="所有者不可选择" />
+                        <Avatar member={owner} />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="truncate text-sm font-medium text-tx-primary">{displayName(owner)}</span>
+                            {owner.userId === me?.id && <span className="text-xs text-tx-tertiary">我自己</span>}
+                            <span className="rounded border border-accent-primary/35 bg-accent-primary/5 px-1.5 py-0.5 text-[11px] text-accent-primary">所有者</span>
+                          </div>
+                          <div className="mt-0.5 truncate text-xs text-tx-tertiary">拥有全部权限，可管理协作者与分享范围</div>
+                        </div>
+                        {canTransferOwnership ? (
+                          <button onClick={openTransfer} className="shrink-0 text-sm font-medium text-accent-primary">转交所有者</button>
+                        ) : (
+                          <span className="shrink-0 text-xs text-tx-tertiary">可管理</span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="px-4 pb-1 pt-3 text-xs text-tx-tertiary">协作者</div>
+                  {filteredCollaborators.length === 0 ? (
+                    <div className="px-4 py-10 text-center text-sm text-tx-tertiary">
+                      {collaborators.length === 0 ? "暂时没有其他协作者" : "没有匹配的协作者"}
+                    </div>
+                  ) : (
+                    filteredCollaborators.map((member) => (
+                      <div key={member.userId} className="flex items-center gap-3 border-t border-app-border px-4 py-3 first:border-t-0">
+                        <input
+                          type="checkbox"
+                          checked={selectedMemberIds.has(member.userId)}
+                          onChange={() => toggleMemberSelection(member.userId)}
+                          aria-label={`选择 ${displayName(member)}`}
+                        />
+                        <Avatar member={member} />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium text-tx-primary">{displayName(member)}</div>
+                          <div className="mt-0.5 truncate text-xs text-tx-tertiary">{sourceLabel(member.source)}{member.email ? ` · ${member.email}` : ""}</div>
+                        </div>
+                        <select
+                          value={member.role}
+                          onChange={(event) => changeMemberRole(member, event.target.value as MemberRole)}
+                          className="h-8 rounded-md border border-app-border bg-app-bg px-2 text-xs"
+                          aria-label={`${displayName(member)} 的权限`}
+                        >
+                          <option value="viewer">可查看</option>
+                          <option value="editor">可编辑</option>
+                        </select>
+                        <button
+                          onClick={() => removeMember(member)}
+                          className="rounded-md p-1.5 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500"
+                          title="移除协作者"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </section>
+
+              <button
+                onClick={() => setView("permissions")}
+                className="flex w-full items-center gap-3 rounded-xl px-2 py-3 text-left hover:bg-app-hover"
+              >
+                <Gear size={20} className="text-tx-secondary" />
+                <div className="flex-1">
+                  <div className="text-base font-medium text-tx-primary">权限配置</div>
+                  <div className="mt-0.5 text-xs text-tx-tertiary">设置子目录继承、指定用户覆盖、下载与二次分享权限</div>
+                </div>
+                <ChevronRight size={18} className="text-tx-tertiary" />
+              </button>
+            </div>
+          ) : view === "scope" ? (
+            <div className="space-y-4">
+              <section className={cn("rounded-xl border p-4", scopeMode === "private" ? "border-accent-primary bg-accent-primary/[0.04]" : "border-app-border")}>
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><LockKeyhole size={19} /></div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2"><h3 className="text-sm font-semibold">仅协作者可访问</h3>{scopeMode === "private" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div>
+                    <p className="mt-1 text-xs text-tx-tertiary">只有上一级页面中列出的协作者可以打开，安全性最高。</p>
+                  </div>
+                  {scopeMode !== "private" && <Button size="sm" variant="outline" disabled={saving} onClick={setPrivateScope}>设为当前范围</Button>}
+                </div>
+              </section>
+
+              <section className={cn("rounded-xl border p-4", scopeMode === "invite" ? "border-accent-primary bg-accent-primary/[0.04]" : "border-app-border")}>
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><Users size={19} /></div>
+                  <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><h3 className="text-sm font-semibold">登录后持链接加入</h3>{scopeMode === "invite" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div><p className="mt-1 text-xs text-tx-tertiary">适合内部团队快速加入，加入后会出现在协作者列表中。</p></div>
+                </div>
+                <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">加入权限</span><select value={role} onChange={(event) => setRole(event.target.value as MemberRole)} className="h-9 w-full rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="viewer">可查看</option><option value="editor">可编辑</option></select></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">最大加入人数</span><Input type="number" min={1} value={inviteMaxUses} onChange={(event) => setInviteMaxUses(event.target.value)} placeholder="不限" className="h-9" /></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">有效期</span><Input type="datetime-local" value={inviteExpiresAt} onChange={(event) => setInviteExpiresAt(event.target.value)} className="h-9" /></label>
+                </div>
+                {link && <div className="mt-3"><div className="flex gap-2"><Input readOnly value={shareUrl} className="h-9 text-xs" /><Button variant="outline" onClick={() => copy(shareUrl)}><Copy size={14} className="mr-1" />复制</Button></div><p className="mt-1 text-[11px] text-tx-tertiary">已加入 {link.useCount || 0}{link.maxUses ? ` / ${link.maxUses}` : ""} 人</p></div>}
+                <div className="mt-3 flex flex-wrap justify-end gap-2">{link && <><Button variant="outline" onClick={resetInviteUses}><RotateCcw size={13} className="mr-1" />清零统计</Button><Button variant="outline" onClick={rotateInvite}><RefreshCw size={13} className="mr-1" />换链接</Button><Button variant="outline" className="text-red-500" onClick={revokeInvite}><Unlink size={13} className="mr-1" />关闭</Button></>}<Button onClick={saveInvite} disabled={saving}>{link ? "保存邀请设置" : "开启邀请链接"}</Button></div>
+              </section>
+
+              <section className={cn("rounded-xl border p-4", scopeMode === "public" ? "border-accent-primary bg-accent-primary/[0.04]" : "border-app-border")}>
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><ShieldCheck size={19} /></div>
+                  <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><h3 className="text-sm font-semibold">通过公开链接访问</h3>{scopeMode === "public" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div><p className="mt-1 text-xs text-tx-tertiary">适合对外发布，可设置访问码、密码、有效期及细粒度能力。</p></div>
+                </div>
+                <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">访问方式</span><select value={accessMode} onChange={(event) => setAccessMode(event.target.value as NotebookPublicationAccessMode)} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="public">任何人可访问</option><option value="link">持链接访问</option><option value="code">访问码</option><option value="password">密码保护</option></select></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">基础权限</span><select value={publicPermission} onChange={(event) => { const next = event.target.value as NotebookPublicationPermission; setPublicPermission(next); if (next === "read") { setAllowComment(false); setAllowEdit(false); } else if (next === "comment") setAllowComment(true); }} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="read">可查看</option><option value="comment">可查看、评论</option><option value="write">登录后可编辑</option></select></label>
+                </div>
+                {(accessMode === "code" || accessMode === "password") && <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">{accessMode === "code" ? "访问码" : "密码"}</span><Input type={accessMode === "password" ? "password" : "text"} value={publicSecret} onChange={(event) => setPublicSecret(event.target.value)} placeholder={publication?.hasSecret ? "留空保持原凭证" : "设置访问凭证"} /></label>}
+                <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">有效期</span><Input type="datetime-local" value={expiresAt} onChange={(event) => setExpiresAt(event.target.value)} /></label>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2"><Toggle checked={allowDownload} onChange={setAllowDownload} title="允许附件下载" /><Toggle checked={allowComment} onChange={setAllowComment} title="允许游客评论" /><Toggle checked={allowEdit} onChange={setAllowEdit} disabled={publicPermission !== "write"} title="登录后加入编辑" /><Toggle checked={allowReshare} onChange={setAllowReshare} title="允许二次分享" /></div>
+                {publicationUrl && <div className="mt-3 flex gap-2"><Input readOnly value={publicationUrl} className="text-xs" /><Button variant="outline" onClick={() => copy(publicationUrl)}><Copy size={14} className="mr-1" />复制</Button></div>}
+                <div className="mt-4 flex justify-end gap-2">{activePublication && <Button variant="outline" className="text-red-500" onClick={revokePublication}>关闭公开访问</Button>}<Button onClick={savePublication} disabled={saving}>{activePublication ? "保存公开设置" : "开启公开访问"}</Button></div>
+              </section>
+
+              {activePublication && <section><div className="mb-2 flex items-center justify-between"><div className="flex items-center gap-2 text-sm font-semibold"><MessageCircle size={15} />公开评论管理</div><Button size="sm" variant="ghost" onClick={loadComments}><RefreshCw size={13} /></Button></div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{comments.length === 0 ? <div className="p-6 text-center text-sm text-tx-tertiary">暂无公开评论</div> : comments.map((comment) => <div key={comment.id} className={cn("p-3", bool(comment.isHidden) && "opacity-60")}><div className="flex items-center justify-between gap-3"><div className="text-xs font-medium">{comment.nickname} · {comment.noteTitle}</div><div className="text-[10px] text-tx-tertiary">{new Date(comment.createdAt).toLocaleString()}</div></div><p className="mt-1 whitespace-pre-wrap text-sm">{comment.content}</p><div className="mt-2 flex gap-2"><Button size="sm" variant="outline" onClick={() => moderate(comment, { isResolved: !bool(comment.isResolved) })}>{bool(comment.isResolved) ? "取消解决" : "标记解决"}</Button><Button size="sm" variant="outline" onClick={() => moderate(comment, { isHidden: !bool(comment.isHidden) })}>{bool(comment.isHidden) ? "恢复显示" : "隐藏"}</Button><Button size="sm" variant="outline" className="text-red-500" onClick={() => deleteComment(comment)}><Trash2 size={13} /></Button></div></div>)}</div></section>}
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <section className="rounded-xl border border-app-border bg-app-hover/20 p-4">
+                <div className="flex items-start gap-3"><AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" /><div><h3 className="text-sm font-semibold">目录级权限继承</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">最近的显式规则优先，并向全部子目录继承。{inheritsFromParent ? "当前目录存在父级规则，可添加覆盖或删除覆盖恢复继承。" : "当前目录是权限树根节点。"}</p></div></div>
+              </section>
+              <section>
+                <div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]"><select value={aclPermission} onChange={(event) => setAclPermission(event.target.value as NotebookDirectoryPermission)} className="h-9 rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><Input value={aclQuery} onChange={(event) => setAclQuery(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void searchUsers("acl"); }} placeholder="搜索要设置独立权限的用户" className="h-9" /><Button variant="outline" onClick={() => searchUsers("acl")}><Search size={14} className="mr-1" />搜索</Button></div>
+                <div className="mt-2 flex gap-4 text-xs"><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowDownload} onChange={(event) => setAclAllowDownload(event.target.checked)} />允许下载</label><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowReshare} onChange={(event) => setAclAllowReshare(event.target.checked)} />允许二次分享</label></div>
+                {aclCandidates.map((user) => <button key={user.id} onClick={() => addOverride(user.id)} className="mt-2 flex w-full items-center justify-between rounded-lg border border-app-border px-3 py-2.5 text-sm hover:bg-app-hover"><span>{user.displayName || user.username}</span><span className="text-accent-primary">设为{permissionLabel(aclPermission)}</span></button>)}
+              </section>
+              <section><div className="mb-2 text-sm font-semibold">独立权限规则</div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{overrides.length === 0 ? <div className="p-8 text-center text-sm text-tx-tertiary">没有显式覆盖，当前完全继承上级权限</div> : overrides.map((entry) => <div key={entry.userId} className="flex items-center gap-3 px-3 py-3"><div className="min-w-0 flex-1"><div className="truncate text-sm">{entry.displayName || entry.username}</div><div className="text-[11px] text-tx-tertiary">{bool(entry.allowDownload) ? "可下载" : "不可下载"} · {bool(entry.allowReshare) ? "可二次分享" : "不可二次分享"}</div></div><select value={entry.permission} onChange={(event) => updateOverride(entry, event.target.value as NotebookDirectoryPermission)} className="h-8 rounded border border-app-border bg-app-bg px-2 text-xs"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><button onClick={() => removeOverride(entry.userId)} className="rounded p-1.5 text-red-500 hover:bg-red-500/10"><Trash2 size={14} /></button></div>)}</div></section>
+            </div>
+          )}
+        </main>
+
+        {transferOpen && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/45 px-5 backdrop-blur-sm">
+            <div className="w-full max-w-md rounded-2xl border border-app-border bg-app-surface p-5 shadow-2xl">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600"><Crown size={20} /></div>
+                <div><h3 className="text-base font-semibold">转交所有者</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">接收人将获得当前目录及全部子目录的所有权。你会保留可编辑权限，但不再能转交或删除其他协作者。</p></div>
+              </div>
+              <label className="mt-4 block space-y-1.5"><span className="text-xs text-tx-secondary">选择接收人</span><select value={transferTargetId} onChange={(event) => setTransferTargetId(event.target.value)} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm">{collaborators.map((member) => <option key={member.userId} value={member.userId}>{displayName(member)} · {memberRoleLabel(member.role)}</option>)}</select></label>
+              <div className="mt-5 flex justify-end gap-2"><Button variant="outline" onClick={() => setTransferOpen(false)} disabled={transferring}>取消</Button><Button onClick={transferOwnership} disabled={!transferTargetId || transferring} className="bg-amber-600 hover:bg-amber-700">{transferring ? "正在转交..." : "确认转交"}</Button></div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/NotebookShareDialog.tsx
+++ b/frontend/src/components/NotebookShareDialog.tsx
@@ -2,11 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
   ArrowLeft,
-  Check,
   ChevronRight,
   Copy,
   Crown,
-  Gear,
   Link2,
   LockKeyhole,
   MessageCircle,
@@ -14,6 +12,7 @@ import {
   RefreshCw,
   RotateCcw,
   Search,
+  Settings2,
   ShieldCheck,
   Trash2,
   Unlink,
@@ -29,7 +28,10 @@ import { copyText } from "@/lib/clipboard";
 import { buildPublicWebUrl } from "@/lib/publicWebOrigin";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
-import type { Notebook, NotebookMember, NotebookShareLink, User, UserPublicInfo } from "@/types";
+import {
+  notebookPermissionManagementApi,
+  type NotebookPermissionSummary,
+} from "@/lib/notebookPermissionManagementApi";
 import {
   notebookPublicationApi,
   type ManagedPublicationComment,
@@ -39,6 +41,7 @@ import {
   type NotebookPublicationAccessMode,
   type NotebookPublicationPermission,
 } from "@/lib/notebookPublicationApi";
+import type { Notebook, NotebookMember, NotebookShareLink, User, UserPublicInfo } from "@/types";
 
 interface Props {
   notebook: Notebook;
@@ -48,76 +51,82 @@ interface Props {
 type View = "overview" | "scope" | "permissions";
 type MemberRole = "viewer" | "editor";
 
-const bool = (value: number | boolean | undefined) => value === true || value === 1;
-const localDateTime = (value: string | null | undefined) =>
-  value
-    ? new Date(new Date(value).getTime() - new Date(value).getTimezoneOffset() * 60_000)
-        .toISOString()
-        .slice(0, 16)
-    : "";
+type PublicationDraft = {
+  accessMode: NotebookPublicationAccessMode;
+  permission: NotebookPublicationPermission;
+  secret: string;
+  expiresAt: string;
+  allowDownload: boolean;
+  allowComment: boolean;
+  allowEdit: boolean;
+  allowReshare: boolean;
+};
 
-const permissionLabel = (permission: NotebookDirectoryPermission) =>
-  ({ none: "不可见", read: "可查看", comment: "可评论", write: "可编辑", manage: "可管理" })[
-    permission
-  ];
+const bool = (value: number | boolean | undefined) => value === 1 || value === true;
 
-const memberRoleLabel = (role: NotebookMember["role"]) =>
-  role === "owner" ? "所有者" : role === "editor" ? "可编辑" : "可查看";
+function toLocalDateTime(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "";
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+    .toISOString()
+    .slice(0, 16);
+}
 
-function displayName(member: Pick<NotebookMember, "displayName" | "username" | "userId">) {
+function memberName(member: Pick<NotebookMember, "displayName" | "username" | "userId">): string {
   return member.displayName || member.username || member.userId;
 }
 
-function sourceLabel(source: NotebookMember["source"]) {
-  if (source === "invite_link") return "通过邀请链接加入";
-  if (source === "publication") return "通过公开发布加入";
+function memberSource(member: NotebookMember): string {
+  if (member.source === "invite_link") return "通过邀请链接加入";
+  if (member.source === "publication") return "通过公开发布加入";
   return "直接添加";
 }
 
-function Avatar({ member, size = 38 }: { member: NotebookMember; size?: number }) {
-  const name = displayName(member);
+function permissionLabel(permission: NotebookDirectoryPermission): string {
+  return {
+    none: "不可见",
+    read: "可查看",
+    comment: "可评论",
+    write: "可编辑",
+    manage: "可管理",
+  }[permission];
+}
+
+function Avatar({ member }: { member: NotebookMember }) {
+  const name = memberName(member);
   return member.avatarUrl ? (
-    <img
-      src={member.avatarUrl}
-      alt=""
-      className="shrink-0 rounded-md object-cover"
-      style={{ width: size, height: size }}
-    />
+    <img src={member.avatarUrl} alt="" className="h-10 w-10 shrink-0 rounded-md object-cover" />
   ) : (
-    <div
-      className="flex shrink-0 items-center justify-center rounded-md bg-accent-primary/10 text-sm font-semibold text-accent-primary"
-      style={{ width: size, height: size }}
-    >
+    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent-primary/10 text-sm font-semibold text-accent-primary">
       {name.slice(0, 1).toUpperCase()}
     </div>
   );
 }
 
-function Toggle({
+function CapabilityToggle({
   checked,
-  onChange,
-  title,
   disabled,
+  label,
+  onChange,
 }: {
   checked: boolean;
-  onChange: (value: boolean) => void;
-  title: string;
   disabled?: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
 }) {
   return (
-    <label
-      className={cn(
-        "flex cursor-pointer items-center gap-2 rounded-lg border border-app-border p-3 text-xs",
-        disabled && "cursor-not-allowed opacity-50",
-      )}
-    >
+    <label className={cn(
+      "flex items-center gap-2 rounded-lg border border-app-border p-3 text-xs",
+      disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+    )}>
       <input
         type="checkbox"
         checked={checked}
         disabled={disabled}
         onChange={(event) => onChange(event.target.checked)}
       />
-      <span>{title}</span>
+      {label}
     </label>
   );
 }
@@ -127,35 +136,38 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [me, setMe] = useState<User | null>(null);
+  const [summary, setSummary] = useState<NotebookPermissionSummary | null>(null);
   const [members, setMembers] = useState<NotebookMember[]>([]);
-  const [link, setLink] = useState<NotebookShareLink | null>(null);
+  const [invite, setInvite] = useState<NotebookShareLink | null>(null);
   const [publication, setPublication] = useState<NotebookPublication | null>(null);
+  const [comments, setComments] = useState<ManagedPublicationComment[]>([]);
   const [overrides, setOverrides] = useState<NotebookPermissionOverride[]>([]);
   const [inheritsFromParent, setInheritsFromParent] = useState<string | null>(null);
-  const [comments, setComments] = useState<ManagedPublicationComment[]>([]);
 
   const [memberSearch, setMemberSearch] = useState("");
-  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showAddMember, setShowAddMember] = useState(false);
-  const [query, setQuery] = useState("");
-  const [candidates, setCandidates] = useState<UserPublicInfo[]>([]);
-  const [role, setRole] = useState<MemberRole>("viewer");
+  const [userQuery, setUserQuery] = useState("");
+  const [userCandidates, setUserCandidates] = useState<UserPublicInfo[]>([]);
+  const [newMemberRole, setNewMemberRole] = useState<MemberRole>("viewer");
 
   const [transferOpen, setTransferOpen] = useState(false);
   const [transferTargetId, setTransferTargetId] = useState("");
-  const [transferring, setTransferring] = useState(false);
 
-  const [inviteExpiresAt, setInviteExpiresAt] = useState("");
+  const [inviteRole, setInviteRole] = useState<MemberRole>("viewer");
   const [inviteMaxUses, setInviteMaxUses] = useState("");
+  const [inviteExpiresAt, setInviteExpiresAt] = useState("");
 
-  const [accessMode, setAccessMode] = useState<NotebookPublicationAccessMode>("link");
-  const [publicPermission, setPublicPermission] = useState<NotebookPublicationPermission>("read");
-  const [publicSecret, setPublicSecret] = useState("");
-  const [expiresAt, setExpiresAt] = useState("");
-  const [allowDownload, setAllowDownload] = useState(true);
-  const [allowComment, setAllowComment] = useState(false);
-  const [allowEdit, setAllowEdit] = useState(false);
-  const [allowReshare, setAllowReshare] = useState(false);
+  const [publicationDraft, setPublicationDraft] = useState<PublicationDraft>({
+    accessMode: "link",
+    permission: "read",
+    secret: "",
+    expiresAt: "",
+    allowDownload: true,
+    allowComment: false,
+    allowEdit: false,
+    allowReshare: false,
+  });
 
   const [aclQuery, setAclQuery] = useState("");
   const [aclCandidates, setAclCandidates] = useState<UserPublicInfo[]>([]);
@@ -163,102 +175,88 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
   const [aclAllowDownload, setAclAllowDownload] = useState(true);
   const [aclAllowReshare, setAclAllowReshare] = useState(false);
 
-  const shareUrl = useMemo(
-    () => (link?.token ? buildPublicWebUrl(`/notebook-share/${link.token}`) : ""),
-    [link?.token],
+  const owner = useMemo(() => members.find((member) => member.role === "owner") || null, [members]);
+  const collaborators = useMemo(() => members.filter((member) => member.role !== "owner"), [members]);
+  const filteredCollaborators = useMemo(() => {
+    const keyword = memberSearch.trim().toLowerCase();
+    if (!keyword) return collaborators;
+    return collaborators.filter((member) =>
+      [member.displayName, member.username, member.email]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(keyword)),
+    );
+  }, [collaborators, memberSearch]);
+
+  const inviteUrl = useMemo(
+    () => invite?.token ? buildPublicWebUrl(`/notebook-share/${invite.token}`) : "",
+    [invite?.token],
   );
   const publicationUrl = useMemo(
-    () =>
-      publication?.token && bool(publication.isActive)
-        ? buildPublicWebUrl(`/public/${publication.token}`)
-        : "",
+    () => publication?.token && bool(publication.isActive)
+      ? buildPublicWebUrl(`/public/${publication.token}`)
+      : "",
     [publication?.token, publication?.isActive],
   );
 
-  const owner = useMemo(() => members.find((member) => member.role === "owner") || null, [members]);
-  const collaborators = useMemo(
-    () => members.filter((member) => member.role !== "owner"),
-    [members],
-  );
-  const normalizedMemberSearch = memberSearch.trim().toLowerCase();
-  const filteredCollaborators = useMemo(
-    () =>
-      collaborators.filter((member) => {
-        if (!normalizedMemberSearch) return true;
-        return [member.displayName, member.username, member.email]
-          .filter(Boolean)
-          .some((value) => String(value).toLowerCase().includes(normalizedMemberSearch));
-      }),
-    [collaborators, normalizedMemberSearch],
-  );
+  const publicationActive = Boolean(publication && bool(publication.isActive));
+  const scopeMode: "private" | "invite" | "public" = publicationActive
+    ? "public"
+    : invite
+      ? "invite"
+      : "private";
+  const scopeTitle = scopeMode === "public"
+    ? "通过公开链接访问"
+    : scopeMode === "invite"
+      ? "登录后持链接加入"
+      : "仅文档协作者可访问";
+  const scopeDescription = scopeMode === "public"
+    ? `公开权限：${publication?.permission === "write" ? "登录后可编辑" : publication?.permission === "comment" ? "可评论" : "仅查看"}`
+    : scopeMode === "invite"
+      ? `新成员加入后${invite?.role === "editor" ? "可编辑" : "仅查看"}`
+      : "未被添加的用户无法访问此目录";
+  const copyUrl = publicationUrl || inviteUrl;
+  const canTransfer = !notebook.workspaceId && owner?.userId === me?.id && collaborators.length > 0;
 
-  const activePublication = Boolean(publication && bool(publication.isActive));
-  const scopeMode = activePublication ? "public" : link ? "invite" : "private";
-  const scopeTitle =
-    scopeMode === "public"
-      ? "通过公开链接访问"
-      : scopeMode === "invite"
-        ? "登录后持链接加入"
-        : "仅文档协作者可访问";
-  const scopeDescription =
-    scopeMode === "public"
-      ? `公开权限：${publicPermission === "write" ? "登录后可编辑" : publicPermission === "comment" ? "可评论" : "仅查看"}`
-      : scopeMode === "invite"
-        ? `新成员加入后${role === "editor" ? "可编辑" : "仅查看"}`
-        : "未被添加的用户无法访问此目录";
-  const currentCopyUrl = publicationUrl || shareUrl;
-  const canTransferOwnership =
-    notebook.workspaceId === null && owner?.userId === me?.id && collaborators.length > 0;
+  function applyInvite(next: NotebookShareLink | null) {
+    setInvite(next);
+    if (!next) return;
+    setInviteRole(next.role);
+    setInviteMaxUses(next.maxUses ? String(next.maxUses) : "");
+    setInviteExpiresAt(toLocalDateTime(next.expiresAt));
+  }
 
-  const applyPublication = (value: NotebookPublication | null) => {
-    setPublication(value);
-    if (!value) return;
-    setAccessMode(value.accessMode);
-    setPublicPermission(value.permission);
-    setExpiresAt(localDateTime(value.expiresAt));
-    setAllowDownload(bool(value.allowDownload));
-    setAllowComment(bool(value.allowComment));
-    setAllowEdit(bool(value.allowEdit));
-    setAllowReshare(bool(value.allowReshare));
-    setPublicSecret("");
-  };
+  function applyPublication(next: NotebookPublication | null) {
+    setPublication(next);
+    if (!next) return;
+    setPublicationDraft({
+      accessMode: next.accessMode,
+      permission: next.permission,
+      secret: "",
+      expiresAt: toLocalDateTime(next.expiresAt),
+      allowDownload: bool(next.allowDownload),
+      allowComment: bool(next.allowComment),
+      allowEdit: bool(next.allowEdit),
+      allowReshare: bool(next.allowReshare),
+    });
+  }
 
-  const applyLink = (value: NotebookShareLink | null) => {
-    setLink(value);
-    if (!value) return;
-    setRole(value.role);
-    setInviteExpiresAt(localDateTime(value.expiresAt));
-    setInviteMaxUses(value.maxUses ? String(value.maxUses) : "");
-  };
-
-  const reload = async () => {
-    const [nextMe, nextMembers, nextLink, nextPublication, nextOverrides] = await Promise.all([
+  async function reload() {
+    const [nextMe, nextSummary, nextInvite, nextPublication, nextOverrides] = await Promise.all([
       api.getMe(),
-      api.getNotebookMembers(notebook.id),
+      notebookPermissionManagementApi.getSummary(notebook.id),
       api.getNotebookShareLink(notebook.id),
       notebookPublicationApi.getPublication(notebook.id),
       notebookPublicationApi.getPermissionOverrides(notebook.id),
     ]);
     setMe(nextMe);
-    setMembers(nextMembers);
-    applyLink(nextLink);
+    setSummary(nextSummary);
+    setMembers(nextSummary.members);
+    applyInvite(nextInvite);
     applyPublication(nextPublication);
     setOverrides(nextOverrides.direct);
     setInheritsFromParent(nextOverrides.inheritsFromParent);
-    setSelectedMemberIds(new Set());
-  };
-
-  const loadComments = async () => {
-    if (!publication || !bool(publication.isActive)) {
-      setComments([]);
-      return;
-    }
-    try {
-      setComments(await notebookPublicationApi.getManagedComments(notebook.id));
-    } catch (error: any) {
-      toast.error(error?.message || "加载公开评论失败");
-    }
-  };
+    setSelectedIds(new Set());
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -266,71 +264,62 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     reload()
       .catch((error: any) => !cancelled && toast.error(error?.message || "加载权限设置失败"))
       .finally(() => !cancelled && setLoading(false));
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [notebook.id]);
 
-  useEffect(() => {
-    if (view === "scope" && activePublication) void loadComments();
-  }, [view, publication?.id, publication?.isActive]);
-
-  const copy = async (value: string) => {
+  async function copyLink(value: string) {
     if (!value) {
-      toast.warning("当前仅协作者可访问，请先在“分享范围”中开启链接访问");
+      toast.warning("请先在分享范围中开启链接访问");
       return;
     }
-    const copied = await copyText(value);
-    if (copied) toast.success("链接已复制");
+    if (await copyText(value)) toast.success("链接已复制");
     else toast.error("复制失败");
-  };
+  }
 
-  const searchUsers = async (kind: "member" | "acl") => {
-    const keyword = (kind === "member" ? query : aclQuery).trim();
-    if (!keyword) return;
+  async function searchUsers(kind: "member" | "acl") {
+    const query = (kind === "member" ? userQuery : aclQuery).trim();
+    if (!query) return;
     try {
-      const rows = await api.searchUsers(keyword);
+      const rows = await api.searchUsers(query);
       if (kind === "member") {
-        setCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
+        setUserCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
       } else {
         setAclCandidates(rows.filter((user) => !overrides.some((entry) => entry.userId === user.id)));
       }
     } catch (error: any) {
       toast.error(error?.message || "搜索用户失败");
     }
-  };
+  }
 
-  const addMember = async (userId: string) => {
+  async function addMember(userId: string) {
     try {
-      await api.addNotebookMember(notebook.id, { userId, role });
-      setQuery("");
-      setCandidates([]);
+      await api.addNotebookMember(notebook.id, { userId, role: newMemberRole });
       setShowAddMember(false);
+      setUserQuery("");
+      setUserCandidates([]);
       toast.success("协作者已添加");
       await reload();
     } catch (error: any) {
       toast.error(error?.message || "添加协作者失败");
     }
-  };
+  }
 
-  const changeMemberRole = async (member: NotebookMember, next: MemberRole) => {
+  async function setMemberRole(member: NotebookMember, role: MemberRole) {
     try {
-      await api.updateNotebookMember(notebook.id, member.userId, { role: next });
+      await api.updateNotebookMember(notebook.id, member.userId, { role });
       toast.success("协作者权限已更新");
       await reload();
     } catch (error: any) {
       toast.error(error?.message || "权限更新失败");
     }
-  };
+  }
 
-  const removeMember = async (member: NotebookMember) => {
-    if (
-      !await confirm({
-        title: `移除 ${displayName(member)}？`,
-        description: "该协作者会立即失去当前目录及全部子目录的访问权限。",
-        danger: true,
-      })
-    ) return;
+  async function removeMember(member: NotebookMember) {
+    if (!await confirm({
+      title: `移除 ${memberName(member)}？`,
+      description: "该协作者会立即失去当前目录及全部子目录的访问权限。",
+      danger: true,
+    })) return;
     try {
       await api.removeNotebookMember(notebook.id, member.userId);
       toast.success("协作者已移除");
@@ -338,59 +327,52 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     } catch (error: any) {
       toast.error(error?.message || "移除协作者失败");
     }
-  };
+  }
 
-  const toggleMemberSelection = (userId: string) => {
-    setSelectedMemberIds((current) => {
+  function toggleMember(userId: string) {
+    setSelectedIds((current) => {
       const next = new Set(current);
       if (next.has(userId)) next.delete(userId);
       else next.add(userId);
       return next;
     });
-  };
+  }
 
-  const toggleAllVisible = () => {
+  function toggleVisibleMembers() {
     const visibleIds = filteredCollaborators.map((member) => member.userId);
-    const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedMemberIds.has(id));
-    setSelectedMemberIds((current) => {
+    const allSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id));
+    setSelectedIds((current) => {
       const next = new Set(current);
-      visibleIds.forEach((id) => {
-        if (allSelected) next.delete(id);
-        else next.add(id);
-      });
+      visibleIds.forEach((id) => allSelected ? next.delete(id) : next.add(id));
       return next;
     });
-  };
+  }
 
-  const batchSetRole = async (nextRole: MemberRole) => {
-    const targets = collaborators.filter((member) => selectedMemberIds.has(member.userId));
+  async function batchSetRole(role: MemberRole) {
+    const targets = collaborators.filter((member) => selectedIds.has(member.userId));
     if (targets.length === 0) return;
     setSaving(true);
     try {
-      await Promise.all(
-        targets.map((member) =>
-          api.updateNotebookMember(notebook.id, member.userId, { role: nextRole }),
-        ),
-      );
-      toast.success(`已将 ${targets.length} 位协作者设为${nextRole === "editor" ? "可编辑" : "可查看"}`);
+      await Promise.all(targets.map((member) =>
+        api.updateNotebookMember(notebook.id, member.userId, { role }),
+      ));
+      toast.success(`已更新 ${targets.length} 位协作者`);
       await reload();
     } catch (error: any) {
       toast.error(error?.message || "批量更新失败");
     } finally {
       setSaving(false);
     }
-  };
+  }
 
-  const batchRemove = async () => {
-    const targets = collaborators.filter((member) => selectedMemberIds.has(member.userId));
+  async function batchRemove() {
+    const targets = collaborators.filter((member) => selectedIds.has(member.userId));
     if (targets.length === 0) return;
-    if (
-      !await confirm({
-        title: `移除 ${targets.length} 位协作者？`,
-        description: "这些用户会立即失去当前目录及全部子目录的访问权限。",
-        danger: true,
-      })
-    ) return;
+    if (!await confirm({
+      title: `移除 ${targets.length} 位协作者？`,
+      description: "这些用户会立即失去当前目录及全部子目录的访问权限。",
+      danger: true,
+    })) return;
     setSaving(true);
     try {
       await Promise.all(targets.map((member) => api.removeNotebookMember(notebook.id, member.userId)));
@@ -401,36 +383,34 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     } finally {
       setSaving(false);
     }
-  };
+  }
 
-  const openTransfer = () => {
-    const first = collaborators[0];
-    if (!first) return;
-    setTransferTargetId(first.userId);
+  function openTransfer() {
+    if (!collaborators[0]) return;
+    setTransferTargetId(collaborators[0].userId);
     setTransferOpen(true);
-  };
+  }
 
-  const transferOwnership = async () => {
-    if (!transferTargetId || transferring) return;
+  async function transferOwnership() {
     const target = collaborators.find((member) => member.userId === transferTargetId);
     if (!target) return;
-    setTransferring(true);
+    setSaving(true);
     try {
-      const result = await api.transferNotebookOwnership(notebook.id, transferTargetId);
+      const result = await notebookPermissionManagementApi.transferOwnership(notebook.id, target.userId);
       setTransferOpen(false);
-      toast.success(`已将所有权转交给 ${displayName(target)}`);
-      await reload();
+      toast.success(`已将所有权转交给 ${memberName(target)}`);
       if (result.detachedFromParent) {
-        toast.info("该目录已从原父目录中分离，并成为新所有者个人空间的根目录");
+        toast.info("该目录已提升为新所有者个人空间的根目录");
       }
+      await reload();
     } catch (error: any) {
       toast.error(error?.message || "转交所有者失败");
     } finally {
-      setTransferring(false);
+      setSaving(false);
     }
-  };
+  }
 
-  const saveInvite = async () => {
+  async function saveInvite() {
     const maxUses = inviteMaxUses.trim() ? Number(inviteMaxUses) : null;
     if (maxUses !== null && (!Number.isInteger(maxUses) || maxUses < 1)) {
       toast.error("最大加入人数必须是正整数");
@@ -439,59 +419,50 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     setSaving(true);
     try {
       const input = {
-        role,
-        expiresAt: inviteExpiresAt ? new Date(inviteExpiresAt).toISOString() : null,
+        role: inviteRole,
         maxUses,
+        expiresAt: inviteExpiresAt ? new Date(inviteExpiresAt).toISOString() : null,
       };
-      const next = link
+      const next = invite
         ? await api.updateNotebookShareLink(notebook.id, input)
         : await api.createNotebookShareLink(notebook.id, input);
-      applyLink(next);
-      toast.success(link ? "邀请设置已保存" : "邀请链接已生成");
+      applyInvite(next);
+      toast.success(invite ? "邀请设置已保存" : "邀请链接已开启");
     } catch (error: any) {
       toast.error(error?.message || "邀请链接保存失败");
     } finally {
       setSaving(false);
     }
-  };
+  }
 
-  const rotateInvite = async () => {
-    if (
-      !await confirm({
-        title: "更换邀请链接？",
-        description: "旧链接立即失效，使用次数会清零；已加入的协作者不受影响。",
-      })
-    ) return;
-    const next = await api.updateNotebookShareLink(notebook.id, { rotateToken: true });
-    applyLink(next);
+  async function rotateInvite() {
+    if (!await confirm({ title: "更换邀请链接？", description: "旧链接会立即失效，已加入的协作者不受影响。" })) return;
+    applyInvite(await api.updateNotebookShareLink(notebook.id, { rotateToken: true }));
     toast.success("已生成新邀请链接");
-  };
+  }
 
-  const resetInviteUses = async () => {
-    const next = await api.updateNotebookShareLink(notebook.id, { resetUses: true });
-    applyLink(next);
+  async function resetInviteUses() {
+    applyInvite(await api.updateNotebookShareLink(notebook.id, { resetUses: true }));
     toast.success("加入人数统计已清零");
-  };
+  }
 
-  const revokeInvite = async () => {
-    if (
-      !await confirm({
-        title: "关闭邀请链接？",
-        description: "旧链接立即失效，仅通过该链接加入的成员会被移除；手动添加的协作者不受影响。",
-        danger: true,
-      })
-    ) return;
+  async function revokeInvite() {
+    if (!await confirm({
+      title: "关闭邀请链接？",
+      description: "仅通过该链接加入的成员会被移除，直接添加的协作者不受影响。",
+      danger: true,
+    })) return;
     await api.deleteNotebookShareLink(notebook.id);
-    applyLink(null);
+    applyInvite(null);
     toast.success("邀请链接已关闭");
     await reload();
-  };
+  }
 
-  const savePublication = async () => {
+  async function savePublication() {
     if (
-      (accessMode === "code" || accessMode === "password") &&
+      (publicationDraft.accessMode === "code" || publicationDraft.accessMode === "password") &&
       !publication?.hasSecret &&
-      !publicSecret.trim()
+      !publicationDraft.secret.trim()
     ) {
       toast.error("请设置访问凭证");
       return;
@@ -499,104 +470,116 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     setSaving(true);
     try {
       const next = await notebookPublicationApi.savePublication(notebook.id, {
-        accessMode,
-        permission: publicPermission,
-        secret: publicSecret.trim() || undefined,
-        allowDownload,
-        allowComment,
-        allowEdit,
-        allowReshare,
-        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+        accessMode: publicationDraft.accessMode,
+        permission: publicationDraft.permission,
+        secret: publicationDraft.secret.trim() || undefined,
+        expiresAt: publicationDraft.expiresAt
+          ? new Date(publicationDraft.expiresAt).toISOString()
+          : null,
+        allowDownload: publicationDraft.allowDownload,
+        allowComment: publicationDraft.allowComment,
+        allowEdit: publicationDraft.allowEdit,
+        allowReshare: publicationDraft.allowReshare,
       });
       applyPublication(next);
       toast.success("公开访问设置已保存");
     } catch (error: any) {
-      toast.error(error?.message || "公开发布失败");
+      toast.error(error?.message || "公开访问设置保存失败");
     } finally {
       setSaving(false);
     }
-  };
+  }
 
-  const revokePublication = async () => {
-    if (
-      !await confirm({
-        title: "关闭公开访问？",
-        description: "公开链接、附件签名以及仅通过公开发布加入的成员会立即失效。",
-        danger: true,
-      })
-    ) return;
+  async function revokePublication() {
+    if (!await confirm({
+      title: "关闭公开访问？",
+      description: "公开链接、附件签名和通过公开发布加入的成员会立即失效。",
+      danger: true,
+    })) return;
     await notebookPublicationApi.revokePublication(notebook.id);
     setPublication((current) => current ? { ...current, isActive: 0 } : current);
     setComments([]);
     toast.success("公开访问已关闭");
     await reload();
-  };
+  }
 
-  const setPrivateScope = async () => {
+  async function setPrivateScope() {
     if (scopeMode === "private") return;
-    if (
-      !await confirm({
-        title: "改为仅协作者可访问？",
-        description: "邀请链接和公开链接将全部失效，仅保留当前协作者。",
-      })
-    ) return;
+    if (!await confirm({
+      title: "改为仅协作者可访问？",
+      description: "邀请链接和公开链接都会关闭，仅保留当前协作者。",
+    })) return;
     setSaving(true);
     try {
-      if (link) await api.deleteNotebookShareLink(notebook.id);
-      if (activePublication) await notebookPublicationApi.revokePublication(notebook.id);
-      applyLink(null);
+      if (invite) await api.deleteNotebookShareLink(notebook.id);
+      if (publicationActive) await notebookPublicationApi.revokePublication(notebook.id);
+      applyInvite(null);
       setPublication((current) => current ? { ...current, isActive: 0 } : null);
       toast.success("已改为仅协作者可访问");
       await reload();
     } catch (error: any) {
-      toast.error(error?.message || "更新分享范围失败");
+      toast.error(error?.message || "分享范围更新失败");
     } finally {
       setSaving(false);
     }
-  };
+  }
 
-  const moderate = async (
+  async function loadComments() {
+    if (!publicationActive) return setComments([]);
+    try {
+      setComments(await notebookPublicationApi.getManagedComments(notebook.id));
+    } catch (error: any) {
+      toast.error(error?.message || "评论加载失败");
+    }
+  }
+
+  async function moderateComment(
     comment: ManagedPublicationComment,
     input: { isResolved?: boolean; isHidden?: boolean },
-  ) => {
+  ) {
     await notebookPublicationApi.moderateComment(notebook.id, comment.id, input);
     await loadComments();
-  };
+  }
 
-  const deleteComment = async (comment: ManagedPublicationComment) => {
+  async function deleteComment(comment: ManagedPublicationComment) {
     if (!await confirm({ title: "删除评论？", description: "该操作不可恢复。", danger: true })) return;
     await notebookPublicationApi.deleteManagedComment(notebook.id, comment.id);
     await loadComments();
-  };
+  }
 
-  const addOverride = async (userId: string) => {
-    await notebookPublicationApi.setPermissionOverride(notebook.id, userId, {
-      permission: aclPermission,
-      allowDownload: aclAllowDownload,
-      allowReshare: aclAllowReshare,
-    });
-    setAclQuery("");
-    setAclCandidates([]);
-    toast.success("目录权限已添加");
-    await reload();
-  };
+  async function addOverride(userId: string) {
+    try {
+      await notebookPublicationApi.setPermissionOverride(notebook.id, userId, {
+        permission: aclPermission,
+        allowDownload: aclAllowDownload,
+        allowReshare: aclAllowReshare,
+      });
+      setAclQuery("");
+      setAclCandidates([]);
+      toast.success("独立权限已添加");
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "权限添加失败");
+    }
+  }
 
-  const updateOverride = async (
-    entry: NotebookPermissionOverride,
-    permission: NotebookDirectoryPermission,
-  ) => {
-    await notebookPublicationApi.setPermissionOverride(notebook.id, entry.userId, {
-      permission,
-      allowDownload: bool(entry.allowDownload),
-      allowReshare: bool(entry.allowReshare),
-    });
-    await reload();
-  };
+  async function updateOverride(entry: NotebookPermissionOverride, permission: NotebookDirectoryPermission) {
+    try {
+      await notebookPublicationApi.setPermissionOverride(notebook.id, entry.userId, {
+        permission,
+        allowDownload: bool(entry.allowDownload),
+        allowReshare: bool(entry.allowReshare),
+      });
+      await reload();
+    } catch (error: any) {
+      toast.error(error?.message || "权限更新失败");
+    }
+  }
 
-  const removeOverride = async (userId: string) => {
+  async function removeOverride(userId: string) {
     await notebookPublicationApi.removePermissionOverride(notebook.id, userId);
     await reload();
-  };
+  }
 
   const headerTitle = view === "overview" ? "权限管理" : view === "scope" ? "分享范围" : "权限配置";
 
@@ -606,11 +589,7 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
         <header className="flex items-center justify-between px-6 py-5">
           <div className="flex min-w-0 items-center gap-2.5">
             {view !== "overview" && (
-              <button
-                onClick={() => setView("overview")}
-                className="rounded-lg p-1.5 text-tx-secondary hover:bg-app-hover"
-                aria-label="返回"
-              >
+              <button onClick={() => setView("overview")} className="rounded-lg p-1.5 text-tx-secondary hover:bg-app-hover" aria-label="返回">
                 <ArrowLeft size={18} />
               </button>
             )}
@@ -621,11 +600,7 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
               </p>
             </div>
           </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 text-tx-secondary hover:bg-app-hover"
-            aria-label="关闭"
-          >
+          <button onClick={onClose} className="rounded-lg p-2 text-tx-secondary hover:bg-app-hover" aria-label="关闭">
             <X size={20} />
           </button>
         </header>
@@ -638,22 +613,11 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
               <section>
                 <div className="mb-3 flex items-center justify-between">
                   <h3 className="text-base font-medium text-tx-secondary">分享范围</h3>
-                  <button
-                    onClick={() => copy(currentCopyUrl)}
-                    className={cn(
-                      "flex items-center gap-1.5 text-sm font-medium text-accent-primary",
-                      !currentCopyUrl && "opacity-60",
-                    )}
-                    title={currentCopyUrl ? "复制当前分享链接" : "请先开启链接访问"}
-                  >
-                    <Link2 size={17} />
-                    复制链接
+                  <button onClick={() => copyLink(copyUrl)} className="flex items-center gap-1.5 text-sm font-medium text-accent-primary">
+                    <Link2 size={17} />复制链接
                   </button>
                 </div>
-                <button
-                  onClick={() => setView("scope")}
-                  className="flex w-full items-center gap-3 rounded-lg border border-app-border bg-app-hover/35 px-4 py-3 text-left transition-colors hover:bg-app-hover"
-                >
+                <button onClick={() => setView("scope")} className="flex w-full items-center gap-3 rounded-lg border border-app-border bg-app-hover/35 px-4 py-3 text-left hover:bg-app-hover">
                   <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-app-surface text-tx-secondary shadow-sm">
                     {scopeMode === "private" ? <LockKeyhole size={18} /> : scopeMode === "invite" ? <Users size={18} /> : <ShieldCheck size={18} />}
                   </div>
@@ -669,59 +633,29 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                 <div className="mb-3 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <h3 className="text-base font-medium text-tx-secondary">所有协作者</h3>
-                    <span className="rounded-full bg-app-hover px-2 py-0.5 text-[11px] text-tx-tertiary">
-                      {members.length}
-                    </span>
+                    <span className="rounded-full bg-app-hover px-2 py-0.5 text-[11px] text-tx-tertiary">{members.length}</span>
                   </div>
-                  <button
-                    onClick={() => {
-                      setShowAddMember((current) => !current);
-                      setCandidates([]);
-                    }}
-                    className="flex items-center gap-1 text-sm font-medium text-accent-primary"
-                  >
-                    <Plus size={18} />
-                    添加协作者
+                  <button onClick={() => setShowAddMember((current) => !current)} className="flex items-center gap-1 text-sm font-medium text-accent-primary">
+                    <Plus size={18} />添加协作者
                   </button>
                 </div>
 
                 {showAddMember && (
                   <div className="mb-3 rounded-xl border border-accent-primary/25 bg-accent-primary/[0.04] p-3">
                     <div className="flex flex-col gap-2 sm:flex-row">
-                      <select
-                        value={role}
-                        onChange={(event) => setRole(event.target.value as MemberRole)}
-                        className="h-9 rounded-lg border border-app-border bg-app-bg px-3 text-sm"
-                      >
+                      <select value={newMemberRole} onChange={(event) => setNewMemberRole(event.target.value as MemberRole)} className="h-9 rounded-lg border border-app-border bg-app-bg px-3 text-sm">
                         <option value="viewer">可查看</option>
                         <option value="editor">可编辑</option>
                       </select>
-                      <Input
-                        value={query}
-                        onChange={(event) => setQuery(event.target.value)}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter") void searchUsers("member");
-                        }}
-                        placeholder="搜索用户名或邮箱"
-                        className="h-9 flex-1"
-                        autoFocus
-                      />
-                      <Button variant="outline" onClick={() => searchUsers("member")}>
-                        <Search size={14} className="mr-1" />搜索
-                      </Button>
+                      <Input value={userQuery} onChange={(event) => setUserQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers("member")} placeholder="搜索用户名或邮箱" className="h-9 flex-1" autoFocus />
+                      <Button variant="outline" onClick={() => searchUsers("member")}><Search size={14} className="mr-1" />搜索</Button>
                     </div>
-                    {candidates.length > 0 && (
+                    {userCandidates.length > 0 && (
                       <div className="mt-2 overflow-hidden rounded-lg border border-app-border bg-app-surface">
-                        {candidates.map((user) => (
-                          <button
-                            key={user.id}
-                            onClick={() => addMember(user.id)}
-                            className="flex w-full items-center justify-between border-b border-app-border px-3 py-2.5 text-left last:border-b-0 hover:bg-app-hover"
-                          >
+                        {userCandidates.map((user) => (
+                          <button key={user.id} onClick={() => addMember(user.id)} className="flex w-full items-center justify-between border-b border-app-border px-3 py-2.5 text-left last:border-b-0 hover:bg-app-hover">
                             <span className="text-sm">{user.displayName || user.username}</span>
-                            <span className="flex items-center gap-1 text-xs text-accent-primary">
-                              <UserPlus size={13} />添加
-                            </span>
+                            <span className="flex items-center gap-1 text-xs text-accent-primary"><UserPlus size={13} />添加</span>
                           </button>
                         ))}
                       </div>
@@ -733,30 +667,20 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                   <div className="flex h-12 items-center gap-3 border-b border-app-border px-4">
                     <input
                       type="checkbox"
-                      checked={
-                        filteredCollaborators.length > 0 &&
-                        filteredCollaborators.every((member) => selectedMemberIds.has(member.userId))
-                      }
-                      onChange={toggleAllVisible}
+                      checked={filteredCollaborators.length > 0 && filteredCollaborators.every((member) => selectedIds.has(member.userId))}
+                      onChange={toggleVisibleMembers}
                       aria-label="全选协作者"
                     />
                     <span className="text-sm font-medium text-tx-primary">全选</span>
                     <div className="ml-auto flex w-52 items-center gap-2 rounded-lg bg-app-hover/50 px-2.5 py-1.5">
                       <Search size={15} className="text-tx-tertiary" />
-                      <input
-                        value={memberSearch}
-                        onChange={(event) => setMemberSearch(event.target.value)}
-                        placeholder="搜索协作者"
-                        className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-tx-tertiary"
-                      />
+                      <input value={memberSearch} onChange={(event) => setMemberSearch(event.target.value)} placeholder="搜索协作者" className="min-w-0 flex-1 bg-transparent text-xs outline-none" />
                     </div>
                   </div>
 
-                  {selectedMemberIds.size > 0 && (
+                  {selectedIds.size > 0 && (
                     <div className="flex flex-wrap items-center gap-2 border-b border-app-border bg-accent-primary/[0.04] px-4 py-2">
-                      <span className="mr-auto text-xs text-tx-secondary">
-                        已选择 {selectedMemberIds.size} 人
-                      </span>
+                      <span className="mr-auto text-xs text-tx-secondary">已选择 {selectedIds.size} 人</span>
                       <Button size="sm" variant="outline" disabled={saving} onClick={() => batchSetRole("viewer")}>设为可查看</Button>
                       <Button size="sm" variant="outline" disabled={saving} onClick={() => batchSetRole("editor")}>设为可编辑</Button>
                       <Button size="sm" variant="outline" disabled={saving} className="text-red-500" onClick={batchRemove}>移除</Button>
@@ -771,13 +695,13 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                         <Avatar member={owner} />
                         <div className="min-w-0 flex-1">
                           <div className="flex flex-wrap items-center gap-2">
-                            <span className="truncate text-sm font-medium text-tx-primary">{displayName(owner)}</span>
+                            <span className="truncate text-sm font-medium text-tx-primary">{memberName(owner)}</span>
                             {owner.userId === me?.id && <span className="text-xs text-tx-tertiary">我自己</span>}
                             <span className="rounded border border-accent-primary/35 bg-accent-primary/5 px-1.5 py-0.5 text-[11px] text-accent-primary">所有者</span>
                           </div>
-                          <div className="mt-0.5 truncate text-xs text-tx-tertiary">拥有全部权限，可管理协作者与分享范围</div>
+                          <div className="mt-0.5 text-xs text-tx-tertiary">拥有全部权限，可管理协作者与分享范围</div>
                         </div>
-                        {canTransferOwnership ? (
+                        {canTransfer ? (
                           <button onClick={openTransfer} className="shrink-0 text-sm font-medium text-accent-primary">转交所有者</button>
                         ) : (
                           <span className="shrink-0 text-xs text-tx-tertiary">可管理</span>
@@ -791,50 +715,29 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                     <div className="px-4 py-10 text-center text-sm text-tx-tertiary">
                       {collaborators.length === 0 ? "暂时没有其他协作者" : "没有匹配的协作者"}
                     </div>
-                  ) : (
-                    filteredCollaborators.map((member) => (
-                      <div key={member.userId} className="flex items-center gap-3 border-t border-app-border px-4 py-3 first:border-t-0">
-                        <input
-                          type="checkbox"
-                          checked={selectedMemberIds.has(member.userId)}
-                          onChange={() => toggleMemberSelection(member.userId)}
-                          aria-label={`选择 ${displayName(member)}`}
-                        />
-                        <Avatar member={member} />
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate text-sm font-medium text-tx-primary">{displayName(member)}</div>
-                          <div className="mt-0.5 truncate text-xs text-tx-tertiary">{sourceLabel(member.source)}{member.email ? ` · ${member.email}` : ""}</div>
-                        </div>
-                        <select
-                          value={member.role}
-                          onChange={(event) => changeMemberRole(member, event.target.value as MemberRole)}
-                          className="h-8 rounded-md border border-app-border bg-app-bg px-2 text-xs"
-                          aria-label={`${displayName(member)} 的权限`}
-                        >
-                          <option value="viewer">可查看</option>
-                          <option value="editor">可编辑</option>
-                        </select>
-                        <button
-                          onClick={() => removeMember(member)}
-                          className="rounded-md p-1.5 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500"
-                          title="移除协作者"
-                        >
-                          <Trash2 size={15} />
-                        </button>
+                  ) : filteredCollaborators.map((member) => (
+                    <div key={member.userId} className="flex items-center gap-3 border-t border-app-border px-4 py-3">
+                      <input type="checkbox" checked={selectedIds.has(member.userId)} onChange={() => toggleMember(member.userId)} aria-label={`选择 ${memberName(member)}`} />
+                      <Avatar member={member} />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-tx-primary">{memberName(member)}</div>
+                        <div className="mt-0.5 truncate text-xs text-tx-tertiary">{memberSource(member)}{member.email ? ` · ${member.email}` : ""}</div>
                       </div>
-                    ))
-                  )}
+                      <select value={member.role} onChange={(event) => setMemberRole(member, event.target.value as MemberRole)} className="h-8 rounded-md border border-app-border bg-app-bg px-2 text-xs">
+                        <option value="viewer">可查看</option>
+                        <option value="editor">可编辑</option>
+                      </select>
+                      <button onClick={() => removeMember(member)} className="rounded-md p-1.5 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500" title="移除协作者"><Trash2 size={15} /></button>
+                    </div>
+                  ))}
                 </div>
               </section>
 
-              <button
-                onClick={() => setView("permissions")}
-                className="flex w-full items-center gap-3 rounded-xl px-2 py-3 text-left hover:bg-app-hover"
-              >
-                <Gear size={20} className="text-tx-secondary" />
+              <button onClick={() => setView("permissions")} className="flex w-full items-center gap-3 rounded-xl px-2 py-3 text-left hover:bg-app-hover">
+                <Settings2 size={20} className="text-tx-secondary" />
                 <div className="flex-1">
                   <div className="text-base font-medium text-tx-primary">权限配置</div>
-                  <div className="mt-0.5 text-xs text-tx-tertiary">设置子目录继承、指定用户覆盖、下载与二次分享权限</div>
+                  <div className="mt-0.5 text-xs text-tx-tertiary">设置目录继承、用户覆盖、下载与二次分享权限</div>
                 </div>
                 <ChevronRight size={18} className="text-tx-tertiary" />
               </button>
@@ -845,56 +748,84 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                 <div className="flex items-start gap-3">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><LockKeyhole size={19} /></div>
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2"><h3 className="text-sm font-semibold">仅协作者可访问</h3>{scopeMode === "private" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div>
-                    <p className="mt-1 text-xs text-tx-tertiary">只有上一级页面中列出的协作者可以打开，安全性最高。</p>
+                    <h3 className="text-sm font-semibold">仅协作者可访问</h3>
+                    <p className="mt-1 text-xs text-tx-tertiary">只有协作者列表中的用户可以打开，安全性最高。</p>
                   </div>
-                  {scopeMode !== "private" && <Button size="sm" variant="outline" disabled={saving} onClick={setPrivateScope}>设为当前范围</Button>}
+                  {scopeMode !== "private" && <Button size="sm" variant="outline" onClick={setPrivateScope} disabled={saving}>设为当前范围</Button>}
                 </div>
               </section>
 
               <section className={cn("rounded-xl border p-4", scopeMode === "invite" ? "border-accent-primary bg-accent-primary/[0.04]" : "border-app-border")}>
                 <div className="flex items-start gap-3">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><Users size={19} /></div>
-                  <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><h3 className="text-sm font-semibold">登录后持链接加入</h3>{scopeMode === "invite" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div><p className="mt-1 text-xs text-tx-tertiary">适合内部团队快速加入，加入后会出现在协作者列表中。</p></div>
+                  <div><h3 className="text-sm font-semibold">登录后持链接加入</h3><p className="mt-1 text-xs text-tx-tertiary">适合团队内部快速加入，加入后会出现在协作者列表。</p></div>
                 </div>
                 <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                  <label className="space-y-1"><span className="text-xs text-tx-secondary">加入权限</span><select value={role} onChange={(event) => setRole(event.target.value as MemberRole)} className="h-9 w-full rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="viewer">可查看</option><option value="editor">可编辑</option></select></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">加入权限</span><select value={inviteRole} onChange={(event) => setInviteRole(event.target.value as MemberRole)} className="h-9 w-full rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="viewer">可查看</option><option value="editor">可编辑</option></select></label>
                   <label className="space-y-1"><span className="text-xs text-tx-secondary">最大加入人数</span><Input type="number" min={1} value={inviteMaxUses} onChange={(event) => setInviteMaxUses(event.target.value)} placeholder="不限" className="h-9" /></label>
                   <label className="space-y-1"><span className="text-xs text-tx-secondary">有效期</span><Input type="datetime-local" value={inviteExpiresAt} onChange={(event) => setInviteExpiresAt(event.target.value)} className="h-9" /></label>
                 </div>
-                {link && <div className="mt-3"><div className="flex gap-2"><Input readOnly value={shareUrl} className="h-9 text-xs" /><Button variant="outline" onClick={() => copy(shareUrl)}><Copy size={14} className="mr-1" />复制</Button></div><p className="mt-1 text-[11px] text-tx-tertiary">已加入 {link.useCount || 0}{link.maxUses ? ` / ${link.maxUses}` : ""} 人</p></div>}
-                <div className="mt-3 flex flex-wrap justify-end gap-2">{link && <><Button variant="outline" onClick={resetInviteUses}><RotateCcw size={13} className="mr-1" />清零统计</Button><Button variant="outline" onClick={rotateInvite}><RefreshCw size={13} className="mr-1" />换链接</Button><Button variant="outline" className="text-red-500" onClick={revokeInvite}><Unlink size={13} className="mr-1" />关闭</Button></>}<Button onClick={saveInvite} disabled={saving}>{link ? "保存邀请设置" : "开启邀请链接"}</Button></div>
+                {invite && <div className="mt-3"><div className="flex gap-2"><Input readOnly value={inviteUrl} className="h-9 text-xs" /><Button variant="outline" onClick={() => copyLink(inviteUrl)}><Copy size={14} className="mr-1" />复制</Button></div><p className="mt-1 text-[11px] text-tx-tertiary">已加入 {invite.useCount || 0}{invite.maxUses ? ` / ${invite.maxUses}` : ""} 人</p></div>}
+                <div className="mt-3 flex flex-wrap justify-end gap-2">
+                  {invite && <><Button variant="outline" onClick={resetInviteUses}><RotateCcw size={13} className="mr-1" />清零</Button><Button variant="outline" onClick={rotateInvite}><RefreshCw size={13} className="mr-1" />换链接</Button><Button variant="outline" className="text-red-500" onClick={revokeInvite}><Unlink size={13} className="mr-1" />关闭</Button></>}
+                  <Button onClick={saveInvite} disabled={saving}>{invite ? "保存邀请设置" : "开启邀请链接"}</Button>
+                </div>
               </section>
 
               <section className={cn("rounded-xl border p-4", scopeMode === "public" ? "border-accent-primary bg-accent-primary/[0.04]" : "border-app-border")}>
                 <div className="flex items-start gap-3">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-app-hover"><ShieldCheck size={19} /></div>
-                  <div className="min-w-0 flex-1"><div className="flex items-center gap-2"><h3 className="text-sm font-semibold">通过公开链接访问</h3>{scopeMode === "public" && <span className="rounded-full bg-accent-primary/10 px-2 py-0.5 text-[10px] text-accent-primary">当前</span>}</div><p className="mt-1 text-xs text-tx-tertiary">适合对外发布，可设置访问码、密码、有效期及细粒度能力。</p></div>
+                  <div><h3 className="text-sm font-semibold">通过公开链接访问</h3><p className="mt-1 text-xs text-tx-tertiary">适合对外发布，可设置访问凭证和细粒度能力。</p></div>
                 </div>
                 <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                  <label className="space-y-1"><span className="text-xs text-tx-secondary">访问方式</span><select value={accessMode} onChange={(event) => setAccessMode(event.target.value as NotebookPublicationAccessMode)} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="public">任何人可访问</option><option value="link">持链接访问</option><option value="code">访问码</option><option value="password">密码保护</option></select></label>
-                  <label className="space-y-1"><span className="text-xs text-tx-secondary">基础权限</span><select value={publicPermission} onChange={(event) => { const next = event.target.value as NotebookPublicationPermission; setPublicPermission(next); if (next === "read") { setAllowComment(false); setAllowEdit(false); } else if (next === "comment") setAllowComment(true); }} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="read">可查看</option><option value="comment">可查看、评论</option><option value="write">登录后可编辑</option></select></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">访问方式</span><select value={publicationDraft.accessMode} onChange={(event) => setPublicationDraft((draft) => ({ ...draft, accessMode: event.target.value as NotebookPublicationAccessMode }))} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="public">任何人可访问</option><option value="link">持链接访问</option><option value="code">访问码</option><option value="password">密码保护</option></select></label>
+                  <label className="space-y-1"><span className="text-xs text-tx-secondary">基础权限</span><select value={publicationDraft.permission} onChange={(event) => { const permission = event.target.value as NotebookPublicationPermission; setPublicationDraft((draft) => ({ ...draft, permission, allowComment: permission !== "read", allowEdit: permission === "write" })); }} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm"><option value="read">可查看</option><option value="comment">可查看、评论</option><option value="write">登录后可编辑</option></select></label>
                 </div>
-                {(accessMode === "code" || accessMode === "password") && <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">{accessMode === "code" ? "访问码" : "密码"}</span><Input type={accessMode === "password" ? "password" : "text"} value={publicSecret} onChange={(event) => setPublicSecret(event.target.value)} placeholder={publication?.hasSecret ? "留空保持原凭证" : "设置访问凭证"} /></label>}
-                <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">有效期</span><Input type="datetime-local" value={expiresAt} onChange={(event) => setExpiresAt(event.target.value)} /></label>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2"><Toggle checked={allowDownload} onChange={setAllowDownload} title="允许附件下载" /><Toggle checked={allowComment} onChange={setAllowComment} title="允许游客评论" /><Toggle checked={allowEdit} onChange={setAllowEdit} disabled={publicPermission !== "write"} title="登录后加入编辑" /><Toggle checked={allowReshare} onChange={setAllowReshare} title="允许二次分享" /></div>
-                {publicationUrl && <div className="mt-3 flex gap-2"><Input readOnly value={publicationUrl} className="text-xs" /><Button variant="outline" onClick={() => copy(publicationUrl)}><Copy size={14} className="mr-1" />复制</Button></div>}
-                <div className="mt-4 flex justify-end gap-2">{activePublication && <Button variant="outline" className="text-red-500" onClick={revokePublication}>关闭公开访问</Button>}<Button onClick={savePublication} disabled={saving}>{activePublication ? "保存公开设置" : "开启公开访问"}</Button></div>
+                {(publicationDraft.accessMode === "code" || publicationDraft.accessMode === "password") && <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">{publicationDraft.accessMode === "code" ? "访问码" : "密码"}</span><Input type={publicationDraft.accessMode === "password" ? "password" : "text"} value={publicationDraft.secret} onChange={(event) => setPublicationDraft((draft) => ({ ...draft, secret: event.target.value }))} placeholder={publication?.hasSecret ? "留空保持原凭证" : "设置访问凭证"} /></label>}
+                <label className="mt-3 block space-y-1"><span className="text-xs text-tx-secondary">有效期</span><Input type="datetime-local" value={publicationDraft.expiresAt} onChange={(event) => setPublicationDraft((draft) => ({ ...draft, expiresAt: event.target.value }))} /></label>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <CapabilityToggle checked={publicationDraft.allowDownload} label="允许附件下载" onChange={(checked) => setPublicationDraft((draft) => ({ ...draft, allowDownload: checked }))} />
+                  <CapabilityToggle checked={publicationDraft.allowComment} label="允许游客评论" onChange={(checked) => setPublicationDraft((draft) => ({ ...draft, allowComment: checked }))} />
+                  <CapabilityToggle checked={publicationDraft.allowEdit} disabled={publicationDraft.permission !== "write"} label="登录后加入编辑" onChange={(checked) => setPublicationDraft((draft) => ({ ...draft, allowEdit: checked }))} />
+                  <CapabilityToggle checked={publicationDraft.allowReshare} label="允许二次分享" onChange={(checked) => setPublicationDraft((draft) => ({ ...draft, allowReshare: checked }))} />
+                </div>
+                {publicationUrl && <div className="mt-3 flex gap-2"><Input readOnly value={publicationUrl} className="text-xs" /><Button variant="outline" onClick={() => copyLink(publicationUrl)}><Copy size={14} className="mr-1" />复制</Button></div>}
+                <div className="mt-4 flex justify-end gap-2">{publicationActive && <Button variant="outline" className="text-red-500" onClick={revokePublication}>关闭公开访问</Button>}<Button onClick={savePublication} disabled={saving}>{publicationActive ? "保存公开设置" : "开启公开访问"}</Button></div>
               </section>
 
-              {activePublication && <section><div className="mb-2 flex items-center justify-between"><div className="flex items-center gap-2 text-sm font-semibold"><MessageCircle size={15} />公开评论管理</div><Button size="sm" variant="ghost" onClick={loadComments}><RefreshCw size={13} /></Button></div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{comments.length === 0 ? <div className="p-6 text-center text-sm text-tx-tertiary">暂无公开评论</div> : comments.map((comment) => <div key={comment.id} className={cn("p-3", bool(comment.isHidden) && "opacity-60")}><div className="flex items-center justify-between gap-3"><div className="text-xs font-medium">{comment.nickname} · {comment.noteTitle}</div><div className="text-[10px] text-tx-tertiary">{new Date(comment.createdAt).toLocaleString()}</div></div><p className="mt-1 whitespace-pre-wrap text-sm">{comment.content}</p><div className="mt-2 flex gap-2"><Button size="sm" variant="outline" onClick={() => moderate(comment, { isResolved: !bool(comment.isResolved) })}>{bool(comment.isResolved) ? "取消解决" : "标记解决"}</Button><Button size="sm" variant="outline" onClick={() => moderate(comment, { isHidden: !bool(comment.isHidden) })}>{bool(comment.isHidden) ? "恢复显示" : "隐藏"}</Button><Button size="sm" variant="outline" className="text-red-500" onClick={() => deleteComment(comment)}><Trash2 size={13} /></Button></div></div>)}</div></section>}
+              {publicationActive && (
+                <section>
+                  <div className="mb-2 flex items-center justify-between"><div className="flex items-center gap-2 text-sm font-semibold"><MessageCircle size={15} />公开评论管理</div><Button size="sm" variant="ghost" onClick={loadComments}><RefreshCw size={13} /></Button></div>
+                  <div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">
+                    {comments.length === 0 ? <div className="p-6 text-center text-sm text-tx-tertiary">点击刷新加载公开评论</div> : comments.map((comment) => (
+                      <div key={comment.id} className={cn("p-3", bool(comment.isHidden) && "opacity-60")}>
+                        <div className="flex items-center justify-between gap-3"><div className="text-xs font-medium">{comment.nickname} · {comment.noteTitle}</div><div className="text-[10px] text-tx-tertiary">{new Date(comment.createdAt).toLocaleString()}</div></div>
+                        <p className="mt-1 whitespace-pre-wrap text-sm">{comment.content}</p>
+                        <div className="mt-2 flex gap-2"><Button size="sm" variant="outline" onClick={() => moderateComment(comment, { isResolved: !bool(comment.isResolved) })}>{bool(comment.isResolved) ? "取消解决" : "标记解决"}</Button><Button size="sm" variant="outline" onClick={() => moderateComment(comment, { isHidden: !bool(comment.isHidden) })}>{bool(comment.isHidden) ? "恢复显示" : "隐藏"}</Button><Button size="sm" variant="outline" className="text-red-500" onClick={() => deleteComment(comment)}><Trash2 size={13} /></Button></div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
             </div>
           ) : (
             <div className="space-y-5">
               <section className="rounded-xl border border-app-border bg-app-hover/20 p-4">
-                <div className="flex items-start gap-3"><AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" /><div><h3 className="text-sm font-semibold">目录级权限继承</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">最近的显式规则优先，并向全部子目录继承。{inheritsFromParent ? "当前目录存在父级规则，可添加覆盖或删除覆盖恢复继承。" : "当前目录是权限树根节点。"}</p></div></div>
+                <div className="flex items-start gap-3"><AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" /><div><h3 className="text-sm font-semibold">目录级权限继承</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">最近的显式规则优先，并向全部子目录继承。{inheritsFromParent ? "当前存在父级规则，可添加覆盖或删除覆盖恢复继承。" : "当前目录是权限树根节点。"}</p></div></div>
               </section>
               <section>
-                <div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]"><select value={aclPermission} onChange={(event) => setAclPermission(event.target.value as NotebookDirectoryPermission)} className="h-9 rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><Input value={aclQuery} onChange={(event) => setAclQuery(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void searchUsers("acl"); }} placeholder="搜索要设置独立权限的用户" className="h-9" /><Button variant="outline" onClick={() => searchUsers("acl")}><Search size={14} className="mr-1" />搜索</Button></div>
+                <div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]"><select value={aclPermission} onChange={(event) => setAclPermission(event.target.value as NotebookDirectoryPermission)} className="h-9 rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><Input value={aclQuery} onChange={(event) => setAclQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers("acl")} placeholder="搜索要设置独立权限的用户" className="h-9" /><Button variant="outline" onClick={() => searchUsers("acl")}><Search size={14} className="mr-1" />搜索</Button></div>
                 <div className="mt-2 flex gap-4 text-xs"><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowDownload} onChange={(event) => setAclAllowDownload(event.target.checked)} />允许下载</label><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowReshare} onChange={(event) => setAclAllowReshare(event.target.checked)} />允许二次分享</label></div>
                 {aclCandidates.map((user) => <button key={user.id} onClick={() => addOverride(user.id)} className="mt-2 flex w-full items-center justify-between rounded-lg border border-app-border px-3 py-2.5 text-sm hover:bg-app-hover"><span>{user.displayName || user.username}</span><span className="text-accent-primary">设为{permissionLabel(aclPermission)}</span></button>)}
               </section>
-              <section><div className="mb-2 text-sm font-semibold">独立权限规则</div><div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">{overrides.length === 0 ? <div className="p-8 text-center text-sm text-tx-tertiary">没有显式覆盖，当前完全继承上级权限</div> : overrides.map((entry) => <div key={entry.userId} className="flex items-center gap-3 px-3 py-3"><div className="min-w-0 flex-1"><div className="truncate text-sm">{entry.displayName || entry.username}</div><div className="text-[11px] text-tx-tertiary">{bool(entry.allowDownload) ? "可下载" : "不可下载"} · {bool(entry.allowReshare) ? "可二次分享" : "不可二次分享"}</div></div><select value={entry.permission} onChange={(event) => updateOverride(entry, event.target.value as NotebookDirectoryPermission)} className="h-8 rounded border border-app-border bg-app-bg px-2 text-xs"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><button onClick={() => removeOverride(entry.userId)} className="rounded p-1.5 text-red-500 hover:bg-red-500/10"><Trash2 size={14} /></button></div>)}</div></section>
+              <section>
+                <div className="mb-2 text-sm font-semibold">独立权限规则</div>
+                <div className="divide-y divide-app-border overflow-hidden rounded-xl border border-app-border">
+                  {overrides.length === 0 ? <div className="p-8 text-center text-sm text-tx-tertiary">没有显式覆盖，当前完全继承上级权限</div> : overrides.map((entry) => (
+                    <div key={entry.userId} className="flex items-center gap-3 px-3 py-3"><div className="min-w-0 flex-1"><div className="truncate text-sm">{entry.displayName || entry.username}</div><div className="text-[11px] text-tx-tertiary">{bool(entry.allowDownload) ? "可下载" : "不可下载"} · {bool(entry.allowReshare) ? "可二次分享" : "不可二次分享"}</div></div><select value={entry.permission} onChange={(event) => updateOverride(entry, event.target.value as NotebookDirectoryPermission)} className="h-8 rounded border border-app-border bg-app-bg px-2 text-xs"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><button onClick={() => removeOverride(entry.userId)} className="rounded p-1.5 text-red-500 hover:bg-red-500/10"><Trash2 size={14} /></button></div>
+                  ))}
+                </div>
+              </section>
             </div>
           )}
         </main>
@@ -902,12 +833,9 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
         {transferOpen && (
           <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/45 px-5 backdrop-blur-sm">
             <div className="w-full max-w-md rounded-2xl border border-app-border bg-app-surface p-5 shadow-2xl">
-              <div className="flex items-start gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600"><Crown size={20} /></div>
-                <div><h3 className="text-base font-semibold">转交所有者</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">接收人将获得当前目录及全部子目录的所有权。你会保留可编辑权限，但不再能转交或删除其他协作者。</p></div>
-              </div>
-              <label className="mt-4 block space-y-1.5"><span className="text-xs text-tx-secondary">选择接收人</span><select value={transferTargetId} onChange={(event) => setTransferTargetId(event.target.value)} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm">{collaborators.map((member) => <option key={member.userId} value={member.userId}>{displayName(member)} · {memberRoleLabel(member.role)}</option>)}</select></label>
-              <div className="mt-5 flex justify-end gap-2"><Button variant="outline" onClick={() => setTransferOpen(false)} disabled={transferring}>取消</Button><Button onClick={transferOwnership} disabled={!transferTargetId || transferring} className="bg-amber-600 hover:bg-amber-700">{transferring ? "正在转交..." : "确认转交"}</Button></div>
+              <div className="flex items-start gap-3"><div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600"><Crown size={20} /></div><div><h3 className="text-base font-semibold">转交所有者</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">接收人将获得当前目录及全部子目录的所有权。你会保留可编辑权限，但不再能管理其他协作者。</p></div></div>
+              <label className="mt-4 block space-y-1.5"><span className="text-xs text-tx-secondary">选择接收人</span><select value={transferTargetId} onChange={(event) => setTransferTargetId(event.target.value)} className="h-10 w-full rounded-lg border border-app-border bg-app-bg px-3 text-sm">{collaborators.map((member) => <option key={member.userId} value={member.userId}>{memberName(member)}</option>)}</select></label>
+              <div className="mt-5 flex justify-end gap-2"><Button variant="outline" onClick={() => setTransferOpen(false)} disabled={saving}>取消</Button><Button onClick={transferOwnership} disabled={!transferTargetId || saving} className="bg-amber-600 hover:bg-amber-700">{saving ? "正在转交..." : "确认转交"}</Button></div>
             </div>
           </div>
         )}

--- a/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
+++ b/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
@@ -18,6 +18,13 @@ describe("Notebook permission management", () => {
     expect(source).toContain("权限配置");
   });
 
+  it("supports search, selection and batch collaborator operations", () => {
+    expect(source).toContain("memberSearch");
+    expect(source).toContain("toggleVisibleMembers");
+    expect(source).toContain("batchSetRole");
+    expect(source).toContain("batchRemove");
+  });
+
   it("supports owner transfer without exposing it for workspace notebooks", () => {
     expect(source).toContain("!notebook.workspaceId");
     expect(source).toContain("notebookPermissionManagementApi.transferOwnership");

--- a/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
+++ b/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const source = readFileSync(path.resolve(__dirname, "../NotebookShareDialog.tsx"), "utf8");
-const apiSource = readFileSync(path.resolve(__dirname, "../../lib/api.impl.ts"), "utf8");
+const apiSource = readFileSync(
+  path.resolve(__dirname, "../../lib/notebookPermissionManagementApi.ts"),
+  "utf8",
+);
 
 describe("Notebook permission management", () => {
   it("uses a collaborator-first permission management hierarchy", () => {
@@ -16,16 +19,22 @@ describe("Notebook permission management", () => {
   });
 
   it("supports owner transfer without exposing it for workspace notebooks", () => {
-    expect(source).toContain("notebook.workspaceId === null");
-    expect(source).toContain("api.transferNotebookOwnership");
+    expect(source).toContain("!notebook.workspaceId");
+    expect(source).toContain("notebookPermissionManagementApi.transferOwnership");
     expect(source).toContain("转交所有者");
-    expect(apiSource).toContain("transferNotebookOwnership:");
+    expect(apiSource).toContain("transferOwnership(");
     expect(apiSource).toContain("/transfer-owner");
   });
 
-  it("keeps existing invitation, publication and ACL capabilities reachable", () => {
+  it("loads an explicit permission summary instead of guessing the owner", () => {
+    expect(source).toContain("notebookPermissionManagementApi.getSummary");
+    expect(apiSource).toContain("/permission-summary");
+  });
+
+  it("keeps invitation, publication, comments and ACL capabilities reachable", () => {
     expect(source).toContain("登录后持链接加入");
     expect(source).toContain("通过公开链接访问");
+    expect(source).toContain("公开评论管理");
     expect(source).toContain("目录级权限继承");
     expect(source).toContain("notebookPublicationApi.setPermissionOverride");
   });

--- a/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
+++ b/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(path.resolve(__dirname, "../NotebookShareDialog.tsx"), "utf8");
+const apiSource = readFileSync(path.resolve(__dirname, "../../lib/api.impl.ts"), "utf8");
+
+describe("Notebook permission management", () => {
+  it("uses a collaborator-first permission management hierarchy", () => {
+    expect(source).toContain('type View = "overview" | "scope" | "permissions"');
+    expect(source).toContain("权限管理");
+    expect(source).toContain("分享范围");
+    expect(source).toContain("所有协作者");
+    expect(source).toContain("添加协作者");
+    expect(source).toContain("权限配置");
+  });
+
+  it("supports owner transfer without exposing it for workspace notebooks", () => {
+    expect(source).toContain("notebook.workspaceId === null");
+    expect(source).toContain("api.transferNotebookOwnership");
+    expect(source).toContain("转交所有者");
+    expect(apiSource).toContain("transferNotebookOwnership:");
+    expect(apiSource).toContain("/transfer-owner");
+  });
+
+  it("keeps existing invitation, publication and ACL capabilities reachable", () => {
+    expect(source).toContain("登录后持链接加入");
+    expect(source).toContain("通过公开链接访问");
+    expect(source).toContain("目录级权限继承");
+    expect(source).toContain("notebookPublicationApi.setPermissionOverride");
+  });
+});

--- a/frontend/src/components/__tests__/NotebookShareDialogClipboard.test.ts
+++ b/frontend/src/components/__tests__/NotebookShareDialogClipboard.test.ts
@@ -7,7 +7,7 @@ const source = readFileSync(path.resolve(__dirname, "../NotebookShareDialog.tsx"
 describe("NotebookShareDialog clipboard compatibility", () => {
   it("uses the shared HTTP-compatible clipboard fallback", () => {
     expect(source).toContain('import { copyText } from "@/lib/clipboard";');
-    expect(source).toContain("const copied = await copyText(value);");
+    expect(source).toMatch(/await copyText\(value\)/);
     expect(source).not.toContain("navigator.clipboard.writeText");
   });
 });

--- a/frontend/src/lib/notebookPermissionManagementApi.ts
+++ b/frontend/src/lib/notebookPermissionManagementApi.ts
@@ -1,0 +1,64 @@
+import { getBaseUrl } from "@/lib/api.impl";
+import type { NotebookMember } from "@/types";
+
+export interface NotebookPermissionSummary {
+  notebookId: string;
+  workspaceId: string | null;
+  ownerId: string;
+  members: NotebookMember[];
+}
+
+export interface NotebookOwnershipTransferResult {
+  notebookId: string;
+  previousOwnerId: string;
+  newOwnerId: string;
+  notebookCount: number;
+  noteCount: number;
+  attachmentCount: number;
+  detachedFromParent: boolean;
+}
+
+class NotebookPermissionManagementApiError extends Error {
+  code?: string;
+  status?: number;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    credentials: "include",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new NotebookPermissionManagementApiError(
+      typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
+    );
+    error.code = payload?.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
+export const notebookPermissionManagementApi = {
+  getSummary(notebookId: string): Promise<NotebookPermissionSummary> {
+    return request(`/notebooks/${encodeURIComponent(notebookId)}/permission-summary`);
+  },
+
+  transferOwnership(
+    notebookId: string,
+    targetUserId: string,
+  ): Promise<NotebookOwnershipTransferResult> {
+    return request(`/notebooks/${encodeURIComponent(notebookId)}/transfer-owner`, {
+      method: "POST",
+      body: JSON.stringify({ targetUserId }),
+    });
+  },
+};


### PR DESCRIPTION
## 背景

当前“分享与发布”按成员、公开发布、目录权限拆成三个技术型标签页，普通用户很难快速理解当前谁能访问、有什么权限，也缺少完整的所有权转交闭环。

## 产品与 UI 调整

- 默认页改为钉钉式“权限管理”结构：**分享范围 → 所有协作者 → 权限配置**。
- 分享范围卡片直接展示当前状态，并提供复制链接入口。
- 协作者列表增加所有者分组、头像、来源说明、搜索、全选及批量权限操作。
- 添加协作者改为当前页内联完成。
- 邀请链接与公开发布收拢到“分享范围”。
- 目录继承、指定用户覆盖、下载及二次分享能力收拢到“权限配置”。
- 保留现有邀请链接、公开发布、评论管理及 ACL 能力，不做功能降级。

## 权限模型与接口

- 新增独立权限摘要接口，前端不再从成员数据猜测所有者。
- 权限管理路由以模块化 runtime 接入，不继续扩张原有大型 notebooks 路由。
- 分享链接复制继续使用项目统一的 HTTP/Edge 兼容剪贴板降级。

## 所有权转交

- 个人空间目录支持转交给已有直接协作者。
- 转交完整覆盖当前目录、子目录、笔记及附件归属。
- 原所有者自动保留可编辑权限。
- 子目录原位于其他目录下时，转交后自动提升为新所有者个人空间根目录，避免跨用户父子链。
- 转交事务在不关闭数据库树结构守卫的前提下，临时拆分子树、更新归属后恢复内部结构。
- 团队空间不提供单目录转交入口，继续由工作区角色管理。

## 验证

专项 `Notebook Permission Management CI` 已覆盖：

- 所有权转交事务及树结构守卫回归
- 后端 TypeScript 类型检查
- 权限管理 UI 与剪贴板回归测试
- 前端生产构建
