### PR TITLE
fix(ui): 全端默认关闭拼写检查波浪线

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN" class="dark">
+<html lang="zh-CN" class="dark" spellcheck="false">
   <head>
     <meta charset="UTF-8" />
     <!-- SEC-ELECTRON-01-E3.4: CSP — 保留严格默认策略，补齐 nowen-note 实际资源来源 -->

--- a/frontend/src/components/__tests__/EditorSpellcheck.test.ts
+++ b/frontend/src/components/__tests__/EditorSpellcheck.test.ts
@@ -2,6 +2,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+const frontendIndexSource = readFileSync(
+  path.resolve(__dirname, "../../../index.html"),
+  "utf8",
+);
+
 const tiptapEditorSource = readFileSync(
   path.resolve(__dirname, "../TiptapEditor.tsx"),
   "utf8",
@@ -12,7 +17,13 @@ const markdownEditorSource = readFileSync(
   "utf8",
 );
 
-describe("editor spellcheck", () => {
+describe("spellcheck", () => {
+  it("disables spellcheck globally for every shared frontend client", () => {
+    expect(frontendIndexSource).toContain(
+      '<html lang="zh-CN" class="dark" spellcheck="false">',
+    );
+  });
+
   it("disables spellcheck for the rich text title and document body", () => {
     expect(tiptapEditorSource).toContain("spellCheck={false}");
     expect(tiptapEditorSource).toContain('spellcheck: "false"');


### PR DESCRIPTION
## 变更内容

- 在共享前端根节点设置 `spellcheck="false"`
- Web、Electron 桌面端、Capacitor 移动端默认继承关闭拼写检查
- 覆盖重命名弹窗、普通输入框、文本域、可编辑区域以及后续新增的输入控件
- 保留富文本与 Markdown 编辑器现有的显式关闭配置
- 补充全局回归测试，防止后续误删根节点配置

## 原因

型号、缩写、文件名等内容经常被浏览器或系统词典误判，出现红色波浪下划线。该提示不属于业务校验，因此默认全端关闭。

## 验证

- 差异仅涉及共享入口和测试文件
- 分支相对 `main`：2 个文件变更，新增 13 行、删除 2 行
