### PR TITLE
fix(permissions): 修复权限管理打开时提示 Not Found

### DIFF
--- a/.github/workflows/notebook-permission-management-ci.yml
+++ b/.github/workflows/notebook-permission-management-ci.yml
@@ -6,6 +6,7 @@ on:
       - "backend/src/index.hardened.ts"
       - "backend/src/runtime/notebook-permission-management.ts"
       - "backend/src/runtime/knowledge-tree-migration-bootstrap.ts"
+      - "backend/src/runtime/task-stats-hardening.ts"
       - "backend/src/services/notebookOwnershipTransfer.ts"
       - "backend/tests/migration-bootstrap-order.test.ts"
       - "backend/tests/notebook-owner-transfer.test.ts"

--- a/backend/src/runtime/task-stats-hardening.ts
+++ b/backend/src/runtime/task-stats-hardening.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import { Hono } from "hono";
 import type { Context } from "hono";
+// Both backend entrypoints load this runtime after the migration bootstrap. Keep the
+// modular permission routes installed when a tsc/legacy build starts src/index.ts directly.
+import "./notebook-permission-management.js";
 import { getDb } from "../db/schema.js";
 import {
   canManageResource,

--- a/backend/tests/migration-bootstrap-order.test.ts
+++ b/backend/tests/migration-bootstrap-order.test.ts
@@ -3,6 +3,22 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
+function assertOrderedImports(
+  source: string,
+  firstImport: string,
+  secondImport: string,
+  entryLabel: string,
+): void {
+  const firstIndex = source.indexOf(firstImport);
+  const secondIndex = source.indexOf(secondImport);
+  assert.ok(firstIndex >= 0, `${entryLabel} must contain ${firstImport}`);
+  assert.ok(secondIndex >= 0, `${entryLabel} must contain ${secondImport}`);
+  assert.ok(
+    firstIndex < secondIndex,
+    `${entryLabel} must register feature migrations before database-consuming runtimes`,
+  );
+}
+
 test("knowledge-tree bootstrap registers schema versions 60-64 before migrations.ts is evaluated", async () => {
   await import("../src/runtime/knowledge-tree-migration-bootstrap");
   const { CURRENT_SCHEMA_VERSION, MIGRATIONS } = await import("../src/db/migrations");
@@ -17,9 +33,17 @@ test("knowledge-tree bootstrap registers schema versions 60-64 before migrations
   );
 });
 
-test("database-consuming permission runtime loads after the migration bootstrap", () => {
-  const indexSource = fs.readFileSync(
+test("permission routes load after migration bootstrap in hardened and legacy entries", () => {
+  const hardenedIndexSource = fs.readFileSync(
     path.resolve(__dirname, "../src/index.hardened.ts"),
+    "utf8",
+  );
+  const legacyIndexSource = fs.readFileSync(
+    path.resolve(__dirname, "../src/index.ts"),
+    "utf8",
+  );
+  const taskStatsRuntimeSource = fs.readFileSync(
+    path.resolve(__dirname, "../src/runtime/task-stats-hardening.ts"),
     "utf8",
   );
   const bootstrapSource = fs.readFileSync(
@@ -27,14 +51,22 @@ test("database-consuming permission runtime loads after the migration bootstrap"
     "utf8",
   );
 
-  const bootstrapIndex = indexSource.indexOf('import "./runtime/knowledge-tree-migration-bootstrap.js";');
-  const permissionRuntimeIndex = indexSource.indexOf('import "./runtime/notebook-permission-management.js";');
-
-  assert.ok(bootstrapIndex >= 0, "index.hardened must import the migration bootstrap");
-  assert.ok(permissionRuntimeIndex >= 0, "index.hardened must import the permission runtime");
-  assert.ok(
-    bootstrapIndex < permissionRuntimeIndex,
-    "feature migrations must be registered before permission runtime evaluation",
+  assertOrderedImports(
+    hardenedIndexSource,
+    'import "./runtime/knowledge-tree-migration-bootstrap.js";',
+    'import "./runtime/notebook-permission-management.js";',
+    "index.hardened",
+  );
+  assertOrderedImports(
+    legacyIndexSource,
+    'import "./runtime/knowledge-tree-migration-bootstrap";',
+    'import "./runtime/task-stats-hardening";',
+    "index",
+  );
+  assert.match(
+    taskStatsRuntimeSource,
+    /import\s+["']\.\/notebook-permission-management\.js["'];/,
+    "legacy startup runtime must install notebook permission routes",
   );
   assert.doesNotMatch(
     bootstrapSource,


### PR DESCRIPTION
## 问题

部分使用 TypeScript/legacy 后端入口启动的构建只加载了 `src/index.ts`。该入口虽然先执行了知识树迁移引导，但没有安装 `notebook-permission-management` 的模块化路由，导致权限管理弹窗请求：

- `GET /api/notebooks/:id/permission-summary`

落入全局 404，前端显示 `Not Found`。

## 修复

- 让两个后端启动入口都会在迁移注册完成后安装笔记本权限管理路由。
- 保留 `index.hardened.ts` 现有显式加载路径，并为直接启动 `index.ts` 的 tsc/legacy 构建补齐兼容加载。
- 扩展迁移启动顺序回归测试，同时覆盖 hardened 与 legacy 两条入口链路。
- 将兼容运行时文件加入权限管理 CI 的路径触发范围。

## 验证

CI 将执行：

- `migration-bootstrap-order.test.ts`
- `notebook-owner-transfer.test.ts`
- 后端 TypeScript typecheck
- 权限管理前端回归测试
- 前端生产构建

修复后，打开“权限管理”不再因 `permission-summary` 路由未注册而提示 `Not Found`。