### PR TITLE
fix(micloud): avoid stale notebook scope causing per-note 500

### DIFF
--- a/backend/src/runtime/micloud-import-hardening.ts
+++ b/backend/src/runtime/micloud-import-hardening.ts
@@ -7,13 +7,18 @@ import { extractSearchableText } from "../lib/searchIndex.js";
 import { hasPermission, resolveNotebookPermission } from "../middleware/acl.js";
 import { extractInlineBase64Images } from "../routes/attachments.js";
 import miCloudRouter from "../routes/micloud.js";
-import { synchronizeLegacyNoteHierarchy } from "../services/legacyKnowledgeHierarchy.js";
+import {
+  synchronizeLegacyNoteHierarchy,
+  synchronizeLegacyNotebookHierarchy,
+} from "../services/legacyKnowledgeHierarchy.js";
 
 const ROUTE_PATCH_FLAG = Symbol.for("nowen.micloudImportHardening.routePatch");
 const ROUTER_INSTALLED_FLAG = Symbol.for("nowen.micloudImportHardening.routerInstalled");
+const LEGACY_ERROR_HANDLER_FLAG = Symbol.for("nowen.micloudImportHardening.legacyErrorHandler");
 const globals = globalThis as typeof globalThis & Record<symbol, boolean>;
 
 const SOURCE_TYPE = "xiaomi-note";
