### PR TITLE
ci(pg): trigger latest main merge

### DIFF
--- a/.github/workflows/pg-main-merge-command.yml
+++ b/.github/workflows/pg-main-merge-command.yml
@@ -42,3 +42,5 @@ jobs:
           test -z "$(git diff --name-only --diff-filter=U)"
           git commit -m "chore(pg): merge latest main after structure migration"
           git push origin HEAD:pg-migration-unified
+
+# Trigger latest main merge.


### PR DESCRIPTION
临时触发 PostgreSQL 迁移分支与最新 main 的双父合并。工作流会保留迁移分支 hardening 入口、带入小米云导入实现，并把 workflow 文件交给 GitHub 连接器单独同步。本 PR 不合并。