### PR TITLE
docs(mcp): restore installation entry and complete setup guides

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,6 +11,7 @@
     <a href="http://note.nowen.cn/">Live Demo</a> ·
     <a href="https://github.com/cropflre/nowen-note/releases">Downloads</a> ·
     <a href="./docs/tutorials/README.md">Tutorials</a> ·
+    <a href="./docs/tutorials/mcp.en.md">MCP Installation</a> ·
     <a href="./CHANGELOG.md">Changelog</a>
   </p>
 </div>
@@ -26,6 +27,16 @@
 </div>
 
 > Nowen Note is more than an editor. It is designed as user-controlled knowledge infrastructure that can run long-term on a NAS or server and remain accessible from the web, desktop, and mobile clients.
+
+## Connect AI clients to Nowen Note
+
+Nowen Note still includes a supported MCP Server. Claude Code, Cursor, VS Code, and other compatible AI clients can search, read, create, and update notes within the permissions granted by your account and token.
+
+- [MCP Server installation guide](./docs/tutorials/mcp.en.md)
+- [中文安装教程](./docs/tutorials/mcp.md)
+- [Standalone nowen-mcp package README](./packages/nowen-mcp/README.md)
+
+The currently supported distribution is a source build: install Node.js 20+, build `packages/nowen-mcp`, create a restricted Personal API Token in Nowen Note, and configure the absolute path to `dist/scoped-entry.js` in your client. The guide covers Windows, macOS, Linux/WSL, NAS addresses, Claude Code, Cursor, VS Code, verification, updates, and troubleshooting.
 
 ## Why Nowen Note
 
@@ -53,7 +64,7 @@
 | **Import, export, and migration** | Import Markdown, Word/DOCX, web URLs, WeChat articles, SingleFile HTML, SiYuan ZIP archives, and Callouts. Export Markdown, PDF, Word, images, or full ZIP packages with permission mapping, conflict preview, reports, and controlled rollback. Exported notes include `contentFormat` so re-import can restore the original editor format. |
 | **Attachments and storage** | Local attachments organized under `YYYY/MM`; reuse existing files from the attachment library and insert portable relative links; thumbnails, note ownership, reference checks, orphan rescans and cleanup; local disk or S3/R2/MinIO storage. |
 | **Accounts and security** | Multiple-account history, remembered accounts, auto-login, remote server connections, session validation and revocation, 2FA, scoped Personal API Tokens, audit logs, and protected attachment access. |
-| **Backups, automation, and developer APIs** | Local backups, full ZIP backups, email backup, encrypted WebDAV backup credentials, managed Docker updates and rollback checks, webhooks, plugins, OpenAPI, TypeScript SDK, CLI, MCP Server, and a browser clipper. |
+| **Backups, automation, and developer APIs** | Local backups, full ZIP backups, email backup, encrypted WebDAV backup credentials, managed Docker updates and rollback checks, webhooks, plugins, OpenAPI, TypeScript SDK, CLI, [MCP Server](./docs/tutorials/mcp.en.md), and a browser clipper. |
 | **Cross-platform access** | Web, Electron for Windows/macOS/Linux, Android, iOS project, HarmonyOS project, and Docker/NAS deployment. Mobile includes Markdown import, recent-first navigation, step-by-step browsing, tree mode, and an optional compact density setting. |
 
 ## Recent highlights
@@ -295,6 +306,8 @@ nowen-note/
 
 ## Documentation
 
