### PR TITLE
fix(migrations): 修复权限 runtime 提前冻结 Schema 版本

### DIFF
--- a/.github/workflows/notebook-permission-management-ci.yml
+++ b/.github/workflows/notebook-permission-management-ci.yml
@@ -3,9 +3,11 @@ name: Notebook Permission Management CI
 on:
   pull_request:
     paths:
+      - "backend/src/index.hardened.ts"
       - "backend/src/runtime/notebook-permission-management.ts"
       - "backend/src/runtime/knowledge-tree-migration-bootstrap.ts"
       - "backend/src/services/notebookOwnershipTransfer.ts"
+      - "backend/tests/migration-bootstrap-order.test.ts"
       - "backend/tests/notebook-owner-transfer.test.ts"
       - "frontend/src/components/NotebookShareDialog.tsx"
       - "frontend/src/components/__tests__/NotebookPermissionManagement.test.ts"
@@ -26,26 +28,28 @@ jobs:
           cache-dependency-path: backend/package-lock.json
       - working-directory: backend
         run: npm ci
-      - name: Ownership transfer regression
-        id: ownership
+      - name: Permission backend regressions
+        id: permission_backend
         working-directory: backend
         shell: bash
         run: |
           set +e
-          node --import tsx --import ./tests/setup-db-isolation.ts --test tests/notebook-owner-transfer.test.ts > ownership-test.log 2>&1
+          node --import tsx --import ./tests/setup-db-isolation.ts --test \
+            tests/migration-bootstrap-order.test.ts \
+            tests/notebook-owner-transfer.test.ts > permission-backend-test.log 2>&1
           code=$?
-          cat ownership-test.log
+          cat permission-backend-test.log
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
-      - name: Upload ownership diagnostics
+      - name: Upload permission backend diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: notebook-owner-transfer-log
-          path: backend/ownership-test.log
+          name: notebook-permission-backend-log
+          path: backend/permission-backend-test.log
           if-no-files-found: error
-      - name: Require ownership regression
-        if: steps.ownership.outputs.exit_code != '0'
+      - name: Require permission backend regressions
+        if: steps.permission_backend.outputs.exit_code != '0'
         run: exit 1
       - name: Backend typecheck
         working-directory: backend

--- a/backend/src/index.hardened.ts
+++ b/backend/src/index.hardened.ts
@@ -2,6 +2,9 @@
 import "./runtime/url-import-dns-compat.js";
 // Register feature migrations before any runtime imports can initialize the database.
 import "./runtime/knowledge-tree-migration-bootstrap.js";
+// Permission routes import ACL services that may initialize database guards, so they must load
+// only after the feature migration list has been registered.
+import "./runtime/notebook-permission-management.js";
 // Install schema/route hardening before the main backend module evaluates.
 import "./runtime/task-stats-hardening.js";
 // Recover interrupted embedding jobs before the legacy worker starts polling.

--- a/backend/src/runtime/knowledge-tree-migration-bootstrap.ts
+++ b/backend/src/runtime/knowledge-tree-migration-bootstrap.ts
@@ -1,4 +1,3 @@
-import "./notebook-permission-management.js";
 import { knowledgeTreeMigration } from "../db/knowledgeTreeMigration.js";
 import { knowledgeTreeResourceMigration } from "../db/knowledgeTreeResourceMigration.js";
 import { knowledgeTreeParentPreservationMigration } from "../db/knowledgeTreeParentPreservationMigration.js";
@@ -7,10 +6,12 @@ import { knowledgeTreeStructuralGuardMigration } from "../db/knowledgeTreeStruct
 import { MIGRATIONS as BASE_MIGRATIONS } from "../db/migrations.impl.js";
 
 // index.hardened imports this module before any runtime that can open the database.
-// Keep modular route installers here as well, so they are attached to their shared routers
-// before the application mounts those routers under /api.
 // Mutating the historical base list here lets migrations.ts compute CURRENT_SCHEMA_VERSION
 // with the feature migrations included, without coupling the main migration wrapper to them.
