### PR TITLE
feat(mobile): 增加目录浏览模式开关

### DIFF
--- a/.github/workflows/mobile-knowledge-tree-ci.yml
+++ b/.github/workflows/mobile-knowledge-tree-ci.yml
@@ -5,8 +5,11 @@ on:
     paths:
       - "frontend/src/components/MobileKnowledgeTreePanel.tsx"
       - "frontend/src/components/Sidebar.tsx"
+      - "frontend/src/components/SidebarSearchExperienceBridge.tsx"
       - "frontend/src/components/__tests__/MobileKnowledgeTreePanel.test.ts"
+      - "frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts"
       - "frontend/src/lib/mobileKnowledgeTree.ts"
+      - "frontend/src/lib/mobileKnowledgeTreeViewMode.ts"
       - "frontend/src/lib/__tests__/mobileKnowledgeTree.test.ts"
       - ".github/workflows/mobile-knowledge-tree-ci.yml"
   workflow_dispatch:
@@ -31,6 +34,7 @@ jobs:
           npm run test:run --
           src/lib/__tests__/mobileKnowledgeTree.test.ts
           src/components/__tests__/MobileKnowledgeTreePanel.test.ts
+          src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
       - name: Frontend typecheck
         id: typecheck
         shell: bash

--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -1,15 +1,41 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { Clock3, TreePine } from "lucide-react";
 
+import KnowledgeTreePanel from "@/components/KnowledgeTreePanel";
 import KnowledgeTreeSortButton from "@/components/KnowledgeTreeSortButton";
 import {
   applySidebarSearchExperience,
   KNOWLEDGE_TREE_FILTER_SELECTOR,
   SIDEBAR_SEARCH_SURFACE_SELECTOR,
 } from "@/lib/sidebarSearchExperience";
+import {
+  loadMobileKnowledgeTreeViewMode,
+  MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT,
+  saveMobileKnowledgeTreeViewMode,
+  type MobileKnowledgeTreeViewMode,
+} from "@/lib/mobileKnowledgeTreeViewMode";
+import { cn } from "@/lib/utils";
 
 const SORT_SLOT_ATTRIBUTE = "data-knowledge-tree-sort-slot";
+const MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE = "data-mobile-knowledge-tree-mode-switch-slot";
+const MOBILE_TREE_SLOT_ATTRIBUTE = "data-mobile-knowledge-tree-classic-slot";
+const MOBILE_NAVIGATOR_SELECTOR = '[data-sidebar-variant="mobile"] [data-nowen-mobile-knowledge-tree="flat-navigation"]';
 let sortSlotSequence = 0;
