### PR TITLE
fix(micloud): import every row returned by Xiaomi

### DIFF
--- a/backend/src/runtime/micloud-import-hardening.ts
+++ b/backend/src/runtime/micloud-import-hardening.ts
@@ -64,12 +64,12 @@ function ensureImportOriginSchema(): void {
 
 function normalizeNoteIds(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
-  return Array.from(new Set(
-    value
-      .filter((item): item is string => typeof item === "string")
-      .map((item) => item.trim())
-      .filter(Boolean),
-  )).slice(0, MAX_IMPORT_NOTE_IDS);
+  // 小米云返回多少行就处理多少行：只过滤无效空值，保留原始顺序与重复 ID。
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, MAX_IMPORT_NOTE_IDS);
 }
 
 function safeErrorText(value: unknown, fallback: string): string {
@@ -163,21 +163,6 @@ function ensureDefaultPersonalNotebook(userId: string): NotebookScope {
     workspaceId: null,
     workspaceScope: "personal",
   };
-}
-
-function findImportedOrigin(userId: string, scope: NotebookScope, externalId: string) {
-  return getDb().prepare(`
-    SELECT o.noteId, n.title, n.notebookId
-    FROM note_import_origins o
-    JOIN notes n ON n.id = o.noteId
-    WHERE o.userId = ?
-      AND o.workspaceScope = ?
-      AND o.sourceType = ?
-      AND o.externalId = ?
-    LIMIT 1
-  `).get(userId, scope.workspaceScope, SOURCE_TYPE, externalId) as
-    | { noteId: string; title: string; notebookId: string }
-    | undefined;
 }
 
 function recordImportedOrigin(
@@ -318,20 +303,11 @@ async function hardenedMiCloudImport(c: Context) {
 
   const imported: Array<{ id: string; title: string }> = [];
   const errors: string[] = [];
-  let skippedCount = 0;
-  let targetNotebookId = scope.notebookId;
+  const targetNotebookId = scope.notebookId;
 
-  // 旧实现把一个批次的所有 DB INSERT 放在同一事务中：任意一条旧笔记含异常字符、
-  // FTS 写入失败或附件过大，整个批次都会回滚并冒泡为纯文本 500。
-  // 这里按单条调用旧转换器，把故障隔离到具体笔记，其余笔记继续导入。
+  // 每个输入行都独立调用旧转换器。即使多个行拥有相同的小米 noteId，也不做去重、
+  // 不做幂等跳过，确保“小米返回多少条，Nowen 就实际创建多少条”。
   for (const externalId of noteIds) {
-    const existing = findImportedOrigin(userId, scope, externalId);
-    if (existing) {
-      skippedCount += 1;
-      imported.push({ id: existing.noteId, title: existing.title });
-      continue;
-    }
-
     try {
       const { response, payload, raw } = await invokeLegacySingleImport(
         cookie,
@@ -384,7 +360,7 @@ async function hardenedMiCloudImport(c: Context) {
       success: false,
       count: 0,
       createdCount: 0,
-      skippedCount,
+      skippedCount: 0,
       notebookId: targetNotebookId,
       notes: [],
       errors,
@@ -395,10 +371,9 @@ async function hardenedMiCloudImport(c: Context) {
 
   return c.json({
     success: true,
-    // 兼容现有前端：count 表示本批已成功处理数量，包含幂等跳过项。
     count: acceptedCount,
-    createdCount: acceptedCount - skippedCount,
-    skippedCount,
+    createdCount: acceptedCount,
+    skippedCount: 0,
     notebookId: targetNotebookId,
     notes: imported,
     errors,

--- a/backend/tests/micloud-import-hardening.test.ts
+++ b/backend/tests/micloud-import-hardening.test.ts
@@ -153,19 +153,30 @@ test("ignores a deleted Xiaomi notebook and creates a new active personal target
   assert.equal(note.workspaceId, null);
 });
 
-test("retries are idempotent and do not duplicate already imported Xiaomi notes", async () => {
+test("creates one Nowen note for every returned row even when Xiaomi note IDs repeat", async () => {
   const app = createApp();
-  const first = await importNotes(app, ["note-1", "note-2"]);
-  assert.equal(first.response.status, 201);
+  const first = await importNotes(app, ["note-1", "note-1", "note-2"]);
 
-  const second = await importNotes(app, ["note-1", "note-2"]);
+  assert.equal(first.response.status, 201);
+  assert.equal(first.payload.count, 3);
+  assert.equal(first.payload.createdCount, 3);
+  assert.equal(first.payload.skippedCount, 0);
+
+  const firstRows = getDb().prepare(`
+    SELECT title FROM notes ORDER BY createdAt, id
+  `).all() as Array<{ title: string }>;
+  assert.equal(firstRows.length, 3);
+  assert.equal(firstRows.filter((row) => row.title === "Title note-1").length, 2);
+  assert.equal(firstRows.filter((row) => row.title === "Title note-2").length, 1);
+
+  const second = await importNotes(app, ["note-1"]);
   assert.equal(second.response.status, 201);
-  assert.equal(second.payload.count, 2);
-  assert.equal(second.payload.createdCount, 0);
-  assert.equal(second.payload.skippedCount, 2);
+  assert.equal(second.payload.count, 1);
+  assert.equal(second.payload.createdCount, 1);
+  assert.equal(second.payload.skippedCount, 0);
 
   const row = getDb().prepare("SELECT COUNT(*) AS count FROM notes").get() as { count: number };
-  assert.equal(row.count, 2);
+  assert.equal(row.count, 4);
 });
 
 test("one database failure no longer rolls back the other notes or returns a plain batch 500", async () => {

--- a/frontend/src/lib/__tests__/miNoteService.test.ts
+++ b/frontend/src/lib/__tests__/miNoteService.test.ts
@@ -76,6 +76,27 @@ describe("importMiNotes", () => {
     });
   });
 
+  it("preserves every returned row, including repeated Xiaomi note IDs", async () => {
+    const requestBodies: Array<{ noteIds: string[] }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || "{}")) as { noteIds: string[] };
+      requestBodies.push(body);
+      return response({
+        success: true,
+        count: body.noteIds.length,
+        notebookId: "created-notebook",
+        errors: [],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const noteIds = ["note-1", "note-1", "note-2", "note-1"];
+    const result = await importMiNotes("cookie", noteIds);
+
+    expect(result).toEqual({ success: true, count: 4, errors: [] });
+    expect(requestBodies.flatMap((body) => body.noteIds)).toEqual(noteIds);
+  });
+
   it("reports how many notes were imported before a later batch fails", async () => {
     const fetchMock = vi
       .fn()

--- a/frontend/src/lib/miNoteService.ts
+++ b/frontend/src/lib/miNoteService.ts
@@ -158,18 +158,19 @@ async function importMiNoteBatch(
 // 后端接口会在响应前逐条读取小米云详情和图片。这里按固定小批次串行调用：
 // 1. 避免通用 POST 30 秒超时终止整个 600+ 条导入；
 // 2. 避免一次请求体和服务端内存过大；
-// 3. 第一批自动创建目标笔记本后，后续批次复用返回的 notebookId。
+// 3. 第一批自动创建目标笔记本后，后续批次复用返回的 notebookId；
+// 4. 严格保留小米云列表返回的每一行及原始顺序，不按 noteId 去重。
 export async function importMiNotes(
   cookie: string,
   noteIds: string[],
   notebookId?: string
 ): Promise<{ success: boolean; count: number; errors: string[] }> {
-  const uniqueNoteIds = Array.from(new Set(noteIds.filter((id) => typeof id === "string" && id.length > 0)));
-  if (uniqueNoteIds.length === 0) {
+  const selectedNoteIds = noteIds.filter((id) => typeof id === "string" && id.length > 0);
+  if (selectedNoteIds.length === 0) {
     return { success: false, count: 0, errors: ["请选择要导入的笔记"] };
   }
 
-  const batches = splitIntoImportBatches(uniqueNoteIds);
+  const batches = splitIntoImportBatches(selectedNoteIds);
   const errors: string[] = [];
   let importedCount = 0;
   let processedCount = 0;
@@ -185,7 +186,7 @@ export async function importMiNotes(
         targetNotebookId = result.notebookId;
       }
     } catch (error) {
-      const remainingCount = uniqueNoteIds.length - processedCount;
+      const remainingCount = selectedNoteIds.length - processedCount;
       const reason = error instanceof Error ? error.message : String(error || "未知错误");
       const prefix = importedCount > 0
         ? `已成功导入 ${importedCount} 条，剩余 ${remainingCount} 条未完成。`


### PR DESCRIPTION
## 需求

小米云页面显示 639 条时，Nowen 必须按 639 条执行导入，不允许因为 noteId 重复而在前端、后端或幂等层静默合并成 419 条。

## 修改

- 前端导入服务不再用 `Set` 去重，严格保留选中列表的原始顺序和重复 ID。
- 后端请求归一化只过滤空值，不再去重。
- 后端不再根据 `note_import_origins` 跳过已经出现过的小米 noteId；每个输入行都会实际创建一篇 Nowen 笔记。
- 返回的 `count`、`createdCount` 与本次实际创建的行数保持一致，`skippedCount` 固定为 0。
- 保留批次拆分、单条错误隔离、目标笔记本修复、图片附件化和结构化错误信息。

## 行为说明

该模式完全遵循“小米返回多少条就导入多少条”。如果小米列表中多个行使用同一个 noteId，Nowen 也会创建多篇内容相同的笔记；重复点击导入同样会再次创建，这是取消去重和幂等跳过后的预期行为。

## 回归测试

- 前端验证重复 ID 按原始顺序完整提交。
- 后端验证 `[note-1, note-1, note-2]` 实际创建 3 篇笔记。
- 再次导入同一 noteId 仍会新增笔记。
- 保留超时、批次、知识树与单条失败隔离测试。