+//
+// Do not import route/runtime installers from this file. Some of them depend on ACL services
+// that install database guards at module-evaluation time. Opening the database here would load
+// migrations.ts before versions 60-64 are appended and freeze CURRENT_SCHEMA_VERSION at 59.
 for (const featureMigration of [
   knowledgeTreeMigration,
   knowledgeTreeResourceMigration,

--- a/backend/src/services/notebookOwnershipTransfer.ts
+++ b/backend/src/services/notebookOwnershipTransfer.ts
@@ -34,6 +34,12 @@ function placeholders(count: number): string {
   return Array.from({ length: count }, () => "?").join(",");
 }
 
+function tableExists(db: Database.Database, table: string): boolean {
+  return Boolean(db.prepare(
+    "SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(table));
+}
+
 /**
  * 将个人空间目录及完整子树转交给一个现有协作者。
  *
@@ -127,18 +133,56 @@ export function transferNotebookOwnership(
       Boolean(row.parentId && notebookIdSet.has(row.parentId)),
   );
   const notebookMarks = placeholders(notebookIds.length);
-  const noteIds = (db.prepare(
-    `SELECT id FROM notes WHERE notebookId IN (${notebookMarks})`,
-  ).all(...notebookIds) as Array<{ id: string }>).map((row) => row.id);
+  const noteRows = db.prepare(
+    `SELECT id, notebookId FROM notes WHERE notebookId IN (${notebookMarks})`,
+  ).all(...notebookIds) as Array<{ id: string; notebookId: string }>;
+  const noteIds = noteRows.map((row) => row.id);
   const noteMarks = noteIds.length > 0 ? placeholders(noteIds.length) : "";
+
+  // The unified tree can preserve richer parents than notes.notebookId/notebooks.parentId.
+  // Capture all internal edges before detaching so ownership changes can happen without ever
+  // exposing a cross-user parent relation to the v64 structural guard.
+  let knowledgeTreeRows: Array<{ id: string; parentId: string | null }> = [];
+  if (tableExists(db, "knowledge_tree_nodes")) {
+    const predicates = [`(resourceType = 'notebook' AND resourceId IN (${notebookMarks}))`];
+    const params: string[] = [...notebookIds];
+    if (noteIds.length > 0) {
+      predicates.push(`(resourceType = 'note' AND resourceId IN (${noteMarks}))`);
+      params.push(...noteIds);
+    }
+    knowledgeTreeRows = db.prepare(
+      `SELECT id, parentId
+         FROM knowledge_tree_nodes
+        WHERE ${predicates.join(" OR ")}`,
+    ).all(...params) as Array<{ id: string; parentId: string | null }>;
+  }
+  const knowledgeTreeNodeIds = knowledgeTreeRows.map((row) => row.id);
+  const knowledgeTreeNodeIdSet = new Set(knowledgeTreeNodeIds);
+  const knowledgeTreeInternalEdges = knowledgeTreeRows.filter(
+    (row): row is { id: string; parentId: string } =>
+      Boolean(row.parentId && knowledgeTreeNodeIdSet.has(row.parentId)),
+  );
+  const knowledgeTreeMarks = knowledgeTreeNodeIds.length > 0
+    ? placeholders(knowledgeTreeNodeIds.length)
+    : "";
 
   let attachmentCount = 0;
   const detachedFromParent = Boolean(root.parentId);
   ensureNotebookAclOverridesTable();
 
   const execute = db.transaction(() => {
-    // Tree guards intentionally reject a half-transferred tree. Temporarily detach the subtree,
-    // move resources and ownership while every node is a root, then restore only internal edges.
+    // First detach the unified nodes themselves. Updating a note owner fires the legacy-to-unified
+    // sync trigger; if its unified parent still belongs to the old owner, v64 correctly rejects it.
+    if (knowledgeTreeNodeIds.length > 0) {
+      db.prepare(
+        `UPDATE knowledge_tree_nodes
+            SET parentId = NULL, updatedAt = datetime('now')
+          WHERE id IN (${knowledgeTreeMarks}) AND parentId IS NOT NULL`,
+      ).run(...knowledgeTreeNodeIds);
+    }
+
+    // Legacy tree guards also reject a half-transferred tree. Temporarily detach every physical
+    // notebook, move notes/resources and ownership while each node is a root, then restore edges.
     db.prepare(
       `UPDATE notebooks
           SET parentId = NULL, updatedAt = datetime('now')
@@ -166,11 +210,23 @@ export function transferNotebookOwnership(
         WHERE id IN (${notebookMarks})`,
     ).run(targetUserId, ...notebookIds);
 
-    const restoreParent = db.prepare(
+    const restoreLegacyParent = db.prepare(
       "UPDATE notebooks SET parentId = ?, updatedAt = datetime('now') WHERE id = ?",
     );
     for (const edge of internalEdges) {
-      restoreParent.run(edge.parentId, edge.id);
+      restoreLegacyParent.run(edge.parentId, edge.id);
+    }
+
+    // Legacy sync restores physical notebook edges. Reapply the captured unified-tree edges last
+    // so richer note/folder nesting remains intact. Edges to nodes outside the transferred subtree
+    // intentionally stay detached, making the transferred root safe in the recipient's space.
+    if (knowledgeTreeInternalEdges.length > 0) {
+      const restoreKnowledgeParent = db.prepare(
+        "UPDATE knowledge_tree_nodes SET parentId = ?, updatedAt = datetime('now') WHERE id = ?",
+      );
+      for (const edge of knowledgeTreeInternalEdges) {
+        restoreKnowledgeParent.run(edge.parentId, edge.id);
+      }
     }
 
     db.prepare(

--- a/backend/tests/migration-bootstrap-order.test.ts
+++ b/backend/tests/migration-bootstrap-order.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("knowledge-tree bootstrap registers schema versions 60-64 before migrations.ts is evaluated", async () => {
+  await import("../src/runtime/knowledge-tree-migration-bootstrap");
+  const { CURRENT_SCHEMA_VERSION, MIGRATIONS } = await import("../src/db/migrations");
+  const versions = new Set(MIGRATIONS.map((migration) => migration.version));
+
+  for (const version of [60, 61, 62, 63, 64]) {
+    assert.ok(versions.has(version), `feature migration v${version} must be registered`);
+  }
+  assert.ok(
+    CURRENT_SCHEMA_VERSION >= 64,
+    `expected schema support >= 64, received ${CURRENT_SCHEMA_VERSION}`,
+  );
+});
+
+test("database-consuming permission runtime loads after the migration bootstrap", () => {
+  const indexSource = fs.readFileSync(
+    path.resolve(__dirname, "../src/index.hardened.ts"),
+    "utf8",
+  );
+  const bootstrapSource = fs.readFileSync(
+    path.resolve(__dirname, "../src/runtime/knowledge-tree-migration-bootstrap.ts"),
+    "utf8",
+  );
+
+  const bootstrapIndex = indexSource.indexOf('import "./runtime/knowledge-tree-migration-bootstrap.js";');
+  const permissionRuntimeIndex = indexSource.indexOf('import "./runtime/notebook-permission-management.js";');
+
+  assert.ok(bootstrapIndex >= 0, "index.hardened must import the migration bootstrap");
+  assert.ok(permissionRuntimeIndex >= 0, "index.hardened must import the permission runtime");
+  assert.ok(
+    bootstrapIndex < permissionRuntimeIndex,
+    "feature migrations must be registered before permission runtime evaluation",
+  );
+  assert.doesNotMatch(
+    bootstrapSource,
+    /import\s+["']\.\/notebook-permission-management\.js["']/,
+    "migration bootstrap must not import database-consuming runtimes",
+  );
+});


### PR DESCRIPTION
## 问题

合并权限管理重构后，`knowledge-tree-migration-bootstrap.ts` 直接导入了权限管理 runtime。该 runtime 的 ACL 依赖会在模块求值阶段调用 `getDb()`，使 `migrations.ts` 在知识树 v60～v64 注册前就被加载，`CURRENT_SCHEMA_VERSION` 因而冻结为 59。

已有 v64 数据库启动时会报：

```text
数据库版本 64 高于当前程序支持的 59
```

数据库本身没有损坏，也不应手工回退 `schema_migrations`。

## 修复

- 迁移 bootstrap 只负责注册迁移，不再导入任何可能打开数据库的 runtime。
- 在 `index.hardened.ts` 中严格按以下顺序加载：
  1. 注册知识树 v60～v64；
  2. 加载权限管理 runtime；
  3. 加载其他数据库/路由 hardening。
- 新增回归测试，验证 v60～v64 均已注册，并锁定 bootstrap 与权限 runtime 的加载顺序。

## 影响

- 不修改数据库内容。
- 不需要降级或删除 v60～v64 迁移记录。
- 拉取修复后的代码重新启动即可正常识别 v64 数据库。