+let mobileModeSurfaceSequence = 0;
+
+interface MobileModeSurface {
+  id: string;
+  navigatorSurface: HTMLElement;
+  switchSlot: HTMLElement;
+  treeSlot: HTMLElement;
+}
+
+function directChildWithAttribute(parent: HTMLElement, attribute: string): HTMLElement | null {
+  return Array.from(parent.children).find(
+    (child): child is HTMLElement => child instanceof HTMLElement && child.hasAttribute(attribute),
+  ) || null;
+}
 
 function collectSortSlots(): HTMLElement[] {
   const slots: HTMLElement[] = [];
@@ -20,9 +46,7 @@ function collectSortSlots(): HTMLElement[] {
     const toolbar = filterSurface?.parentElement;
     if (!(filterSurface instanceof HTMLElement) || !(toolbar instanceof HTMLElement)) continue;
 
-    let slot = Array.from(toolbar.children).find(
-      (child): child is HTMLElement => child instanceof HTMLElement && child.hasAttribute(SORT_SLOT_ATTRIBUTE),
-    );
+    let slot = directChildWithAttribute(toolbar, SORT_SLOT_ATTRIBUTE);
     if (!slot) {
       slot = document.createElement("span");
       slot.setAttribute(SORT_SLOT_ATTRIBUTE, "");
@@ -36,8 +60,153 @@ function collectSortSlots(): HTMLElement[] {
   return slots;
 }
 
+function collectMobileModeSurfaces(): MobileModeSurface[] {
+  const result: MobileModeSurface[] = [];
+  const navigatorSurfaces = Array.from(document.querySelectorAll<HTMLElement>(MOBILE_NAVIGATOR_SELECTOR));
+
+  for (const navigatorSurface of navigatorSurfaces) {
+    const contentHost = navigatorSurface.parentElement;
+    const section = contentHost?.parentElement;
+    const header = contentHost?.previousElementSibling;
+    if (!(contentHost instanceof HTMLElement) || !(section instanceof HTMLElement) || !(header instanceof HTMLElement)) continue;
+
+    header.classList.add("flex", "items-center", "justify-between", "gap-2");
+
+    let switchSlot = directChildWithAttribute(header, MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE);
+    if (!switchSlot) {
+      switchSlot = document.createElement("span");
+      switchSlot.setAttribute(MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE, "");
+      switchSlot.className = "contents";
+      header.appendChild(switchSlot);
+    }
+
+    let treeSlot = directChildWithAttribute(contentHost, MOBILE_TREE_SLOT_ATTRIBUTE);
+    if (!treeSlot) {
+      treeSlot = document.createElement("span");
+      treeSlot.setAttribute(MOBILE_TREE_SLOT_ATTRIBUTE, "");
+      treeSlot.className = "contents";
+      contentHost.appendChild(treeSlot);
+    }
+
+    let id = navigatorSurface.dataset.mobileKnowledgeTreeModeSurfaceId;
+    if (!id) {
+      id = `mobile-tree-mode-${++mobileModeSurfaceSequence}`;
+      navigatorSurface.dataset.mobileKnowledgeTreeModeSurfaceId = id;
+    }
+
+    result.push({ id, navigatorSurface, switchSlot, treeSlot });
+  }
+
+  return result;
+}
+
 function sameSlots(current: HTMLElement[], next: HTMLElement[]): boolean {
   return current.length === next.length && current.every((slot, index) => slot === next[index]);
+}
+
+function sameMobileModeSurfaces(current: MobileModeSurface[], next: MobileModeSurface[]): boolean {
+  return current.length === next.length && current.every((surface, index) => (
+    surface.navigatorSurface === next[index]?.navigatorSurface
+    && surface.switchSlot === next[index]?.switchSlot
+    && surface.treeSlot === next[index]?.treeSlot
+  ));
+}
+
+function MobileKnowledgeTreeModeSurface({ surface }: { surface: MobileModeSurface }) {
+  const [mode, setMode] = useState<MobileKnowledgeTreeViewMode>(() => loadMobileKnowledgeTreeViewMode());
+
+  useEffect(() => {
+    const sync = (event: Event) => {
+      const next = (event as CustomEvent<{ mode?: MobileKnowledgeTreeViewMode }>).detail?.mode;
+      setMode(next || loadMobileKnowledgeTreeViewMode());
+    };
+    const syncStorage = (event: StorageEvent) => {
+      if (event.key) setMode(loadMobileKnowledgeTreeViewMode());
+    };
+    window.addEventListener(MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT, sync);
+    window.addEventListener("storage", syncStorage);
+    return () => {
+      window.removeEventListener(MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT, sync);
+      window.removeEventListener("storage", syncStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    surface.navigatorSurface.style.display = mode === "tree" ? "none" : "";
+    return () => {
+      surface.navigatorSurface.style.display = "";
+    };
+  }, [mode, surface.navigatorSurface]);
+
+  const chooseMode = (next: MobileKnowledgeTreeViewMode) => {
+    setMode(next);
+    saveMobileKnowledgeTreeViewMode(next);
+  };
+
+  return (
+    <>
+      {createPortal(
+        <div
+          role="group"
+          aria-label="目录浏览方式"
+          className="flex shrink-0 items-center rounded-lg border border-app-border bg-app-bg p-0.5"
+          data-mobile-knowledge-tree-mode-switch=""
+        >
+          <button
+            type="button"
+            aria-pressed={mode === "navigator"}
+            onClick={() => chooseMode("navigator")}
+            className={cn(
+              "flex h-6 items-center gap-1 rounded-md px-2 text-[10px] font-medium transition-colors",
+              mode === "navigator"
+                ? "bg-app-active text-accent-primary shadow-sm"
+                : "text-tx-tertiary hover:bg-app-hover hover:text-tx-primary",
+            )}
+            title="最近与全部：优先展示最近文档，目录逐层进入"
+          >
+            <Clock3 size={11} />
+            <span>最近 / 全部</span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "tree"}
+            onClick={() => chooseMode("tree")}
+            className={cn(
+              "flex h-6 items-center gap-1 rounded-md px-2 text-[10px] font-medium transition-colors",
+              mode === "tree"
+                ? "bg-app-active text-accent-primary shadow-sm"
+                : "text-tx-tertiary hover:bg-app-hover hover:text-tx-primary",
+            )}
+            title="树形目录：使用原来的可展开目录树"
+          >
+            <TreePine size={11} />
+            <span>树形目录</span>
+          </button>
+        </div>,
+        surface.switchSlot,
+        `${surface.id}:switch`,
+      )}
+      {mode === "tree" && createPortal(
+        <KnowledgeTreePanel variant="mobile" />,
+        surface.treeSlot,
+        `${surface.id}:tree`,
+      )}
+    </>
+  );
+}
+
+function mutationContainsRelevantSurface(node: Node): boolean {
+  if (!(node instanceof Element)) return false;
+  return (
+    node.matches(SIDEBAR_SEARCH_SURFACE_SELECTOR)
+    || Boolean(node.querySelector(SIDEBAR_SEARCH_SURFACE_SELECTOR))
+    || node.matches(MOBILE_NAVIGATOR_SELECTOR)
+    || Boolean(node.querySelector(MOBILE_NAVIGATOR_SELECTOR))
+    || node.hasAttribute(SORT_SLOT_ATTRIBUTE)
+    || node.hasAttribute(MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE)
+    || node.hasAttribute(MOBILE_TREE_SLOT_ATTRIBUTE)
+    || Boolean(node.querySelector(`[${SORT_SLOT_ATTRIBUTE}], [${MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE}], [${MOBILE_TREE_SLOT_ATTRIBUTE}]`))
+  );
 }
 
 /**
@@ -45,46 +214,31 @@ function sameSlots(current: HTMLElement[], next: HTMLElement[]): boolean {
  *
  * - 退休与树筛选语义冲突的旧全文搜索框；
  * - 在统一树工具栏恢复排序入口；
+ * - 为移动端提供「最近 / 全部」与原树形目录的持久化切换；
  * - 同时兼容桌面与移动 Sidebar 的挂载和工作区切换。
  */
 export default function SidebarSearchExperienceBridge() {
   const [sortSlots, setSortSlots] = useState<HTMLElement[]>([]);
+  const [mobileModeSurfaces, setMobileModeSurfaces] = useState<MobileModeSurface[]>([]);
 
   useEffect(() => {
     const applyDocument = () => {
       applySidebarSearchExperience(document);
-      const next = collectSortSlots();
-      setSortSlots((current) => sameSlots(current, next) ? current : next);
+      const nextSortSlots = collectSortSlots();
+      const nextMobileModeSurfaces = collectMobileModeSurfaces();
+      setSortSlots((current) => sameSlots(current, nextSortSlots) ? current : nextSortSlots);
+      setMobileModeSurfaces((current) => (
+        sameMobileModeSurfaces(current, nextMobileModeSurfaces) ? current : nextMobileModeSurfaces
+      ));
     };
 
     applyDocument();
 
     const observer = new MutationObserver((records) => {
-      let relevant = false;
-      for (const record of records) {
-        for (const addedNode of record.addedNodes) {
-          if (!(addedNode instanceof Element)) continue;
-          if (
-            addedNode.matches(SIDEBAR_SEARCH_SURFACE_SELECTOR)
-            || addedNode.querySelector(SIDEBAR_SEARCH_SURFACE_SELECTOR)
-          ) {
-            relevant = true;
-            break;
-          }
-        }
-        if (relevant) break;
-        for (const removedNode of record.removedNodes) {
-          if (!(removedNode instanceof Element)) continue;
-          if (
-            removedNode.hasAttribute(SORT_SLOT_ATTRIBUTE)
-            || removedNode.querySelector(`[${SORT_SLOT_ATTRIBUTE}]`)
-          ) {
-            relevant = true;
-            break;
-          }
-        }
-        if (relevant) break;
-      }
+      const relevant = records.some((record) => (
+        Array.from(record.addedNodes).some(mutationContainsRelevantSurface)
+        || Array.from(record.removedNodes).some(mutationContainsRelevantSurface)
+      ));
       if (relevant) applyDocument();
     });
     observer.observe(document.body, { childList: true, subtree: true });
@@ -103,6 +257,9 @@ export default function SidebarSearchExperienceBridge() {
         <KnowledgeTreeSortButton />,
         slot,
         slot.dataset.knowledgeTreeSortSlotId,
+      ))}
+      {mobileModeSurfaces.map((surface) => (
+        <MobileKnowledgeTreeModeSurface key={surface.id} surface={surface} />
       ))}
     </>
   );

--- a/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
+++ b/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const bridgeSource = readFileSync(path.resolve(__dirname, "../SidebarSearchExperienceBridge.tsx"), "utf8");
+const helperSource = readFileSync(path.resolve(__dirname, "../../lib/mobileKnowledgeTreeViewMode.ts"), "utf8");
+
+describe("mobile knowledge tree mode switch contract", () => {
+  it("offers the recent/all navigator and the previous recursive tree", () => {
+    expect(bridgeSource).toContain("最近 / 全部");
+    expect(bridgeSource).toContain("树形目录");
+    expect(bridgeSource).toContain('<KnowledgeTreePanel variant="mobile" />');
+    expect(bridgeSource).toContain('mode === "tree" && createPortal');
+    expect(bridgeSource).toContain('surface.navigatorSurface.style.display = mode === "tree" ? "none" : ""');
+  });
+
+  it("renders an accessible two-option switch in the mobile content header", () => {
+    expect(bridgeSource).toContain('role="group"');
+    expect(bridgeSource).toContain('aria-label="目录浏览方式"');
+    expect(bridgeSource).toContain('aria-pressed={mode === "navigator"}');
+    expect(bridgeSource).toContain('aria-pressed={mode === "tree"}');
+    expect(bridgeSource).toContain("MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE");
+  });
+
+  it("persists the choice and keeps the new navigator as the default", () => {
+    expect(helperSource).toContain('export type MobileKnowledgeTreeViewMode = "navigator" | "tree"');
+    expect(helperSource).toContain('return value && VALID_MODES.has(value) ? value : "navigator"');
+    expect(helperSource).toContain("MOBILE_KNOWLEDGE_TREE_VIEW_MODE_STORAGE_KEY");
+    expect(helperSource).toContain("MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT");
+  });
+});

--- a/frontend/src/lib/mobileKnowledgeTreeViewMode.ts
+++ b/frontend/src/lib/mobileKnowledgeTreeViewMode.ts
@@ -1,0 +1,31 @@
+export type MobileKnowledgeTreeViewMode = "navigator" | "tree";
+
+export const MOBILE_KNOWLEDGE_TREE_VIEW_MODE_STORAGE_KEY = "nowen.mobileKnowledgeTree.viewMode.v1";
+export const MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT = "nowen:mobile-knowledge-tree-view-mode-changed";
+
+const VALID_MODES = new Set<MobileKnowledgeTreeViewMode>(["navigator", "tree"]);
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadMobileKnowledgeTreeViewMode(): MobileKnowledgeTreeViewMode {
+  const value = storage()?.getItem(MOBILE_KNOWLEDGE_TREE_VIEW_MODE_STORAGE_KEY) as MobileKnowledgeTreeViewMode | null;
+  return value && VALID_MODES.has(value) ? value : "navigator";
+}
+
+export function saveMobileKnowledgeTreeViewMode(mode: MobileKnowledgeTreeViewMode): void {
+  try {
+    storage()?.setItem(MOBILE_KNOWLEDGE_TREE_VIEW_MODE_STORAGE_KEY, mode);
+  } catch {
+    // The current React state still switches immediately when storage is unavailable.
+  }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(MOBILE_KNOWLEDGE_TREE_VIEW_MODE_CHANGED_EVENT, { detail: { mode } }));
+  }
+}


### PR DESCRIPTION
## 背景

移动端新的「最近 / 全部」逐层导航更适合快速查找，但部分用户仍习惯原来的递归树目录。两种方式各有使用场景，不应强制替换。

## 实现

- 在移动端“内容”区域新增双选开关：
  - `最近 / 全部`：最近文档优先、目录逐层进入。
  - `树形目录`：恢复原来的可展开递归树。
- 默认继续使用「最近 / 全部」。
- 选择保存在本机 `localStorage`，再次打开仍保持用户选择。
- 切换立即生效，不影响桌面端目录树。
- 树形模式复用现有 `KnowledgeTreePanel variant="mobile"`，保留搜索、排序、新建、更多菜单、分享、权限和移动等能力。

## 验证

- 新增移动端模式开关产品契约测试。
- 补充专项 CI 路径。
- 执行移动导航测试、TypeScript 检查和生产构建。
