### PR TITLE
fix(micloud): isolate backend imports and prevent batch 500

### DIFF
--- a/.github/workflows/micloud-import-ci.yml
+++ b/.github/workflows/micloud-import-ci.yml
@@ -5,18 +5,46 @@ on:
     paths:
       - "frontend/src/lib/miNoteService.ts"
       - "frontend/src/lib/__tests__/miNoteService.test.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/runtime/micloud-import-hardening.ts"
+      - "backend/src/routes/micloud.ts"
+      - "backend/tests/micloud-import-hardening.test.ts"
       - ".github/workflows/micloud-import-ci.yml"
   push:
     branches: [main]
     paths:
       - "frontend/src/lib/miNoteService.ts"
       - "frontend/src/lib/__tests__/miNoteService.test.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/runtime/micloud-import-hardening.ts"
+      - "backend/src/routes/micloud.ts"
+      - "backend/tests/micloud-import-hardening.test.ts"
       - ".github/workflows/micloud-import-ci.yml"
 
 permissions:
   contents: read
 
 jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: MiCloud backend import regression tests
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/micloud-import-hardening.test.ts
+      - name: Backend typecheck
+        if: always()
+        run: npm run build:tsc
+
   frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/backend/src/index.hardened.ts
+++ b/backend/src/index.hardened.ts
@@ -7,6 +7,8 @@ import "./runtime/knowledge-tree-migration-bootstrap.js";
 import "./runtime/notebook-permission-management.js";
 // Install schema/route hardening before the main backend module evaluates.
 import "./runtime/task-stats-hardening.js";
+// Replace the fragile batch Xiaomi import with an isolated, idempotent route before /api/micloud mounts.
+import "./runtime/micloud-import-hardening.js";
 // Recover interrupted embedding jobs before the legacy worker starts polling.
 import "./runtime/embedding-queue-hardening.js";
 // Must load after task-stats-hardening so this wrapper registers selected-section splitting before

