### PR TITLE
fix(permissions): 统一人员选择器下拉交互

### DIFF
--- a/frontend/src/components/NotebookShareDialog.tsx
+++ b/frontend/src/components/NotebookShareDialog.tsx
@@ -8,7 +8,6 @@ import {
   Link2,
   LockKeyhole,
   MessageCircle,
-  Plus,
   RefreshCw,
   RotateCcw,
   Search,
@@ -138,8 +137,7 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
   const [memberSearch, setMemberSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showAddMember, setShowAddMember] = useState(false);
-  const [userQuery, setUserQuery] = useState("");
-  const [userCandidates, setUserCandidates] = useState<UserPublicInfo[]>([]);
+  const [memberSelectedUser, setMemberSelectedUser] = useState<UserPublicInfo | null>(null);
   const [newMemberRole, setNewMemberRole] = useState<MemberRole>("viewer");
 
   const [transferOpen, setTransferOpen] = useState(false);
@@ -206,6 +204,12 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
       : "未被添加的用户无法访问此目录";
   const copyUrl = publicationUrl || inviteUrl;
   const canTransfer = !notebook.workspaceId && owner?.userId === me?.id && collaborators.length > 0;
+  const memberDisabledUserLabels = useMemo(() => {
+    const labels: Record<string, string> = {};
+    members.forEach((member) => { labels[member.userId] = "已是协作者"; });
+    if (me?.id) labels[me.id] = "你自己";
+    return labels;
+  }, [me?.id, members]);
   const aclDisabledUserLabels = useMemo(() => {
     const labels: Record<string, string> = {};
     if (me?.id) labels[me.id] = "你自己";
@@ -272,27 +276,19 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     else toast.error("复制失败");
   }
 
-  async function searchUsers() {
-    const query = userQuery.trim();
-    if (!query) return;
+  async function addMember() {
+    if (!memberSelectedUser || saving) return;
+    setSaving(true);
     try {
-      const rows = await api.searchUsers(query);
-      setUserCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
-    } catch (error: any) {
-      toast.error(error?.message || "搜索用户失败");
-    }
-  }
-
-  async function addMember(userId: string) {
-    try {
-      await api.addNotebookMember(notebook.id, { userId, role: newMemberRole });
+      await api.addNotebookMember(notebook.id, { userId: memberSelectedUser.id, role: newMemberRole });
       setShowAddMember(false);
-      setUserQuery("");
-      setUserCandidates([]);
+      setMemberSelectedUser(null);
       toast.success("协作者已添加");
       await reload();
     } catch (error: any) {
       toast.error(error?.message || "添加协作者失败");
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -630,31 +626,38 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                     <h3 className="text-base font-medium text-tx-secondary">所有协作者</h3>
                     <span className="rounded-full bg-app-hover px-2 py-0.5 text-[11px] text-tx-tertiary">{members.length}</span>
                   </div>
-                  <button onClick={() => setShowAddMember((current) => !current)} className="flex items-center gap-1 text-sm font-medium text-accent-primary">
-                    <Plus size={18} />添加协作者
+                  <button
+                    onClick={() => {
+                      setMemberSelectedUser(null);
+                      setShowAddMember((current) => !current);
+                    }}
+                    className="flex items-center gap-1 text-sm font-medium text-accent-primary"
+                  >
+                    <UserPlus size={17} />添加协作者
                   </button>
                 </div>
 
                 {showAddMember && (
                   <div className="mb-3 rounded-xl border border-accent-primary/25 bg-accent-primary/[0.04] p-3">
                     <div className="flex flex-col gap-2 sm:flex-row">
-                      <select value={newMemberRole} onChange={(event) => setNewMemberRole(event.target.value as MemberRole)} className="h-9 rounded-lg border border-app-border bg-app-bg px-3 text-sm">
+                      <div className="min-w-0 flex-1">
+                        <UserPickerCombobox
+                          value={memberSelectedUser}
+                          onChange={setMemberSelectedUser}
+                          disabledUserLabels={memberDisabledUserLabels}
+                          placeholder="搜索用户名、显示名或邮箱"
+                          autoFocus
+                          idPrefix="notebook-member-user"
+                        />
+                      </div>
+                      <select value={newMemberRole} onChange={(event) => setNewMemberRole(event.target.value as MemberRole)} className="h-10 rounded-lg border border-app-border bg-app-bg px-3 text-sm sm:w-28">
                         <option value="viewer">可查看</option>
                         <option value="editor">可编辑</option>
                       </select>
-                      <Input value={userQuery} onChange={(event) => setUserQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers()} placeholder="搜索用户名或邮箱" className="h-9 flex-1" autoFocus />
-                      <Button variant="outline" onClick={() => searchUsers()}><Search size={14} className="mr-1" />搜索</Button>
+                      <Button disabled={!memberSelectedUser || saving} onClick={() => void addMember()}>
+                        {saving ? "添加中..." : "添加"}
+                      </Button>
                     </div>
-                    {userCandidates.length > 0 && (
-                      <div className="mt-2 overflow-hidden rounded-lg border border-app-border bg-app-surface">
-                        {userCandidates.map((user) => (
-                          <button key={user.id} onClick={() => addMember(user.id)} className="flex w-full items-center justify-between border-b border-app-border px-3 py-2.5 text-left last:border-b-0 hover:bg-app-hover">
-                            <span className="text-sm">{user.displayName || user.username}</span>
-                            <span className="flex items-center gap-1 text-xs text-accent-primary"><UserPlus size={13} />添加</span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
                   </div>
                 )}
 

--- a/frontend/src/components/NotebookShareDialog.tsx
+++ b/frontend/src/components/NotebookShareDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { confirm } from "@/components/ui/confirm";
+import UserPickerCombobox from "@/components/UserPickerCombobox";
 import { api } from "@/lib/api";
 import { copyText } from "@/lib/clipboard";
 import { buildPublicWebUrl } from "@/lib/publicWebOrigin";
@@ -81,16 +82,6 @@ function memberSource(member: NotebookMember): string {
   if (member.source === "invite_link") return "通过邀请链接加入";
   if (member.source === "publication") return "通过公开发布加入";
   return "直接添加";
-}
-
-function permissionLabel(permission: NotebookDirectoryPermission): string {
-  return {
-    none: "不可见",
-    read: "可查看",
-    comment: "可评论",
-    write: "可编辑",
-    manage: "可管理",
-  }[permission];
 }
 
 function Avatar({ member }: { member: NotebookMember }) {
@@ -169,8 +160,7 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     allowReshare: false,
   });
 
-  const [aclQuery, setAclQuery] = useState("");
-  const [aclCandidates, setAclCandidates] = useState<UserPublicInfo[]>([]);
+  const [aclSelectedUser, setAclSelectedUser] = useState<UserPublicInfo | null>(null);
   const [aclPermission, setAclPermission] = useState<NotebookDirectoryPermission>("read");
   const [aclAllowDownload, setAclAllowDownload] = useState(true);
   const [aclAllowReshare, setAclAllowReshare] = useState(false);
@@ -216,6 +206,12 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
       : "未被添加的用户无法访问此目录";
   const copyUrl = publicationUrl || inviteUrl;
   const canTransfer = !notebook.workspaceId && owner?.userId === me?.id && collaborators.length > 0;
+  const aclDisabledUserLabels = useMemo(() => {
+    const labels: Record<string, string> = {};
+    if (me?.id) labels[me.id] = "你自己";
+    overrides.forEach((entry) => { labels[entry.userId] = "已设置独立权限"; });
+    return labels;
+  }, [me?.id, overrides]);
 
   function applyInvite(next: NotebookShareLink | null) {
     setInvite(next);
@@ -276,16 +272,12 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     else toast.error("复制失败");
   }
 
-  async function searchUsers(kind: "member" | "acl") {
-    const query = (kind === "member" ? userQuery : aclQuery).trim();
+  async function searchUsers() {
+    const query = userQuery.trim();
     if (!query) return;
     try {
       const rows = await api.searchUsers(query);
-      if (kind === "member") {
-        setUserCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
-      } else {
-        setAclCandidates(rows.filter((user) => !overrides.some((entry) => entry.userId === user.id)));
-      }
+      setUserCandidates(rows.filter((user) => !members.some((member) => member.userId === user.id)));
     } catch (error: any) {
       toast.error(error?.message || "搜索用户失败");
     }
@@ -547,19 +539,22 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
     await loadComments();
   }
 
-  async function addOverride(userId: string) {
+  async function addOverride() {
+    if (!aclSelectedUser || saving) return;
+    setSaving(true);
     try {
-      await notebookPublicationApi.setPermissionOverride(notebook.id, userId, {
+      await notebookPublicationApi.setPermissionOverride(notebook.id, aclSelectedUser.id, {
         permission: aclPermission,
         allowDownload: aclAllowDownload,
         allowReshare: aclAllowReshare,
       });
-      setAclQuery("");
-      setAclCandidates([]);
+      setAclSelectedUser(null);
       toast.success("独立权限已添加");
       await reload();
     } catch (error: any) {
       toast.error(error?.message || "权限添加失败");
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -647,8 +642,8 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                         <option value="viewer">可查看</option>
                         <option value="editor">可编辑</option>
                       </select>
-                      <Input value={userQuery} onChange={(event) => setUserQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers("member")} placeholder="搜索用户名或邮箱" className="h-9 flex-1" autoFocus />
-                      <Button variant="outline" onClick={() => searchUsers("member")}><Search size={14} className="mr-1" />搜索</Button>
+                      <Input value={userQuery} onChange={(event) => setUserQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers()} placeholder="搜索用户名或邮箱" className="h-9 flex-1" autoFocus />
+                      <Button variant="outline" onClick={() => searchUsers()}><Search size={14} className="mr-1" />搜索</Button>
                     </div>
                     {userCandidates.length > 0 && (
                       <div className="mt-2 overflow-hidden rounded-lg border border-app-border bg-app-surface">
@@ -814,9 +809,26 @@ export default function NotebookShareDialog({ notebook, onClose }: Props) {
                 <div className="flex items-start gap-3"><AlertTriangle size={18} className="mt-0.5 shrink-0 text-amber-500" /><div><h3 className="text-sm font-semibold">目录级权限继承</h3><p className="mt-1 text-xs leading-5 text-tx-tertiary">最近的显式规则优先，并向全部子目录继承。{inheritsFromParent ? "当前存在父级规则，可添加覆盖或删除覆盖恢复继承。" : "当前目录是权限树根节点。"}</p></div></div>
               </section>
               <section>
-                <div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]"><select value={aclPermission} onChange={(event) => setAclPermission(event.target.value as NotebookDirectoryPermission)} className="h-9 rounded-lg border border-app-border bg-app-bg px-2 text-sm"><option value="none">不可见</option><option value="read">可查看</option><option value="comment">可评论</option><option value="write">可编辑</option><option value="manage">可管理</option></select><Input value={aclQuery} onChange={(event) => setAclQuery(event.target.value)} onKeyDown={(event) => event.key === "Enter" && void searchUsers("acl")} placeholder="搜索要设置独立权限的用户" className="h-9" /><Button variant="outline" onClick={() => searchUsers("acl")}><Search size={14} className="mr-1" />搜索</Button></div>
+                <div className="grid gap-2 sm:grid-cols-[140px_1fr_auto]">
+                  <select value={aclPermission} onChange={(event) => setAclPermission(event.target.value as NotebookDirectoryPermission)} className="h-10 rounded-lg border border-app-border bg-app-bg px-2 text-sm">
+                    <option value="none">不可见</option>
+                    <option value="read">可查看</option>
+                    <option value="comment">可评论</option>
+                    <option value="write">可编辑</option>
+                    <option value="manage">可管理</option>
+                  </select>
+                  <UserPickerCombobox
+                    value={aclSelectedUser}
+                    onChange={setAclSelectedUser}
+                    disabledUserLabels={aclDisabledUserLabels}
+                    placeholder="搜索要设置独立权限的用户"
+                    idPrefix="notebook-acl-user"
+                  />
+                  <Button disabled={!aclSelectedUser || saving} onClick={() => void addOverride()}>
+                    {saving ? "添加中..." : "添加"}
+                  </Button>
+                </div>
                 <div className="mt-2 flex gap-4 text-xs"><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowDownload} onChange={(event) => setAclAllowDownload(event.target.checked)} />允许下载</label><label className="flex items-center gap-1.5"><input type="checkbox" checked={aclAllowReshare} onChange={(event) => setAclAllowReshare(event.target.checked)} />允许二次分享</label></div>
-                {aclCandidates.map((user) => <button key={user.id} onClick={() => addOverride(user.id)} className="mt-2 flex w-full items-center justify-between rounded-lg border border-app-border px-3 py-2.5 text-sm hover:bg-app-hover"><span>{user.displayName || user.username}</span><span className="text-accent-primary">设为{permissionLabel(aclPermission)}</span></button>)}
               </section>
               <section>
                 <div className="mb-2 text-sm font-semibold">独立权限规则</div>

--- a/frontend/src/components/UserPickerCombobox.tsx
+++ b/frontend/src/components/UserPickerCombobox.tsx
@@ -13,6 +13,8 @@ interface Props {
   idPrefix?: string;
 }
 
+const EMPTY_DISABLED_USER_LABELS: Record<string, string> = {};
+
 function userName(user: UserPublicInfo): string {
   return user.displayName || user.username;
 }
@@ -20,7 +22,7 @@ function userName(user: UserPublicInfo): string {
 export default function UserPickerCombobox({
   value,
   onChange,
-  disabledUserLabels = {},
+  disabledUserLabels = EMPTY_DISABLED_USER_LABELS,
   placeholder = "搜索用户名、显示名或邮箱",
   autoFocus = false,
   idPrefix = "user-picker",

--- a/frontend/src/components/UserPickerCombobox.tsx
+++ b/frontend/src/components/UserPickerCombobox.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Search, X } from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { UserPublicInfo } from "@/types";
+
+interface Props {
+  value: UserPublicInfo | null;
+  onChange: (user: UserPublicInfo | null) => void;
+  disabledUserLabels?: Record<string, string>;
+  placeholder?: string;
+  autoFocus?: boolean;
+  idPrefix?: string;
+}
+
+function userName(user: UserPublicInfo): string {
+  return user.displayName || user.username;
+}
+
+export default function UserPickerCombobox({
+  value,
+  onChange,
+  disabledUserLabels = {},
+  placeholder = "搜索用户名、显示名或邮箱",
+  autoFocus = false,
+  idPrefix = "user-picker",
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [candidates, setCandidates] = useState<UserPublicInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [focusInput, setFocusInput] = useState(autoFocus);
+
+  const selectableIndexes = useMemo(
+    () => candidates
+      .map((user, index) => ({ user, index }))
+      .filter(({ user }) => !disabledUserLabels[user.id])
+      .map(({ index }) => index),
+    [candidates, disabledUserLabels],
+  );
+
+  useEffect(() => {
+    if (!open || value) return;
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    setCandidates([]);
+    setActiveIndex(-1);
+    const timer = window.setTimeout(() => {
+      api.searchUsers(query.trim() || undefined)
+        .then((users) => {
+          if (cancelled) return;
+          setCandidates(users);
+          setActiveIndex(users.findIndex((user) => !disabledUserLabels[user.id]));
+        })
+        .catch((nextError: any) => {
+          if (cancelled) return;
+          setCandidates([]);
+          setError(nextError?.message || "加载人员失败，请重试");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, query.trim() ? 250 : 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [disabledUserLabels, open, query, value]);
+
+  function selectUser(user: UserPublicInfo) {
+    if (disabledUserLabels[user.id]) return;
+    onChange(user);
+    setOpen(false);
+    setFocusInput(false);
+    setActiveIndex(-1);
+  }
+
+  function moveActive(direction: 1 | -1) {
+    if (selectableIndexes.length === 0) return;
+    const currentPosition = selectableIndexes.indexOf(activeIndex);
+    const nextPosition = currentPosition < 0
+      ? (direction === 1 ? 0 : selectableIndexes.length - 1)
+      : (currentPosition + direction + selectableIndexes.length) % selectableIndexes.length;
+    setActiveIndex(selectableIndexes[nextPosition]);
+  }
+
+  function clearSelection() {
+    onChange(null);
+    setQuery("");
+    setCandidates([]);
+    setOpen(true);
+    setFocusInput(true);
+    setActiveIndex(-1);
+  }
+
+  const listboxId = `${idPrefix}-options`;
+
+  return (
+    <div className="relative min-w-0">
+      {value ? (
+        <div className="flex h-10 items-center gap-2 rounded-lg border border-accent-primary bg-app-bg px-2.5">
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-accent-primary/10 text-xs font-semibold text-accent-primary">
+            {value.avatarUrl
+              ? <img src={value.avatarUrl} alt="" className="h-full w-full object-cover" />
+              : userName(value).slice(0, 1).toLocaleUpperCase()}
+          </div>
+          <div className="min-w-0 flex-1 truncate text-sm text-tx-primary">
+            {userName(value)}
+            {value.displayName && <span className="ml-1.5 text-xs text-tx-tertiary">@{value.username}</span>}
+          </div>
+          <button
+            type="button"
+            onClick={clearSelection}
+            className="rounded p-1 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+            aria-label={`取消选择 ${userName(value)}`}
+          >
+            <X size={14} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex h-10 items-center gap-2 rounded-lg border border-app-border bg-app-bg px-3 focus-within:border-accent-primary focus-within:ring-2 focus-within:ring-accent-primary/15">
+          <Search size={15} className="shrink-0 text-tx-tertiary" />
+          <input
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setCandidates([]);
+              setActiveIndex(-1);
+              setOpen(true);
+            }}
+            onFocus={() => {
+              setOpen(true);
+              setFocusInput(false);
+            }}
+            onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                event.stopPropagation();
+                setOpen(true);
+                moveActive(1);
+                return;
+              }
+              if (event.key === "ArrowUp") {
+                event.preventDefault();
+                event.stopPropagation();
+                setOpen(true);
+                moveActive(-1);
+                return;
+              }
+              if (event.key === "Escape" && open) {
+                event.preventDefault();
+                event.stopPropagation();
+                setOpen(false);
+                return;
+              }
+              if (event.key === "Enter") {
+                event.preventDefault();
+                event.stopPropagation();
+                const candidate = candidates[activeIndex];
+                if (candidate) selectUser(candidate);
+              }
+            }}
+            placeholder={placeholder}
+            autoFocus={focusInput}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listboxId}
+            aria-autocomplete="list"
+            aria-activedescendant={open && activeIndex >= 0
+              ? `${idPrefix}-option-${candidates[activeIndex]?.id}`
+              : undefined}
+            className="min-w-0 flex-1 bg-transparent text-sm text-tx-primary outline-none placeholder:text-tx-tertiary"
+          />
+          {loading && <Loader2 size={15} className="shrink-0 animate-spin text-tx-tertiary" />}
+          {query && !loading && (
+            <button
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => setQuery("")}
+              className="rounded p-1 text-tx-tertiary hover:bg-app-hover"
+              aria-label="清空人员搜索"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      )}
+
+      {!value && open && (
+        <div id={listboxId} role="listbox" className="absolute left-0 right-0 top-11 z-30 max-h-60 overflow-y-auto rounded-xl border border-app-border bg-app-surface py-1 shadow-xl">
+          {loading && candidates.length === 0 ? (
+            <div className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-tx-tertiary">
+              <Loader2 size={16} className="animate-spin" />正在加载人员
+            </div>
+          ) : error ? (
+            <div className="px-3 py-6 text-center text-sm text-red-500">{error}</div>
+          ) : candidates.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-tx-tertiary">没有找到匹配人员</div>
+          ) : candidates.map((user, index) => {
+            const unavailableLabel = disabledUserLabels[user.id];
+            const unavailable = Boolean(unavailableLabel);
+            return (
+              <button
+                key={user.id}
+                id={`${idPrefix}-option-${user.id}`}
+                type="button"
+                role="option"
+                aria-selected={activeIndex === index}
+                disabled={unavailable}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => { if (!unavailable) setActiveIndex(index); }}
+                onClick={() => selectUser(user)}
+                className={`flex w-full items-center gap-3 px-3 py-2.5 text-left disabled:cursor-not-allowed disabled:opacity-50 ${activeIndex === index ? "bg-app-hover" : "hover:bg-app-hover"}`}
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-accent-primary/10 text-xs font-semibold text-accent-primary">
+                  {user.avatarUrl
+                    ? <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                    : userName(user).slice(0, 1).toLocaleUpperCase()}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-tx-primary">{userName(user)}</div>
+                  <div className="truncate text-xs text-tx-tertiary">@{user.username}</div>
+                </div>
+                <span className={unavailable ? "text-xs text-tx-tertiary" : "text-xs font-medium text-accent-primary"}>
+                  {unavailableLabel || "选择"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
+++ b/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
@@ -29,8 +29,11 @@ describe("Notebook permission management", () => {
     expect(source).toContain("batchRemove");
   });
 
-  it("uses the same searchable dropdown picker for explicit permission rules", () => {
+  it("uses the same searchable dropdown picker for collaborators and explicit rules", () => {
     expect(source).toContain('import UserPickerCombobox from "@/components/UserPickerCombobox"');
+    expect(source).toContain("memberSelectedUser");
+    expect(source).toContain('idPrefix="notebook-member-user"');
+    expect(source).toContain('disabledUserLabels={memberDisabledUserLabels}');
     expect(source).toContain("aclSelectedUser");
     expect(source).toContain('idPrefix="notebook-acl-user"');
     expect(source).toContain('disabledUserLabels={aclDisabledUserLabels}');
@@ -38,11 +41,13 @@ describe("Notebook permission management", () => {
     expect(userPickerSource).toContain('role="combobox"');
     expect(userPickerSource).toContain('role="listbox"');
     expect(userPickerSource).toContain('event.key === "ArrowDown"');
+    expect(userPickerSource).toContain('event.key === "ArrowUp"');
     expect(userPickerSource).toContain("正在加载人员");
     expect(userPickerSource).toContain("没有找到匹配人员");
   });
 
-  it("prevents selecting the current user or an existing explicit rule", () => {
+  it("prevents selecting the current user, an existing collaborator or explicit rule", () => {
+    expect(source).toContain('labels[member.userId] = "已是协作者"');
     expect(source).toContain('labels[me.id] = "你自己"');
     expect(source).toContain('labels[entry.userId] = "已设置独立权限"');
     expect(userPickerSource).toContain("disabledUserLabels[user.id]");

--- a/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
+++ b/frontend/src/components/__tests__/NotebookPermissionManagement.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const source = readFileSync(path.resolve(__dirname, "../NotebookShareDialog.tsx"), "utf8");
+const userPickerSource = readFileSync(
+  path.resolve(__dirname, "../UserPickerCombobox.tsx"),
+  "utf8",
+);
 const apiSource = readFileSync(
   path.resolve(__dirname, "../../lib/notebookPermissionManagementApi.ts"),
   "utf8",
@@ -23,6 +27,25 @@ describe("Notebook permission management", () => {
     expect(source).toContain("toggleVisibleMembers");
     expect(source).toContain("batchSetRole");
     expect(source).toContain("batchRemove");
+  });
+
+  it("uses the same searchable dropdown picker for explicit permission rules", () => {
+    expect(source).toContain('import UserPickerCombobox from "@/components/UserPickerCombobox"');
+    expect(source).toContain("aclSelectedUser");
+    expect(source).toContain('idPrefix="notebook-acl-user"');
+    expect(source).toContain('disabledUserLabels={aclDisabledUserLabels}');
+    expect(source).not.toContain('searchUsers("acl")');
+    expect(userPickerSource).toContain('role="combobox"');
+    expect(userPickerSource).toContain('role="listbox"');
+    expect(userPickerSource).toContain('event.key === "ArrowDown"');
+    expect(userPickerSource).toContain("正在加载人员");
+    expect(userPickerSource).toContain("没有找到匹配人员");
+  });
+
+  it("prevents selecting the current user or an existing explicit rule", () => {
+    expect(source).toContain('labels[me.id] = "你自己"');
+    expect(source).toContain('labels[entry.userId] = "已设置独立权限"');
+    expect(userPickerSource).toContain("disabledUserLabels[user.id]");
   });
 
   it("supports owner transfer without exposing it for workspace notebooks", () => {


### PR DESCRIPTION
## 背景

“权限管理”内存在两套人员添加交互：

- “添加协作者”原来需要输入关键词、点击搜索，再从普通列表直接添加。
- “权限配置”添加独立权限规则也采用输入框 + 搜索按钮。

它们与“成员与权限 → 添加成员”的可搜索人员下拉选择器不一致。

## 修改

- 新增可复用的 `UserPickerCombobox` 人员选择器，并同时接入：
  - 权限管理 → 添加协作者
  - 权限管理 → 权限配置 → 独立权限规则
- 人员选择器支持：
  - 聚焦后自动加载人员
  - 输入 250ms 防抖搜索用户名、显示名或邮箱
  - 下拉展示头像、显示名和用户名
  - 上下方向键切换、Enter 选择、Esc 收起
  - 加载、错误和空结果状态
  - 选中后以人员标签展示，可清除重选
- 防止重复或无效选择：
  - 当前账号显示“你自己”并禁用
  - 已是协作者的用户显示“已是协作者”并禁用
  - 已设置独立权限的用户显示“已设置独立权限”并禁用
- 未选择人员前禁用“添加”；保存期间阻止重复提交。
- 增加回归测试，锁定两处选择器、键盘操作和不可选人员提示。

## 验证建议

1. 打开“权限管理”，点击“添加协作者”，聚焦输入框后应立即出现人员下拉列表。
2. 打开“权限配置”，人员输入框也应使用同样的下拉交互。
3. 输入用户名、显示名或邮箱，列表应自动过滤，无需点击搜索。
4. 使用上下方向键与 Enter 可选择人员，Esc 可收起列表。
5. 当前用户、已有协作者和已有独立权限用户不能重复选择。
6. 选择人员和权限后点击“添加”，应正常写入并刷新成员或规则列表。
