### PR TITLE
fix(share): show guest nickname in public comments

### DIFF
--- a/.github/workflows/shared-comment-ci.yml
+++ b/.github/workflows/shared-comment-ci.yml
@@ -7,18 +7,24 @@ on:
       - "frontend/vite.config.ts"
       - "frontend/src/components/SharedNoteView.tsx"
       - "frontend/src/components/SharedNoteCommentIdentityRuntime.tsx"
+      - "frontend/src/components/SharedNoteCommentDisplayRuntime.tsx"
       - "frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx"
+      - "frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx"
       - "frontend/src/lib/api.impl.ts"
       - "backend/src/routes/shares.ts"
+      - "backend/src/repositories/shareCommentsRepository.ts"
       - ".github/workflows/shared-comment-ci.yml"
   pull_request:
     paths:
       - "frontend/vite.config.ts"
       - "frontend/src/components/SharedNoteView.tsx"
       - "frontend/src/components/SharedNoteCommentIdentityRuntime.tsx"
+      - "frontend/src/components/SharedNoteCommentDisplayRuntime.tsx"
       - "frontend/src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx"
+      - "frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx"
       - "frontend/src/lib/api.impl.ts"
       - "backend/src/routes/shares.ts"
+      - "backend/src/repositories/shareCommentsRepository.ts"
       - ".github/workflows/shared-comment-ci.yml"
 
 permissions:
@@ -39,8 +45,11 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
-      - name: Guest comment identity regression
-        run: npm run test:run -- src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx
+      - name: Guest comment identity regressions
+        run: >-
+          npm run test:run --
+          src/components/__tests__/SharedNoteCommentIdentityRuntime.test.tsx
+          src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b

--- a/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+import SharedNoteCommentIdentityRuntime from "./SharedNoteCommentIdentityRuntime";
+import { api } from "@/lib/api";
+
+const COMMENT_DISPLAY_STATE_KEY = "__nowenSharedCommentDisplayRuntime__" as const;
+
+type GetSharedComments = typeof api.getSharedComments;
+type AddSharedComment = typeof api.addSharedComment;
+
+type SharedCommentIdentityFields = {
+  username?: string | null;
+  displayName?: string | null;
+  guestName?: string | null;
+  [key: string]: unknown;
+};
+
+interface CommentDisplayRuntimeState {
+  version: number;
+  nativeGetSharedComments: GetSharedComments | null;
+  nativeAddSharedComment: AddSharedComment | null;
+}
+
+function getCommentDisplayRuntimeState(): CommentDisplayRuntimeState {
+  const globalStore = globalThis as typeof globalThis & {
+    __nowenSharedCommentDisplayRuntime__?: CommentDisplayRuntimeState;
+  };
+  if (!globalStore[COMMENT_DISPLAY_STATE_KEY]) {
+    globalStore[COMMENT_DISPLAY_STATE_KEY] = {
+      version: 0,
+      nativeGetSharedComments: null,
+      nativeAddSharedComment: null,
+    };
+  }
+  return globalStore[COMMENT_DISPLAY_STATE_KEY]!;
+}
+
+/**
+ * SharedNoteView still renders `comment.username`, while the public comment API deliberately
+ * returns anonymous visitor identity through `displayName` / `guestName`. Project the public
+ * identity into the legacy field at the runtime boundary so both existing and newly-added
+ * comments render the nickname without changing the management-side comment contract.
+ */
+export function normalizeSharedCommentDisplayName<T extends SharedCommentIdentityFields>(comment: T): T {
+  const displayName = [comment.displayName, comment.guestName, comment.username]
+    .find((value) => typeof value === "string" && value.trim())
+    ?.trim() || "匿名";
+
+  if (comment.username === displayName && comment.displayName === displayName) return comment;
+  return {
+    ...comment,
+    username: displayName,
+    displayName,
+  } as T;
+}
+
+function installCommentDisplayBridge(): void {
+  const state = getCommentDisplayRuntimeState();
+  if (state.version >= 1) return;
+
+  state.nativeGetSharedComments = state.nativeGetSharedComments || api.getSharedComments.bind(api);
+  state.nativeAddSharedComment = state.nativeAddSharedComment || api.addSharedComment.bind(api);
+
+  const nativeGetSharedComments = state.nativeGetSharedComments;
+  const nativeAddSharedComment = state.nativeAddSharedComment;
+
+  api.getSharedComments = (async (...args: Parameters<GetSharedComments>) => {
+    const comments = await nativeGetSharedComments(...args);
+    return comments.map((comment) => normalizeSharedCommentDisplayName(comment));
+  }) as GetSharedComments;
+
+  api.addSharedComment = (async (...args: Parameters<AddSharedComment>) => {
+    const comment = await nativeAddSharedComment(...args);
+    return normalizeSharedCommentDisplayName(comment);
+  }) as AddSharedComment;
+
+  state.version = 1;
+}
+
+installCommentDisplayBridge();
+
+interface SharedNoteCommentDisplayRuntimeProps {
+  shareToken: string;
+}
+
+export default function SharedNoteCommentDisplayRuntime({
+  shareToken,
+}: SharedNoteCommentDisplayRuntimeProps) {
+  return <SharedNoteCommentIdentityRuntime shareToken={shareToken} />;
+}