+- [MCP Server installation and usage](./docs/tutorials/mcp.en.md)
+- [MCP Server 中文安装教程](./docs/tutorials/mcp.md)
 - [Tutorial center](./docs/tutorials/README.md)
 - [Feature documentation](http://nowen.cn/docs/nowen-note-features)
 - [Installation and troubleshooting](http://nowen.cn/docs/nowen-note-help)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     <a href="http://note.nowen.cn/">在线体验</a> ·
     <a href="https://github.com/cropflre/nowen-note/releases">下载客户端</a> ·
     <a href="./docs/tutorials/README.md">教程中心</a> ·
+    <a href="./docs/tutorials/mcp.md">MCP 安装</a> ·
     <a href="./CHANGELOG.md">更新日志</a>
   </p>
 </div>
@@ -26,6 +27,16 @@
 </div>
 
 > Nowen Note 不只是一个编辑器。它希望成为一套由你掌控数据、可长期运行在 NAS / 服务器上，并能通过 Web、桌面端和移动端随时访问的个人与团队知识基础设施。
+
+## 让 AI 连接 Nowen Note
+
+Nowen Note 仍然完整支持 MCP Server，可让 Claude Code、Cursor、VS Code 等 AI 客户端在授权范围内搜索、读取、创建和更新笔记。
+
+- [MCP Server 中文安装教程](./docs/tutorials/mcp.md)
+- [MCP Server English guide](./docs/tutorials/mcp.en.md)
+- [nowen-mcp 独立包说明](./packages/nowen-mcp/README.md)
+
+当前正式可用方式为源码构建：安装 Node.js 20+，构建 `packages/nowen-mcp`，在 Nowen Note 创建 restricted Personal API Token，再把 `dist/scoped-entry.js` 的绝对路径配置到客户端。教程已覆盖 Windows、macOS、Linux / WSL、NAS 地址、Claude Code、Cursor、VS Code、连接验证、升级和排障。
 
 ## 为什么选择 Nowen Note
 
@@ -53,7 +64,7 @@
 | **导入、导出与迁移** | 支持 Markdown、Word / DOCX、网页 URL、微信公众号文章、SingleFile HTML、思源 ZIP 与 Callout 等导入路径；支持 Markdown、PDF、Word、图片和完整 ZIP 导出，并提供权限映射、冲突预检、报告与受控撤销。导出内容会记录 `contentFormat`，重新导入时可恢复原编辑格式。 |
 | **附件与存储** | 本地附件按 `YYYY/MM` 归档；编辑器可从文件管理器搜索并复用已有附件，插入可迁移的相对链接；支持缩略图、笔记归属、引用检查、孤儿重新扫描 / 清理，可使用本地磁盘或 S3 / R2 / MinIO。 |
 | **账号与安全** | 多账号登录历史、记住账号 / 自动登录、远程服务连接、会话有效性校验与撤销、2FA、Personal API Token 权限范围、审计日志与安全化附件访问。 |
-| **备份、自动化与开放能力** | 本地自动备份、完整 ZIP、邮件备份、凭据加密的 WebDAV 远程备份、Docker 在线升级与回滚检查、Webhook、插件系统、OpenAPI、TypeScript SDK、CLI、MCP Server 与浏览器剪藏扩展。 |
+| **备份、自动化与开放能力** | 本地自动备份、完整 ZIP、邮件备份、凭据加密的 WebDAV 远程备份、Docker 在线升级与回滚检查、Webhook、插件系统、OpenAPI、TypeScript SDK、CLI、[MCP Server](./docs/tutorials/mcp.md) 与浏览器剪藏扩展。 |
 | **多端访问** | Web、Electron（Windows / macOS / Linux）、Android、iOS 工程、HarmonyOS 工程，以及 Docker / NAS 部署；移动端支持 Markdown 导入、最近优先、逐层目录、树形目录和可切换紧凑模式。 |
 
 ## 近期重点增强
@@ -295,6 +306,8 @@ nowen-note/
 
 ## 文档导航
 
+- [MCP Server 安装与使用](./docs/tutorials/mcp.md)
+- [MCP Server installation guide](./docs/tutorials/mcp.en.md)
 - [教程与帮助中心](./docs/tutorials/README.md)
 - [官网功能帮助中心](http://nowen.cn/docs/nowen-note-features)
 - [官网安装与问题解答](http://nowen.cn/docs/nowen-note-help)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -2,7 +2,17 @@
 
 > 面向普通用户、NAS 用户、团队管理员和开发者的统一文档入口。
 
-[官方网站](http://nowen.cn/) · [在线体验](http://note.nowen.cn/) · [客户端下载](https://github.com/cropflre/nowen-note/releases) · [问题反馈](https://github.com/cropflre/nowen-note/issues)
+[官方网站](http://nowen.cn/) · [在线体验](http://note.nowen.cn/) · [客户端下载](https://github.com/cropflre/nowen-note/releases) · [MCP 安装](./mcp.md) · [问题反馈](https://github.com/cropflre/nowen-note/issues)
+
+## MCP 快速入口
+
+需要让 Claude Code、Cursor、VS Code 等 AI 客户端访问 Nowen Note？直接阅读：
+
+- [MCP Server 安装与使用教程](./mcp.md)
+- [MCP Server installation guide](./mcp.en.md)
+- [nowen-mcp 独立包说明](../../packages/nowen-mcp/README.md)
+
+教程包含 Node.js 安装、源码构建、Personal API Token、Windows / macOS / Linux 路径、Claude Code / Cursor / VS Code 配置、连接验证、升级和常见错误排查。
 
 ## 在线帮助中心
 
@@ -24,7 +34,8 @@
 | **部署到 NAS / 服务器** | [Docker 部署](./docker-deploy.md) → [NAS 部署](./nas-deploy.md) → [备份与迁移](./backup-migrate.md) |
 | **高效写作和整理知识** | [富文本编辑器](./editor-rich-text.md) → [Markdown 编辑器](./editor-markdown.md) → [标签与收藏](./tags-favorites.md) → [搜索](./search.md) |
 | **团队协作与公开发布** | [工作区](./workspace.md) → [实时协作](./realtime-collab.md) → [分享与权限](./sharing.md) |
-| **接入 AI 和自动化** | [AI 配置](./ai-setup.md) → [AI 知识问答](./ai-rag.md) → [API](./api.md) → [MCP](./mcp.md) |
+| **让 AI 客户端操作笔记** | [MCP 5 分钟安装](./mcp.md) → 创建 restricted Token → 配置客户端 → 验证工具 |
+| **接入其他自动化** | [API](./api.md) → [SDK](./sdk.md) → [CLI](./cli.md) → [Webhook](./webhook.md) |
 
 ---
 
@@ -125,14 +136,14 @@ Nowen Note 还支持把笔记本发布为公开知识空间，并按目录继承
 
 | 教程 | 内容 |
 |---|---|
+| [MCP Server（中文）](./mcp.md) / [English](./mcp.en.md) | Claude Code、Cursor、VS Code 等客户端的完整安装、配置、验证与排障 |
 | [OpenAPI](./api.md) | REST API、鉴权和接口调试 |
 | [TypeScript SDK](./sdk.md) | 在 Node.js / TypeScript 中调用 Nowen Note |
 | [CLI](./cli.md) | 命令行管理笔记、附件和其他资源 |
-| [MCP Server](./mcp.md) | 让支持 MCP 的 AI 客户端访问知识库 |
 | [Webhook](./webhook.md) | 事件通知和外部工作流 |
 | [浏览器剪藏](./clipper.md) | 从 Chrome / Edge 保存网页内容 |
 
-Personal API Token 支持权限范围和笔记本资源范围。自动化场景应遵循最小权限原则，不要把管理员 Token 写入公开脚本。
+Personal API Token 支持权限范围和笔记本资源范围。自动化场景应遵循最小权限原则，不要把管理员 Token 或真实 API Token 写入公开脚本和仓库配置。
 
 ## 10. 常见问题
 
@@ -151,5 +162,6 @@ Personal API Token 支持权限范围和笔记本资源范围。自动化场景�
 
 - 教程内容以 `main` 分支当前实现和最新稳定 Release 为准，不再绑定某个过期版本号。
 - 新功能应同时更新仓库教程入口和 `nowen-blog` 官网帮助中心。
+- MCP 的安装路径、客户端配置格式和 Token 安全要求发生变化时，应同步更新 `mcp.md`、`mcp.en.md`、根 README 和 `packages/nowen-mcp/README.md`。
 - 安装包、平台支持范围和版本号以 [GitHub Releases](https://github.com/cropflre/nowen-note/releases) 为准。
 - 发现过期步骤或错误链接，请直接提交 [Issue](https://github.com/cropflre/nowen-note/issues)。

--- a/docs/tutorials/mcp.en.md
+++ b/docs/tutorials/mcp.en.md
@@ -1,0 +1,379 @@
+# MCP Server installation and usage
+
+> Connect Claude Code, Cursor, VS Code, and other MCP clients to Nowen Note so they can search, read, and maintain notes within the permissions you grant.
+
+[Back to tutorials](./README.md) · [简体中文](./mcp.md) · [Package README](../../packages/nowen-mcp/README.md)
+
+## What you need to know
+
+- MCP support is still available under `packages/nowen-mcp/`.
+- The repository currently provides a **source installation**. Install Node.js 20+, Git, and npm first.
+- Replace every `/absolute/path/...` placeholder with the real absolute path on your computer.
+- When Nowen Note runs on a NAS or another server, `NOWEN_URL` must be reachable from the computer running the AI client, for example `http://192.168.1.20:3001`.
+- Use a dedicated restricted Personal API Token instead of storing an administrator password in the MCP configuration.
+
+## Five-minute setup
+
+### 1. Verify the Nowen Note server
+
+Open the server from the same computer that runs your MCP client:
+
+```text
+http://192.168.1.20:3001
+```
+
+Use `http://localhost:3001` only when Nowen Note runs on that same computer.
+
+### 2. Check prerequisites
+
+```bash
+node --version
+npm --version
+git --version
+```
+
+Node.js must be version 20 or newer.
+
+### 3. Clone and build the MCP server
+
+#### Windows PowerShell
+
+```powershell
+git clone https://github.com/cropflre/nowen-note.git
+cd nowen-note\packages\nowen-mcp
+npm install
+npm run build
+Test-Path .\dist\scoped-entry.js
+```
+
+The final command must return `True`.
+
+#### macOS / Linux / WSL
+
+```bash
+git clone https://github.com/cropflre/nowen-note.git
+cd nowen-note/packages/nowen-mcp
+npm install
+npm run build
+test -f ./dist/scoped-entry.js && echo "MCP build OK"
+```
+
+`npm test` is a development validation command, not an installation requirement.
+
+### 4. Create a Personal API Token
+
+In Nowen Note, open:
+
+```text
+Settings → Personal access tokens → Create token
+```
+
+Recommended settings:
+
+1. Create a separate token for each client.
+2. Grant only the required scopes, such as `notes:read` and `notes:write`.
+3. Restrict the token to specific notebooks.
+4. Choose read-only or read-write per notebook.
+5. Include child notebooks only when needed.
+6. Set an expiration date.
+
+Copy the generated token, for example `nkn_xxx`.
+
+### 5. Resolve the absolute script path
+
+Windows PowerShell:
+
+```powershell
+(Resolve-Path .\dist\scoped-entry.js).Path
+```
+
+macOS / Linux / WSL:
+
+```bash
+realpath ./dist/scoped-entry.js
+```
+
+Windows paths must be escaped in JSON:
+
+```json
+"C:\\Users\\YourName\\nowen-note\\packages\\nowen-mcp\\dist\\scoped-entry.js"
+```
+
+## Claude Code
+
+macOS / Linux / WSL:
+
+```bash
+claude mcp add nowen-note --scope user \
+  --env NOWEN_URL=http://192.168.1.20:3001 \
+  --env NOWEN_API_TOKEN=nkn_xxx \
+  -- node /home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js
+```
+
+Windows PowerShell:
+
+```powershell
+claude mcp add nowen-note --scope user `
+  --env NOWEN_URL=http://192.168.1.20:3001 `
+  --env NOWEN_API_TOKEN=nkn_xxx `
+  -- node "C:\Users\YourName\nowen-note\packages\nowen-mcp\dist\scoped-entry.js"
+```
+
+Verify it:
+
+```bash
+claude mcp get nowen-note
+claude mcp list
+```
+
+Restart the Claude Code session after changing the configuration.
+
+Official reference: [Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp)
+
+## Cursor
+
+Use `.cursor/mcp.json` for a project configuration or `~/.cursor/mcp.json` for a global configuration.
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "/home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+On Windows, replace the script path with an escaped absolute Windows path. Fully quit and reopen Cursor, then confirm that `nowen-note` appears under MCP or Available Tools.
+
+Official reference: [Cursor MCP](https://docs.cursor.com/context/model-context-protocol)
+
+## VS Code / GitHub Copilot
+
+Run `MCP: Add Server` from the Command Palette, or create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "nowen-note": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "/home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+VS Code uses the top-level `servers` field, not Cursor's `mcpServers` field.
+
+Run `MCP: List Servers`, select `nowen-note`, and choose Start or Restart. Choose Show Output when debugging. Avoid committing real tokens to a repository; prefer user-level configuration or VS Code input variables for secrets.
+
+Official reference: [VS Code MCP servers](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
+
+## Claude Desktop and generic stdio clients
+
+Most clients that accept local stdio MCP servers use this structure:
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+Current Claude Desktop versions prefer Desktop Extensions (DXT) under Settings → Extensions. Nowen Note currently ships the source-based stdio server, so use the local developer MCP entry exposed by your client version. A local stdio script cannot be added as a remote Claude connector; remote MCP requires a separate HTTP transport and authentication implementation.
+
+Official reference: [Local MCP servers on Claude Desktop](https://support.anthropic.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+
+## Verify the connection
+
+After restarting the client, confirm that tools such as these appear:
+
+```text
+nowen_list_notebooks
+nowen_list_notes
+nowen_read_note
+nowen_search
+```
+
+Start with a read-only test:
+
+```text
+Use the Nowen Note MCP server to list the notebooks I can access. Do not modify anything.
+```
+
+Then test search:
+
+```text
+Use Nowen Note MCP to search for "test" and return only titles and notebook names.
+```
+
+Only after read operations work should you test creating or updating a note.
+
+## Update the MCP server
+
+```bash
+git pull
+cd packages/nowen-mcp
+npm install
+npm run build
+```
+
+Restart the MCP server or the client afterwards. If you move the repository, update the absolute script path in every client configuration.
+
+## Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `NOWEN_URL` | Nowen Note server URL | `http://localhost:3001` |
+| `NOWEN_API_TOKEN` | Personal API Token; preferred over username/password | — |
+| `NOWEN_USERNAME` | Legacy username authentication | `admin` |
+| `NOWEN_PASSWORD` | Legacy password authentication | `admin123` |
+| `ALLOWED_NOTEBOOK_IDS` | Additional comma-separated local notebook allowlist; an explicit empty value denies all | disabled |
+| `MCP_ACCESS_MODE` | `read-only` or `read-write` | `read-write` |
+| `MCP_INCLUDE_DESCENDANTS` | Include descendants of locally allowed notebooks | `false` |
+
+Authentication priority:
+
+1. `NOWEN_API_TOKEN`
+2. `NOWEN_USERNAME` + `NOWEN_PASSWORD`
+
+New installations should use a token.
+
+## Permission model
+
+The effective server permission is:
+
+```text
+User ACL ∩ Token scopes ∩ Token notebook resource grants
+```
+
+You can add an MCP-side allowlist as a second layer:
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": ["/absolute/path/to/dist/scoped-entry.js"],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx",
+        "ALLOWED_NOTEBOOK_IDS": "notebook-id-1,notebook-id-2",
+        "MCP_ACCESS_MODE": "read-only",
+        "MCP_INCLUDE_DESCENDANTS": "true"
+      }
+    }
+  }
+}
+```
+
+See [MCP token notebook resource scopes](./mcp-token-resource-scope.md) for the detailed design.
+
+## Troubleshooting
+
+### `node` is not found
+
+Check `node --version` in the environment used by the GUI client. If necessary, set `command` to the absolute Node executable path.
+
+Windows:
+
+```powershell
+(Get-Command node).Source
+```
+
+macOS / Linux:
+
+```bash
+which node
+```
+
+### `dist/scoped-entry.js` is missing
+
+```bash
+cd packages/nowen-mcp
+npm install
+npm run build
+```
+
+Confirm that the client configuration uses the absolute path.
+
+### Connection failure
+
+- Same computer: `http://localhost:3001`
+- NAS or server: `http://<LAN-IP>:3001`
+- Reverse proxy: the full HTTPS origin, such as `https://note.example.com`
+
+Open the URL in a browser on the client computer first.
+
+### HTTP 401 or 403
+
+- 401 usually means an invalid, expired, or revoked token.
+- 403 means user ACLs, token scopes, notebook grants, or the local MCP allowlist denied access.
+
+Do not replace a restricted token with an administrator password merely to bypass a 403.
+
+### Reads work but writes fail
+
+All of the following must allow writing:
+
+- the user account's notebook permission;
+- a write scope such as `notes:write`;
+- read-write access for that notebook in the token resource grants;
+- `MCP_ACCESS_MODE` must not be `read-only`.
+
+### Tools do not appear
+
+1. Run `npm run build` again.
+2. Fully restart the client.
+3. Restart the MCP server from the client.
+4. In VS Code, run `MCP: Reset Cached Tools`.
+5. Inspect logs for Node, path, network, or authentication errors.
+
+### Running the script shows no output
+
+A stdio MCP server normally waits for client input and can remain silent:
+
+```bash
+node /absolute/path/to/dist/scoped-entry.js
+```
+
+If it stays running without crashing, the script can start. Press `Ctrl+C` to stop it.
+
+## Security
+
+- Run local MCP code only from trusted sources.
+- Never commit a token-bearing MCP configuration to a public repository.
+- Validate the connection with a read-only token first.
+- Use separate tokens per agent for revocation and auditing.
+- Use HTTPS, strong passwords, backups, and restricted CORS for internet-facing deployments.
+
+## Related documentation
+
+- [MCP token notebook resource scopes](./mcp-token-resource-scope.md)
+- [OpenAPI guide](./api.md)
+- [SDK guide](./sdk.md)
+- [CLI guide](./cli.md)

--- a/docs/tutorials/mcp.md
+++ b/docs/tutorials/mcp.md
@@ -1,21 +1,96 @@
-# MCP Server 使用教程
+# MCP Server 安装与使用教程
 
-> 通过 MCP 协议让 AI 助手直接操作你的 nowen-note 笔记库。
+> 通过 Model Context Protocol（MCP），让 Claude Code、Cursor、VS Code 等 AI 客户端在授权范围内搜索、读取和维护你的 Nowen Note 笔记。
 
----
+[返回教程中心](./README.md) · [English](./mcp.en.md) · [MCP 包说明](../../packages/nowen-mcp/README.md)
 
-## 安装
+## 先看结论
 
-```bash
-cd packages/nowen-mcp
-npm install
-npm run build
-npm test
+- MCP 功能仍然受支持，服务端代码位于 `packages/nowen-mcp/`。
+- 当前官方仓库提供的是**源码安装方式**，需要 Node.js 20+、Git 和 npm。
+- 不要直接照抄 `/path/to/...`。客户端配置中的脚本路径必须替换为你电脑上的**绝对路径**。
+- 如果 Nowen Note 部署在 NAS 或其他服务器，`NOWEN_URL` 应填写该设备能从当前电脑访问的地址，例如 `http://192.168.1.20:3001`，而不是 `localhost`。
+- 推荐使用独立的 restricted Personal API Token，不要把管理员密码写进 MCP 配置。
+
+## 5 分钟快速接入
+
+### 1. 确认 Nowen Note 可以访问
+
+先在运行 AI 客户端的电脑浏览器中打开：
+
+```text
+http://你的服务器IP:3001
 ```
 
----
+示例：
 
-## 推荐配置：服务端 restricted Token
+```text
+http://192.168.1.20:3001
+```
+
+本机部署才使用：
+
+```text
+http://localhost:3001
+```
+
+如果浏览器都打不开，请先处理 Docker 端口、NAS 防火墙、反向代理或局域网访问问题，MCP 无法绕过网络连接问题。
+
+### 2. 安装 Node.js 20+ 和 Git
+
+检查版本：
+
+```bash
+node --version
+npm --version
+git --version
+```
+
+`node --version` 应为 `v20` 或更高版本。
+
+### 3. 下载并构建 MCP Server
+
+#### Windows PowerShell
+
+```powershell
+git clone https://github.com/cropflre/nowen-note.git
+cd nowen-note\packages\nowen-mcp
+npm install
+npm run build
+```
+
+构建后应存在：
+
+```text
+nowen-note\packages\nowen-mcp\dist\scoped-entry.js
+```
+
+检查文件：
+
+```powershell
+Test-Path .\dist\scoped-entry.js
+```
+
+返回 `True` 才表示构建产物存在。
+
+#### macOS / Linux / WSL
+
+```bash
+git clone https://github.com/cropflre/nowen-note.git
+cd nowen-note/packages/nowen-mcp
+npm install
+npm run build
+```
+
+检查文件：
+
+```bash
+test -f ./dist/scoped-entry.js && echo "MCP build OK"
+```
+
+> 安装只要求 `npm install` 和 `npm run build`。`npm test` 是开发验证步骤，不是用户安装的必要条件。
+
+### 4. 创建 Personal API Token
 
 进入 Nowen Note：
 
@@ -23,35 +98,308 @@ npm test
 设置 → 个人访问令牌 → 创建令牌
 ```
 
-为每个 Agent 创建独立 Token，并设置：
+建议：
 
-- 能力 scopes，例如 `notes:read`、`notes:write`；
-- 资源范围选择“限定笔记本”；
-- 每个笔记本配置“只读”或“读写”；
-- 按需开启“自动包含子笔记本”；
-- 设置合理过期时间。
+1. 为每个 AI 客户端创建独立 Token，例如“Claude Code”或“Cursor”。
+2. 只开启实际需要的 scopes，例如 `notes:read`、`notes:write`。
+3. 资源范围选择“限定笔记本”。
+4. 每个笔记本设置“只读”或“读写”。
+5. 按需开启“自动包含子笔记本”。
+6. 设置合理过期时间，Token 泄露后立即撤销。
 
-服务端最终权限为：
+复制生成的 Token，例如：
 
 ```text
-用户 ACL ∩ Token scopes ∩ Token 笔记本资源授权
+nkn_xxxxxxxxxxxxxxxxx
 ```
 
-restricted Token 即使被拿去绕过 MCP 直接调用 REST API，也不能访问未授权笔记本。历史 Token 默认保持 `unrestricted`，兼容升级前行为。
+Token 通常只展示一次，请妥善保存。
 
-详细设计参见：[MCP Token 笔记本资源授权](./mcp-token-resource-scope.md)。
+### 5. 找到 MCP 脚本的绝对路径
+
+#### Windows PowerShell
+
+在 `packages/nowen-mcp` 目录执行：
+
+```powershell
+(Resolve-Path .\dist\scoped-entry.js).Path
+```
+
+示例结果：
+
+```text
+C:\Users\YourName\nowen-note\packages\nowen-mcp\dist\scoped-entry.js
+```
+
+写进 JSON 时，Windows 反斜杠需要写成双反斜杠：
+
+```json
+"C:\\Users\\YourName\\nowen-note\\packages\\nowen-mcp\\dist\\scoped-entry.js"
+```
+
+#### macOS / Linux / WSL
+
+```bash
+realpath ./dist/scoped-entry.js
+```
+
+示例结果：
+
+```text
+/home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js
+```
+
+然后选择下面对应的客户端配置。
 
 ---
 
-## MCP 环境变量
+## Claude Code
+
+Claude Code 可以直接通过命令添加 stdio MCP Server。
+
+### macOS / Linux / WSL
+
+```bash
+claude mcp add nowen-note --scope user \
+  --env NOWEN_URL=http://192.168.1.20:3001 \
+  --env NOWEN_API_TOKEN=nkn_xxx \
+  -- node /home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js
+```
+
+### Windows PowerShell
+
+```powershell
+claude mcp add nowen-note --scope user `
+  --env NOWEN_URL=http://192.168.1.20:3001 `
+  --env NOWEN_API_TOKEN=nkn_xxx `
+  -- node "C:\Users\YourName\nowen-note\packages\nowen-mcp\dist\scoped-entry.js"
+```
+
+确认配置：
+
+```bash
+claude mcp get nowen-note
+claude mcp list
+```
+
+修改配置后重新启动 Claude Code 会话。
+
+官方参考：[Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp)
+
+---
+
+## Cursor
+
+Cursor 支持项目级和全局 MCP 配置：
+
+- 项目级：项目目录下 `.cursor/mcp.json`
+- 全局：`~/.cursor/mcp.json`
+
+### macOS / Linux
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "/home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "C:\\Users\\YourName\\nowen-note\\packages\\nowen-mcp\\dist\\scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+保存后完全退出并重新打开 Cursor，在 MCP 设置或 Available Tools 中确认 `nowen-note` 已启动。
+
+官方参考：[Cursor MCP](https://docs.cursor.com/context/model-context-protocol)
+
+---
+
+## VS Code / GitHub Copilot
+
+推荐使用命令面板：
+
+```text
+MCP: Add Server
+```
+
+也可以创建项目级配置：
+
+```text
+.vscode/mcp.json
+```
+
+VS Code 的顶层字段是 `servers`，不是 Cursor 的 `mcpServers`。
+
+### macOS / Linux
+
+```json
+{
+  "servers": {
+    "nowen-note": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "/home/yourname/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+### Windows
+
+```json
+{
+  "servers": {
+    "nowen-note": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "C:\\Users\\YourName\\nowen-note\\packages\\nowen-mcp\\dist\\scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+保存后运行：
+
+```text
+MCP: List Servers
+```
+
+选择 `nowen-note`，执行 Start 或 Restart；出现问题时选择 Show Output 查看日志。
+
+不要把真实 Token 提交到公开仓库。个人使用优先放在 VS Code 用户级 MCP 配置中，团队配置可使用输入变量或环境变量。
+
+官方参考：[VS Code MCP Server](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
+
+---
+
+## Claude Desktop 与其他通用客户端
+
+支持本地 stdio MCP 的客户端通常使用以下结构：
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+注意：
+
+- 必须使用绝对路径。
+- Windows JSON 路径中的 `\` 必须转义为 `\\`。
+- 当前 Claude Desktop 更推荐通过 Settings → Extensions 安装 DXT 扩展；Nowen Note 目前仍以源码 stdio Server 为正式可用方式。使用 Claude Desktop 的本地开发者 MCP 配置时，请以客户端当前版本提供的入口为准。
+- Claude.ai / Claude Desktop 的远程 Connector 不能直接连接这个本地 stdio 脚本；远程 MCP 需要单独的 HTTP 传输和认证实现。
+
+官方参考：[Claude Desktop local MCP](https://support.anthropic.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+
+---
+
+## 验证是否安装成功
+
+重启客户端后，先确认工具列表中出现以下任意工具：
+
+```text
+nowen_list_notebooks
+nowen_list_notes
+nowen_read_note
+nowen_search
+```
+
+然后让 AI 执行只读测试：
+
+```text
+请使用 Nowen Note MCP 列出我有权限访问的笔记本，不要修改任何内容。
+```
+
+继续测试搜索：
+
+```text
+请使用 Nowen Note MCP 搜索“测试”，只返回标题和所属笔记本。
+```
+
+最后再测试写入权限：
+
+```text
+请在“测试”笔记本创建一篇标题为“MCP 连接测试”的 Markdown 笔记，正文写入当前日期。
+```
+
+如果只读成功而写入失败，通常是 Token scope、笔记本资源权限或 `MCP_ACCESS_MODE` 限制导致，这属于正常的安全拦截。
+
+---
+
+## 更新 MCP Server
+
+进入仓库目录：
+
+```bash
+git pull
+cd packages/nowen-mcp
+npm install
+npm run build
+```
+
+然后完全重启 MCP 客户端，或在客户端中 Restart Server / Reset Cached Tools。
+
+如果仓库移动到新目录，客户端配置中的绝对路径也必须同步修改。
+
+---
+
+## 环境变量
 
 | 变量 | 说明 | 默认值 |
 |---|---|---|
-| `NOWEN_URL` | 服务器地址 | `http://localhost:3001` |
+| `NOWEN_URL` | Nowen Note 服务地址 | `http://localhost:3001` |
 | `NOWEN_API_TOKEN` | Personal API Token；配置后优先于用户名密码 | — |
 | `NOWEN_USERNAME` | 兼容旧配置的登录用户名 | `admin` |
 | `NOWEN_PASSWORD` | 兼容旧配置的登录密码 | `admin123` |
-| `ALLOWED_NOTEBOOK_IDS` | MCP 实例侧的第二道笔记本白名单，逗号分隔；显式空值代表拒绝全部 | 未启用本地作用域 |
+| `ALLOWED_NOTEBOOK_IDS` | MCP 实例侧笔记本白名单，逗号分隔；显式空值代表拒绝全部 | 未启用本地作用域 |
 | `MCP_ACCESS_MODE` | `read-only` 或 `read-write` | `read-write` |
 | `MCP_INCLUDE_DESCENDANTS` | 本地白名单是否包含全部子笔记本 | `false` |
 
@@ -60,16 +408,30 @@ restricted Token 即使被拿去绕过 MCP 直接调用 REST API，也不能访�
 1. `NOWEN_API_TOKEN`
 2. `NOWEN_USERNAME` + `NOWEN_PASSWORD`
 
-服务端 restricted Token 已经保存资源范围时，最简配置如下：
+新安装应优先使用 `NOWEN_API_TOKEN`。用户名密码只用于兼容旧配置，不建议继续用于长期自动化。
+
+---
+
+## 推荐安全配置：restricted Token
+
+服务端最终权限为：
+
+```text
+用户 ACL ∩ Token scopes ∩ Token 笔记本资源授权
+```
+
+restricted Token 即使被绕过 MCP 直接调用 REST API，也不能访问未授权笔记本。历史 Token 默认保持 `unrestricted`，兼容升级前行为。
+
+最简配置：
 
 ```json
 {
   "mcpServers": {
-    "nowen-investment": {
+    "nowen-note": {
       "command": "node",
-      "args": ["/path/to/nowen-mcp/dist/scoped-entry.js"],
+      "args": ["/absolute/path/to/dist/scoped-entry.js"],
       "env": {
-        "NOWEN_URL": "http://localhost:3001",
+        "NOWEN_URL": "http://192.168.1.20:3001",
         "NOWEN_API_TOKEN": "nkn_xxx"
       }
     }
@@ -77,19 +439,19 @@ restricted Token 即使被拿去绕过 MCP 直接调用 REST API，也不能访�
 }
 ```
 
-也可以叠加 MCP 本地白名单作为第二道限制：
+还可以叠加 MCP 本地白名单作为第二道限制：
 
 ```json
 {
   "mcpServers": {
-    "nowen-charging": {
+    "nowen-note": {
       "command": "node",
-      "args": ["/path/to/nowen-mcp/dist/scoped-entry.js"],
+      "args": ["/absolute/path/to/dist/scoped-entry.js"],
       "env": {
-        "NOWEN_URL": "http://localhost:3001",
+        "NOWEN_URL": "http://192.168.1.20:3001",
         "NOWEN_API_TOKEN": "nkn_xxx",
-        "ALLOWED_NOTEBOOK_IDS": "charging-notebook-id",
-        "MCP_ACCESS_MODE": "read-write",
+        "ALLOWED_NOTEBOOK_IDS": "notebook-id-1,notebook-id-2",
+        "MCP_ACCESS_MODE": "read-only",
         "MCP_INCLUDE_DESCENDANTS": "true"
       }
     }
@@ -99,35 +461,7 @@ restricted Token 即使被拿去绕过 MCP 直接调用 REST API，也不能访�
 
 两层同时启用时，实际范围是服务端授权与本地白名单的交集。
 
----
-
-## 安全行为
-
-### 服务端 Token 资源防火墙
-
-restricted Token 会在所有受保护 REST API 上强制执行资源范围：
-
-- 笔记本列表、详情、创建、更新和移动；
-- 笔记列表、搜索、详情、创建、更新、移动和删除；
-- 文件与附件列表、详情、上传和修改；
-- 标签读取以及笔记标签关联；
-- 知识库问答；
-- scope 管理的导入导出能力。
-
-通过 `noteId` 或附件 ID 直接访问时，服务端会反查所属笔记本再校验，不能通过猜测 ID 绕过。
-
-API Token 不能调用 Token 管理接口创建或扩张自己的权限。授权变更必须使用正常登录会话完成。
-
-### MCP 实例侧防火墙
-
-配置 `ALLOWED_NOTEBOOK_IDS` 后，MCP 还会执行一层本地校验：
-
-- 列表和搜索结果与本地白名单取交集；
-- 读写笔记前反查所属笔记本；
-- 移动笔记时校验原笔记和目标笔记本；
-- `read-only` 拒绝创建、更新、删除、上传和标签变更；
-- 显式空白名单采用 fail-closed；
-- 无法映射到笔记本的备份、审计、Webhook、插件等全局能力默认拒绝。
+详细设计参见：[MCP Token 笔记本资源授权](./mcp-token-resource-scope.md)。
 
 ---
 
@@ -140,38 +474,28 @@ API Token 不能调用 Token 管理接口创建或扩张自己的权限。授权
 | `nowen_list_notebooks` | 列出当前 Token 可以访问的笔记本 |
 | `nowen_create_notebook` | 创建笔记本；restricted 模式下需拥有目标父笔记本写权限 |
 
-### 笔记
+### 笔记与搜索
 
 | 工具 | 说明 |
 |---|---|
 | `nowen_list_notes` | 列出授权范围内的笔记 |
-| `nowen_read_note` | 读取笔记，服务端会根据 `noteId` 校验笔记本范围 |
+| `nowen_read_note` | 读取笔记，服务端根据 `noteId` 校验资源范围 |
 | `nowen_create_note` | 在拥有写权限的笔记本创建笔记 |
 | `nowen_update_note` | 更新授权范围内笔记 |
 | `nowen_delete_note` | 删除授权范围内笔记 |
+| `nowen_search` | 全文搜索，结果自动限定在授权范围内 |
 
-### 搜索
-
-| 工具 | 说明 |
-|---|---|
-| `nowen_search` | 全文搜索，结果自动限定在 Token 和本地白名单交集中 |
-
-### 附件
+### 附件与标签
 
 | 工具 | 说明 |
 |---|---|
 | `nowen_upload_attachment` | restricted 模式必须绑定到有写权限的笔记 |
 | `nowen_list_attachments` | 只返回授权笔记本中的附件 |
 | `nowen_attach_to_note` | 将附件插入有写权限的 Markdown 笔记 |
-
-### 标签
-
-| 工具 | 说明 |
-|---|---|
 | `nowen_list_tags` | restricted Token 只返回授权笔记关联的标签 |
 | `nowen_manage_tags` | 只允许修改授权范围内笔记的标签关联 |
 
-### AI
+### AI 与知识库
 
 | 工具 | 说明 |
 |---|---|
@@ -189,52 +513,116 @@ nowen_ai_ask({
 })
 ```
 
-`includeChildren=true` 时，涉及的子笔记本也必须属于授权范围；否则服务端拒绝请求。
-
 ---
 
 ## 常见问题
 
+### 客户端提示找不到 `node`
+
+在客户端自身的终端环境检查：
+
+```bash
+node --version
+```
+
+如果终端可以运行但 GUI 客户端找不到，使用 Node 可执行文件的绝对路径作为 `command`，然后重启客户端。
+
+Windows 查找路径：
+
+```powershell
+(Get-Command node).Source
+```
+
+macOS / Linux：
+
+```bash
+which node
+```
+
+### 提示找不到 `dist/scoped-entry.js`
+
+重新构建：
+
+```bash
+cd packages/nowen-mcp
+npm install
+npm run build
+```
+
+确认配置使用的是绝对路径，并检查仓库是否被移动或删除。
+
+### `NOWEN_URL` 连接失败
+
+- MCP 与 Nowen Note 在同一台电脑：使用 `http://localhost:3001`。
+- Nowen Note 在 NAS：使用 `http://NAS局域网IP:3001`。
+- 使用 HTTPS 反向代理：填写完整公网地址，例如 `https://note.example.com`。
+- 先在运行客户端的电脑浏览器中验证该地址。
+
+### 返回 401 或 403
+
+- 401：Token 错误、过期或已撤销。
+- 403：Token scope、用户 ACL、笔记本资源授权或本地 MCP 白名单拒绝了请求。
+- 不要为了绕过 403 改用管理员密码；应修正最小权限配置。
+
 ### 所有笔记本请求都被拒绝
 
-检查以下两处：
+检查：
 
-1. 设置页中 restricted Token 是否配置了至少一个笔记本；
-2. MCP 环境中是否显式配置了空的 `ALLOWED_NOTEBOOK_IDS`。
+1. restricted Token 是否至少授权了一个笔记本；
+2. 是否误配置了空的 `ALLOWED_NOTEBOOK_IDS`；
+3. Token 是否拥有 `notes:read` 等必要 scope；
+4. 当前用户本身是否拥有该笔记本权限。
 
-两者都是 fail-closed 设计。
+restricted Token 和显式空白名单都采用 fail-closed 设计。
 
 ### 读操作成功但写操作被拒绝
 
 需要同时满足：
 
 - 用户本人对该笔记本具有写权限；
-- Token 包含对应写 scope，例如 `notes:write`；
-- Token 对该笔记本的资源权限设置为“读写”；
-- 本地 MCP 未设置为 `MCP_ACCESS_MODE=read-only`。
+- Token 包含写 scope，例如 `notes:write`；
+- Token 对该笔记本设置为“读写”；
+- 本地 MCP 未设置 `MCP_ACCESS_MODE=read-only`。
 
 ### 子笔记本没有显示
 
-服务端授权中开启“自动包含子笔记本”；使用本地白名单时还需设置：
+服务端 Token 授权中开启“自动包含子笔记本”。如果还使用本地白名单，同时设置：
 
 ```env
 MCP_INCLUDE_DESCENDANTS=true
 ```
 
-### 知识库问答提示必须指定 notebookId
-
-restricted Token 不允许无范围的全库问答。调用 `nowen_ai_ask` 时明确传入目标笔记本 ID。
-
 ### 工具没有出现
 
-确认 MCP Server 已重新构建，并重启 Claude Desktop、Cursor 或其他 MCP 客户端。
+1. 重新运行 `npm run build`；
+2. 完全退出并重启客户端；
+3. 在客户端中 Restart Server；
+4. VS Code 可执行 `MCP: Reset Cached Tools`；
+5. 查看 MCP 日志中的脚本路径、Node、网络和认证错误。
+
+### 运行脚本后终端没有输出
+
+直接执行：
+
+```bash
+node /absolute/path/to/dist/scoped-entry.js
+```
+
+stdio MCP Server 正常情况下会等待客户端输入，可能没有任何提示并保持运行。这说明脚本至少能够启动；按 `Ctrl+C` 退出即可。
 
 ---
+
+## 安全说明
+
+- 本地 MCP Server 与普通本地程序一样，以当前用户权限运行，只从官方仓库获取代码。
+- Token 会出现在客户端配置中，不要把包含 Token 的 `.cursor/mcp.json`、`.vscode/mcp.json` 或其他配置提交到公开仓库。
+- 优先使用只读 Token 验证连接，再按需要增加写权限。
+- 每个 Agent 使用独立 Token，方便撤销和审计。
+- 对外网开放 Nowen Note 时配置 HTTPS、强密码、备份和最小 CORS 范围。
 
 ## 下一步
 
 - [MCP Token 笔记本资源授权](./mcp-token-resource-scope.md)
 - [OpenAPI 接入指南](./api.md)
 - [SDK 使用教程](./sdk.md)
-
-> 本教程已覆盖 Issue #189 的 MCP 本地作用域、服务端 Token 资源强制校验和管理 UI。
+- [CLI 使用教程](./cli.md)

--- a/packages/nowen-mcp/README.md
+++ b/packages/nowen-mcp/README.md
@@ -1,0 +1,156 @@
+# nowen-mcp
+
+Nowen Note 的本地 stdio MCP Server，让支持 Model Context Protocol 的 AI 客户端在授权范围内搜索、读取和维护笔记。
+
+> 完整用户教程：[中文安装指南](../../docs/tutorials/mcp.md) · [English guide](../../docs/tutorials/mcp.en.md)
+
+## 要求
+
+- Node.js 20+
+- npm
+- 一个可以从当前电脑访问的 Nowen Note 服务
+- 推荐使用 restricted Personal API Token
+
+## 从仓库安装
+
+```bash
+git clone https://github.com/cropflre/nowen-note.git
+cd nowen-note/packages/nowen-mcp
+npm install
+npm run build
+```
+
+构建入口：
+
+```text
+dist/scoped-entry.js
+```
+
+快速检查：
+
+```bash
+node ./dist/scoped-entry.js
+```
+
+stdio Server 正常情况下会等待客户端输入并保持静默。没有立即退出或报错即说明脚本可以启动，按 `Ctrl+C` 结束。
+
+## 最小客户端配置
+
+```json
+{
+  "mcpServers": {
+    "nowen-note": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+必须替换：
+
+- `args` 中的脚本绝对路径；
+- `NOWEN_URL`；
+- `NOWEN_API_TOKEN`。
+
+Windows JSON 路径示例：
+
+```json
+"C:\\Users\\YourName\\nowen-note\\packages\\nowen-mcp\\dist\\scoped-entry.js"
+```
+
+VS Code 的 `.vscode/mcp.json` 使用顶层 `servers` 字段：
+
+```json
+{
+  "servers": {
+    "nowen-note": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "/absolute/path/to/nowen-note/packages/nowen-mcp/dist/scoped-entry.js"
+      ],
+      "env": {
+        "NOWEN_URL": "http://192.168.1.20:3001",
+        "NOWEN_API_TOKEN": "nkn_xxx"
+      }
+    }
+  }
+}
+```
+
+## Claude Code
+
+```bash
+claude mcp add nowen-note --scope user \
+  --env NOWEN_URL=http://192.168.1.20:3001 \
+  --env NOWEN_API_TOKEN=nkn_xxx \
+  -- node /absolute/path/to/dist/scoped-entry.js
+```
+
+验证：
+
+```bash
+claude mcp get nowen-note
+claude mcp list
+```
+
+## 环境变量
+
+| 变量 | 说明 | 默认值 |
+|---|---|---|
+| `NOWEN_URL` | Nowen Note 服务地址 | `http://localhost:3001` |
+| `NOWEN_API_TOKEN` | Personal API Token | — |
+| `NOWEN_USERNAME` | 旧版用户名认证 | `admin` |
+| `NOWEN_PASSWORD` | 旧版密码认证 | `admin123` |
+| `ALLOWED_NOTEBOOK_IDS` | MCP 本地笔记本白名单，逗号分隔 | 未启用 |
+| `MCP_ACCESS_MODE` | `read-only` 或 `read-write` | `read-write` |
+| `MCP_INCLUDE_DESCENDANTS` | 本地白名单是否包含子笔记本 | `false` |
+
+认证优先级：
+
+1. `NOWEN_API_TOKEN`
+2. `NOWEN_USERNAME` + `NOWEN_PASSWORD`
+
+## 常用命令
+
+```bash
+npm run dev
+npm run build
+npm start
+npm test
+```
+
+- `npm run dev`：监听源码并启动开发 Server。
+- `npm run build`：编译到 `dist/`。
+- `npm start`：运行已构建的 Server。
+- `npm test`：构建并执行作用域策略测试。
+
+## 更新
+
+```bash
+git pull
+cd packages/nowen-mcp
+npm install
+npm run build
+```
+
+更新后重启 MCP 客户端或在客户端中 Restart Server。
+
+## 安全建议
+
+- 每个 AI 客户端使用独立 Token。
+- 先用只读 Token 验证，再按需增加写权限。
+- 不要把 Token 提交到 Git 仓库。
+- `NOWEN_URL` 指向 NAS 时，先从客户端电脑浏览器验证地址可访问。
+- 权限结果为：用户 ACL、Token scopes、Token 笔记本授权以及本地 MCP 白名单的交集。
+
+## 发行说明
+
+当前仓库保证的是源码构建方式。除非 Nowen Note 的 Release 或官方文档明确宣布 npm / DXT 包，避免假设 `npx nowen-mcp` 或一键 DXT 已经可用。

--- a/packages/nowen-mcp/package.json
+++ b/packages/nowen-mcp/package.json
@@ -7,36 +7,11 @@
   "bin": {
     "nowen-mcp": "./dist/scoped-entry.js"
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "engines": {
-    "node": ">=20"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cropflre/nowen-note.git",
-    "directory": "packages/nowen-mcp"
-  },
-  "homepage": "https://github.com/cropflre/nowen-note/blob/main/docs/tutorials/mcp.md",
-  "bugs": {
-    "url": "https://github.com/cropflre/nowen-note/issues"
-  },
-  "license": "GPL-3.0",
-  "keywords": [
-    "nowen-note",
-    "mcp",
-    "model-context-protocol",
-    "notes",
-    "knowledge-base"
-  ],
   "scripts": {
     "dev": "tsx watch src/scoped-entry.ts",
     "build": "tsc",
     "start": "node dist/scoped-entry.js",
-    "test": "npm run build && node --test dist/scope-policy.test.js",
-    "prepack": "npm run build"
+    "test": "npm run build && node --test dist/scope-policy.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/packages/nowen-mcp/package.json
+++ b/packages/nowen-mcp/package.json
@@ -7,11 +7,36 @@
   "bin": {
     "nowen-mcp": "./dist/scoped-entry.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cropflre/nowen-note.git",
+    "directory": "packages/nowen-mcp"
+  },
+  "homepage": "https://github.com/cropflre/nowen-note/blob/main/docs/tutorials/mcp.md",
+  "bugs": {
+    "url": "https://github.com/cropflre/nowen-note/issues"
+  },
+  "license": "GPL-3.0",
+  "keywords": [
+    "nowen-note",
+    "mcp",
+    "model-context-protocol",
+    "notes",
+    "knowledge-base"
+  ],
   "scripts": {
     "dev": "tsx watch src/scoped-entry.ts",
     "build": "tsc",
     "start": "node dist/scoped-entry.js",
-    "test": "npm run build && node --test dist/scope-policy.test.js"
+    "test": "npm run build && node --test dist/scope-policy.test.js",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## 问题

用户从 GitHub 首页无法直接找到 MCP 安装入口，现有教程只给出了仓库内构建命令和占位路径，普通用户容易误认为 MCP 已取消，或者无法独立完成配置。

## 修复

- 在中英文根 README 顶部和正文增加 MCP 一级入口
- 重写中文 MCP 教程，补齐 5 分钟接入流程
- 新增英文 MCP 安装教程
- 新增 `packages/nowen-mcp/README.md`
- 在教程中心增加 MCP 快速入口和独立阅读路线
- 补齐 Windows、macOS、Linux / WSL 路径说明
- 补齐 NAS / 远程服务地址说明
- 补齐 restricted Personal API Token 配置
- 补齐 Claude Code、Cursor、VS Code 和通用 stdio 客户端配置
- 补齐连接验证、升级、日志和 401 / 403 / 路径 / Node 排障
- 明确当前正式分发方式为源码构建，避免误导用户使用不存在的一键 npm / DXT 安装

## 影响范围

仅文档变更，不修改 MCP Server 或业务代码。

## 验证

- 对比 main 后仅 6 个 Markdown 文件发生变化
- 中英文 README 均可直接进入 MCP 教程
- 教程中的相对链接均指向本次新增或现有文件
- Cursor 使用 `mcpServers`，VS Code 使用 `servers` + `type: stdio`
- Windows JSON 路径提供双反斜杠示例
