### PR TITLE
fix(share): prompt guest nickname before public comments

### DIFF
--- a/.github/workflows/shared-comment-ci.yml
+++ b/.github/workflows/shared-comment-ci.yml
@@ -1,0 +1,46 @@
+name: Shared Comment CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/vite.config.ts"
+      - "frontend/src/components/SharedNoteView.tsx"
+      - "frontend/src/components/SharedNoteCommentIdentityRuntime.tsx"
+      - "frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx"
+      - "frontend/src/lib/api.impl.ts"
+      - "backend/src/routes/shares.ts"
+      - ".github/workflows/shared-comment-ci.yml"
+  pull_request:
+    paths:
+      - "frontend/vite.config.ts"
+      - "frontend/src/components/SharedNoteView.tsx"
+      - "frontend/src/components/SharedNoteCommentIdentityRuntime.tsx"
+      - "frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx"
+      - "frontend/src/lib/api.impl.ts"
+      - "backend/src/routes/shares.ts"
+      - ".github/workflows/shared-comment-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Guest comment identity regression
+        run: npm run test:run -- src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx
+      - name: Frontend typecheck
+        if: always()
+        run: npx tsc -b

--- a/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 
 const GUEST_NAME_KEY = "nowen-guest-name";
-const COMMENT_IDENTITY_STATE_KEY = Symbol.for("nowen.shared-comment-identity-runtime");
+const COMMENT_IDENTITY_STATE_KEY = "__nowenSharedCommentIdentityRuntime__" as const;
 
 type GuestNameRequester = () => Promise<string | null>;
 
