### PR TITLE
test(permissions): 补充 v64 统一树所有权转交回归

### DIFF
--- a/backend/tests/notebook-owner-transfer.test.ts
+++ b/backend/tests/notebook-owner-transfer.test.ts
@@ -52,13 +52,34 @@ test("personal notebook owner can transfer the complete subtree to an existing c
   assert.equal(result.notebookCount, 2);
   assert.equal(result.noteCount, 1);
 
-  const notebooks = db.prepare("SELECT id, userId FROM notebooks ORDER BY id").all() as Array<{ id: string; userId: string }>;
+  const notebooks = db.prepare("SELECT id, userId, parentId FROM notebooks ORDER BY id").all() as Array<{
+    id: string;
+    userId: string;
+    parentId: string | null;
+  }>;
   assert.deepEqual(notebooks, [
-    { id: "child", userId: "target" },
-    { id: "root", userId: "target" },
+    { id: "child", userId: "target", parentId: "root" },
+    { id: "root", userId: "target", parentId: null },
   ]);
   const note = db.prepare("SELECT userId FROM notes WHERE id = 'note'").get() as { userId: string };
   assert.equal(note.userId, "target");
+
+  const knowledgeNodes = db.prepare(
+    `SELECT id, userId, scopeKey, parentId
+       FROM knowledge_tree_nodes
+      WHERE id IN ('notebook:root', 'notebook:child', 'note:note')
+      ORDER BY id`,
+  ).all() as Array<{
+    id: string;
+    userId: string;
+    scopeKey: string;
+    parentId: string | null;
+  }>;
+  assert.deepEqual(knowledgeNodes, [
+    { id: "note:note", userId: "target", scopeKey: "personal:target", parentId: "notebook:child" },
+    { id: "notebook:child", userId: "target", scopeKey: "personal:target", parentId: "notebook:root" },
+    { id: "notebook:root", userId: "target", scopeKey: "personal:target", parentId: null },
+  ]);
 
   const memberships = db.prepare(
     "SELECT userId, role, status FROM notebook_members WHERE notebookId = 'root' ORDER BY role DESC, userId ASC",


### PR DESCRIPTION
## 背景

PR #516 已修复迁移 bootstrap 顺序，并同步修复所有权转交在知识树 v64 守卫下的原子更新。但仓库自动合并发生在最后一条增强断言提交之前。

## 本 PR

仅补充回归测试，验证所有权转交后：

- 旧 `notebooks` 父子结构保持正确；
- `notes.userId` 已转交；
- `knowledge_tree_nodes.userId` 与 `scopeKey` 全部切换到新所有者；
- 统一树内部父子边完整恢复；
- 根目录保持为新所有者个人空间根节点；
- 原所有者保留 editor，接收人成为 owner。

不包含业务代码变更。