### PR TITLE
docs: 恢复微信与支付宝赞赏码

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,23 @@ npm run build:all
 - [GitHub Issues](https://github.com/cropflre/nowen-note/issues)
 - QQ 群：`1093473044`
 
+## 支持作者
+
+如果 Nowen Note 对你有帮助，欢迎扫码请作者喝杯咖啡。感谢每一份支持，它会帮助项目持续维护和迭代。
+
+<table align="center">
+  <tr>
+    <th>微信赞赏</th>
+    <th>支付宝赞赏</th>
+  </tr>
+  <tr>
+    <td align="center"><img src="./frontend/public/weixin.jpg" alt="微信赞赏码" width="260" /></td>
+    <td align="center"><img src="./frontend/public/zhifubao.png" alt="支付宝赞赏码" width="260" /></td>
+  </tr>
+</table>
+
+也可以阅读 [作者感言](./AUTHOR_STORY.md)。
+
 ## License
 
 Nowen Note 基于 [GNU General Public License v3.0](./LICENSE) 开源。


### PR DESCRIPTION
## 问题

上一轮精简 README 时误删了「支持作者」区域，导致微信与支付宝赞赏码不再展示。

## 修复

- 恢复「支持作者」章节
- 并排展示微信赞赏码与支付宝赞赏码
- 继续保留作者感言入口
- 复用仓库现有图片：
  - `frontend/public/weixin.jpg`
  - `frontend/public/zhifubao.png`

## 影响范围

仅修改 `README.md`，新增 17 行，不涉及运行时代码。