### PR TITLE
fix(desktop): 修复公共空间入口点击无响应

### DIFF
--- a/frontend/src/components/PublicNotebookView.tsx
+++ b/frontend/src/components/PublicNotebookView.tsx
@@ -21,6 +21,7 @@ import TiptapEditor from "@/components/TiptapEditor";
 import type { Note } from "@/types";
 import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
+import { navigateToAppPath } from "@/lib/appPathNavigation";
 import {
   notebookPublicationApi,
   type PublicComment,
@@ -79,7 +80,7 @@ function PublicNotebookIndex() {
             </div>
           </div>
           {hasLoginToken() && (
-            <Button variant="outline" onClick={() => window.location.assign("/")}>返回工作台</Button>
+            <Button variant="outline" onClick={() => navigateToAppPath("/")}>返回工作台</Button>
           )}
         </div>
       </header>
@@ -103,7 +104,7 @@ function PublicNotebookIndex() {
               <button
                 key={item.token}
                 type="button"
-                onClick={() => window.location.assign(`/public/${item.token}`)}
+                onClick={() => navigateToAppPath(`/public/${item.token}`)}
                 className="group rounded-2xl border border-app-border bg-app-surface p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-accent-primary/40 hover:shadow-md"
               >
                 <div className="flex items-start justify-between gap-3">
@@ -318,7 +319,7 @@ function PublicNotebookReader({ token }: { token: string }) {
     try {
       await notebookPublicationApi.joinPublication(token, accessToken || undefined);
       toast.success(info?.permission === "write" && info.allowEdit ? "已加入，可在工作台编辑" : "已加入到共享笔记本");
-      window.location.assign("/");
+      navigateToAppPath("/");
     } catch (err: any) {
       toast.error(err?.message || "加入失败");
     } finally {
@@ -337,7 +338,7 @@ function PublicNotebookReader({ token }: { token: string }) {
           <LockKeyhole size={30} className="mx-auto mb-3 text-tx-tertiary" />
           <h1 className="font-semibold">无法访问公共知识库</h1>
           <p className="mt-2 text-sm text-tx-secondary">{error || "发布不存在或已被撤销"}</p>
-          <Button variant="outline" className="mt-5" onClick={() => window.location.assign("/public")}>返回公共空间</Button>
+          <Button variant="outline" className="mt-5" onClick={() => navigateToAppPath("/public")}>返回公共空间</Button>
         </div>
       </div>
     );
@@ -362,7 +363,7 @@ function PublicNotebookReader({ token }: { token: string }) {
             autoFocus
           />
           <Button className="mt-3 w-full" onClick={verifySecret} disabled={!secret.trim()}>验证并进入</Button>
-          <button className="mt-4 w-full text-center text-xs text-tx-tertiary hover:text-accent-primary" onClick={() => window.location.assign("/public")}>返回公共空间</button>
+          <button className="mt-4 w-full text-center text-xs text-tx-tertiary hover:text-accent-primary" onClick={() => navigateToAppPath("/public")}>返回公共空间</button>
         </div>
       </div>
     );
@@ -372,7 +373,7 @@ function PublicNotebookReader({ token }: { token: string }) {
     <div className="flex h-screen min-h-0 bg-app-bg text-tx-primary">
       <aside className="hidden w-[280px] shrink-0 flex-col border-r border-app-border bg-app-surface md:flex">
         <div className="border-b border-app-border p-4">
-          <button className="flex min-w-0 items-center gap-3 text-left" onClick={() => window.location.assign("/public")}>
+          <button className="flex min-w-0 items-center gap-3 text-left" onClick={() => navigateToAppPath("/public")}>
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-app-hover text-xl">{info.icon || "📚"}</div>
             <div className="min-w-0"><div className="truncate text-sm font-semibold">{info.name}</div><div className="truncate text-[11px] text-tx-tertiary">{info.ownerDisplayName || info.ownerUsername} 的公共知识库</div></div>
           </button>
@@ -412,7 +413,7 @@ function PublicNotebookReader({ token }: { token: string }) {
       <main className="min-w-0 flex-1 overflow-y-auto">
         <header className="sticky top-0 z-10 border-b border-app-border bg-app-surface/90 px-4 py-3 backdrop-blur-xl md:hidden">
           <div className="flex items-center justify-between gap-3">
-            <button className="flex min-w-0 items-center gap-2" onClick={() => window.location.assign("/public")}><BookOpen size={17} className="text-accent-primary" /><span className="truncate text-sm font-semibold">{info.name}</span></button>
+            <button className="flex min-w-0 items-center gap-2" onClick={() => navigateToAppPath("/public")}><BookOpen size={17} className="text-accent-primary" /><span className="truncate text-sm font-semibold">{info.name}</span></button>
             <Button size="sm" variant="outline" onClick={join}><UserPlus size={13} className="mr-1" />加入</Button>
           </div>
           <select className="mt-3 h-9 w-full rounded-lg border border-app-border bg-app-bg px-3 text-xs" value={activeNoteId} onChange={(event) => setActiveNoteId(event.target.value)}>

--- a/frontend/src/components/PublicSpaceLauncher.tsx
+++ b/frontend/src/components/PublicSpaceLauncher.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useKeyboardVisible } from "@/hooks/useKeyboardVisible";
+import { navigateToAppPath } from "@/lib/appPathNavigation";
 
 const LEGACY_TRANSFER_TRIGGER = 'button[aria-label="跨空间转移笔记"]';
 const RAIL_MOUNT_ATTRIBUTE = "data-nowen-space-actions-mount";
@@ -214,7 +215,7 @@ export default function PublicSpaceLauncher() {
 
   const openPublicSpace = () => {
     setPanel(null);
-    window.location.assign("/public");
+    navigateToAppPath("/public");
   };
 
   const renderRailButton = (mount: RailMount) => {

--- a/frontend/src/lib/__tests__/appPathNavigation.test.ts
+++ b/frontend/src/lib/__tests__/appPathNavigation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAppPathUrl,
+  resolveCurrentAppPathname,
+} from "../appPathNavigation";
+
+describe("app path navigation", () => {
+  it("keeps normal web navigation paths unchanged", () => {
+    expect(buildAppPathUrl("/public", "https://note.example.com/workspace")).toBe("/public");
+    expect(resolveCurrentAppPathname("https://note.example.com/public/demo")).toBe("/public/demo");
+  });
+
+  it("stores desktop public routes on the existing file entry URL", () => {
+    const nextUrl = buildAppPathUrl(
+      "/public/demo-token",
+      "file:///C:/Program%20Files/Nowen/frontend/index.html?serverUrl=http%3A%2F%2F127.0.0.1%3A3001",
+    );
+    const parsed = new URL(nextUrl);
+
+    expect(parsed.pathname).toBe("/C:/Program%20Files/Nowen/frontend/index.html");
+    expect(parsed.searchParams.get("serverUrl")).toBe("http://127.0.0.1:3001");
+    expect(parsed.searchParams.get("nowenAppPath")).toBe("/public/demo-token");
+    expect(resolveCurrentAppPathname(nextUrl)).toBe("/public/demo-token");
+  });
+
+  it("returns to the workspace without dropping the desktop server address", () => {
+    const nextUrl = buildAppPathUrl(
+      "/",
+      "file:///opt/nowen/frontend/index.html?serverUrl=https%3A%2F%2Fnote.example.com&nowenAppPath=%2Fpublic",
+    );
+    const parsed = new URL(nextUrl);
+
+    expect(parsed.pathname).toBe("/opt/nowen/frontend/index.html");
+    expect(parsed.searchParams.get("serverUrl")).toBe("https://note.example.com");
+    expect(parsed.searchParams.has("nowenAppPath")).toBe(false);
+    expect(resolveCurrentAppPathname(nextUrl)).toBe("/");
+  });
+});

--- a/frontend/src/lib/appPathNavigation.ts
+++ b/frontend/src/lib/appPathNavigation.ts
@@ -1,0 +1,49 @@
+const FILE_ROUTE_QUERY_KEY = "nowenAppPath";
+
+function normalizeAppPath(rawPath: string): string {
+  const value = String(rawPath || "/").trim();
+  if (!value || value === "/") return "/";
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+export function buildAppPathUrl(
+  appPath: string,
+  currentHref: string = window.location.href,
+): string {
+  const normalizedPath = normalizeAppPath(appPath);
+  const currentUrl = new URL(currentHref);
+
+  if (currentUrl.protocol !== "file:") {
+    return normalizedPath;
+  }
+
+  if (normalizedPath === "/") {
+    currentUrl.searchParams.delete(FILE_ROUTE_QUERY_KEY);
+  } else {
+    currentUrl.searchParams.set(FILE_ROUTE_QUERY_KEY, normalizedPath);
+  }
+  currentUrl.hash = "";
+  return currentUrl.toString();
+}
+
+export function navigateToAppPath(appPath: string): void {
+  window.location.assign(buildAppPathUrl(appPath));
+}
+
+export function resolveCurrentAppPathname(
+  currentHref: string = window.location.href,
+): string {
+  const currentUrl = new URL(currentHref);
+  if (currentUrl.protocol !== "file:") {
+    return currentUrl.pathname;
+  }
+
+  const appPath = currentUrl.searchParams.get(FILE_ROUTE_QUERY_KEY);
+  if (!appPath) return "/";
+
+  try {
+    return new URL(normalizeAppPath(appPath), "https://nowen.local").pathname;
+  } catch {
+    return "/";
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -70,6 +70,7 @@ import { installIssue210SignoffRuntime } from "./lib/issue210Signoff";
 import { cleanupRemovedServerProfiles } from "./lib/removedServerProfileCleanup";
 import { installKnowledgeTreeScrollbarBridge } from "./lib/knowledgeTreeScrollbarBridge";
 import { installKnowledgeTreeMarkdownDrop } from "./lib/knowledgeTreeMarkdownDrop";
+import { resolveCurrentAppPathname } from "./lib/appPathNavigation";
 
 void cleanupRemovedServerProfiles();
 
@@ -131,7 +132,7 @@ try {
 }
 
 function resolvePublicNotebookRoute(): { matched: boolean; token?: string } {
-  const match = window.location.pathname.match(/^\/public(?:\/([^/]+))?\/?$/);
+  const match = resolveCurrentAppPathname().match(/^\/public(?:\/([^/]+))?\/?$/);
   if (!match) return { matched: false };
   if (!match[1]) return { matched: true };
   try {


### PR DESCRIPTION
## 问题原因

Electron 桌面端通过 `file://.../frontend/index.html` 加载共享前端。公共空间入口原先直接执行 `window.location.assign("/public")`，会把主窗口导航到磁盘根目录下的 `file:///.../public`。

该地址既不是应用入口文件，也会被桌面端的安全导航策略拦截，因此用户看到点击后没有任何反应。

## 修复内容

- 新增统一的应用内路径导航工具
- Web/移动端继续使用原有 `/public` 路径
- Electron `file://` 环境将应用路径保存到当前入口文件的 `nowenAppPath` 查询参数中
- 保留桌面端原有 `serverUrl`，避免 Lite/远程服务地址丢失
- 主入口支持从 `nowenAppPath` 解析公共空间及知识库 Token
- 公共空间首页、知识库详情、返回公共空间、返回工作台全部使用统一导航
- 新增 Windows、Linux/macOS 文件路径及 Web 路径回归测试

## 影响范围

仅调整应用内页面导航方式，不修改公共空间接口、发布数据、权限和 Electron 安全策略。

## 验证点

- 桌面端点击“空间 → 公共空间”可以进入公共空间
- 点击公开知识库可以进入详情
- 从详情返回公共空间正常
- 从公共空间返回工作台正常
- Lite 模式的远端 `serverUrl` 在页面切换后保持不变
- 分支基于最新 `main`，当前领先 5 个提交、落后 0 个提交