--- a/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
@@ -2,18 +2,12 @@ import React from "react";
 
 import SharedNoteCommentIdentityRuntime from "./SharedNoteCommentIdentityRuntime";
 import { api } from "@/lib/api";
+import type { ShareComment } from "@/types";
 
 const COMMENT_DISPLAY_STATE_KEY = "__nowenSharedCommentDisplayRuntime__" as const;
 
 type GetSharedComments = typeof api.getSharedComments;
 type AddSharedComment = typeof api.addSharedComment;
-
-type SharedCommentIdentityFields = {
-  username?: string | null;
-  displayName?: string | null;
-  guestName?: string | null;
-  [key: string]: unknown;
-};
 
 interface CommentDisplayRuntimeState {
   version: number;
@@ -41,7 +35,7 @@ function getCommentDisplayRuntimeState(): CommentDisplayRuntimeState {
  * identity into the legacy field at the runtime boundary so both existing and newly-added
  * comments render the nickname without changing the management-side comment contract.
  */
-export function normalizeSharedCommentDisplayName<T extends SharedCommentIdentityFields>(comment: T): T {
+export function normalizeSharedCommentDisplayName(comment: ShareComment): ShareComment {
   const displayName = [comment.displayName, comment.guestName, comment.username]
     .find((value) => typeof value === "string" && value.trim())
     ?.trim() || "匿名";
@@ -51,7 +45,7 @@ export function normalizeSharedCommentDisplayName<T extends SharedCommentIdentit
     ...comment,
     username: displayName,
     displayName,
-  } as T;
+  };
 }
 
 function installCommentDisplayBridge(): void {
@@ -64,15 +58,15 @@ function installCommentDisplayBridge(): void {
   const nativeGetSharedComments = state.nativeGetSharedComments;
   const nativeAddSharedComment = state.nativeAddSharedComment;
 
-  api.getSharedComments = (async (...args: Parameters<GetSharedComments>) => {
+  api.getSharedComments = async (...args: Parameters<GetSharedComments>) => {
     const comments = await nativeGetSharedComments(...args);
-    return comments.map((comment) => normalizeSharedCommentDisplayName(comment));
-  }) as GetSharedComments;
+    return comments.map(normalizeSharedCommentDisplayName);
+  };
 
-  api.addSharedComment = (async (...args: Parameters<AddSharedComment>) => {
+  api.addSharedComment = async (...args: Parameters<AddSharedComment>) => {
     const comment = await nativeAddSharedComment(...args);
     return normalizeSharedCommentDisplayName(comment);
-  }) as AddSharedComment;
+  };
 
   state.version = 1;
 }

--- a/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
+++ b/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSharedComments: vi.fn(),
+  addSharedComment: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getSharedComments: mocks.getSharedComments,
+    addSharedComment: mocks.addSharedComment,
+  },
+}));
+
+vi.mock("../SharedNoteCommentIdentityRuntime", () => ({
+  default: ({ shareToken }: { shareToken: string }) => (
+    <div data-testid="identity-runtime">{shareToken}</div>
+  ),
+}));
+
+import { api } from "@/lib/api";
+import SharedNoteCommentDisplayRuntime, {
+  normalizeSharedCommentDisplayName,
+} from "../SharedNoteCommentDisplayRuntime";
+
+const BASE_COMMENT = {
+  id: "comment-1",
+  noteId: "note-1",
+  userId: null,
+  content: "test",
+  createdAt: new Date(0).toISOString(),
+};
+
+describe("SharedNoteCommentDisplayRuntime", () => {
+  beforeEach(() => {
+    mocks.getSharedComments.mockReset();
+    mocks.addSharedComment.mockReset();
+  });
+
+  it("projects displayName into username for existing public comments", async () => {
+    mocks.getSharedComments.mockResolvedValue([
+      {
+        ...BASE_COMMENT,
+        username: null,
+        guestName: "访客甲",
+        displayName: "访客甲",
+      },
+    ]);
+
+    const comments = await api.getSharedComments("share-token");
+
+    expect(comments[0].username).toBe("访客甲");
+    expect(comments[0].displayName).toBe("访客甲");
+  });
+
+  it("projects the nickname immediately after an anonymous comment is added", async () => {
+    mocks.addSharedComment.mockResolvedValue({
+      ...BASE_COMMENT,
+      username: null,
+      guestName: "访客乙",
+      displayName: "访客乙",
+    });
+
+    const comment = await api.addSharedComment(
+      "share-token",
+      { content: "test", guestName: "访客乙" },
+    );
+
+    expect(comment.username).toBe("访客乙");
+    expect(comment.displayName).toBe("访客乙");
+  });
+
+  it("falls back from displayName to guestName and finally 匿名", () => {
+    expect(normalizeSharedCommentDisplayName({ guestName: " 小王 " }).username).toBe("小王");
+    expect(normalizeSharedCommentDisplayName({}).username).toBe("匿名");
+  });
+
+  it("keeps the identity runtime mounted", () => {
+    const element = SharedNoteCommentDisplayRuntime({ shareToken: "share-token" });
+    expect(element.props.shareToken).toBe("share-token");
+  });
+});

--- a/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
+++ b/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShareComment } from "@/types";
 
 const mocks = vi.hoisted(() => ({
   getSharedComments: vi.fn(),
@@ -26,12 +27,22 @@ import SharedNoteCommentDisplayRuntime, {
   normalizeSharedCommentDisplayName,
 } from "../SharedNoteCommentDisplayRuntime";
 
-const BASE_COMMENT = {
+const NOW = new Date(0).toISOString();
+const BASE_COMMENT: ShareComment = {
   id: "comment-1",
   noteId: "note-1",
   userId: null,
+  displayName: undefined,
+  isGuest: true,
+  guestName: null,
+  username: null,
+  avatarUrl: null,
+  parentId: null,
   content: "test",
-  createdAt: new Date(0).toISOString(),
+  anchorData: null,
+  isResolved: 0,
+  createdAt: NOW,
+  updatedAt: NOW,
 };
 
 describe("SharedNoteCommentDisplayRuntime", () => {
@@ -44,7 +55,6 @@ describe("SharedNoteCommentDisplayRuntime", () => {
     mocks.getSharedComments.mockResolvedValue([
       {
         ...BASE_COMMENT,
-        username: null,
         guestName: "访客甲",
         displayName: "访客甲",
       },
@@ -59,7 +69,6 @@ describe("SharedNoteCommentDisplayRuntime", () => {
   it("projects the nickname immediately after an anonymous comment is added", async () => {
     mocks.addSharedComment.mockResolvedValue({
       ...BASE_COMMENT,
-      username: null,
       guestName: "访客乙",
       displayName: "访客乙",
     });
@@ -74,8 +83,11 @@ describe("SharedNoteCommentDisplayRuntime", () => {
   });
 
   it("falls back from displayName to guestName and finally 匿名", () => {
-    expect(normalizeSharedCommentDisplayName({ guestName: " 小王 " }).username).toBe("小王");
-    expect(normalizeSharedCommentDisplayName({}).username).toBe("匿名");
+    expect(normalizeSharedCommentDisplayName({
+      ...BASE_COMMENT,
+      guestName: " 小王 ",
+    }).username).toBe("小王");
+    expect(normalizeSharedCommentDisplayName(BASE_COMMENT).username).toBe("匿名");
   });
 
   it("keeps the identity runtime mounted", () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,11 +81,11 @@ export default defineConfig({
         find: /^@\/lib\/largeMarkdownSafety$/,
         replacement: path.resolve(__dirname, "./src/lib/largeMarkdownSafetyRuntime.ts"),
       },
-      // 公开分享评论：匿名访客首次评论前收集昵称，失效登录态按服务端结果回退重试。
-      // 壳组件通过相对路径加载原 SharedNoteView，避免精确别名递归。
+      // 公开分享评论：先收集匿名访客昵称，再把后端 displayName/guestName 投影到旧 username 展示字段。
+      // 壳组件通过相对路径串联身份与展示运行时，避免精确别名递归。
       {
         find: /^@\/components\/SharedNoteView$/,
-        replacement: path.resolve(__dirname, "./src/components/SharedNoteCommentIdentityRuntime.tsx"),
+        replacement: path.resolve(__dirname, "./src/components/SharedNoteCommentDisplayRuntime.tsx"),
       },
       // Issue #369 P2：在不侵入 EditorPane 主体的前提下增加事务化文档拆分入口。
       {


### PR DESCRIPTION
## 问题

公开评论接口已经正确保存并返回匿名访客的 `guestName`，同时返回计算字段 `displayName`。但 `SharedNoteView` 的旧评论 UI 仍只读取 `comment.username`，匿名访客的 `userId` 为 `NULL`，所以无论填写什么昵称，页面都显示“匿名”。

## 修复

- 新增公开评论展示运行时，在 API 边界把 `displayName / guestName` 投影到旧 UI 使用的 `username` 字段。
- 评论列表加载时统一修正已有评论的展示名称。
- 新评论提交成功后立即修正返回对象，无需刷新即可显示刚填写的昵称。
- 保留原有首次评论昵称弹窗和失效登录态回退逻辑。
- 增加已有评论、新增评论和匿名兜底回归测试，并纳入 Shared Comment CI。

## 预期结果

- 访客填写“小王”，评论卡片显示“小王”，不再显示“匿名”。
- 历史访客评论重新打开分享页后也按保存的昵称展示。
- 登录用户继续显示真实用户名。
- 没有任何身份字段的异常旧数据才回退显示“匿名”。