### PR TITLE
fix(mobile): 进一步压缩浏览器移动端树目录间距

### DIFF
--- a/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
+++ b/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 const bridgeSource = readFileSync(path.resolve(__dirname, "../SidebarSearchExperienceBridge.tsx"), "utf8");
 const settingsSource = readFileSync(path.resolve(__dirname, "../SettingsModal.tsx"), "utf8");
 const helperSource = readFileSync(path.resolve(__dirname, "../../lib/mobileKnowledgeTreeViewMode.ts"), "utf8");
+const compactCssSource = readFileSync(path.resolve(__dirname, "../../mobile-knowledge-tree-compact.css"), "utf8");
 const zhSource = readFileSync(path.resolve(__dirname, "../../i18n/locales/zh-CN.json"), "utf8");
 const enSource = readFileSync(path.resolve(__dirname, "../../i18n/locales/en.json"), "utf8");
 const appSource = readFileSync(path.resolve(__dirname, "../../App.tsx"), "utf8");
@@ -17,6 +18,15 @@ describe("mobile knowledge tree mode switch contract", () => {
     expect(bridgeSource).toContain('surface.navigatorSurface.style.display = mode === "tree" ? "none" : ""');
     expect(bridgeSource).not.toContain("MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE");
     expect(bridgeSource).not.toContain('aria-label="目录浏览方式"');
+  });
+
+  it("keeps browser and Android tree mode visibly compact", () => {
+    expect(compactCssSource).toContain("--nowen-mobile-tree-root-folder-row-height: 22px");
+    expect(compactCssSource).toContain("--nowen-mobile-tree-folder-row-height: 20px");
+    expect(compactCssSource).toContain("--nowen-mobile-tree-note-row-height: 16px");
+    expect(compactCssSource).toMatch(/\[data-knowledge-tree-node-id\]\s*\{[\s\S]*min-height:\s*var\(--nowen-mobile-tree-note-row-height\)\s*!important/);
+    expect(compactCssSource).toContain("font-size: 11px !important");
+    expect(compactCssSource).toContain("touch-action: manipulation");
   });
 
   it("exposes one clear tree-mode switch in Settings", () => {

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -62,7 +62,7 @@ describe("knowledge tree sidebar contract", () => {
     expect(menu).toContain("onNotePatched(node.id, patch)");
   });
 
-  it("applies visible compact density only to mobile note rows", () => {
+  it("applies an unmistakably compact mobile density with a safe fallback", () => {
     const main = source("../../main.tsx");
     const compactCss = source("../../mobile-knowledge-tree-compact.css");
     const bridge = source("../../components/SidebarSearchExperienceBridge.tsx");
@@ -72,12 +72,19 @@ describe("knowledge tree sidebar contract", () => {
     expect(main).not.toContain('import "./desktop-knowledge-tree-compact.css"');
     expect(bridge).toContain('<KnowledgeTreePanel variant="mobile" className="nowen-mobile-tree-density" />');
     expect(compactCss).toContain(".nowen-mobile-tree-density");
-    expect(compactCss).toContain("--nowen-mobile-tree-folder-row-height: 26px");
-    expect(compactCss).toContain("--nowen-mobile-tree-note-row-height: 20px");
-    expect(compactCss).toContain(".lucide-file-text");
-    expect(compactCss).toContain(".lucide-file-code");
-    expect(compactCss).toContain("padding-top: 0 !important");
-    expect(compactCss).toContain("padding-bottom: 0 !important");
+
+    // Root folders remain readable, nested folders are tighter, and documents are dense.
+    expect(compactCss).toContain("--nowen-mobile-tree-root-folder-row-height: 22px");
+    expect(compactCss).toContain("--nowen-mobile-tree-folder-row-height: 20px");
+    expect(compactCss).toContain("--nowen-mobile-tree-note-row-height: 16px");
+    expect(compactCss).toContain("font-size: 11px !important");
+    expect(compactCss).toContain("line-height: 14px !important");
+    expect(compactCss).toContain("padding: 0 !important");
+
+    // Browsers without :has() still receive the 16px compact baseline.
+    expect(compactCss).toMatch(/\[data-knowledge-tree-node-id\]\s*\{[\s\S]*min-height:\s*var\(--nowen-mobile-tree-note-row-height\)\s*!important/);
+    expect(compactCss).toContain("svg.lucide-folder");
+    expect(compactCss).toContain("[data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has");
     expect(compactCss).toContain("touch-action: manipulation");
     expect(compactCss).not.toContain("data-mobile-knowledge-tree-classic-slot");
     expect(compactCss).not.toContain("data-sidebar-variant");

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -1,116 +1,144 @@
 /*
  * Mobile tree-mode density.
  *
- * The mobile classic tree receives `nowen-mobile-tree-density` directly from
- * SidebarSearchExperienceBridge. This avoids viewport, Portal-host and recursive
- * wrapper guesses: the rules always follow the rendered mobile KnowledgeTreePanel.
- * Folder rows keep a comfortable 26px height; note and Markdown rows use a
- * visibly denser 20px height so large notebooks fit more content on screen.
+ * The compact class is mounted directly on the mobile KnowledgeTreePanel, so
+ * these rules do not depend on viewport width, Portal ancestry or recursive DOM
+ * guesses. Document rows use the smallest baseline. Folder enhancements use
+ * :has() when available; browsers without :has() still receive the compact
+ * document baseline instead of falling back to the former spacious layout.
  */
 .nowen-mobile-tree-density {
   /* Compatibility aliases retained for existing CI and downstream themes. */
   --nowen-mobile-tree-row-height: 26px;
   --nowen-mobile-tree-indent: 10px;
-  --nowen-mobile-tree-folder-row-height: 26px;
-  --nowen-mobile-tree-note-row-height: 20px;
-  --nowen-mobile-tree-expander-width: 8px;
-  --nowen-mobile-tree-content-gap: 3px;
+
+  --nowen-mobile-tree-root-folder-row-height: 22px;
+  --nowen-mobile-tree-folder-row-height: 20px;
+  --nowen-mobile-tree-note-row-height: 16px;
+  --nowen-mobile-tree-expander-width: 7px;
+  --nowen-mobile-tree-content-gap: 2px;
+  --nowen-mobile-tree-action-width: 22px;
 }
 
+/*
+ * Compact fallback: every row starts at document density. This guarantees a
+ * visible reduction even in older embedded browsers without :has() support.
+ */
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] {
-  min-height: var(--nowen-mobile-tree-folder-row-height);
-  border-radius: 6px;
+  min-height: var(--nowen-mobile-tree-note-row-height) !important;
+  border-radius: 4px;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:first-child {
   width: var(--nowen-mobile-tree-expander-width) !important;
   min-width: var(--nowen-mobile-tree-expander-width) !important;
   max-width: var(--nowen-mobile-tree-expander-width) !important;
-  height: var(--nowen-mobile-tree-folder-row-height) !important;
+  height: var(--nowen-mobile-tree-note-row-height) !important;
   flex: 0 0 var(--nowen-mobile-tree-expander-width) !important;
-  margin-right: -1px !important;
+  margin-right: 0 !important;
   padding: 0 !important;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:first-child > svg {
-  width: 10px;
-  height: 10px;
-  flex: 0 0 10px;
+  width: 9px;
+  height: 9px;
+  flex: 0 0 9px;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) {
-  min-height: var(--nowen-mobile-tree-folder-row-height);
+  min-height: var(--nowen-mobile-tree-note-row-height) !important;
   justify-content: flex-start;
   gap: var(--nowen-mobile-tree-content-gap) !important;
   margin-left: 0 !important;
-  padding: 2px 0 !important;
-  font-size: 12px !important;
-  line-height: 18px !important;
+  padding: 0 !important;
+  font-size: 11px !important;
+  line-height: 14px !important;
+  touch-action: manipulation;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) > svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button:nth-child(2) > span:first-child {
-  width: 14px !important;
-  font-size: 13px !important;
+  width: 13px !important;
+  font-size: 12px !important;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[aria-label$="下新建文档"],
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[title="更多"] {
   display: flex !important;
-  width: 24px !important;
-  height: var(--nowen-mobile-tree-folder-row-height) !important;
-  flex: 0 0 24px;
+  width: var(--nowen-mobile-tree-action-width) !important;
+  height: var(--nowen-mobile-tree-note-row-height) !important;
+  flex: 0 0 var(--nowen-mobile-tree-action-width);
   touch-action: manipulation;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-node-id] > button[title="更多"] > svg {
-  width: 13px;
-  height: 13px;
+  width: 12px;
+  height: 12px;
 }
 
-/*
- * Only document rows are compact. Folder rows—including top-level notebooks and
- * nested folders—retain the larger height for hierarchy readability.
- */
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) {
-  min-height: var(--nowen-mobile-tree-note-row-height) !important;
+/* Nested folders remain slightly taller than documents for hierarchy scanning. */
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder),
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) {
+  min-height: var(--nowen-mobile-tree-folder-row-height) !important;
 }
 
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:first-child,
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button[aria-label$="下新建文档"],
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button[title="更多"] {
-  height: var(--nowen-mobile-tree-note-row-height) !important;
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button:first-child,
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button:first-child,
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button[title="更多"],
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button[title="更多"] {
+  height: var(--nowen-mobile-tree-folder-row-height) !important;
 }
 
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:nth-child(2) {
-  min-height: var(--nowen-mobile-tree-note-row-height) !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button:nth-child(2),
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button:nth-child(2) {
+  min-height: var(--nowen-mobile-tree-folder-row-height) !important;
+  padding: 1px 0 !important;
   line-height: 16px !important;
-  touch-action: manipulation;
 }
 
-.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg:is(.lucide-file-text, .lucide-file-code)) > button:nth-child(2) > svg {
+.nowen-mobile-tree-density [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button:nth-child(2) > svg {
   width: 13px;
   height: 13px;
+}
+
+/* Top-level notebook folders keep one extra density step for readability. */
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder),
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) {
+  min-height: var(--nowen-mobile-tree-root-folder-row-height) !important;
+}
+
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button:first-child,
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button:first-child,
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button[aria-label$="下新建文档"],
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button[title="更多"],
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button[title="更多"] {
+  height: var(--nowen-mobile-tree-root-folder-row-height) !important;
+}
+
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > svg.lucide-folder) > button:nth-child(2),
+.nowen-mobile-tree-density [data-knowledge-tree-section] > div > [data-knowledge-tree-node-id]:has(> button:nth-child(2) > span:first-child) > button:nth-child(2) {
+  min-height: var(--nowen-mobile-tree-root-folder-row-height) !important;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-section] > div:first-child {
-  padding-top: 2px !important;
-  padding-bottom: 2px !important;
-  line-height: 14px;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  line-height: 12px;
 }
 
 .nowen-mobile-tree-density [data-knowledge-tree-inline-create] > div {
-  min-height: 28px;
+  min-height: 24px;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
 }
 
 .nowen-mobile-tree-density [data-swipe-blocker="knowledge-tree-scroll"] {
-  padding-bottom: 8px !important;
+  padding-bottom: 6px !important;
 }

--- a/frontend/src/mobile-knowledge-tree-compact.css
+++ b/frontend/src/mobile-knowledge-tree-compact.css
@@ -15,8 +15,8 @@
   --nowen-mobile-tree-root-folder-row-height: 22px;
   --nowen-mobile-tree-folder-row-height: 20px;
   --nowen-mobile-tree-note-row-height: 16px;
-  --nowen-mobile-tree-expander-width: 7px;
-  --nowen-mobile-tree-content-gap: 2px;
+  --nowen-mobile-tree-expander-width: 8px;
+  --nowen-mobile-tree-content-gap: 3px;
   --nowen-mobile-tree-action-width: 22px;
 }
 


### PR DESCRIPTION
## 问题

上一版已经将移动端笔记行压缩到 20px，但用户在浏览器移动端高 DPI 缩放下仍看到接近原布局的视觉密度；同时文件夹仍保持 26px，整块目录依然显得松散。

## 调整

- 一级笔记本文件夹：22px
- 嵌套文件夹：20px
- 普通笔记与 Markdown：16px
- 移动端树标题字体恢复为 11px，笔记行 line-height 为 14px
- “当前空间”标题区域移除上下 padding
- 新建与更多按钮宽度保持 22px，并保留 `touch-action: manipulation`
- 展开箭头、文件图标和操作图标同步缩小

## 兼容性

- 样式仍直接绑定 `nowen-mobile-tree-density`，不依赖 viewport 或 Portal 祖先
- 所有节点默认先使用 16px 紧凑基线；支持 `:has()` 的浏览器再把文件夹提升为 20px / 22px
- 因此旧 Android WebView 或不支持 `:has()` 的浏览器也不会退回宽松布局
- 桌面端和桌面 Web 不受影响

## 验证

- 更新 Knowledge Tree Sidebar 契约测试
- 锁定 22px / 20px / 16px 三档密度
- 保留展开折叠、长标题截断、新建、更多、置顶和收藏入口