+const DEFAULT_NOTEBOOK_NAME = "小米云笔记";
 const MAX_IMPORT_NOTE_IDS = 50;
 
 type LegacyImportPayload = {
@@ -23,10 +28,11 @@ type LegacyImportPayload = {
   notes?: Array<{ id?: string; title?: string }>;
   errors?: string[];
   error?: string;
+  code?: string;
 };
 
 type NotebookScope = {
-  notebookId?: string;
+  notebookId: string;
   workspaceId: string | null;
   workspaceScope: string;
 };
@@ -72,6 +78,12 @@ function safeErrorText(value: unknown, fallback: string): string {
   return text.replace(/\s+/g, " ").slice(0, 500);
 }
 
+function errorCode(value: unknown, fallback: string): string {
+  if (!value || typeof value !== "object") return fallback;
+  const code = (value as { code?: unknown }).code;
+  return typeof code === "string" && code.trim() ? code.trim().slice(0, 100) : fallback;
+}
+
 async function readLegacyPayload(response: Response): Promise<{ payload: LegacyImportPayload; raw: string }> {
   const raw = await response.text();
   if (!raw.trim()) return { payload: {}, raw: "" };
@@ -82,11 +94,7 @@ async function readLegacyPayload(response: Response): Promise<{ payload: LegacyI
   }
 }
 
-function resolveNotebookScope(notebookId: string | undefined, userId: string): NotebookScope | null {
-  if (!notebookId) {
-    return { notebookId: undefined, workspaceId: null, workspaceScope: "personal" };
-  }
-
+function resolveNotebookScope(notebookId: string, userId: string): NotebookScope | null {
   const db = getDb();
   const notebook = db.prepare(`
     SELECT id, workspaceId, isDeleted
@@ -95,6 +103,16 @@ function resolveNotebookScope(notebookId: string | undefined, userId: string): N
   `).get(notebookId) as { id: string; workspaceId: string | null; isDeleted: number } | undefined;
   if (!notebook || notebook.isDeleted === 1) return null;
 
+  // 旧数据可能存在业务笔记本行但缺少统一内容树节点。先做一次幂等修复，
+  // 否则 notes 的知识树 INSERT 守卫会在写入时统一抛 500。
+  synchronizeLegacyNotebookHierarchy({
+    db,
+    notebookId,
+    actorUserId: userId,
+    reason: "metadata",
+    parentMode: "resource",
+  });
+
   const { permission } = resolveNotebookPermission(notebookId, userId);
   if (!hasPermission(permission, "write")) return null;
 
@@ -102,6 +120,48 @@ function resolveNotebookScope(notebookId: string | undefined, userId: string): N
     notebookId,
     workspaceId: notebook.workspaceId || null,
     workspaceScope: notebook.workspaceId || "personal",
+  };
+}
+
+function ensureDefaultPersonalNotebook(userId: string): NotebookScope {
+  const db = getDb();
+  const notebookId = db.transaction(() => {
+    // 必须限定个人空间且排除软删除记录。旧实现只按 userId + name 查询，
+    // 可能误选同名工作区笔记本或回收站里的笔记本，随后 notes.workspaceId=NULL
+    // 与父节点 scope 不一致，知识树守卫会让每一条导入都报 500。
+    let existing = db.prepare(`
+      SELECT id
+      FROM notebooks
+      WHERE userId = ?
+        AND workspaceId IS NULL
+        AND isDeleted = 0
+        AND name = ?
+      ORDER BY createdAt ASC, id ASC
+      LIMIT 1
+    `).get(userId, DEFAULT_NOTEBOOK_NAME) as { id: string } | undefined;
+
+    if (!existing) {
+      existing = { id: crypto.randomUUID() };
+      db.prepare(`
+        INSERT INTO notebooks (id, userId, workspaceId, name, icon)
+        VALUES (?, ?, NULL, ?, '📱')
+      `).run(existing.id, userId, DEFAULT_NOTEBOOK_NAME);
+    }
+
+    synchronizeLegacyNotebookHierarchy({
+      db,
+      notebookId: existing.id,
+      actorUserId: userId,
+      reason: "metadata",
+      parentMode: "resource",
+    });
+    return existing.id;
+  })();
+
+  return {
+    notebookId,
+    workspaceId: null,
+    workspaceScope: "personal",
   };
 }
 
@@ -205,7 +265,7 @@ function hardenImportedNote(noteId: string, userId: string, scope: NotebookScope
 async function invokeLegacySingleImport(
   cookie: string,
   externalId: string,
-  notebookId: string | undefined,
+  notebookId: string,
   userId: string,
 ): Promise<{ response: Response; payload: LegacyImportPayload; raw: string }> {
   const response = await miCloudRouter.request("/import", {
@@ -240,9 +300,20 @@ async function hardenedMiCloudImport(c: Context) {
   }
 
   ensureImportOriginSchema();
-  let scope = resolveNotebookScope(requestedNotebookId, userId);
-  if (!scope) {
-    return c.json({ error: "目标笔记本不存在、已删除或无写入权限", code: "NOTEBOOK_FORBIDDEN" }, 403);
+  let scope: NotebookScope;
+  try {
+    const resolved = requestedNotebookId
+      ? resolveNotebookScope(requestedNotebookId, userId)
+      : ensureDefaultPersonalNotebook(userId);
+    if (!resolved) {
+      return c.json({ error: "目标笔记本不存在、已删除或无写入权限", code: "NOTEBOOK_FORBIDDEN" }, 403);
+    }
+    scope = resolved;
+  } catch (error) {
+    const code = errorCode(error, "MICLOUD_NOTEBOOK_PREPARE_FAILED");
+    const detail = safeErrorText(error instanceof Error ? error.message : error, "目标笔记本初始化失败");
+    console.error("[micloud/import] prepare notebook failed", { userId, code, detail });
+    return c.json({ error: `目标笔记本初始化失败：${detail}`, code }, 500);
   }
 
   const imported: Array<{ id: string; title: string }> = [];
@@ -257,7 +328,6 @@ async function hardenedMiCloudImport(c: Context) {
     const existing = findImportedOrigin(userId, scope, externalId);
     if (existing) {
       skippedCount += 1;
-      targetNotebookId ||= existing.notebookId;
       imported.push({ id: existing.noteId, title: existing.title });
       continue;
     }
@@ -275,11 +345,11 @@ async function hardenedMiCloudImport(c: Context) {
           payload.error || raw,
           `HTTP ${response.status}`,
         );
-        errors.push(`笔记 ${externalId} 导入失败：${detail}`);
+        const suffix = payload.code ? ` [${payload.code}]` : "";
+        errors.push(`笔记 ${externalId} 导入失败：${detail}${suffix}`);
         continue;
       }
 
-      targetNotebookId ||= payload.notebookId;
       const resolvedScope = resolveNotebookScope(targetNotebookId, userId);
       if (!resolvedScope) {
         errors.push(`笔记 ${externalId} 已写入，但无法确认目标笔记本权限`);
@@ -335,12 +405,25 @@ async function hardenedMiCloudImport(c: Context) {
   }, 201);
 }
 
+function installLegacyErrorHandler(): void {
+  if (globals[LEGACY_ERROR_HANDLER_FLAG]) return;
+  globals[LEGACY_ERROR_HANDLER_FLAG] = true;
+  miCloudRouter.onError((error, c) => {
+    const code = errorCode(error, "MICLOUD_LEGACY_IMPORT_FAILED");
+    const detail = safeErrorText(error instanceof Error ? error.message : error, "小米笔记写入失败");
+    console.error("[micloud/import] legacy route failed", { code, detail });
+    return c.json({ success: false, error: detail, code }, 500);
+  });
+}
+
 export function installMiCloudImportHardening(root: Hono<any>): void {
   const taggedRoot = root as Hono<any> & Record<symbol, boolean>;
   if (taggedRoot[ROUTER_INSTALLED_FLAG]) return;
   taggedRoot[ROUTER_INSTALLED_FLAG] = true;
   root.post("/api/micloud/import", hardenedMiCloudImport);
 }
+
+installLegacyErrorHandler();
 
 if (!globals[ROUTE_PATCH_FLAG]) {
   globals[ROUTE_PATCH_FLAG] = true;

--- a/backend/tests/micloud-import-hardening.test.ts
+++ b/backend/tests/micloud-import-hardening.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, beforeEach, test } from "node:test";
 import { Hono } from "hono";
+import "../src/runtime/knowledge-tree-migration-bootstrap.js";
 import { getDb, closeDb } from "../src/db/schema.js";
 import miCloudRouter from "../src/routes/micloud.js";
 import "../src/runtime/micloud-import-hardening.js";
@@ -119,6 +120,39 @@ test("isolates each Xiaomi note and stores imported content as HTML", async () =
   assert.equal(originCount.count, 2);
 });
 
+test("ignores a deleted Xiaomi notebook and creates a new active personal target", async () => {
+  const db = getDb();
+  const deletedNotebookId = "deleted-xiaomi-notebook";
+  db.prepare(`
+    INSERT INTO notebooks (id, userId, workspaceId, name, icon, isDeleted, deletedAt)
+    VALUES (?, ?, NULL, '小米云笔记', '📱', 1, datetime('now'))
+  `).run(deletedNotebookId, USER_ID);
+
+  const app = createApp();
+  const { response, payload } = await importNotes(app, ["note-after-delete"]);
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.createdCount, 1);
+  assert.notEqual(payload.notebookId, deletedNotebookId);
+
+  const activeNotebooks = db.prepare(`
+    SELECT id, workspaceId, isDeleted
+    FROM notebooks
+    WHERE userId = ? AND name = '小米云笔记' AND isDeleted = 0
+  `).all(USER_ID) as Array<{ id: string; workspaceId: string | null; isDeleted: number }>;
+  assert.equal(activeNotebooks.length, 1);
+  assert.equal(activeNotebooks[0].workspaceId, null);
+
+  const note = db.prepare(`
+    SELECT notebookId, workspaceId
+    FROM notes
+    WHERE title = 'Title note-after-delete'
+  `).get() as { notebookId: string; workspaceId: string | null };
+  assert.equal(note.notebookId, activeNotebooks[0].id);
+  assert.equal(note.workspaceId, null);
+});
+
 test("retries are idempotent and do not duplicate already imported Xiaomi notes", async () => {
   const app = createApp();
   const first = await importNotes(app, ["note-1", "note-2"]);
@@ -154,6 +188,7 @@ test("one database failure no longer rolls back the other notes or returns a pla
   assert.equal(payload.createdCount, 1);
   assert.equal(payload.errors.length, 1);
   assert.match(payload.errors[0], /bad-note/);
+  assert.match(payload.errors[0], /forced Xiaomi note failure/);
 
   const notes = db.prepare("SELECT title FROM notes ORDER BY title").all() as Array<{ title: string }>;
   assert.deepEqual(notes.map((row) => row.title), ["Title good-note"]);


### PR DESCRIPTION
## 复现

PR #555 已经把批次拆成单条隔离，因此接口不再整批回滚，但生产环境仍然出现每条笔记都返回 `Internal Server Error`。

根因是默认目标笔记本的选择仍沿用旧逻辑：只按 `userId + name='小米云笔记'` 查询，没有限定个人空间，也没有排除软删除记录。数据库里只要存在同名工作区笔记本或回收站笔记本，旧导入器就会把个人空间笔记写到错误父节点。知识树运行期守卫检测到 `notes.workspaceId` 与父节点 scope 不一致后，统一抛出 500。

之前的专项测试没有加载生产知识树迁移，因此没有覆盖这个场景。

## 修复

- 未指定目标笔记本时，在进入旧转换器之前主动准备一个有效的个人空间“小米云笔记”。
- 默认笔记本查询增加 `workspaceId IS NULL`、`isDeleted = 0`，避免命中工作区或回收站同名记录。
- 新建或复用目标笔记本后，幂等修复统一内容树节点，再传明确的 `notebookId` 给旧导入器。
- 指定目标笔记本时同样先修复知识树节点并校验写权限。
- 给旧 MiCloud 子路由增加结构化错误处理，后续数据库异常会返回真实错误码和消息，不再只显示 `Internal Server Error`。

## 回归测试

- 测试启动时加载生产知识树迁移与运行期守卫。
- 新增“同名默认笔记本已软删除”的回归场景，确认会创建新的有效个人笔记本并成功导入。
- 单条数据库失败场景现在同时断言响应包含真实 SQLite 错误，而非纯文本 500。