@@ -18,7 +18,7 @@ interface CommentIdentityRuntimeState {
 
 function getCommentIdentityRuntimeState(): CommentIdentityRuntimeState {
   const globalStore = globalThis as typeof globalThis & {
-    [COMMENT_IDENTITY_STATE_KEY]?: CommentIdentityRuntimeState;
+    __nowenSharedCommentIdentityRuntime__?: CommentIdentityRuntimeState;
   };
   if (!globalStore[COMMENT_IDENTITY_STATE_KEY]) {
     globalStore[COMMENT_IDENTITY_STATE_KEY] = {

--- a/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
@@ -8,12 +8,14 @@ import { api } from "@/lib/api";
 const GUEST_NAME_KEY = "nowen-guest-name";
 const COMMENT_IDENTITY_STATE_KEY = "__nowenSharedCommentIdentityRuntime__" as const;
 
+type AddSharedComment = typeof api.addSharedComment;
+type AddSharedCommentArgs = Parameters<AddSharedComment>;
 type GuestNameRequester = () => Promise<string | null>;
 
 interface CommentIdentityRuntimeState {
   requester: GuestNameRequester | null;
   patched: boolean;
-  nativeAddSharedComment: typeof api.addSharedComment | null;
+  nativeAddSharedComment: AddSharedComment | null;
 }
 
 function getCommentIdentityRuntimeState(): CommentIdentityRuntimeState {
@@ -65,7 +67,8 @@ function installCommentIdentityBridge(): void {
   runtime.patched = true;
   runtime.nativeAddSharedComment = api.addSharedComment.bind(api);
 
-  api.addSharedComment = (async (token, data, accessToken) => {
+  api.addSharedComment = (async (...args: AddSharedCommentArgs) => {
+    const [token, data, accessToken] = args;
     const state = getCommentIdentityRuntimeState();
     const nativeAddSharedComment = state.nativeAddSharedComment;
     if (!nativeAddSharedComment) {
@@ -108,7 +111,7 @@ function installCommentIdentityBridge(): void {
         accessToken,
       );
     }
-  }) as typeof api.addSharedComment;
+  }) as AddSharedComment;
 }
 
 installCommentIdentityBridge();

--- a/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
@@ -1,0 +1,241 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { UserCircle2 } from "lucide-react";
+
+import SharedNoteView from "./SharedNoteView";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+
+const GUEST_NAME_KEY = "nowen-guest-name";
+
+type GuestNameRequester = () => Promise<string | null>;
+
+let activeGuestNameRequester: GuestNameRequester | null = null;
+let commentApiPatched = false;
+
+function readStoredGuestName(): string {
+  try {
+    return localStorage.getItem(GUEST_NAME_KEY)?.trim() || "";
+  } catch {
+    return "";
+  }
+}
+
+function hasAuthToken(): boolean {
+  try {
+    return Boolean(localStorage.getItem("nowen-token"));
+  } catch {
+    return false;
+  }
+}
+
+export function isGuestNameRequiredError(error: unknown): boolean {
+  const candidate = error as { code?: string; message?: string } | null;
+  return candidate?.code === "GUEST_NAME_REQUIRED"
+    || /填写昵称.*评论|昵称后再评论/.test(candidate?.message || "");
+}
+
+function createCancelledCommentError(): Error & { code: string } {
+  const error = new Error("评论已取消") as Error & { code: string };
+  error.code = "COMMENT_CANCELLED";
+  return error;
+}
+
+function installCommentIdentityBridge(): void {
+  if (commentApiPatched) return;
+  commentApiPatched = true;
+
+  const nativeAddSharedComment = api.addSharedComment.bind(api);
+  api.addSharedComment = (async (token, data, accessToken) => {
+    let nextData = { ...data };
+    const explicitName = nextData.guestName?.trim() || "";
+    const storedName = readStoredGuestName();
+
+    if (!explicitName && storedName) {
+      nextData.guestName = storedName;
+    }
+
+    // 普通匿名访客没有登录令牌时，提交前先收集昵称，避免先产生一次 400 请求。
+    if (!nextData.guestName && !hasAuthToken() && activeGuestNameRequester) {
+      const requestedName = await activeGuestNameRequester();
+      if (!requestedName) throw createCancelledCommentError();
+      nextData.guestName = requestedName;
+    }
+
+    try {
+      return await nativeAddSharedComment(token, nextData, accessToken);
+    } catch (error) {
+      // 浏览器可能残留已失效 token，前端误以为已登录；以后端结果为准，再补昵称重试一次。
+      if (
+        nextData.guestName
+        || !activeGuestNameRequester
+        || !isGuestNameRequiredError(error)
+      ) {
+        throw error;
+      }
+
+      const requestedName = await activeGuestNameRequester();
+      if (!requestedName) throw error;
+      return nativeAddSharedComment(
+        token,
+        { ...nextData, guestName: requestedName },
+        accessToken,
+      );
+    }
+  }) as typeof api.addSharedComment;
+}
+
+installCommentIdentityBridge();
+
+interface SharedNoteCommentIdentityRuntimeProps {
+  shareToken: string;
+}
+
+/**
+ * 分享评论身份运行时壳。
+ *
+ * 原分享页只在“访客编辑”时收集昵称，但公开评论接口同样要求匿名访客携带
+ * guestName，导致只评论的访客永远收到 GUEST_NAME_REQUIRED。这里保留原分享页，
+ * 在评论 API 前按需弹出昵称面板，并把昵称保存在本机供后续评论复用。
+ */
+export default function SharedNoteCommentIdentityRuntime({
+  shareToken,
+}: SharedNoteCommentIdentityRuntimeProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState("");
+  const resolverRef = useRef<((name: string | null) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<string | null> | null>(null);
+
+  const settleRequest = useCallback((name: string | null) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    pendingPromiseRef.current = null;
+    setOpen(false);
+    resolve?.(name);
+  }, []);
+
+  const requestGuestName = useCallback<GuestNameRequester>(() => {
+    const storedName = readStoredGuestName();
+    if (storedName) return Promise.resolve(storedName);
+    if (pendingPromiseRef.current) return pendingPromiseRef.current;
+
+    setDraft("");
+    setError("");
+    setOpen(true);
+    const promise = new Promise<string | null>((resolve) => {
+      resolverRef.current = resolve;
+    });
+    pendingPromiseRef.current = promise;
+    return promise;
+  }, []);
+
+  // 子组件在本次 render 后才可能触发评论，因此同步注册可消除 useEffect 首帧空窗。
+  activeGuestNameRequester = requestGuestName;
+
+  useEffect(() => () => {
+    if (activeGuestNameRequester === requestGuestName) {
+      activeGuestNameRequester = null;
+    }
+    resolverRef.current?.(null);
+    resolverRef.current = null;
+    pendingPromiseRef.current = null;
+  }, [requestGuestName]);
+
+  const confirmNickname = useCallback(() => {
+    const name = draft.trim();
+    if (!name) {
+      setError("请输入昵称");
+      return;
+    }
+    if (name.length > 32) {
+      setError("昵称过长，最多 32 个字符");
+      return;
+    }
+    try {
+      localStorage.setItem(GUEST_NAME_KEY, name);
+    } catch {
+      // 受限 WebView / 隐私模式下仍允许本次评论继续提交。
+    }
+    settleRequest(name);
+  }, [draft, settleRequest]);
+
+  return (
+    <>
+      <SharedNoteView shareToken={shareToken} />
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[160] flex items-center justify-center bg-black/40 px-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="share-comment-nickname-title"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) settleRequest(null);
+          }}
+        >
+          <div className="w-full max-w-sm rounded-2xl border border-zinc-200 bg-white p-6 shadow-2xl dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="mb-5 flex flex-col items-center">
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-500/10">
+                <UserCircle2 size={24} className="text-indigo-500" />
+              </div>
+              <h2
+                id="share-comment-nickname-title"
+                className="text-base font-semibold text-zinc-800 dark:text-zinc-200"
+              >
+                发表评论前填写昵称
+              </h2>
+              <p className="mt-1 text-center text-xs text-zinc-500">
+                昵称会显示在评论旁边，方便笔记作者知道是谁参与了讨论。
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <input
+                type="text"
+                value={draft}
+                onChange={(event) => {
+                  setDraft(event.target.value);
+                  if (error) setError("");
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    confirmNickname();
+                  }
+                }}
+                placeholder="例如：小王"
+                maxLength={32}
+                autoFocus
+                className="h-10 w-full rounded-xl border border-zinc-200 bg-zinc-50 px-4 text-sm text-zinc-800 placeholder:text-zinc-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+              />
+              {error && <p className="text-xs text-red-500">{error}</p>}
+
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-10 flex-1 text-sm"
+                  onClick={() => settleRequest(null)}
+                >
+                  取消
+                </Button>
+                <Button
+                  type="button"
+                  className="h-10 flex-1 rounded-xl bg-indigo-500 font-medium text-white hover:bg-indigo-600"
+                  disabled={!draft.trim()}
+                  onClick={confirmNickname}
+                >
+                  确认并评论
+                </Button>
+              </div>
+
+              <p className="text-center text-[10px] text-zinc-400">
+                昵称仅保存在当前浏览器中，下次评论会自动使用。
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentIdentityRuntime.tsx
@@ -6,11 +6,29 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 
 const GUEST_NAME_KEY = "nowen-guest-name";
+const COMMENT_IDENTITY_STATE_KEY = Symbol.for("nowen.shared-comment-identity-runtime");
 
 type GuestNameRequester = () => Promise<string | null>;
 
-let activeGuestNameRequester: GuestNameRequester | null = null;
-let commentApiPatched = false;
+interface CommentIdentityRuntimeState {
+  requester: GuestNameRequester | null;
+  patched: boolean;
+  nativeAddSharedComment: typeof api.addSharedComment | null;
+}
+
+function getCommentIdentityRuntimeState(): CommentIdentityRuntimeState {
+  const globalStore = globalThis as typeof globalThis & {
+    [COMMENT_IDENTITY_STATE_KEY]?: CommentIdentityRuntimeState;
+  };
+  if (!globalStore[COMMENT_IDENTITY_STATE_KEY]) {
+    globalStore[COMMENT_IDENTITY_STATE_KEY] = {
+      requester: null,
+      patched: false,
+      nativeAddSharedComment: null,
+    };
+  }
+  return globalStore[COMMENT_IDENTITY_STATE_KEY]!;
+}
 
 function readStoredGuestName(): string {
   try {
@@ -41,11 +59,19 @@ function createCancelledCommentError(): Error & { code: string } {
 }
 
 function installCommentIdentityBridge(): void {
-  if (commentApiPatched) return;
-  commentApiPatched = true;
+  const runtime = getCommentIdentityRuntimeState();
+  if (runtime.patched) return;
 
-  const nativeAddSharedComment = api.addSharedComment.bind(api);
+  runtime.patched = true;
+  runtime.nativeAddSharedComment = api.addSharedComment.bind(api);
+
   api.addSharedComment = (async (token, data, accessToken) => {
+    const state = getCommentIdentityRuntimeState();
+    const nativeAddSharedComment = state.nativeAddSharedComment;
+    if (!nativeAddSharedComment) {
+      throw new Error("公开评论接口尚未初始化");
+    }
+
     let nextData = { ...data };
     const explicitName = nextData.guestName?.trim() || "";
     const storedName = readStoredGuestName();
@@ -55,8 +81,8 @@ function installCommentIdentityBridge(): void {
     }
 
     // 普通匿名访客没有登录令牌时，提交前先收集昵称，避免先产生一次 400 请求。
-    if (!nextData.guestName && !hasAuthToken() && activeGuestNameRequester) {
-      const requestedName = await activeGuestNameRequester();
+    if (!nextData.guestName && !hasAuthToken() && state.requester) {
+      const requestedName = await state.requester();
       if (!requestedName) throw createCancelledCommentError();
       nextData.guestName = requestedName;
     }
@@ -65,15 +91,16 @@ function installCommentIdentityBridge(): void {
       return await nativeAddSharedComment(token, nextData, accessToken);
     } catch (error) {
       // 浏览器可能残留已失效 token，前端误以为已登录；以后端结果为准，再补昵称重试一次。
+      const requester = getCommentIdentityRuntimeState().requester;
       if (
         nextData.guestName
-        || !activeGuestNameRequester
+        || !requester
         || !isGuestNameRequiredError(error)
       ) {
         throw error;
       }
 
-      const requestedName = await activeGuestNameRequester();
+      const requestedName = await requester();
       if (!requestedName) throw error;
       return nativeAddSharedComment(
         token,
@@ -130,11 +157,12 @@ export default function SharedNoteCommentIdentityRuntime({
   }, []);
 
   // 子组件在本次 render 后才可能触发评论，因此同步注册可消除 useEffect 首帧空窗。
-  activeGuestNameRequester = requestGuestName;
+  getCommentIdentityRuntimeState().requester = requestGuestName;
 
   useEffect(() => () => {
-    if (activeGuestNameRequester === requestGuestName) {
-      activeGuestNameRequester = null;
+    const runtime = getCommentIdentityRuntimeState();
+    if (runtime.requester === requestGuestName) {
+      runtime.requester = null;
     }
     resolverRef.current?.(null);
     resolverRef.current = null;

--- a/frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx
+++ b/frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addSharedComment: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    addSharedComment: mocks.addSharedComment,
+  },
+}));
+
+vi.mock("../SharedNoteView", () => ({
+  default: ({ shareToken }: { shareToken: string }) => {
+    const [status, setStatus] = React.useState("idle");
+    return (
+      <button
+        type="button"
+        data-testid="submit-comment"
+        onClick={() => {
+          setStatus("pending");
+          void import("@/lib/api")
+            .then(({ api }) => api.addSharedComment(shareToken, { content: "test" }))
+            .then(() => setStatus("done"))
+            .catch((error) => setStatus(error?.code || "error"));
+        }}
+      >
+        {status}
+      </button>
+    );
+  },
+}));
+
+import SharedNoteCommentIdentityRuntime from "../SharedNoteCommentIdentityRuntime";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const COMMENT = {
+  id: "comment-1",
+  noteId: "note-1",
+  userId: null,
+  username: "小王",
+  content: "test",
+  createdAt: new Date(0).toISOString(),
+};
+
+describe("SharedNoteCommentIdentityRuntime", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.addSharedComment.mockReset().mockResolvedValue(COMMENT);
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+    document.body.innerHTML = "";
+  });
+
+  async function renderRuntime() {
+    await act(async () => {
+      root.render(<SharedNoteCommentIdentityRuntime shareToken="share-token" />);
+    });
+  }
+
+  async function submitComment() {
+    const button = host.querySelector<HTMLButtonElement>('[data-testid="submit-comment"]');
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button!.click();
+      await Promise.resolve();
+    });
+  }
+
+  async function enterNickname(name: string) {
+    const input = document.querySelector<HTMLInputElement>('input[placeholder="例如：小王"]');
+    expect(input).not.toBeNull();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, name);
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const confirm = Array.from(document.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent?.includes("确认并评论"));
+    expect(confirm).not.toBeUndefined();
+    await act(async () => {
+      confirm!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("asks an anonymous visitor for a nickname before the first comment", async () => {
+    await renderRuntime();
+    await submitComment();
+
+    expect(mocks.addSharedComment).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("发表评论前填写昵称");
+
+    await enterNickname("小王");
+
+    expect(mocks.addSharedComment).toHaveBeenCalledWith(
+      "share-token",
+      { content: "test", guestName: "小王" },
+      undefined,
+    );
+    expect(localStorage.getItem("nowen-guest-name")).toBe("小王");
+    expect(host.textContent).toContain("done");
+  });
+
+  it("reuses the nickname stored by an earlier comment", async () => {
+    localStorage.setItem("nowen-guest-name", "访客甲");
+    await renderRuntime();
+    await submitComment();
+
+    expect(document.body.textContent).not.toContain("发表评论前填写昵称");
+    expect(mocks.addSharedComment).toHaveBeenCalledWith(
+      "share-token",
+      { content: "test", guestName: "访客甲" },
+      undefined,
+    );
+    expect(host.textContent).toContain("done");
+  });
+
+  it("falls back to the nickname dialog when a stale login token is rejected as a guest", async () => {
+    localStorage.setItem("nowen-token", "expired-token");
+    mocks.addSharedComment
+      .mockRejectedValueOnce(new Error("请填写昵称后再评论"))
+      .mockResolvedValueOnce(COMMENT);
+
+    await renderRuntime();
+    await submitComment();
+
+    expect(mocks.addSharedComment).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain("发表评论前填写昵称");
+
+    await enterNickname("小李");
+
+    expect(mocks.addSharedComment).toHaveBeenCalledTimes(2);
+    expect(mocks.addSharedComment).toHaveBeenLastCalledWith(
+      "share-token",
+      { content: "test", guestName: "小李" },
+      undefined,
+    );
+    expect(host.textContent).toContain("done");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,6 +81,12 @@ export default defineConfig({
         find: /^@\/lib\/largeMarkdownSafety$/,
         replacement: path.resolve(__dirname, "./src/lib/largeMarkdownSafetyRuntime.ts"),
       },
+      // 公开分享评论：匿名访客首次评论前收集昵称，并在本机复用。
+      // 壳组件通过相对路径加载原 SharedNoteView，避免精确别名递归。
+      {
+        find: /^@\/components\/SharedNoteView$/,
+        replacement: path.resolve(__dirname, "./src/components/SharedNoteCommentIdentityRuntime.tsx"),
+      },
       // Issue #369 P2：在不侵入 EditorPane 主体的前提下增加事务化文档拆分入口。
       {
         find: /^@\/components\/EditorPane$/,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
         find: /^@\/lib\/largeMarkdownSafety$/,
         replacement: path.resolve(__dirname, "./src/lib/largeMarkdownSafetyRuntime.ts"),
       },
-      // 公开分享评论：匿名访客首次评论前收集昵称，并在本机复用。
+      // 公开分享评论：匿名访客首次评论前收集昵称，失效登录态按服务端结果回退重试。
       // 壳组件通过相对路径加载原 SharedNoteView，避免精确别名递归。
       {
         find: /^@\/components\/SharedNoteView$/,


### PR DESCRIPTION
## 问题

公开分享页允许访客评论，但后端 `POST /shared/:token/comments` 对未登录访客强制要求 `guestName`。当前评论区只有评论正文输入框，昵称弹窗只服务于“访客编辑”，因此普通访客提交的请求只有：

```json
{ "content": "test" }
```

服务端返回 `400 GUEST_NAME_REQUIRED`，评论无法发表。

## 修复

- 新增公开分享评论身份运行时壳，在匿名访客首次发表评论前弹出昵称面板。
- 昵称确认后自动继续原评论提交，不丢失已输入的评论内容。
- 昵称写入 `nowen-guest-name`，同一浏览器后续评论自动复用。
- 已登录用户保持原流程，不额外要求昵称。
- 针对浏览器残留失效登录令牌的情况：若后端仍返回 `GUEST_NAME_REQUIRED`，自动补弹昵称并重试一次。
- 通过 Vite 精确别名挂载运行时壳，内部相对路径加载原 `SharedNoteView`，避免递归别名。
- 增加匿名首次评论、昵称复用、失效令牌回退三类回归测试和独立 CI。

## 预期结果

- 匿名访客输入评论后，首次会先填写昵称，确认后评论直接发布。
- 后续评论不再出现 `400 Bad Request / GUEST_NAME_REQUIRED`。
- 登录用户不受影响。