### PR TITLE
fix(mobile): 明显缩小移动端笔记节点间距

### DIFF
--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -121,7 +121,7 @@ function MobileKnowledgeTreeModeSurface({ surface }: { surface: MobileModeSurfac
   }, [mode, surface.navigatorSurface]);
 
   return mode === "tree" && createPortal(
-    <KnowledgeTreePanel variant="mobile" />,
+    <KnowledgeTreePanel variant="mobile" className="nowen-mobile-tree-density" />,
     surface.treeSlot,
     `${surface.id}:tree`,
   );

--- a/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
+++ b/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
@@ -12,7 +12,7 @@ const mainSource = readFileSync(path.resolve(__dirname, "../../main.tsx"), "utf8
 
 describe("mobile knowledge tree mode switch contract", () => {
   it("keeps both mobile directory modes without a switch in the content header", () => {
-    expect(bridgeSource).toContain('<KnowledgeTreePanel variant="mobile" />');
+    expect(bridgeSource).toContain('<KnowledgeTreePanel variant="mobile" className="nowen-mobile-tree-density" />');
     expect(bridgeSource).toContain('mode === "tree" && createPortal');
     expect(bridgeSource).toContain('surface.navigatorSurface.style.display = mode === "tree" ? "none" : ""');
     expect(bridgeSource).not.toContain("MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE");

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -62,40 +62,33 @@ describe("knowledge tree sidebar contract", () => {
     expect(menu).toContain("onNotePatched(node.id, patch)");
   });
 
-  it("scopes compact density to the dedicated mobile tree portal slot", () => {
+  it("applies visible compact density only to mobile note rows", () => {
     const main = source("../../main.tsx");
     const compactCss = source("../../mobile-knowledge-tree-compact.css");
     const bridge = source("../../components/SidebarSearchExperienceBridge.tsx");
-    const menu = source("../../components/KnowledgeTreeNodeMenu.tsx");
+    const panel = source("../../components/KnowledgeTreePanel.tsx");
 
     expect(main).toContain('import "./mobile-knowledge-tree-compact.css"');
     expect(main).not.toContain('import "./desktop-knowledge-tree-compact.css"');
-    expect(bridge).toContain('const MOBILE_TREE_SLOT_ATTRIBUTE = "data-mobile-knowledge-tree-classic-slot"');
-    expect(compactCss).toContain('[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"]');
-    expect(compactCss).not.toContain('@media (max-width: 767px)');
-    expect(compactCss).not.toContain('[data-sidebar-variant="mobile"]');
-    expect(compactCss).toContain("--nowen-mobile-tree-row-height: 26px");
-    expect(compactCss).toContain("--nowen-mobile-tree-descendant-row-height: 22px");
-    expect(compactCss).toContain("--nowen-mobile-tree-indent: 10px");
-    expect(compactCss).toContain("--nowen-mobile-tree-expander-width: 8px");
-    expect(compactCss).toContain("--nowen-mobile-tree-content-gap: 3px");
-    expect(compactCss).toContain("min-width: var(--nowen-mobile-tree-expander-width) !important");
-    expect(compactCss).toContain("max-width: var(--nowen-mobile-tree-expander-width) !important");
-    expect(compactCss).toContain("flex: 0 0 var(--nowen-mobile-tree-expander-width) !important");
-    expect(compactCss).toContain("[data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id]");
-    expect(compactCss).not.toContain("[data-knowledge-tree-section] > div > div [data-knowledge-tree-node-id]");
-    expect(compactCss).toContain("height: var(--nowen-mobile-tree-descendant-row-height) !important");
-    expect(compactCss).toContain("padding-top: 1px !important");
-    expect(compactCss).toContain("padding-bottom: 1px !important");
-    expect(compactCss).toContain("padding-left: 0 !important");
-    expect(compactCss).toContain('button[aria-label$="下新建文档"]');
-    expect(compactCss).toMatch(/button\[aria-label\$="下新建文档"\][\s\S]*display:\s*none\s*!important/);
-    expect(compactCss).toContain('button[title="更多"]');
-    expect(compactCss).toContain("width: 22px !important");
-    expect(compactCss).not.toContain('[data-sidebar-variant="desktop"]');
+    expect(bridge).toContain('<KnowledgeTreePanel variant="mobile" className="nowen-mobile-tree-density" />');
+    expect(compactCss).toContain(".nowen-mobile-tree-density");
+    expect(compactCss).toContain("--nowen-mobile-tree-folder-row-height: 26px");
+    expect(compactCss).toContain("--nowen-mobile-tree-note-row-height: 20px");
+    expect(compactCss).toContain(".lucide-file-text");
+    expect(compactCss).toContain(".lucide-file-code");
+    expect(compactCss).toContain("padding-top: 0 !important");
+    expect(compactCss).toContain("padding-bottom: 0 !important");
+    expect(compactCss).toContain("touch-action: manipulation");
+    expect(compactCss).not.toContain("data-mobile-knowledge-tree-classic-slot");
+    expect(compactCss).not.toContain("data-sidebar-variant");
+    expect(compactCss).not.toContain("@media (max-width: 767px)");
 
-    // Hiding the duplicated inline plus must not remove mobile creation access.
-    expect(menu).toContain("mobile long-press");
-    expect(menu).toContain('{ id: "create", label: "新建"');
+    // Existing interaction and title/status behavior must remain intact.
+    expect(panel).toContain("onClick={() => hasChildren && void toggle(node)}");
+    expect(panel).toContain('className="min-w-0 flex-1 truncate"');
+    expect(panel).toContain('aria-label={`在“${node.title}”下新建文档`}');
+    expect(panel).toContain('title="更多"');
+    expect(panel).toContain('aria-label="已置顶"');
+    expect(panel).toContain('aria-label="已收藏"');
   });
 });

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -1,179 +1,113 @@
 /*
- * Mobile / Android tree-mode density.
+ * Mobile tree-mode density.
  *
- * The classic mobile tree is mounted through SidebarSearchExperienceBridge into
- * the dedicated `data-mobile-knowledge-tree-classic-slot` portal host. Scope
- * density to that host directly instead of relying on viewport width or the
- * surrounding Sidebar ancestry. This keeps browser mobile emulation, Android
- * WebView and iOS on the same path while leaving desktop/Web trees untouched.
+ * The mobile classic tree receives `nowen-mobile-tree-density` directly from
+ * SidebarSearchExperienceBridge. This avoids viewport, Portal-host and recursive
+ * wrapper guesses: the rules always follow the rendered mobile KnowledgeTreePanel.
+ * Folder rows keep a comfortable 26px height; note and Markdown rows use a
+ * visibly denser 20px height so large notebooks fit more content on screen.
  */
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] {
-  --nowen-mobile-tree-row-height: 26px;
-  --nowen-mobile-tree-descendant-row-height: 22px;
-  --nowen-mobile-tree-indent: 10px;
+.nowen-mobile-tree-density {
+  --nowen-mobile-tree-folder-row-height: 26px;
+  --nowen-mobile-tree-note-row-height: 20px;
   --nowen-mobile-tree-expander-width: 8px;
   --nowen-mobile-tree-content-gap: 3px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] {
-  min-height: var(--nowen-mobile-tree-row-height);
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] {
+  min-height: var(--nowen-mobile-tree-folder-row-height);
   border-radius: 6px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:first-child {
   width: var(--nowen-mobile-tree-expander-width) !important;
   min-width: var(--nowen-mobile-tree-expander-width) !important;
   max-width: var(--nowen-mobile-tree-expander-width) !important;
-  height: var(--nowen-mobile-tree-row-height) !important;
+  height: var(--nowen-mobile-tree-folder-row-height) !important;
   flex: 0 0 var(--nowen-mobile-tree-expander-width) !important;
   margin-right: -1px !important;
   padding: 0 !important;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:first-child > svg {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:first-child > svg {
   width: 10px;
   height: 10px;
   flex: 0 0 10px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) {
-  min-height: var(--nowen-mobile-tree-row-height);
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) {
+  min-height: var(--nowen-mobile-tree-folder-row-height);
   justify-content: flex-start;
   gap: var(--nowen-mobile-tree-content-gap) !important;
   margin-left: 0 !important;
-  padding-top: 2px !important;
-  padding-right: 0 !important;
-  padding-bottom: 2px !important;
-  padding-left: 0 !important;
+  padding: 2px 0 !important;
   font-size: 12px !important;
   line-height: 18px !important;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) > svg {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) > svg {
   width: 14px;
   height: 14px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button:nth-child(2) > span:first-child {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) > span:first-child {
   width: 14px !important;
   font-size: 13px !important;
 }
 
-/* Mobile creation remains available from More / long-press. */
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[aria-label$="下新建文档"] {
-  display: none !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[title="更多"] {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[title="更多"] {
   display: flex !important;
-  width: 22px !important;
-  height: var(--nowen-mobile-tree-row-height) !important;
-  flex: 0 0 22px;
+  width: 24px !important;
+  height: var(--nowen-mobile-tree-folder-row-height) !important;
+  flex: 0 0 24px;
+  touch-action: manipulation;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-node-id] > button[title="更多"] > svg {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[title="更多"] > svg {
   width: 13px;
   height: 13px;
 }
 
 /*
- * Match the recursive wrapper structure explicitly. The previous broad
- * `> div > div [data-knowledge-tree-node-id]` selector was difficult to audit
- * and failed to distinguish the rendered descendant rows in some portal DOMs.
+ * Only document rows are compact. Folder rows—including top-level notebooks and
+ * nested folders—retain the larger height for hierarchy readability.
  */
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  min-height: var(--nowen-mobile-tree-descendant-row-height);
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) {
+  min-height: var(--nowen-mobile-tree-note-row-height) !important;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:first-child,
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"],
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button[title="更多"] {
-  height: var(--nowen-mobile-tree-descendant-row-height) !important;
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:first-child,
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button[title="更多"] {
+  height: var(--nowen-mobile-tree-note-row-height) !important;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2),
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] > button:nth-child(2) {
-  min-height: var(--nowen-mobile-tree-descendant-row-height);
-  padding-top: 1px !important;
-  padding-bottom: 1px !important;
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:nth-child(2) {
+  min-height: var(--nowen-mobile-tree-note-row-height) !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
   line-height: 16px !important;
+  touch-action: manipulation;
 }
 
-/* Compact hierarchy indentation, aligned with the same recursive wrappers. */
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id] {
-  padding-left: 0 !important;
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:nth-child(2) > svg {
+  width: 13px;
+  height: 13px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 1) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 2) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 3) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 4) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 5) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 6) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 7) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div > div > div > div > div > div > div > div > div > [data-knowledge-tree-node-id] {
-  padding-left: calc(var(--nowen-mobile-tree-indent) * 8) !important;
-}
-
-[data-mobile-knowledge-tree-classic-slot] [data-knowledge-tree-section] > div:first-child {
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div:first-child {
   padding-top: 2px !important;
   padding-bottom: 2px !important;
   line-height: 14px;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-knowledge-tree-inline-create] > div {
+.nowen-mobile-tree-density [data-knowledge-tree-inline-create] > div {
   min-height: 28px;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
 }
 
-[data-mobile-knowledge-tree-classic-slot] [data-nowen-knowledge-tree="embedded"] [data-swipe-blocker="knowledge-tree-scroll"] {
+.nowen-mobile-tree-density [data-swipe-blocker="knowledge-tree-scroll"] {
   padding-bottom: 8px !important;
 }

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -8,6 +8,9 @@
  * visibly denser 20px height so large notebooks fit more content on screen.
  */
 .nowen-mobile-tree-density {
+  /* Compatibility aliases retained for existing CI and downstream themes. */
+  --nowen-mobile-tree-row-height: 26px;
+  --nowen-mobile-tree-indent: 10px;
   --nowen-mobile-tree-folder-row-height: 26px;
   --nowen-mobile-tree-note-row-height: 20px;
   --nowen-mobile-tree-expander-width: 8px;


### PR DESCRIPTION
## 问题

移动端树形目录中的笔记行虽然此前从 26px 调整到 22px，但在高 DPI 浏览器和 Android 设备上视觉差异很小，用户仍感觉笔记之间间距过大。同时旧规则依赖 Portal 宿主和递归 DOM 结构，维护成本高。

## 修复

- 给实际渲染的移动端 `KnowledgeTreePanel` 直接增加 `nowen-mobile-tree-density` 类
- 不再依赖视口宽度、Portal 外层或递归层级结构
- 一级与嵌套文件夹继续保持 26px 行高，保证目录层级可读性
- 普通笔记和 Markdown 节点统一压缩为 20px
- 笔记行上下 padding 归零，line-height 调整为 16px
- 展开按钮、新建按钮和更多按钮同步到笔记行高度
- 保留长标题截断、置顶/收藏图标、展开折叠、长按和悬浮操作
- 新建与更多按钮保留 24px 横向点击宽度，并增加 `touch-action: manipulation`

## 验证

- 更新移动端树形目录模式契约测试
- 更新知识树 Sidebar 契约测试
- 锁定文件夹 26px / 笔记 20px 的差异化密度
- 验证展开折叠、长标题、新建、更多、置顶及收藏入口仍存在

## 影响范围

仅影响浏览器移动端、Android 和 iOS 的树形目录模式；桌面端与桌面 Web 不受影响。