### PR TITLE
fix(editor): restore rich-text interaction after format conversion

### DIFF
--- a/.github/workflows/issue-355-content-format-ci.yml
+++ b/.github/workflows/issue-355-content-format-ci.yml
@@ -19,12 +19,15 @@ on:
       - "frontend/src/lib/api.impl.ts"
       - "frontend/src/lib/api.ts"
       - "frontend/src/lib/workspaceRefreshBridge.ts"
+      - "frontend/src/lib/__tests__/editorMode.test.ts"
       - "frontend/src/lib/__tests__/workspaceRefreshBridge.test.ts"
       - "frontend/src/components/FormatAwareEditorPane.tsx"
+      - "frontend/src/components/EditorPaneRuntime.tsx"
       - "frontend/src/components/MarkdownEditorImpl.tsx"
       - "frontend/src/components/LargeMarkdownSafeEditor.tsx"
       - "frontend/src/components/MarkdownPreview.tsx"
       - "frontend/src/components/__tests__/FormatAwareEditorPane.test.tsx"
+      - "frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx"
       - "frontend/src/components/__tests__/MarkdownPreview.issue494.test.tsx"
       - "frontend/src/lib/__tests__/markdownUserContent.test.ts"
       - ".github/workflows/issue-355-content-format-ci.yml"
@@ -45,12 +48,15 @@ on:
       - "frontend/src/lib/api.impl.ts"
       - "frontend/src/lib/api.ts"
       - "frontend/src/lib/workspaceRefreshBridge.ts"
+      - "frontend/src/lib/__tests__/editorMode.test.ts"
       - "frontend/src/lib/__tests__/workspaceRefreshBridge.test.ts"
       - "frontend/src/components/FormatAwareEditorPane.tsx"
+      - "frontend/src/components/EditorPaneRuntime.tsx"
       - "frontend/src/components/MarkdownEditorImpl.tsx"
       - "frontend/src/components/LargeMarkdownSafeEditor.tsx"
       - "frontend/src/components/MarkdownPreview.tsx"
       - "frontend/src/components/__tests__/FormatAwareEditorPane.test.tsx"
+      - "frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx"
       - "frontend/src/components/__tests__/MarkdownPreview.issue494.test.tsx"
       - "frontend/src/lib/__tests__/markdownUserContent.test.ts"
       - ".github/workflows/issue-355-content-format-ci.yml"
@@ -97,7 +103,9 @@ jobs:
         run: >-
           npm run test:run --
           src/lib/__tests__/markdownUserContent.test.ts
+          src/lib/__tests__/editorMode.test.ts
           src/components/__tests__/FormatAwareEditorPane.test.tsx
+          src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
       - name: Issue 494 Callout sanitization regression
         run: >-
           npm run test:run --

--- a/frontend/src/components/EditorPaneRuntime.tsx
+++ b/frontend/src/components/EditorPaneRuntime.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import EditorPane from "./EditorPane";
+import FormatAwareEditorPane from "./FormatAwareEditorPane";
 import NoteSplitDialog from "@/components/NoteSplitDialog";
 import { useApp, useAppActions } from "@/store/AppContext";
 import { canWriteNote } from "@/lib/notePermissions";
@@ -24,7 +24,7 @@ function resolvePreferredLevel(note: Note | null | undefined): NoteSplitHeadingL
 
 /**
  * 文档拆分运行时外壳：打开笔记时扫描一次可用标题层级，
- * 将拆分能力交给编辑器菜单，并持有事务化预览弹窗。
+ * 将拆分能力交给按 contentFormat 路由的编辑器，并持有事务化预览弹窗。
  */
 export default function EditorPaneRuntime() {
   const { state } = useApp();
@@ -79,7 +79,7 @@ export default function EditorPaneRuntime() {
 
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
-      <EditorPane
+      <FormatAwareEditorPane
         canSplitDocument={canSplit}
         onSplitDocument={() => setDialogOpen(true)}
       />

--- a/frontend/src/components/FormatAwareEditorPane.tsx
+++ b/frontend/src/components/FormatAwareEditorPane.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useState } from "react";
-import EditorPane from "@/components/EditorPane";
+import EditorPane from "./EditorPane";
 import { useApp } from "@/store/AppContext";
 import { setActiveNoteEditorModeOverride } from "@/lib/editorMode";
 import {
@@ -7,12 +7,20 @@ import {
   resolveNoteEditorKind,
 } from "@/lib/noteEditorRouting";
 
+export interface FormatAwareEditorPaneProps {
+  canSplitDocument?: boolean;
+  onSplitDocument?: () => void;
+}
+
 /**
  * Route an existing note by its persisted contentFormat before EditorPane mounts.
  * This override is in-memory and note-scoped: it neither mutates the user's global
  * editor preference nor allows the debug URL flag to open an incompatible editor.
  */
-export default function FormatAwareEditorPane() {
+export default function FormatAwareEditorPane({
+  canSplitDocument = false,
+  onSplitDocument,
+}: FormatAwareEditorPaneProps) {
   const { state } = useApp();
   const note = state.activeNote;
   const kind = resolveNoteEditorKind(note?.contentFormat);
@@ -39,5 +47,11 @@ export default function FormatAwareEditorPane() {
     return <div className="flex-1 min-h-0 bg-app-bg" aria-hidden="true" />;
   }
 
-  return <EditorPane key={editorKey} />;
+  return (
+    <EditorPane
+      key={editorKey}
+      canSplitDocument={canSplitDocument}
+      onSplitDocument={onSplitDocument}
+    />
+  );
 }

--- a/frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
+++ b/frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("../EditorPane", () => ({
+vi.mock("../FormatAwareEditorPane", () => ({
   default: (props: {
     canSplitDocument?: boolean;
     onSplitDocument?: () => void;
@@ -75,7 +75,7 @@ describe("EditorPaneRuntime layout", () => {
     }
   });
 
-  it("delegates an available split action to the editor without rendering a floating button", async () => {
+  it("delegates an available split action through the format-aware editor", async () => {
     mocks.state.activeNote = {
       id: "split-note",
       title: "可拆分笔记",

--- a/frontend/src/components/__tests__/FormatAwareEditorPane.test.tsx
+++ b/frontend/src/components/__tests__/FormatAwareEditorPane.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/store/AppContext", () => ({
   useApp: () => ({ state: mocks.state }),
 }));
 
-vi.mock("@/components/EditorPane", () => ({
+vi.mock("../EditorPane", () => ({
   default: () => <div data-testid="editor-pane" />,
 }));
 

--- a/frontend/src/lib/__tests__/editorMode.test.ts
+++ b/frontend/src/lib/__tests__/editorMode.test.ts
@@ -4,7 +4,7 @@
  * 覆盖：
  *   - URL `?md=1|0` 强制优先于 localStorage
  *   - localStorage 合法值 / 非法值回落默认
- *   - persistEditorMode 写入 + 读回
+ *   - persistEditorMode 全局写入与当前笔记作用域隔离
  *   - clearForcedModeFromUrl 删 md=，保留其他参数
  *   - nextEditorMode 两向切换
  */
@@ -15,6 +15,7 @@ import {
   nextEditorMode,
   persistEditorMode,
   resolveEditorMode,
+  setActiveNoteEditorModeOverride,
 } from "@/lib/editorMode";
 
 function setLocation(url: string) {
@@ -23,6 +24,7 @@ function setLocation(url: string) {
 }
 
 beforeEach(() => {
+  setActiveNoteEditorModeOverride(null);
   localStorage.clear();
   setLocation("/");
 });
@@ -70,6 +72,19 @@ describe("persistEditorMode", () => {
 
     persistEditorMode("tiptap");
     expect(localStorage.getItem(EDITOR_MODE_KEY)).toBe("tiptap");
+    expect(resolveEditorMode()).toBe("tiptap");
+  });
+
+  it("当前笔记格式切换不会覆盖全局编辑器偏好", () => {
+    localStorage.setItem(EDITOR_MODE_KEY, "tiptap");
+    setActiveNoteEditorModeOverride("tiptap");
+
+    persistEditorMode("md");
+
+    expect(resolveEditorMode()).toBe("md");
+    expect(localStorage.getItem(EDITOR_MODE_KEY)).toBe("tiptap");
+
+    setActiveNoteEditorModeOverride(null);
     expect(resolveEditorMode()).toBe("tiptap");
   });
 });

--- a/frontend/src/lib/editorMode.ts
+++ b/frontend/src/lib/editorMode.ts
@@ -10,8 +10,9 @@
  *      这里扩展，而不是散落在组件里。
  *
  * 兼容约定：
- *   - 读取优先级：URL `?md=1|0` → localStorage → 默认 `"tiptap"`
- *   - 写入只写 localStorage；URL 上的强制标记由 clearForcedModeFromUrl 显式清除
+ *   - 读取优先级：当前笔记 contentFormat 覆盖 → URL `?md=1|0` → localStorage → 默认 `"tiptap"`
+ *   - 存在当前笔记覆盖时，写入只更新内存覆盖，不污染全局 localStorage / 偏好同步
+ *   - 没有当前笔记覆盖时，写入 localStorage；URL 强制标记由 clearForcedModeFromUrl 显式清除
  *   - 所有方法对 SSR / 无 window 环境安全，读取失败时返回默认值
  */
 
@@ -30,8 +31,9 @@ export function setActiveNoteEditorModeOverride(mode: EditorMode | null): void {
 }
 
 /**
- * 根据 URL / localStorage 解析当前编辑器模式。
+ * 根据当前笔记覆盖 / URL / localStorage 解析当前编辑器模式。
  *
+ * - 当前笔记 contentFormat 覆盖存在时优先使用，避免格式不兼容的编辑器污染笔记
  * - `?md=1` → "md"
  * - `?md=0` → "tiptap"
  * - 否则取 localStorage，非法值回落到 "tiptap"
@@ -57,10 +59,18 @@ export function resolveEditorMode(defaultMode: EditorMode = "tiptap"): EditorMod
 }
 
 /**
- * 把当前选择持久化到 localStorage，并广播给账号偏好同步层。失败时静默
- * （隐私模式 / quota）。调用方应在成功切换后调用。
+ * 保存编辑器模式。
+ *
+ * 当前笔记存在 contentFormat 覆盖时，切换只属于这篇笔记：更新内存覆盖即可，
+ * 不写全局 localStorage，也不广播账号偏好变化。没有笔记覆盖时才保留旧的
+ * 全局偏好行为。失败时静默（隐私模式 / quota）。
  */
 export function persistEditorMode(mode: EditorMode): void {
+  if (activeNoteEditorModeOverride) {
+    activeNoteEditorModeOverride = mode;
+    return;
+  }
+
   try {
     localStorage.setItem(EDITOR_MODE_KEY, mode);
   } catch {


### PR DESCRIPTION
## 问题

Markdown / 富文本互转后，转换逻辑把当前编辑器模式写入全局 `nowen.editor_mode`。同时生产运行时外壳直接挂载核心 `EditorPane`，绕过了已有的 `contentFormat` 路由层，因此打开 `tiptap-json` 笔记时可能继续沿用 MarkdownEditor，出现“编辑 / 预览 / 分屏”等 Markdown 交互污染富文本编辑器。

## 修复

- 让 `EditorPaneRuntime` 始终通过 `FormatAwareEditorPane` 挂载核心编辑器。
- `FormatAwareEditorPane` 改用相对路径加载核心 `EditorPane`，避免 Vite 精确别名形成递归，并继续透传文档拆分能力。
- 当前笔记存在格式覆盖时，`persistEditorMode` 只更新笔记作用域内存状态，不再写全局 localStorage 或广播账号偏好。
- 补充富文本路由、运行时转发与编辑器偏好隔离测试，并纳入 content-format CI。

## 预期结果

- `contentFormat=markdown` 始终进入 MarkdownEditor。
- `contentFormat=tiptap-json` 始终恢复原 Tiptap 富文本工具栏与编辑交互。
- MD ↔ 富文本转换不会污染下一篇笔记或刷新后的全局编辑器偏好。