### PR TITLE
style(tree): 缩小二级笔记节点间距

### DIFF
--- a/frontend/src/desktop-knowledge-tree-compact.css
+++ b/frontend/src/desktop-knowledge-tree-compact.css
@@ -1,0 +1,28 @@
+/*
+ * Desktop knowledge-tree density.
+ *
+ * Keep top-level folders at the existing comfortable height, while compacting
+ * second-level and deeper rows. These descendants are the document-heavy part
+ * of the tree, so a 24px row keeps related notes visually grouped without
+ * shrinking the primary navigation headings.
+ */
+@media (min-width: 768px) {
+  [data-nowen-knowledge-tree="embedded"] {
+    --nowen-desktop-tree-descendant-row-height: 24px;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-section] > div > div [data-knowledge-tree-node-id] {
+    min-height: var(--nowen-desktop-tree-descendant-row-height);
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-section] > div > div [data-knowledge-tree-node-id] > button:first-child {
+    height: var(--nowen-desktop-tree-descendant-row-height) !important;
+  }
+
+  [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-section] > div > div [data-knowledge-tree-node-id] > button:nth-child(2) {
+    min-height: var(--nowen-desktop-tree-descendant-row-height);
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    line-height: 16px;
+  }
+}

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -87,4 +87,17 @@ describe("knowledge tree sidebar contract", () => {
     expect(menu).toContain("mobile long-press");
     expect(menu).toContain('{ id: "create", label: "新建"');
   });
+
+  it("compacts second-level and deeper desktop rows without shrinking root rows", () => {
+    const main = source("../../main.tsx");
+    const compactCss = source("../../desktop-knowledge-tree-compact.css");
+
+    expect(main).toContain('import "./desktop-knowledge-tree-compact.css"');
+    expect(compactCss).toContain("@media (min-width: 768px)");
+    expect(compactCss).toContain("--nowen-desktop-tree-descendant-row-height: 24px");
+    expect(compactCss).toContain("[data-knowledge-tree-section] > div > div [data-knowledge-tree-node-id]");
+    expect(compactCss).toContain("padding-top: 4px !important");
+    expect(compactCss).toContain("padding-bottom: 4px !important");
+    expect(compactCss).not.toMatch(/\[data-knowledge-tree-section\]\s*>\s*div\s*>\s*\[data-knowledge-tree-node-id\]/);
+  });
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -45,6 +45,7 @@ import "./space-actions.css";
 import "./settings-switches.css";
 import "./sidebar-search-experience.css";
 import "./mobile-knowledge-tree-compact.css";
+import "./desktop-knowledge-tree-compact.css";
 import "./siyuan-rich-text-callout.css";
 import "./knowledge-tree-markdown-drop.css";
 import { initCodeBlockTheme } from "./lib/codeBlockTheme";


### PR DESCRIPTION
## 问题

桌面端统一知识树中，二级及更深层级仍沿用一级目录约 28px 的行高。连续笔记较多时，标题之间留白偏大，信息密度较低。

## 调整

- 保持一级目录现有间距不变
- 将二级及更深节点的桌面端行高收紧为 `24px`
- 同步压缩展开按钮和标题区域的纵向 padding
- 不影响移动端现有 `26px` 紧凑样式
- 增加契约测试，锁定：
  - 桌面样式仅作用于二级及更深节点
  - 一级根节点不会被意外压缩
  - 新样式文件已在应用入口加载

## 影响范围

仅涉及知识树展示密度，不改变节点数据、拖拽、展开、新建及菜单交互。

## 文件

- `frontend/src/desktop-knowledge-tree-compact.css`
- `frontend/src/main.tsx`
- `frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts`