### PR TITLE
fix(micloud): prevent large Xiaomi note imports from being aborted

### DIFF
--- a/.github/workflows/micloud-import-ci.yml
+++ b/.github/workflows/micloud-import-ci.yml
@@ -1,0 +1,38 @@
+name: MiCloud Import CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/src/lib/miNoteService.ts"
+      - "frontend/src/lib/__tests__/miNoteService.test.ts"
+      - ".github/workflows/micloud-import-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/src/lib/miNoteService.ts"
+      - "frontend/src/lib/__tests__/miNoteService.test.ts"
+      - ".github/workflows/micloud-import-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: MiCloud import regression tests
+        run: npm run test:run -- src/lib/__tests__/miNoteService.test.ts
+      - name: Frontend typecheck
+        if: always()
+        run: npx tsc -b

--- a/frontend/src/lib/__tests__/miNoteService.test.ts
+++ b/frontend/src/lib/__tests__/miNoteService.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api", () => ({
+  api: {
+    miCloudVerify: vi.fn(),
+    miCloudNotes: vi.fn(),
+  },
+  getBaseUrl: () => "/api",
+}));
+
+import {
+  importMiNotes,
+  MI_CLOUD_IMPORT_BATCH_SIZE,
+  MI_CLOUD_IMPORT_BATCH_TIMEOUT_MS,
+} from "../miNoteService";
+
+function response(payload: unknown, status = 201): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe("importMiNotes", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue("test-token"),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("splits a large import into bounded batches and reuses the created notebook", async () => {
+    const requestBodies: Array<{ noteIds: string[]; notebookId?: string }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || "{}")) as {
+        noteIds: string[];
+        notebookId?: string;
+      };
+      requestBodies.push(body);
+      return response({
+        success: true,
+        count: body.noteIds.length,
+        notebookId: body.notebookId || "created-notebook",
+        errors: [],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const noteIds = Array.from(
+      { length: MI_CLOUD_IMPORT_BATCH_SIZE * 2 + 2 },
+      (_, index) => `note-${index}`,
+    );
+    const result = await importMiNotes("cookie", noteIds);
+
+    expect(result).toEqual({ success: true, count: noteIds.length, errors: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestBodies.map((body) => body.noteIds.length)).toEqual([
+      MI_CLOUD_IMPORT_BATCH_SIZE,
+      MI_CLOUD_IMPORT_BATCH_SIZE,
+      2,
+    ]);
+    expect(requestBodies[0].notebookId).toBeUndefined();
+    expect(requestBodies[1].notebookId).toBe("created-notebook");
+    expect(requestBodies[2].notebookId).toBe("created-notebook");
+
+    const firstRequest = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(firstRequest.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("reports how many notes were imported before a later batch fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({
+        success: true,
+        count: MI_CLOUD_IMPORT_BATCH_SIZE,
+        notebookId: "created-notebook",
+        errors: [],
+      }))
+      .mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const noteIds = Array.from(
+      { length: MI_CLOUD_IMPORT_BATCH_SIZE * 2 },
+      (_, index) => `note-${index}`,
+    );
+
+    await expect(importMiNotes("cookie", noteIds)).rejects.toThrow(
+      `已成功导入 ${MI_CLOUD_IMPORT_BATCH_SIZE} 条，剩余 ${MI_CLOUD_IMPORT_BATCH_SIZE} 条未完成。network down`,
+    );
+  });
+
+  it("turns a batch abort into an actionable import timeout message", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        }, { once: true });
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = importMiNotes("cookie", ["note-1"]);
+    const assertion = expect(pending).rejects.toThrow(
+      "当前批次导入超时。服务端可能仍在处理，请稍后刷新目标笔记本确认结果，避免重复导入。",
+    );
+
+    await vi.advanceTimersByTimeAsync(MI_CLOUD_IMPORT_BATCH_TIMEOUT_MS);
+    await assertion;
+  });
+
+  it("does not call the backend when no valid note IDs are selected", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(importMiNotes("cookie", ["", ""])).resolves.toEqual({
+      success: false,
+      count: 0,
+      errors: ["请选择要导入的笔记"],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/miNoteService.ts
+++ b/frontend/src/lib/miNoteService.ts
@@ -1,4 +1,4 @@
-import { api } from "./api";
+import { api, getBaseUrl } from "./api";
 
 export interface MiNoteEntry {
   id: string;
@@ -20,7 +20,20 @@ export interface MiCloudState {
   importedCount: number;
 }
 
+interface MiCloudImportBatchResponse {
+  success: boolean;
+  count: number;
+  notebookId?: string;
+  errors?: string[];
+}
+
 const MI_CLOUD_COOKIE_KEY = "mi-cloud-cookie";
+
+// 通用 API request() 会给 POST 请求设置 30 秒超时。小米云导入需要逐条拉取详情和图片，
+// 大批量导入不可能在 30 秒内完成，因此这里把一次大请求拆成多个短批次，并给每个
+// 批次独立的长任务超时。这样 600+ 条笔记也不会因为总耗时过长被 AbortController 中断。
+export const MI_CLOUD_IMPORT_BATCH_SIZE = 8;
+export const MI_CLOUD_IMPORT_BATCH_TIMEOUT_MS = 5 * 60 * 1000;
 
 // 保存 cookie 到 sessionStorage（不持久化到 localStorage，安全考虑）
 //
@@ -72,11 +85,118 @@ export async function fetchMiNotes(cookie: string): Promise<{
   };
 }
 
-// 导入选中的笔记
+function splitIntoImportBatches(noteIds: string[]): string[][] {
+  const batches: string[][] = [];
+  for (let index = 0; index < noteIds.length; index += MI_CLOUD_IMPORT_BATCH_SIZE) {
+    batches.push(noteIds.slice(index, index + MI_CLOUD_IMPORT_BATCH_SIZE));
+  }
+  return batches;
+}
+
+function readAuthToken(): string | null {
+  try {
+    return localStorage.getItem("nowen-token");
+  } catch {
+    return null;
+  }
+}
+
+async function importMiNoteBatch(
+  cookie: string,
+  noteIds: string[],
+  notebookId?: string,
+): Promise<MiCloudImportBatchResponse> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeoutId = globalThis.setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, MI_CLOUD_IMPORT_BATCH_TIMEOUT_MS);
+
+  try {
+    const token = readAuthToken();
+    const response = await fetch(`${getBaseUrl()}/micloud/import`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.nowen.internal-note+json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ cookie, noteIds, notebookId }),
+      signal: controller.signal,
+    });
+
+    const payload = (await response.json().catch(() => ({}))) as Partial<MiCloudImportBatchResponse> & {
+      error?: string;
+    };
+
+    if (!response.ok) {
+      throw new Error(payload.error || `小米笔记导入失败: ${response.status}`);
+    }
+
+    return {
+      success: payload.success !== false,
+      count: typeof payload.count === "number" ? payload.count : 0,
+      notebookId: typeof payload.notebookId === "string" ? payload.notebookId : undefined,
+      errors: Array.isArray(payload.errors) ? payload.errors : [],
+    };
+  } catch (error) {
+    const name = (error as { name?: string } | null)?.name;
+    if (timedOut || name === "AbortError") {
+      throw new Error(
+        "当前批次导入超时。服务端可能仍在处理，请稍后刷新目标笔记本确认结果，避免重复导入。",
+      );
+    }
+    throw error;
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+  }
+}
+
+// 导入选中的笔记。
+//
+// 后端接口会在响应前逐条读取小米云详情和图片。这里按固定小批次串行调用：
+// 1. 避免通用 POST 30 秒超时终止整个 600+ 条导入；
+// 2. 避免一次请求体和服务端内存过大；
+// 3. 第一批自动创建目标笔记本后，后续批次复用返回的 notebookId。
 export async function importMiNotes(
   cookie: string,
   noteIds: string[],
   notebookId?: string
 ): Promise<{ success: boolean; count: number; errors: string[] }> {
-  return api.miCloudImport(cookie, noteIds, notebookId);
+  const uniqueNoteIds = Array.from(new Set(noteIds.filter((id) => typeof id === "string" && id.length > 0)));
+  if (uniqueNoteIds.length === 0) {
+    return { success: false, count: 0, errors: ["请选择要导入的笔记"] };
+  }
+
+  const batches = splitIntoImportBatches(uniqueNoteIds);
+  const errors: string[] = [];
+  let importedCount = 0;
+  let processedCount = 0;
+  let targetNotebookId = notebookId;
+
+  for (const batch of batches) {
+    try {
+      const result = await importMiNoteBatch(cookie, batch, targetNotebookId);
+      importedCount += result.count;
+      processedCount += batch.length;
+      errors.push(...(result.errors || []));
+      if (!targetNotebookId && result.notebookId) {
+        targetNotebookId = result.notebookId;
+      }
+    } catch (error) {
+      const remainingCount = uniqueNoteIds.length - processedCount;
+      const reason = error instanceof Error ? error.message : String(error || "未知错误");
+      const prefix = importedCount > 0
+        ? `已成功导入 ${importedCount} 条，剩余 ${remainingCount} 条未完成。`
+        : "";
+      throw new Error(`${prefix}${reason}`);
+    }
+  }
+
+  return {
+    success: importedCount > 0,
+    count: importedCount,
+    errors,
+  };
 }


### PR DESCRIPTION
## 问题

导入数百条小米笔记时，前端通用 `request()` 会对 POST 请求应用 30 秒超时。后端需要逐条读取小米云详情和图片，导致请求被 `AbortController` 中止，并向用户显示 `signal is aborted without reason`。

## 修复

- 将一次大导入拆成每批 8 条的小批次，串行提交，避免整个 600+ 条导入共用一个 30 秒请求生命周期。
- 每批使用独立的 5 分钟长任务超时，并把原始 AbortError 转换为可操作的中文提示。
- 第一批自动创建“小米云笔记”后，后续批次复用后端返回的 `notebookId`，确保所有内容进入同一目标笔记本。
- 对输入 noteId 去重，避免同一次提交中重复导入。
- 中途失败时明确提示已成功数量和未完成数量，减少误判。

## 测试

新增 `miNoteService.test.ts`，覆盖：

- 大批量拆分与目标笔记本复用；
- 后续批次失败时的部分成功提示；
- 批次超时后的友好错误；
- 空选择不发起请求。

Fixes the Xiaomi Cloud import abort reported with 639 selected notes.