--- a/backend/src/runtime/micloud-import-hardening.ts
+++ b/backend/src/runtime/micloud-import-hardening.ts
@@ -192,7 +192,7 @@ function hardenImportedNote(noteId: string, userId: string, scope: NotebookScope
       db,
       noteId,
       actorUserId: userId,
-      reason: "import",
+      reason: "create",
       parentMode: "resource",
     });
   } catch (error) {

--- a/backend/src/runtime/micloud-import-hardening.ts
+++ b/backend/src/runtime/micloud-import-hardening.ts
@@ -1,0 +1,353 @@
+import crypto from "node:crypto";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { getDb } from "../db/schema.js";
+import { syncReferences as syncAttachmentReferences } from "../lib/attachmentRefs.js";
+import { extractSearchableText } from "../lib/searchIndex.js";
+import { hasPermission, resolveNotebookPermission } from "../middleware/acl.js";
+import { extractInlineBase64Images } from "../routes/attachments.js";
+import miCloudRouter from "../routes/micloud.js";
+import { synchronizeLegacyNoteHierarchy } from "../services/legacyKnowledgeHierarchy.js";
+
+const ROUTE_PATCH_FLAG = Symbol.for("nowen.micloudImportHardening.routePatch");
+const ROUTER_INSTALLED_FLAG = Symbol.for("nowen.micloudImportHardening.routerInstalled");
+const globals = globalThis as typeof globalThis & Record<symbol, boolean>;
+
+const SOURCE_TYPE = "xiaomi-note";
+const MAX_IMPORT_NOTE_IDS = 50;
+
+type LegacyImportPayload = {
+  success?: boolean;
+  count?: number;
+  notebookId?: string;
+  notes?: Array<{ id?: string; title?: string }>;
+  errors?: string[];
+  error?: string;
+};
+
+type NotebookScope = {
+  notebookId?: string;
+  workspaceId: string | null;
+  workspaceScope: string;
+};
+
+function ensureImportOriginSchema(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS note_import_origins (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      workspaceScope TEXT NOT NULL,
+      noteId TEXT NOT NULL,
+      sourceType TEXT NOT NULL,
+      externalId TEXT NOT NULL,
+      contentHash TEXT,
+      batchId TEXT,
+      importedAt TEXT NOT NULL DEFAULT (datetime('now')),
+      updatedAt TEXT,
+      metadata TEXT,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (noteId) REFERENCES notes(id) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_note_import_origins_scope_external
+      ON note_import_origins(userId, workspaceScope, sourceType, externalId);
+    CREATE INDEX IF NOT EXISTS idx_note_import_origins_note
+      ON note_import_origins(noteId);
+  `);
+}
+
+function normalizeNoteIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(
+    value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  )).slice(0, MAX_IMPORT_NOTE_IDS);
+}
+
+function safeErrorText(value: unknown, fallback: string): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return fallback;
+  return text.replace(/\s+/g, " ").slice(0, 500);
+}
+
+async function readLegacyPayload(response: Response): Promise<{ payload: LegacyImportPayload; raw: string }> {
+  const raw = await response.text();
+  if (!raw.trim()) return { payload: {}, raw: "" };
+  try {
+    return { payload: JSON.parse(raw) as LegacyImportPayload, raw };
+  } catch {
+    return { payload: {}, raw };
+  }
+}
+
+function resolveNotebookScope(notebookId: string | undefined, userId: string): NotebookScope | null {
+  if (!notebookId) {
+    return { notebookId: undefined, workspaceId: null, workspaceScope: "personal" };
+  }
+
+  const db = getDb();
+  const notebook = db.prepare(`
+    SELECT id, workspaceId, isDeleted
+    FROM notebooks
+    WHERE id = ?
+  `).get(notebookId) as { id: string; workspaceId: string | null; isDeleted: number } | undefined;
+  if (!notebook || notebook.isDeleted === 1) return null;
+
+  const { permission } = resolveNotebookPermission(notebookId, userId);
+  if (!hasPermission(permission, "write")) return null;
+
+  return {
+    notebookId,
+    workspaceId: notebook.workspaceId || null,
+    workspaceScope: notebook.workspaceId || "personal",
+  };
+}
+
+function findImportedOrigin(userId: string, scope: NotebookScope, externalId: string) {
+  return getDb().prepare(`
+    SELECT o.noteId, n.title, n.notebookId
+    FROM note_import_origins o
+    JOIN notes n ON n.id = o.noteId
+    WHERE o.userId = ?
+      AND o.workspaceScope = ?
+      AND o.sourceType = ?
+      AND o.externalId = ?
+    LIMIT 1
+  `).get(userId, scope.workspaceScope, SOURCE_TYPE, externalId) as
+    | { noteId: string; title: string; notebookId: string }
+    | undefined;
+}
+
+function recordImportedOrigin(
+  userId: string,
+  scope: NotebookScope,
+  externalId: string,
+  noteId: string,
+  title: string,
+): void {
+  getDb().prepare(`
+    INSERT INTO note_import_origins (
+      id, userId, workspaceId, workspaceScope, noteId,
+      sourceType, externalId, importedAt, metadata
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), ?)
+    ON CONFLICT(userId, workspaceScope, sourceType, externalId) DO UPDATE SET
+      noteId = excluded.noteId,
+      workspaceId = excluded.workspaceId,
+      importedAt = datetime('now'),
+      metadata = excluded.metadata
+  `).run(
+    crypto.randomUUID(),
+    userId,
+    scope.workspaceId,
+    scope.workspaceScope,
+    noteId,
+    SOURCE_TYPE,
+    externalId,
+    JSON.stringify({ title }),
+  );
+}
+
+function hardenImportedNote(noteId: string, userId: string, scope: NotebookScope): string[] {
+  const db = getDb();
+  const warnings: string[] = [];
+  const row = db.prepare(`
+    SELECT content, title
+    FROM notes
+    WHERE id = ? AND userId = ?
+  `).get(noteId, userId) as { content: string | null; title: string } | undefined;
+  if (!row) return ["导入结果已返回，但数据库中未找到对应笔记"];
+
+  let content = typeof row.content === "string" ? row.content : "<p></p>";
+
+  // 小米图片原先以内联 base64 落库。沿用普通笔记创建流程，把图片迁移为附件，
+  // 避免数百条导入把 SQLite 主表和 FTS 事务瞬间放大。
+  if (content.includes("data:image")) {
+    try {
+      const extracted = extractInlineBase64Images(content, userId, noteId, scope.workspaceId);
+      if (extracted.replacedCount > 0) content = extracted.content;
+    } catch (error) {
+      warnings.push(`图片附件化失败：${safeErrorText(error instanceof Error ? error.message : error, "未知错误")}`);
+    }
+  }
+
+  const contentText = extractSearchableText(content, "html");
+  db.prepare(`
+    UPDATE notes
+    SET content = ?, contentText = ?, contentFormat = 'html', workspaceId = ?
+    WHERE id = ? AND userId = ?
+  `).run(content, contentText, scope.workspaceId, noteId, userId);
+
+  if (content.includes("/api/attachments/")) {
+    try {
+      syncAttachmentReferences(db, noteId, content);
+    } catch (error) {
+      warnings.push(`附件引用索引失败：${safeErrorText(error instanceof Error ? error.message : error, "未知错误")}`);
+    }
+  }
+
+  try {
+    synchronizeLegacyNoteHierarchy({
+      db,
+      noteId,
+      actorUserId: userId,
+      reason: "import",
+      parentMode: "resource",
+    });
+  } catch (error) {
+    warnings.push(`目录索引同步失败：${safeErrorText(error instanceof Error ? error.message : error, "未知错误")}`);
+  }
+
+  return warnings;
+}
+
+async function invokeLegacySingleImport(
+  cookie: string,
+  externalId: string,
+  notebookId: string | undefined,
+  userId: string,
+): Promise<{ response: Response; payload: LegacyImportPayload; raw: string }> {
+  const response = await miCloudRouter.request("/import", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": userId,
+      "Accept": "application/json",
+    },
+    body: JSON.stringify({ cookie, noteIds: [externalId], notebookId }),
+  });
+  const parsed = await readLegacyPayload(response);
+  return { response, ...parsed };
+}
+
+async function hardenedMiCloudImport(c: Context) {
+  const userId = c.req.header("X-User-Id") || "";
+  if (!userId) return c.json({ error: "未授权", code: "UNAUTHENTICATED" }, 401);
+
+  const body = await c.req.json().catch(() => null) as
+    | { cookie?: unknown; noteIds?: unknown; notebookId?: unknown }
+    | null;
+  const cookie = typeof body?.cookie === "string" ? body.cookie.trim() : "";
+  const noteIds = normalizeNoteIds(body?.noteIds);
+  const requestedNotebookId = typeof body?.notebookId === "string" && body.notebookId.trim()
+    ? body.notebookId.trim()
+    : undefined;
+
+  if (!cookie) return c.json({ error: "缺少 Cookie", code: "COOKIE_REQUIRED" }, 400);
+  if (noteIds.length === 0) {
+    return c.json({ error: "请选择要导入的笔记", code: "NOTES_REQUIRED" }, 400);
+  }
+
+  ensureImportOriginSchema();
+  let scope = resolveNotebookScope(requestedNotebookId, userId);
+  if (!scope) {
+    return c.json({ error: "目标笔记本不存在、已删除或无写入权限", code: "NOTEBOOK_FORBIDDEN" }, 403);
+  }
+
+  const imported: Array<{ id: string; title: string }> = [];
+  const errors: string[] = [];
+  let skippedCount = 0;
+  let targetNotebookId = scope.notebookId;
+
+  // 旧实现把一个批次的所有 DB INSERT 放在同一事务中：任意一条旧笔记含异常字符、
+  // FTS 写入失败或附件过大，整个批次都会回滚并冒泡为纯文本 500。
+  // 这里按单条调用旧转换器，把故障隔离到具体笔记，其余笔记继续导入。
+  for (const externalId of noteIds) {
+    const existing = findImportedOrigin(userId, scope, externalId);
+    if (existing) {
+      skippedCount += 1;
+      targetNotebookId ||= existing.notebookId;
+      imported.push({ id: existing.noteId, title: existing.title });
+      continue;
+    }
+
+    try {
+      const { response, payload, raw } = await invokeLegacySingleImport(
+        cookie,
+        externalId,
+        targetNotebookId,
+        userId,
+      );
+
+      if (!response.ok || payload.success === false || !payload.notes?.[0]?.id) {
+        const detail = safeErrorText(
+          payload.error || raw,
+          `HTTP ${response.status}`,
+        );
+        errors.push(`笔记 ${externalId} 导入失败：${detail}`);
+        continue;
+      }
+
+      targetNotebookId ||= payload.notebookId;
+      const resolvedScope = resolveNotebookScope(targetNotebookId, userId);
+      if (!resolvedScope) {
+        errors.push(`笔记 ${externalId} 已写入，但无法确认目标笔记本权限`);
+        continue;
+      }
+      scope = resolvedScope;
+
+      const note = payload.notes[0];
+      const noteId = String(note.id);
+      const title = typeof note.title === "string" && note.title.trim()
+        ? note.title.trim()
+        : "未命名笔记";
+      const warnings = hardenImportedNote(noteId, userId, scope);
+      recordImportedOrigin(userId, scope, externalId, noteId, title);
+      imported.push({ id: noteId, title });
+
+      if (Array.isArray(payload.errors)) {
+        errors.push(...payload.errors.map((message) => `笔记 ${externalId}：${safeErrorText(message, "处理失败")}`));
+      }
+      errors.push(...warnings.map((message) => `笔记 ${externalId}：${message}`));
+    } catch (error) {
+      errors.push(
+        `笔记 ${externalId} 导入异常：${safeErrorText(error instanceof Error ? error.message : error, "未知错误")}`,
+      );
+    }
+  }
+
+  const acceptedCount = imported.length;
+  if (acceptedCount === 0) {
+    const firstError = errors[0] || "没有成功导入任何小米笔记";
+    return c.json({
+      success: false,
+      count: 0,
+      createdCount: 0,
+      skippedCount,
+      notebookId: targetNotebookId,
+      notes: [],
+      errors,
+      error: firstError,
+      code: "MICLOUD_IMPORT_FAILED",
+    }, 500);
+  }
+
+  return c.json({
+    success: true,
+    // 兼容现有前端：count 表示本批已成功处理数量，包含幂等跳过项。
+    count: acceptedCount,
+    createdCount: acceptedCount - skippedCount,
+    skippedCount,
+    notebookId: targetNotebookId,
+    notes: imported,
+    errors,
+  }, 201);
+}
+
+export function installMiCloudImportHardening(root: Hono<any>): void {
+  const taggedRoot = root as Hono<any> & Record<symbol, boolean>;
+  if (taggedRoot[ROUTER_INSTALLED_FLAG]) return;
+  taggedRoot[ROUTER_INSTALLED_FLAG] = true;
+  root.post("/api/micloud/import", hardenedMiCloudImport);
+}
+
+if (!globals[ROUTE_PATCH_FLAG]) {
+  globals[ROUTE_PATCH_FLAG] = true;
+  const prototype = Hono.prototype as any;
+  const nativeRoute = prototype.route as (this: Hono<any>, path: string, subApp: Hono<any>) => Hono<any>;
+  prototype.route = function patchedRoute(this: Hono<any>, path: string, subApp: Hono<any>) {
+    if (path === "/api/micloud") installMiCloudImportHardening(this);
+    return nativeRoute.call(this, path, subApp);
+  };
+}

--- a/backend/tests/micloud-import-hardening.test.ts
+++ b/backend/tests/micloud-import-hardening.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, test } from "node:test";
+import { Hono } from "hono";
+import { getDb, closeDb } from "../src/db/schema.js";
+import miCloudRouter from "../src/routes/micloud.js";
+import "../src/runtime/micloud-import-hardening.js";
+
+const USER_ID = "micloud-test-user";
+const originalFetch = globalThis.fetch;
+
+function resetDatabase(): void {
+  const db = getDb();
+  db.exec(`
+    DROP TRIGGER IF EXISTS micloud_test_fail_note;
+    DELETE FROM note_import_origins;
+    DELETE FROM notes;
+    DELETE FROM notebooks;
+    DELETE FROM users;
+  `);
+  db.prepare(`
+    INSERT INTO users (id, username, passwordHash, role)
+    VALUES (?, ?, ?, 'admin')
+  `).run(USER_ID, `micloud-${Date.now()}`, "test-password-hash");
+}
+
+function installMiCloudFetchMock(): void {
+  globalThis.fetch = async (input: string | URL | Request): Promise<Response> => {
+    const rawUrl = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    const url = new URL(rawUrl);
+    const match = url.pathname.match(/\/note\/note\/([^/]+)\/?$/);
+    if (!match) {
+      return new Response(JSON.stringify({ code: 0, data: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const noteId = decodeURIComponent(match[1]);
+    const title = noteId === "bad-note" ? "Bad note" : `Title ${noteId}`;
+    return new Response(JSON.stringify({
+      code: 0,
+      data: {
+        entry: {
+          id: noteId,
+          subject: title,
+          content: `<size>${title}</size>\n正文 ${noteId}`,
+          createDate: 1_420_070_400_000,
+          modifyDate: 1_420_070_460_000,
+        },
+      },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.route("/api/micloud", miCloudRouter);
+  return app;
+}
+
+async function importNotes(app: Hono, noteIds: string[]) {
+  const response = await app.request("/api/micloud/import", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-User-Id": USER_ID,
+    },
+    body: JSON.stringify({ cookie: "serviceToken=test", noteIds }),
+  });
+  const payload = await response.json() as any;
+  return { response, payload };
+}
+
+beforeEach(() => {
+  resetDatabase();
+  installMiCloudFetchMock();
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  closeDb();
+});
+
+test("isolates each Xiaomi note and stores imported content as HTML", async () => {
+  const app = createApp();
+  const { response, payload } = await importNotes(app, ["note-1", "note-2"]);
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.count, 2);
+  assert.equal(payload.createdCount, 2);
+  assert.equal(payload.skippedCount, 0);
+
+  const rows = getDb().prepare(`
+    SELECT title, contentFormat, workspaceId, contentText
+    FROM notes
+    ORDER BY title
+  `).all() as Array<{
+    title: string;
+    contentFormat: string;
+    workspaceId: string | null;
+    contentText: string;
+  }>;
+  assert.equal(rows.length, 2);
+  assert.ok(rows.every((row) => row.contentFormat === "html"));
+  assert.ok(rows.every((row) => row.workspaceId === null));
+  assert.ok(rows.every((row) => row.contentText.includes("正文")));
+
+  const originCount = getDb().prepare(
+    "SELECT COUNT(*) AS count FROM note_import_origins WHERE sourceType = 'xiaomi-note'",
+  ).get() as { count: number };
+  assert.equal(originCount.count, 2);
+});
+
+test("retries are idempotent and do not duplicate already imported Xiaomi notes", async () => {
+  const app = createApp();
+  const first = await importNotes(app, ["note-1", "note-2"]);
+  assert.equal(first.response.status, 201);
+
+  const second = await importNotes(app, ["note-1", "note-2"]);
+  assert.equal(second.response.status, 201);
+  assert.equal(second.payload.count, 2);
+  assert.equal(second.payload.createdCount, 0);
+  assert.equal(second.payload.skippedCount, 2);
+
+  const row = getDb().prepare("SELECT COUNT(*) AS count FROM notes").get() as { count: number };
+  assert.equal(row.count, 2);
+});
+
+test("one database failure no longer rolls back the other notes or returns a plain batch 500", async () => {
+  const db = getDb();
+  db.exec(`
+    CREATE TRIGGER micloud_test_fail_note
+    BEFORE INSERT ON notes
+    WHEN NEW.title = 'Bad note'
+    BEGIN
+      SELECT RAISE(ABORT, 'forced Xiaomi note failure');
+    END;
+  `);
+
+  const app = createApp();
+  const { response, payload } = await importNotes(app, ["good-note", "bad-note"]);
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.count, 1);
+  assert.equal(payload.createdCount, 1);
+  assert.equal(payload.errors.length, 1);
+  assert.match(payload.errors[0], /bad-note/);
+
+  const notes = db.prepare("SELECT title FROM notes ORDER BY title").all() as Array<{ title: string }>;
+  assert.deepEqual(notes.map((row) => row.title), ["Title good-note"]);
+});


### PR DESCRIPTION
## 问题

前端已经把 639 条小米笔记拆成小批次，但后端 `/api/micloud/import` 仍会把一个批次内的所有笔记放进同一 SQLite 事务。任意一条旧笔记在 FTS、附件或字段写入阶段异常，整个批次都会回滚；异常没有被路由捕获，Hono 最终只返回纯文本 `500 Internal Server Error`。

## 修复

- 在 hardened 入口提前挂载新的 `/api/micloud/import` 处理器。
- 每条小米笔记独立调用原转换器和数据库事务，单条失败不再拖垮整个批次。
- 部分成功时返回 `201 + errors[]`，让前端继续导入后续批次；全部失败时返回结构化 JSON 500，不再返回无信息的纯文本错误。
- 使用 `note_import_origins` 记录小米笔记源 ID，重复导入会幂等跳过，避免前面批次成功后重试产生重复笔记。
- 导入成功后把内容格式修正为 `html`，重新派生 `contentText`，同步工作区和目录索引。
- 将内联 base64 图片迁移为附件，避免批量导入持续膨胀 SQLite 主表。
- 校验目标笔记本存在、未删除且当前用户拥有写权限。

## 测试

新增后端回归测试，覆盖：

1. 普通小米笔记成功导入并保存为 HTML；
2. 重试不会重复创建笔记；
3. 人工制造其中一条数据库写入失败时，其他笔记仍成功，不再出现整批纯文本 500。

同时扩展 `MiCloud Import CI`，执行后端专项测试、后端类型检查、原前端测试和前端类型检查。