### PR TITLE
feat(comments): add inline text annotations with permission-aware threads

### DIFF
--- a/backend/tests/share-management-route.test.ts
+++ b/backend/tests/share-management-route.test.ts
@@ -19,9 +19,25 @@ function db() {
   return getDb();
 }
 
-async function getJson(url: string, userId: string) {
-  const response = await app.request(url, { headers: { "X-User-Id": userId } });
+async function requestJson(
+  url: string,
+  userId: string,
+  method = "GET",
+  body?: unknown,
+) {
+  const response = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": userId,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
   return { status: response.status, json: await response.json() as any };
+}
+
+async function getJson(url: string, userId: string) {
+  return requestJson(url, userId);
 }
 
 test.before(async () => {
@@ -34,13 +50,24 @@ test.before(async () => {
   getDb = schemaModule.getDb;
   closeDb = schemaModule.closeDb;
 
-  for (const id of ["owner", "manager", "outsider"]) {
+  for (const id of ["owner", "manager", "editor", "commenter", "viewer", "outsider"]) {
     db().prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)").run(id, id, "hash");
   }
-  db().prepare("INSERT INTO notebooks (id, userId, name) VALUES (?, ?, ?)")
-    .run("nb", "owner", "共享目录");
-  db().prepare("INSERT INTO notes (id, userId, notebookId, title, content, contentText) VALUES (?, ?, ?, ?, '{}', '')")
-    .run("note", "owner", "nb", "公开笔记");
+  db().prepare("INSERT INTO workspaces (id, name, description, icon, ownerId) VALUES (?, ?, '', '🏢', ?)")
+    .run("ws", "协作空间", "owner");
+  for (const [userId, role] of [
+    ["owner", "owner"],
+    ["editor", "editor"],
+    ["commenter", "commenter"],
+    ["viewer", "viewer"],
+  ] as const) {
+    db().prepare("INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)")
+      .run("ws", userId, role);
+  }
+  db().prepare("INSERT INTO notebooks (id, userId, workspaceId, name) VALUES (?, ?, ?, ?)")
+    .run("nb", "owner", "ws", "共享目录");
+  db().prepare("INSERT INTO notes (id, userId, notebookId, workspaceId, title, content, contentText) VALUES (?, ?, ?, ?, ?, '{}', '')")
+    .run("note", "owner", "nb", "ws", "公开笔记");
   db().prepare(`INSERT INTO notebook_members
     (id, notebookId, userId, role, status, allowDownload, allowReshare, source)
     VALUES (?, ?, ?, 'owner', 'active', 1, 1, 'manual')`)
@@ -105,4 +132,59 @@ test("note managers can open the existing per-note list and share detail", async
   assert.equal(detail.json.id, "share");
   assert.equal(detail.json.hasPassword, true);
   assert.equal("password" in detail.json, false);
+});
+
+test("workspace comment permissions preserve inline anchor data and management boundaries", async () => {
+  const anchorData = JSON.stringify({
+    version: 1,
+    kind: "text",
+    editor: "tiptap",
+    quote: "需要批注的原文",
+    prefix: "前文",
+    suffix: "后文",
+    start: 4,
+    end: 11,
+    createdAt: 1,
+  });
+
+  const viewerCreate = await requestJson("/shares/note/note/comments", "viewer", "POST", {
+    content: "viewer 不应成功",
+    anchorData,
+  });
+  assert.equal(viewerCreate.status, 403);
+
+  const commenterCreate = await requestJson("/shares/note/note/comments", "commenter", "POST", {
+    content: "这里需要补充说明",
+    anchorData,
+  });
+  assert.equal(commenterCreate.status, 201);
+  assert.equal(commenterCreate.json.userId, "commenter");
+  assert.equal(commenterCreate.json.anchorData, anchorData);
+
+  const viewerList = await getJson("/shares/note/note/comments", "viewer");
+  assert.equal(viewerList.status, 200);
+  assert.equal(viewerList.json.length, 1);
+  assert.equal(viewerList.json[0].content, "这里需要补充说明");
+
+  const editorResolve = await requestJson(
+    `/shares/note/note/comments/${commenterCreate.json.id}/resolve`,
+    "editor",
+    "PATCH",
+  );
+  assert.equal(editorResolve.status, 403);
+
+  const managerResolve = await requestJson(
+    `/shares/note/note/comments/${commenterCreate.json.id}/resolve`,
+    "manager",
+    "PATCH",
+  );
+  assert.equal(managerResolve.status, 200);
+  assert.equal(managerResolve.json.isResolved, 1);
+
+  const commenterDelete = await requestJson(
+    `/shares/note/note/comments/${commenterCreate.json.id}`,
+    "commenter",
+    "DELETE",
+  );
+  assert.equal(commenterDelete.status, 200);
 });

--- a/frontend/src/components/CommentPanel.tsx
+++ b/frontend/src/components/CommentPanel.tsx
@@ -1,11 +1,5 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { X, MessageCircle, Send, Trash2, CheckCircle2, Circle, Reply, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { api } from "@/lib/api";
-import { ShareComment } from "@/types";
-import { cn } from "@/lib/utils";
+import React, { useEffect, useRef } from "react";
+import { openInlineCommentPanel } from "@/lib/inlineCommentEvents";
 
 interface CommentPanelProps {
   noteId: string;
@@ -13,269 +7,24 @@ interface CommentPanelProps {
   onClose: () => void;
 }
 
+/**
+ * Compatibility entry used by EditorPane's existing “评论与批注” menu items.
+ *
+ * The actual UI is now rendered once by InlineCommentBridge so selection
+ * annotations and the legacy whole-note entry share the same right-side
+ * drawer, permission checks, polling and anchor highlighting.
+ */
 export default function CommentPanel({ noteId, noteTitle, onClose }: CommentPanelProps) {
-  const [comments, setComments] = useState<ShareComment[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [newComment, setNewComment] = useState("");
-  const [replyTo, setReplyTo] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
-  const loadComments = useCallback(async () => {
-    try {
-      const data = await api.getNoteComments(noteId);
-      setComments(data);
-    } catch (e) {
-      console.error("加载评论失败:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, [noteId]);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
-    loadComments();
-  }, [loadComments]);
+    openInlineCommentPanel({
+      noteId,
+      noteTitle,
+      onClose: () => onCloseRef.current(),
+    });
+  }, [noteId, noteTitle]);
 
-  // 提交评论
-  const handleSubmit = async () => {
-    if (!newComment.trim() || submitting) return;
-    setSubmitting(true);
-    try {
-      const comment = await api.addNoteComment(noteId, {
-        content: newComment.trim(),
-        parentId: replyTo || undefined,
-      });
-      setComments((prev) => [...prev, comment]);
-      setNewComment("");
-      setReplyTo(null);
-    } catch (e: any) {
-      console.error("提交评论失败:", e);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  // 删除评论
-  const handleDelete = async (commentId: string) => {
-    try {
-      await api.deleteNoteComment(noteId, commentId);
-      setComments((prev) => prev.filter((c) => c.id !== commentId));
-    } catch (e) {
-      console.error("删除评论失败:", e);
-    }
-  };
-
-  // 切换已解决状态
-  const handleToggleResolved = async (commentId: string) => {
-    try {
-      const updated = await api.toggleCommentResolved(noteId, commentId);
-      setComments((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
-    } catch (e) {
-      console.error("更新评论状态失败:", e);
-    }
-  };
-
-  // Ctrl+Enter 提交
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
-
-  const formatTime = (date: string) => {
-    const d = new Date(date);
-    const now = new Date();
-    const diffMs = now.getTime() - d.getTime();
-    const diffMin = Math.floor(diffMs / 60000);
-    const diffHour = Math.floor(diffMs / 3600000);
-    if (diffMin < 1) return "刚刚";
-    if (diffMin < 60) return `${diffMin}分钟前`;
-    if (diffHour < 24) return `${diffHour}小时前`;
-    return d.toLocaleDateString("zh-CN", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
-  };
-
-  // 构建评论树（顶层 + 回复）
-  const topComments = comments.filter((c) => !c.parentId);
-  const getReplies = (parentId: string) => comments.filter((c) => c.parentId === parentId);
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/60 backdrop-blur-sm" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.95 }}
-        transition={{ duration: 0.2 }}
-        className="w-full max-w-lg mx-4 bg-app-elevated rounded-xl shadow-2xl border border-app-border overflow-hidden max-h-[85vh] flex flex-col"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-app-border">
-          <div className="flex items-center gap-2.5">
-            <div className="w-8 h-8 rounded-lg bg-blue-500/10 flex items-center justify-center">
-              <MessageCircle size={16} className="text-blue-500" />
-            </div>
-            <div>
-              <h2 className="text-sm font-semibold text-tx-primary">评论与批注</h2>
-              <p className="text-[11px] text-tx-tertiary truncate max-w-[260px]">{noteTitle} · {comments.length} 条评论</p>
-            </div>
-          </div>
-          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-app-hover text-tx-tertiary hover:text-tx-secondary transition-colors">
-            <X size={18} />
-          </button>
-        </div>
-
-        {/* 评论列表 */}
-        <ScrollArea className="flex-1 min-h-0">
-          <div className="px-5 py-3">
-            {loading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 size={20} className="animate-spin text-tx-tertiary" />
-              </div>
-            ) : comments.length === 0 ? (
-              <div className="text-center py-12">
-                <MessageCircle size={28} className="mx-auto mb-2 text-tx-tertiary/30" />
-                <p className="text-xs text-tx-tertiary">暂无评论</p>
-                <p className="text-[10px] text-tx-tertiary/60 mt-0.5">在下方输入框添加评论</p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {topComments.map((comment) => (
-                  <CommentItem
-                    key={comment.id}
-                    comment={comment}
-                    replies={getReplies(comment.id)}
-                    onReply={(id) => { setReplyTo(id); inputRef.current?.focus(); }}
-                    onDelete={handleDelete}
-                    onToggleResolved={handleToggleResolved}
-                    formatTime={formatTime}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-
-        {/* 输入区域 */}
-        <div className="px-5 py-3 border-t border-app-border bg-app-bg/50">
-          {replyTo && (
-            <div className="flex items-center gap-2 mb-2 text-[11px] text-tx-tertiary">
-              <Reply size={12} />
-              <span>回复评论</span>
-              <button onClick={() => setReplyTo(null)} className="ml-auto text-tx-tertiary hover:text-tx-secondary">
-                <X size={12} />
-              </button>
-            </div>
-          )}
-          <div className="flex gap-2">
-            <textarea
-              ref={inputRef}
-              value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="输入评论... (Ctrl+Enter 发送)"
-              rows={2}
-              className="flex-1 px-3 py-2 text-xs rounded-lg border border-app-border bg-app-bg text-tx-primary placeholder:text-tx-tertiary/50 focus:outline-none focus:border-accent-primary/50 resize-none"
-            />
-            <Button
-              onClick={handleSubmit}
-              disabled={!newComment.trim() || submitting}
-              size="icon"
-              className="h-auto w-10 shrink-0 bg-accent-primary hover:bg-accent-primary/90 text-white rounded-lg"
-            >
-              {submitting ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
-            </Button>
-          </div>
-        </div>
-      </motion.div>
-    </div>
-  );
-}
-
-/* ===== 单条评论 ===== */
-function CommentItem({
-  comment,
-  replies,
-  onReply,
-  onDelete,
-  onToggleResolved,
-  formatTime,
-}: {
-  comment: ShareComment;
-  replies: ShareComment[];
-  onReply: (id: string) => void;
-  onDelete: (id: string) => void;
-  onToggleResolved: (id: string) => void;
-  formatTime: (date: string) => string;
-}) {
-  return (
-    <div className={cn("rounded-lg border p-3 transition-colors", comment.isResolved ? "border-app-border/50 bg-app-bg/30 opacity-60" : "border-app-border bg-app-bg")}>
-      {/* 评论头部 */}
-      <div className="flex items-center gap-2 mb-1.5">
-        <div className={cn(
-          "w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium",
-          // 访客评论用更柔和的灰底，与登录用户的 accent-primary 区分
-          comment.isGuest
-            ? "bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300"
-            : "bg-accent-primary/20 text-accent-primary",
-        )}>
-          {((comment.displayName || comment.username || "?")[0] || "?").toUpperCase()}
-        </div>
-        <span className="text-[11px] font-medium text-tx-primary">
-          {comment.displayName || comment.username || "匿名"}
-        </span>
-        {comment.isGuest && (
-          <span className="px-1 text-[9px] rounded bg-zinc-100 dark:bg-zinc-800 text-tx-tertiary" title="未登录访客留言">
-            访客
-          </span>
-        )}
-        <span className="text-[10px] text-tx-tertiary/60">{formatTime(comment.createdAt)}</span>
-        <div className="ml-auto flex items-center gap-1">
-          <button
-            onClick={() => onToggleResolved(comment.id)}
-            className={cn(
-              "p-1 rounded transition-colors",
-              comment.isResolved
-                ? "text-green-500 hover:bg-green-500/10"
-                : "text-tx-tertiary hover:text-green-500 hover:bg-green-500/10"
-            )}
-            title={comment.isResolved ? "标记为未解决" : "标记为已解决"}
-          >
-            {comment.isResolved ? <CheckCircle2 size={13} /> : <Circle size={13} />}
-          </button>
-          <button onClick={() => onReply(comment.id)} className="p-1 rounded text-tx-tertiary hover:text-accent-primary hover:bg-accent-primary/10 transition-colors" title="回复">
-            <Reply size={13} />
-          </button>
-          <button onClick={() => onDelete(comment.id)} className="p-1 rounded text-tx-tertiary hover:text-red-500 hover:bg-red-500/10 transition-colors" title="删除">
-            <Trash2 size={13} />
-          </button>
-        </div>
-      </div>
-
-      {/* 评论内容 */}
-      <p className="text-xs text-tx-secondary leading-relaxed whitespace-pre-wrap">{comment.content}</p>
-
-      {/* 回复列表 */}
-      {replies.length > 0 && (
-        <div className="mt-2.5 pl-3 border-l-2 border-app-border/50 space-y-2">
-          {replies.map((reply) => (
-            <div key={reply.id} className="text-xs">
-              <div className="flex items-center gap-1.5 mb-0.5">
-                <span className="font-medium text-tx-primary text-[11px]">
-                  {reply.displayName || reply.username || "匿名"}
-                </span>
-                {reply.isGuest && (
-                  <span className="px-1 text-[9px] rounded bg-zinc-100 dark:bg-zinc-800 text-tx-tertiary">访客</span>
-                )}
-                <span className="text-[10px] text-tx-tertiary/60">{formatTime(reply.createdAt)}</span>
-                <button onClick={() => onDelete(reply.id)} className="ml-auto p-0.5 rounded text-tx-tertiary/40 hover:text-red-500 transition-colors">
-                  <Trash2 size={11} />
-                </button>
-              </div>
-              <p className="text-tx-secondary leading-relaxed whitespace-pre-wrap">{reply.content}</p>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+  return null;
 }

--- a/frontend/src/components/InlineCommentBridge.tsx
+++ b/frontend/src/components/InlineCommentBridge.tsx
@@ -1,0 +1,945 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { EditorView } from "@codemirror/view";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  Loader2,
+  MessageCircle,
+  MessageSquarePlus,
+  Quote,
+  Reply,
+  Send,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { api } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
+import type { Note, ShareComment, User } from "@/types";
+import {
+  buildTextCommentAnchor,
+  compactAnchorQuote,
+  parseTextCommentAnchor,
+  resolveTextCommentAnchor,
+  serializeTextCommentAnchor,
+  type InlineCommentEditor,
+  type TextCommentAnchor,
+} from "@/lib/inlineCommentAnchor";
+import {
+  CLOSE_INLINE_COMMENT_PANEL_EVENT,
+  OPEN_INLINE_COMMENT_PANEL_EVENT,
+  type OpenInlineCommentPanelDetail,
+} from "@/lib/inlineCommentEvents";
+
+type SelectionDraft = {
+  note: Note;
+  anchor: TextCommentAnchor;
+  top: number;
+  left: number;
+};
+
+type EditorDocument = {
+  editor: InlineCommentEditor;
+  root: HTMLElement;
+  text: string;
+  view?: EditorView;
+};
+
+const TRACKING_PATCH = Symbol.for("nowen.inline-comments.api-tracking");
+const COMMENT_HIGHLIGHT = "nowen-comment-anchor";
+const ACTIVE_COMMENT_HIGHLIGHT = "nowen-comment-active";
+const noteCache = new Map<string, Note>();
+const noteListeners = new Set<(note: Note) => void>();
+let latestTrackedNote: Note | null = null;
+
+function publishTrackedNote(note: Note | null | undefined): void {
+  if (!note?.id) return;
+  noteCache.set(note.id, note);
+  latestTrackedNote = note;
+  noteListeners.forEach((listener) => listener(note));
+}
+
+function installNoteApiTracking(): void {
+  const mutableApi = api as any;
+  if (mutableApi[TRACKING_PATCH]) return;
+  mutableApi[TRACKING_PATCH] = true;
+
+  const originalGetNote = mutableApi.getNote?.bind(mutableApi);
+  if (originalGetNote) {
+    mutableApi.getNote = async (...args: unknown[]) => {
+      const note = await originalGetNote(...args);
+      publishTrackedNote(note);
+      return note;
+    };
+  }
+
+  const originalCreateNote = mutableApi.createNote?.bind(mutableApi);
+  if (originalCreateNote) {
+    mutableApi.createNote = async (...args: unknown[]) => {
+      const note = await originalCreateNote(...args);
+      publishTrackedNote(note);
+      return note;
+    };
+  }
+
+  const originalUpdateNote = mutableApi.updateNote?.bind(mutableApi);
+  if (originalUpdateNote) {
+    mutableApi.updateNote = async (...args: unknown[]) => {
+      const note = await originalUpdateNote(...args);
+      if (note?.id) {
+        noteCache.set(note.id, note);
+        if (latestTrackedNote?.id === note.id) publishTrackedNote(note);
+      }
+      return note;
+    };
+  }
+}
+
+function subscribeTrackedNote(listener: (note: Note) => void): () => void {
+  noteListeners.add(listener);
+  if (latestTrackedNote) listener(latestTrackedNote);
+  return () => noteListeners.delete(listener);
+}
+
+function canCommentOnNote(note: Note | null): boolean {
+  if (!note) return false;
+  return note.permission == null
+    || note.permission === "comment"
+    || note.permission === "write"
+    || note.permission === "manage";
+}
+
+function canManageComments(note: Note | null): boolean {
+  return !!note && (note.permission == null || note.permission === "manage");
+}
+
+function noteMatchesEditor(note: Note, editor: InlineCommentEditor): boolean {
+  const isMarkdown = note.contentFormat === "markdown";
+  return editor === "markdown" ? isMarkdown : !isMarkdown;
+}
+
+function noteTextForEditor(note: Note, editor: InlineCommentEditor): string {
+  return editor === "markdown" ? (note.content || "") : (note.contentText || "");
+}
+
+function chooseNoteForSelection(anchor: TextCommentAnchor, documentText: string): Note | null {
+  const candidates = Array.from(noteCache.values()).filter((note) => noteMatchesEditor(note, anchor.editor));
+  if (latestTrackedNote && !candidates.some((note) => note.id === latestTrackedNote?.id)) {
+    candidates.push(latestTrackedNote);
+  }
+  if (candidates.length === 0) return latestTrackedNote;
+
+  const scored = candidates.map((note) => {
+    const noteText = noteTextForEditor(note, anchor.editor);
+    let score = 0;
+    if (note.id === latestTrackedNote?.id) score += 8;
+    if (noteText.includes(anchor.quote)) score += 30;
+    if (noteText.length && documentText.length) {
+      const ratio = Math.min(noteText.length, documentText.length) / Math.max(noteText.length, documentText.length);
+      score += ratio * 6;
+    }
+    return { note, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored[0]?.note || latestTrackedNote;
+}
+
+function findEditorRoot(target: Node | null): HTMLElement | null {
+  if (!(target instanceof Element)) return target?.parentElement?.closest?.(".ProseMirror, .cm-content") || null;
+  return target.closest<HTMLElement>(".ProseMirror, .cm-content");
+}
+
+function getCodeMirrorView(root: HTMLElement): EditorView | null {
+  try {
+    return EditorView.findFromDOM(root);
+  } catch {
+    return null;
+  }
+}
+
+function getEditorDocument(root: HTMLElement): EditorDocument | null {
+  if (root.classList.contains("cm-content")) {
+    const view = getCodeMirrorView(root);
+    if (!view) return null;
+    return {
+      editor: "markdown",
+      root,
+      text: view.state.doc.toString(),
+      view,
+    };
+  }
+  return {
+    editor: "tiptap",
+    root,
+    text: root.textContent || "",
+  };
+}
+
+function getTextOffset(root: HTMLElement, container: Node, offset: number): number {
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    range.setEnd(container, offset);
+    return range.toString().length;
+  } catch {
+    return 0;
+  }
+}
+
+function createDomRange(root: HTMLElement, start: number, end: number): Range | null {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  let consumed = 0;
+  let startNode: Text | null = null;
+  let endNode: Text | null = null;
+  let startOffset = 0;
+  let endOffset = 0;
+
+  while (node) {
+    const textNode = node as Text;
+    const length = textNode.data.length;
+    if (!startNode && start <= consumed + length) {
+      startNode = textNode;
+      startOffset = Math.max(0, Math.min(length, start - consumed));
+    }
+    if (end <= consumed + length) {
+      endNode = textNode;
+      endOffset = Math.max(0, Math.min(length, end - consumed));
+      break;
+    }
+    consumed += length;
+    node = walker.nextNode();
+  }
+
+  if (!startNode) return null;
+  if (!endNode) {
+    endNode = startNode;
+    endOffset = startNode.data.length;
+  }
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+function readSelectionDraft(): SelectionDraft | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const range = selection.getRangeAt(0);
+  const root = findEditorRoot(range.commonAncestorContainer);
+  if (!root) return null;
+  const documentInfo = getEditorDocument(root);
+  if (!documentInfo) return null;
+
+  let start = 0;
+  let end = 0;
+  if (documentInfo.editor === "markdown" && documentInfo.view) {
+    const main = documentInfo.view.state.selection.main;
+    start = main.from;
+    end = main.to;
+  } else {
+    start = getTextOffset(root, range.startContainer, range.startOffset);
+    end = getTextOffset(root, range.endContainer, range.endOffset);
+  }
+  if (end < start) [start, end] = [end, start];
+
+  const anchor = buildTextCommentAnchor({
+    editor: documentInfo.editor,
+    documentText: documentInfo.text,
+    start,
+    end,
+  });
+  if (!anchor) return null;
+  const note = chooseNoteForSelection(anchor, documentInfo.text);
+  if (!note || !canCommentOnNote(note)) return null;
+
+  const rect = range.getBoundingClientRect();
+  if (!rect || (!rect.width && !rect.height)) return null;
+  const left = Math.max(8, Math.min(window.innerWidth - 48, rect.right + 8));
+  const top = Math.max(8, Math.min(window.innerHeight - 48, rect.top - 42));
+  return { note, anchor, top, left };
+}
+
+function resolveAnchorInDocument(documentInfo: EditorDocument, anchor: TextCommentAnchor) {
+  return resolveTextCommentAnchor(documentInfo.text, anchor);
+}
+
+function editorDocuments(editor?: InlineCommentEditor): EditorDocument[] {
+  const selector = editor === "markdown"
+    ? ".cm-content"
+    : editor === "tiptap"
+      ? ".ProseMirror"
+      : ".ProseMirror, .cm-content";
+  return Array.from(document.querySelectorAll<HTMLElement>(selector))
+    .map(getEditorDocument)
+    .filter((value): value is EditorDocument => !!value);
+}
+
+function clearCommentHighlights(): void {
+  const highlights = (CSS as any)?.highlights;
+  highlights?.delete?.(COMMENT_HIGHLIGHT);
+  highlights?.delete?.(ACTIVE_COMMENT_HIGHLIGHT);
+}
+
+function renderCommentHighlights(comments: ShareComment[], activeCommentId: string | null): void {
+  const highlights = (CSS as any)?.highlights;
+  const HighlightCtor = (window as any).Highlight;
+  if (!highlights || !HighlightCtor) return;
+
+  const normalRanges: Range[] = [];
+  const activeRanges: Range[] = [];
+  const topLevel = comments.filter((comment) => !comment.parentId && !comment.isResolved);
+  for (const comment of topLevel) {
+    const anchor = parseTextCommentAnchor(comment.anchorData);
+    if (!anchor) continue;
+    for (const documentInfo of editorDocuments(anchor.editor)) {
+      const resolved = resolveAnchorInDocument(documentInfo, anchor);
+      if (!resolved) continue;
+      let range: Range | null = null;
+      if (documentInfo.editor === "markdown" && documentInfo.view) {
+        try {
+          const startDom = documentInfo.view.domAtPos(resolved.start);
+          const endDom = documentInfo.view.domAtPos(resolved.end);
+          range = document.createRange();
+          range.setStart(startDom.node, startDom.offset);
+          range.setEnd(endDom.node, endDom.offset);
+        } catch {
+          range = null;
+        }
+      } else {
+        range = createDomRange(documentInfo.root, resolved.start, resolved.end);
+      }
+      if (!range) continue;
+      (comment.id === activeCommentId ? activeRanges : normalRanges).push(range);
+    }
+  }
+
+  highlights.delete(COMMENT_HIGHLIGHT);
+  highlights.delete(ACTIVE_COMMENT_HIGHLIGHT);
+  if (normalRanges.length) highlights.set(COMMENT_HIGHLIGHT, new HighlightCtor(...normalRanges));
+  if (activeRanges.length) highlights.set(ACTIVE_COMMENT_HIGHLIGHT, new HighlightCtor(...activeRanges));
+}
+
+function caretOffsetFromPoint(documentInfo: EditorDocument, x: number, y: number): number | null {
+  if (documentInfo.editor === "markdown" && documentInfo.view) {
+    try {
+      return documentInfo.view.posAtCoords({ x, y });
+    } catch {
+      return null;
+    }
+  }
+
+  const doc = document as any;
+  const caret = typeof doc.caretPositionFromPoint === "function"
+    ? doc.caretPositionFromPoint(x, y)
+    : typeof doc.caretRangeFromPoint === "function"
+      ? doc.caretRangeFromPoint(x, y)
+      : null;
+  if (!caret) return null;
+  const node = caret.offsetNode || caret.startContainer;
+  const offset = caret.offset ?? caret.startOffset;
+  if (!node || !documentInfo.root.contains(node)) return null;
+  return getTextOffset(documentInfo.root, node, offset);
+}
+
+function focusCommentAnchor(comment: ShareComment): boolean {
+  const anchor = parseTextCommentAnchor(comment.anchorData);
+  if (!anchor) return false;
+  for (const documentInfo of editorDocuments(anchor.editor)) {
+    const resolved = resolveAnchorInDocument(documentInfo, anchor);
+    if (!resolved) continue;
+    if (documentInfo.editor === "markdown" && documentInfo.view) {
+      try {
+        documentInfo.view.dispatch({
+          selection: { anchor: resolved.start, head: resolved.end },
+          effects: EditorView.scrollIntoView(resolved.start, { y: "center" }),
+        });
+        documentInfo.view.focus();
+        return true;
+      } catch {
+        continue;
+      }
+    }
+    const range = createDomRange(documentInfo.root, resolved.start, resolved.end);
+    if (!range) continue;
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const element = range.startContainer.parentElement;
+    element?.scrollIntoView({ block: "center", behavior: "smooth" });
+    return true;
+  }
+  return false;
+}
+
+function formatCommentTime(value: string): string {
+  const date = new Date(value);
+  const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+  if (seconds < 60) return "刚刚";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} 分钟前`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)} 小时前`;
+  return date.toLocaleString("zh-CN", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function CommentThread({
+  comment,
+  replies,
+  active,
+  currentUser,
+  canManage,
+  onActivate,
+  onReply,
+  onDelete,
+  onResolve,
+}: {
+  comment: ShareComment;
+  replies: ShareComment[];
+  active: boolean;
+  currentUser: User | null;
+  canManage: boolean;
+  onActivate: (comment: ShareComment) => void;
+  onReply: (comment: ShareComment) => void;
+  onDelete: (comment: ShareComment) => void;
+  onResolve: (comment: ShareComment) => void;
+}) {
+  const anchor = parseTextCommentAnchor(comment.anchorData);
+  const canDelete = canManage || (!!currentUser && comment.userId === currentUser.id);
+  return (
+    <article
+      className={cn(
+        "rounded-xl border bg-app-surface p-3 transition-colors",
+        active ? "border-amber-400/70 shadow-sm" : "border-app-border",
+        !!comment.isResolved && "opacity-60",
+      )}
+      data-comment-thread-id={comment.id}
+    >
+      {anchor && (
+        <button
+          type="button"
+          onClick={() => onActivate(comment)}
+          className="mb-2 flex w-full items-start gap-2 rounded-lg border-l-2 border-amber-400 bg-amber-400/8 px-2.5 py-2 text-left text-xs text-tx-secondary hover:bg-amber-400/12"
+          title={anchor.quote}
+        >
+          <Quote size={13} className="mt-0.5 shrink-0 text-amber-500" />
+          <span className="line-clamp-2 leading-5">{compactAnchorQuote(anchor, 140)}</span>
+        </button>
+      )}
+
+      <div className="flex items-center gap-2">
+        <div className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold",
+          comment.isGuest
+            ? "bg-zinc-200 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-200"
+            : "bg-accent-primary/15 text-accent-primary",
+        )}>
+          {((comment.displayName || comment.username || "?")[0] || "?").toUpperCase()}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-medium text-tx-primary">
+            {comment.displayName || comment.username || "匿名"}
+          </div>
+          <div className="text-[10px] text-tx-tertiary">{formatCommentTime(comment.createdAt)}</div>
+        </div>
+        <div className="flex items-center gap-0.5">
+          {canManage && (
+            <button
+              type="button"
+              onClick={() => onResolve(comment)}
+              className="rounded-md p-1.5 text-tx-tertiary hover:bg-green-500/10 hover:text-green-500"
+              title={comment.isResolved ? "重新打开" : "标记为已解决"}
+            >
+              {comment.isResolved ? <CheckCircle2 size={14} /> : <Circle size={14} />}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => onReply(comment)}
+            className="rounded-md p-1.5 text-tx-tertiary hover:bg-accent-primary/10 hover:text-accent-primary"
+            title="回复"
+          >
+            <Reply size={14} />
+          </button>
+          {canDelete && (
+            <button
+              type="button"
+              onClick={() => onDelete(comment)}
+              className="rounded-md p-1.5 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500"
+              title="删除"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+      <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-tx-secondary">{comment.content}</p>
+
+      {replies.length > 0 && (
+        <div className="mt-3 space-y-2 border-l-2 border-app-border pl-3">
+          {replies.map((reply) => {
+            const canDeleteReply = canManage || (!!currentUser && reply.userId === currentUser.id);
+            return (
+              <div key={reply.id} className="rounded-lg bg-app-hover/60 px-2.5 py-2">
+                <div className="flex items-center gap-1.5 text-[11px]">
+                  <span className="font-medium text-tx-primary">{reply.displayName || reply.username || "匿名"}</span>
+                  <span className="text-tx-tertiary">{formatCommentTime(reply.createdAt)}</span>
+                  {canDeleteReply && (
+                    <button
+                      type="button"
+                      onClick={() => onDelete(reply)}
+                      className="ml-auto rounded p-1 text-tx-tertiary hover:text-red-500"
+                      title="删除回复"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  )}
+                </div>
+                <p className="mt-1 whitespace-pre-wrap break-words text-xs leading-5 text-tx-secondary">{reply.content}</p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function InlineCommentBridge() {
+  const { t } = useTranslation();
+  const [currentNote, setCurrentNote] = useState<Note | null>(() => latestTrackedNote);
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [comments, setComments] = useState<ShareComment[]>([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [selectionDraft, setSelectionDraft] = useState<SelectionDraft | null>(null);
+  const [pendingAnchor, setPendingAnchor] = useState<TextCommentAnchor | null>(null);
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
+  const [replyTo, setReplyTo] = useState<ShareComment | null>(null);
+  const [composer, setComposer] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [showResolved, setShowResolved] = useState(false);
+  const externalCloseRef = useRef<(() => void) | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const loadRequestRef = useRef(0);
+
+  useEffect(() => {
+    installNoteApiTracking();
+    return subscribeTrackedNote(setCurrentNote);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getMe()
+      .then((user) => { if (!cancelled) setCurrentUser(user); })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, []);
+
+  const loadComments = useCallback(async (noteId: string, quiet = false) => {
+    const requestId = ++loadRequestRef.current;
+    if (!quiet) setCommentsLoading(true);
+    try {
+      const data = await api.getNoteComments(noteId);
+      if (requestId === loadRequestRef.current) setComments(data);
+    } catch (error: any) {
+      if (!quiet) toast.error(error?.message || "加载评论失败");
+    } finally {
+      if (!quiet && requestId === loadRequestRef.current) setCommentsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!currentNote?.id) {
+      setComments([]);
+      return;
+    }
+    setActiveCommentId(null);
+    setReplyTo(null);
+    setPendingAnchor(null);
+    void loadComments(currentNote.id);
+  }, [currentNote?.id, loadComments]);
+
+  useEffect(() => {
+    if (!panelOpen || !currentNote?.id) return;
+    const timer = window.setInterval(() => void loadComments(currentNote.id, true), 10_000);
+    const onFocus = () => void loadComments(currentNote.id, true);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [currentNote?.id, loadComments, panelOpen]);
+
+  const closePanel = useCallback(() => {
+    setPanelOpen(false);
+    setPendingAnchor(null);
+    setReplyTo(null);
+    setComposer("");
+    setActiveCommentId(null);
+    clearCommentHighlights();
+    const callback = externalCloseRef.current;
+    externalCloseRef.current = null;
+    callback?.();
+  }, []);
+
+  useEffect(() => {
+    const onOpen = (event: Event) => {
+      const detail = (event as CustomEvent<OpenInlineCommentPanelDetail>).detail;
+      if (!detail?.noteId) return;
+      externalCloseRef.current = detail.onClose || null;
+      setPendingAnchor(detail.anchor || null);
+      setPanelOpen(true);
+      setSelectionDraft(null);
+      api.getNote(detail.noteId)
+        .then((note) => {
+          publishTrackedNote(note);
+          setCurrentNote(note);
+          void loadComments(note.id);
+        })
+        .catch((error: any) => toast.error(error?.message || "无法打开评论"));
+      window.setTimeout(() => textareaRef.current?.focus(), 120);
+    };
+    const onClose = () => closePanel();
+    window.addEventListener(OPEN_INLINE_COMMENT_PANEL_EVENT, onOpen as EventListener);
+    window.addEventListener(CLOSE_INLINE_COMMENT_PANEL_EVENT, onClose);
+    return () => {
+      window.removeEventListener(OPEN_INLINE_COMMENT_PANEL_EVENT, onOpen as EventListener);
+      window.removeEventListener(CLOSE_INLINE_COMMENT_PANEL_EVENT, onClose);
+    };
+  }, [closePanel, loadComments]);
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => setSelectionDraft(readSelectionDraft()));
+    };
+    const hideOnPointerDown = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (target?.closest("[data-inline-comment-ui]")) return;
+      if (!findEditorRoot(event.target as Node | null)) setSelectionDraft(null);
+    };
+    document.addEventListener("selectionchange", update);
+    document.addEventListener("mouseup", update);
+    document.addEventListener("keyup", update);
+    document.addEventListener("pointerdown", hideOnPointerDown);
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("selectionchange", update);
+      document.removeEventListener("mouseup", update);
+      document.removeEventListener("keyup", update);
+      document.removeEventListener("pointerdown", hideOnPointerDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    let frame = 0;
+    const render = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => renderCommentHighlights(comments, activeCommentId));
+    };
+    render();
+    window.addEventListener("resize", render);
+    document.addEventListener("scroll", render, true);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", render);
+      document.removeEventListener("scroll", render, true);
+      clearCommentHighlights();
+    };
+  }, [activeCommentId, comments]);
+
+  useEffect(() => {
+    const onPointerUp = (event: PointerEvent) => {
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
+      const root = findEditorRoot(event.target as Node | null);
+      if (!root || comments.length === 0) return;
+      const documentInfo = getEditorDocument(root);
+      if (!documentInfo) return;
+      const offset = caretOffsetFromPoint(documentInfo, event.clientX, event.clientY);
+      if (offset == null) return;
+      const hit = comments.find((comment) => {
+        if (comment.parentId || comment.isResolved) return false;
+        const anchor = parseTextCommentAnchor(comment.anchorData);
+        if (!anchor || anchor.editor !== documentInfo.editor) return false;
+        const resolved = resolveAnchorInDocument(documentInfo, anchor);
+        return !!resolved && offset >= resolved.start && offset <= resolved.end;
+      });
+      if (!hit) return;
+      setActiveCommentId(hit.id);
+      setPanelOpen(true);
+      setPendingAnchor(null);
+      window.setTimeout(() => {
+        document.querySelector(`[data-comment-thread-id="${hit.id}"]`)?.scrollIntoView({ block: "center", behavior: "smooth" });
+      }, 80);
+    };
+    document.addEventListener("pointerup", onPointerUp);
+    return () => document.removeEventListener("pointerup", onPointerUp);
+  }, [comments]);
+
+  const openFromSelection = useCallback(() => {
+    if (!selectionDraft) return;
+    publishTrackedNote(selectionDraft.note);
+    setCurrentNote(selectionDraft.note);
+    setPendingAnchor(selectionDraft.anchor);
+    setReplyTo(null);
+    setComposer("");
+    setPanelOpen(true);
+    setSelectionDraft(null);
+    window.setTimeout(() => textareaRef.current?.focus(), 100);
+  }, [selectionDraft]);
+
+  const activateThread = useCallback((comment: ShareComment) => {
+    setActiveCommentId(comment.id);
+    setPanelOpen(true);
+    const located = focusCommentAnchor(comment);
+    if (!located) toast.warning("原文已修改，无法定位该批注");
+  }, []);
+
+  const submitComment = useCallback(async () => {
+    const note = currentNote;
+    const content = composer.trim();
+    if (!note || !content || submitting || !canCommentOnNote(note)) return;
+    setSubmitting(true);
+    try {
+      const created = await api.addNoteComment(note.id, {
+        content,
+        parentId: replyTo?.id,
+        anchorData: !replyTo && pendingAnchor ? serializeTextCommentAnchor(pendingAnchor) : undefined,
+      });
+      setComments((items) => [...items, created]);
+      setComposer("");
+      setReplyTo(null);
+      if (!created.parentId) {
+        setPendingAnchor(null);
+        setActiveCommentId(created.id);
+      }
+      toast.success(replyTo ? "回复已发送" : pendingAnchor ? "批注已添加" : "评论已添加");
+    } catch (error: any) {
+      toast.error(error?.message || "评论发送失败");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [composer, currentNote, pendingAnchor, replyTo, submitting]);
+
+  const deleteComment = useCallback(async (comment: ShareComment) => {
+    if (!currentNote) return;
+    try {
+      await api.deleteNoteComment(currentNote.id, comment.id);
+      await loadComments(currentNote.id, true);
+      if (activeCommentId === comment.id) setActiveCommentId(null);
+      toast.success("评论已删除");
+    } catch (error: any) {
+      toast.error(error?.message || "删除失败");
+    }
+  }, [activeCommentId, currentNote, loadComments]);
+
+  const toggleResolved = useCallback(async (comment: ShareComment) => {
+    if (!currentNote) return;
+    try {
+      const updated = await api.toggleCommentResolved(currentNote.id, comment.id);
+      setComments((items) => items.map((item) => item.id === updated.id ? updated : item));
+    } catch (error: any) {
+      toast.error(error?.message || "更新状态失败");
+    }
+  }, [currentNote]);
+
+  const topComments = useMemo(() => comments.filter((comment) => !comment.parentId), [comments]);
+  const visibleComments = useMemo(
+    () => topComments.filter((comment) => showResolved || !comment.isResolved),
+    [showResolved, topComments],
+  );
+  const unresolvedCount = topComments.filter((comment) => !comment.isResolved).length;
+  const canComment = canCommentOnNote(currentNote);
+  const canManage = canManageComments(currentNote);
+
+  return createPortal(
+    <>
+      {selectionDraft && (
+        <button
+          type="button"
+          data-inline-comment-ui
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={openFromSelection}
+          className="fixed z-[88] flex h-9 w-9 items-center justify-center rounded-lg border border-app-border bg-app-elevated text-accent-primary shadow-lg transition-transform hover:scale-105 hover:bg-app-hover"
+          style={{ top: selectionDraft.top, left: selectionDraft.left }}
+          title={t("comments.addInline", { defaultValue: "添加批注" })}
+          aria-label={t("comments.addInline", { defaultValue: "添加批注" })}
+        >
+          <MessageSquarePlus size={17} />
+        </button>
+      )}
+
+      {!panelOpen && currentNote && (canComment || unresolvedCount > 0) && (
+        <button
+          type="button"
+          data-inline-comment-ui
+          onClick={() => {
+            setPendingAnchor(null);
+            setReplyTo(null);
+            setPanelOpen(true);
+          }}
+          className="nowen-inline-comment-rail fixed right-3 top-1/2 z-[58] hidden -translate-y-1/2 items-center gap-1.5 rounded-full border border-app-border bg-app-elevated px-2.5 py-2 text-xs text-tx-secondary shadow-md hover:bg-app-hover md:flex"
+          title={t("comments.openPanel", { defaultValue: "评论与批注" })}
+        >
+          <MessageCircle size={16} className="text-accent-primary" />
+          {unresolvedCount > 0 && <span className="tabular-nums">{unresolvedCount}</span>}
+        </button>
+      )}
+
+      {panelOpen && (
+        <div className="fixed inset-0 z-[89] pointer-events-none" data-inline-comment-ui>
+          <button
+            type="button"
+            className="absolute inset-0 pointer-events-auto bg-black/20 md:hidden"
+            onClick={closePanel}
+            aria-label="关闭评论面板"
+          />
+          <aside className="nowen-inline-comment-panel pointer-events-auto absolute inset-y-0 right-0 flex w-full flex-col border-l border-app-border bg-app-elevated shadow-2xl sm:w-[390px]">
+            <header className="flex items-center gap-3 border-b border-app-border px-4 py-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent-primary/10 text-accent-primary">
+                <MessageCircle size={18} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-semibold text-tx-primary">评论与批注</h2>
+                <p className="truncate text-[11px] text-tx-tertiary">
+                  {currentNote?.title || "当前笔记"} · {unresolvedCount} 条未解决
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closePanel}
+                className="rounded-lg p-2 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+                aria-label="关闭"
+              >
+                <X size={17} />
+              </button>
+            </header>
+
+            <div className="flex items-center justify-between border-b border-app-border px-4 py-2">
+              <span className="text-xs text-tx-tertiary">{topComments.length} 个讨论</span>
+              <label className="flex cursor-pointer items-center gap-2 text-xs text-tx-secondary">
+                <input
+                  type="checkbox"
+                  checked={showResolved}
+                  onChange={(event) => setShowResolved(event.target.checked)}
+                  className="accent-accent-primary"
+                />
+                显示已解决
+              </label>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-3 py-3">
+              {commentsLoading ? (
+                <div className="flex h-40 items-center justify-center text-tx-tertiary">
+                  <Loader2 size={20} className="animate-spin" />
+                </div>
+              ) : visibleComments.length === 0 ? (
+                <div className="flex h-52 flex-col items-center justify-center text-center">
+                  <MessageCircle size={30} className="mb-3 text-tx-tertiary/30" />
+                  <p className="text-sm text-tx-secondary">暂无评论</p>
+                  <p className="mt-1 max-w-56 text-xs leading-5 text-tx-tertiary">
+                    选中正文后点击批注按钮，或在下方添加整篇笔记评论。
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {visibleComments.map((comment) => (
+                    <CommentThread
+                      key={comment.id}
+                      comment={comment}
+                      replies={comments.filter((reply) => reply.parentId === comment.id)}
+                      active={activeCommentId === comment.id}
+                      currentUser={currentUser}
+                      canManage={canManage}
+                      onActivate={activateThread}
+                      onReply={(target) => {
+                        setReplyTo(target);
+                        setPendingAnchor(null);
+                        window.setTimeout(() => textareaRef.current?.focus(), 0);
+                      }}
+                      onDelete={deleteComment}
+                      onResolve={toggleResolved}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {canComment ? (
+              <footer className="border-t border-app-border bg-app-surface/80 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3">
+                {replyTo && (
+                  <div className="mb-2 flex items-center gap-2 rounded-lg bg-app-hover px-2.5 py-1.5 text-xs text-tx-secondary">
+                    <Reply size={13} />
+                    <span className="min-w-0 flex-1 truncate">回复 {replyTo.displayName || replyTo.username || "评论"}</span>
+                    <button type="button" onClick={() => setReplyTo(null)} className="rounded p-1 hover:bg-app-active">
+                      <X size={12} />
+                    </button>
+                  </div>
+                )}
+                {!replyTo && pendingAnchor && (
+                  <div className="mb-2 rounded-lg border-l-2 border-amber-400 bg-amber-400/8 px-2.5 py-2 text-xs text-tx-secondary">
+                    <div className="mb-1 flex items-center gap-1.5 font-medium text-amber-600 dark:text-amber-400">
+                      <Quote size={12} />
+                      批注选中文字
+                    </div>
+                    <p className="line-clamp-2 leading-5">{compactAnchorQuote(pendingAnchor, 160)}</p>
+                    <button type="button" onClick={() => setPendingAnchor(null)} className="mt-1 text-[11px] text-tx-tertiary hover:text-tx-primary">
+                      改为整篇评论
+                    </button>
+                  </div>
+                )}
+                <div className="flex items-end gap-2">
+                  <textarea
+                    ref={textareaRef}
+                    value={composer}
+                    onChange={(event) => setComposer(event.target.value)}
+                    onKeyDown={(event) => {
+                      if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+                        event.preventDefault();
+                        void submitComment();
+                      }
+                    }}
+                    rows={3}
+                    maxLength={1000}
+                    placeholder={replyTo ? "输入回复…" : pendingAnchor ? "输入批注…" : "输入评论…"}
+                    className="min-h-[72px] flex-1 resize-none rounded-xl border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-primary outline-none placeholder:text-tx-tertiary focus:border-accent-primary/60"
+                  />
+                  <button
+                    type="button"
+                    disabled={!composer.trim() || submitting}
+                    onClick={() => void submitComment()}
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent-primary text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                    title="发送（Ctrl+Enter）"
+                  >
+                    {submitting ? <Loader2 size={16} className="animate-spin" /> : <Send size={16} />}
+                  </button>
+                </div>
+              </footer>
+            ) : (
+              <footer className="flex items-center gap-2 border-t border-app-border px-4 py-3 text-xs text-tx-tertiary">
+                <AlertTriangle size={14} />
+                当前权限仅允许查看评论
+              </footer>
+            )}
+          </aside>
+        </div>
+      )}
+    </>,
+    document.body,
+  );
+}

--- a/frontend/src/inline-comments.css
+++ b/frontend/src/inline-comments.css
@@ -1,0 +1,51 @@
+::highlight(nowen-comment-anchor) {
+  background-color: color-mix(in srgb, #facc15 24%, transparent);
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, #eab308 74%, transparent);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+::highlight(nowen-comment-active) {
+  background-color: color-mix(in srgb, #fb923c 34%, transparent);
+  text-decoration-line: underline;
+  text-decoration-color: #f97316;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+.nowen-inline-comment-panel {
+  animation: nowen-inline-comment-panel-in 180ms ease-out;
+  padding-top: env(safe-area-inset-top);
+}
+
+.nowen-inline-comment-rail {
+  backdrop-filter: blur(14px);
+}
+
+@keyframes nowen-inline-comment-panel-in {
+  from {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nowen-inline-comment-panel {
+    animation: none;
+  }
+}
+
+@supports not (background-color: color-mix(in srgb, red, transparent)) {
+  ::highlight(nowen-comment-anchor) {
+    background-color: rgba(250, 204, 21, 0.22);
+  }
+
+  ::highlight(nowen-comment-active) {
+    background-color: rgba(251, 146, 60, 0.32);
+  }
+}

--- a/frontend/src/lib/__tests__/inlineCommentAnchor.test.ts
+++ b/frontend/src/lib/__tests__/inlineCommentAnchor.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTextCommentAnchor,
+  parseTextCommentAnchor,
+  resolveTextCommentAnchor,
+  serializeTextCommentAnchor,
+} from "@/lib/inlineCommentAnchor";
+
+describe("inlineCommentAnchor", () => {
+  it("trims whitespace and records surrounding context", () => {
+    const text = "第一段。\n  需要批注的内容  \n最后一段。";
+    const start = text.indexOf("  需要");
+    const end = text.indexOf("\n最后");
+    const anchor = buildTextCommentAnchor({ editor: "markdown", documentText: text, start, end });
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.quote).toBe("需要批注的内容");
+    expect(text.slice(anchor!.start, anchor!.end)).toBe(anchor?.quote);
+    expect(anchor?.prefix).toContain("第一段");
+    expect(anchor?.suffix).toContain("最后一段");
+  });
+
+  it("resolves the original exact position first", () => {
+    const text = "开头 目标文字 结尾";
+    const start = text.indexOf("目标");
+    const anchor = buildTextCommentAnchor({
+      editor: "tiptap",
+      documentText: text,
+      start,
+      end: start + "目标文字".length,
+    })!;
+
+    expect(resolveTextCommentAnchor(text, anchor)).toEqual({
+      start,
+      end: start + "目标文字".length,
+      exact: true,
+    });
+  });
+
+  it("recovers after text is inserted before the anchor", () => {
+    const original = "前文。需要批注。后文。";
+    const start = original.indexOf("需要批注");
+    const anchor = buildTextCommentAnchor({
+      editor: "tiptap",
+      documentText: original,
+      start,
+      end: start + "需要批注".length,
+    })!;
+    const updated = `新增内容。${original}`;
+    const resolved = resolveTextCommentAnchor(updated, anchor);
+
+    expect(resolved?.start).toBe(updated.indexOf("需要批注"));
+    expect(resolved?.exact).toBe(false);
+  });
+
+  it("uses prefix and suffix to disambiguate duplicate quotes", () => {
+    const original = "甲段 相同文本 乙段。丙段 相同文本 丁段。";
+    const start = original.lastIndexOf("相同文本");
+    const anchor = buildTextCommentAnchor({
+      editor: "markdown",
+      documentText: original,
+      start,
+      end: start + "相同文本".length,
+    })!;
+    const updated = `前置。${original}`;
+    const resolved = resolveTextCommentAnchor(updated, anchor);
+
+    expect(resolved?.start).toBe(updated.lastIndexOf("相同文本"));
+  });
+
+  it("rejects invalid serialized anchors", () => {
+    expect(parseTextCommentAnchor("not-json")).toBeNull();
+    expect(parseTextCommentAnchor(JSON.stringify({ kind: "text", version: 2 }))).toBeNull();
+  });
+
+  it("round trips a valid anchor", () => {
+    const anchor = buildTextCommentAnchor({
+      editor: "tiptap",
+      documentText: "abc def ghi",
+      start: 4,
+      end: 7,
+    })!;
+    expect(parseTextCommentAnchor(serializeTextCommentAnchor(anchor))).toEqual(anchor);
+  });
+});

--- a/frontend/src/lib/__tests__/shareManagement.test.ts
+++ b/frontend/src/lib/__tests__/shareManagement.test.ts
@@ -6,6 +6,10 @@ import {
   sharePermissionLabel,
   shareStatusMeta,
 } from "@/lib/shareManagement";
+import {
+  buildTextCommentAnchor,
+  resolveTextCommentAnchor,
+} from "@/lib/inlineCommentAnchor";
 
 describe("share management presentation", () => {
   it("maps permissions and lifecycle states to explicit labels", () => {
@@ -34,6 +38,25 @@ describe("share management presentation", () => {
     expect(normalizeShareManagementResponse({ total: 0, page: 1, pageSize: 20 })).toMatchObject({
       items: [],
       total: 0,
+    });
+  });
+
+  it("recovers an inline comment anchor after text is inserted before it", () => {
+    const original = "前文。需要批注。后文。";
+    const start = original.indexOf("需要批注");
+    const anchor = buildTextCommentAnchor({
+      editor: "tiptap",
+      documentText: original,
+      start,
+      end: start + "需要批注".length,
+    });
+    expect(anchor).not.toBeNull();
+
+    const updated = `新增内容。${original}`;
+    expect(resolveTextCommentAnchor(updated, anchor!)).toMatchObject({
+      start: updated.indexOf("需要批注"),
+      end: updated.indexOf("需要批注") + "需要批注".length,
+      exact: false,
     });
   });
 });

--- a/frontend/src/lib/inlineCommentAnchor.ts
+++ b/frontend/src/lib/inlineCommentAnchor.ts
@@ -1,0 +1,151 @@
+export type InlineCommentEditor = "tiptap" | "markdown";
+
+export interface TextCommentAnchor {
+  version: 1;
+  kind: "text";
+  editor: InlineCommentEditor;
+  quote: string;
+  prefix: string;
+  suffix: string;
+  start: number;
+  end: number;
+  createdAt: number;
+}
+
+export interface ResolvedTextCommentAnchor {
+  start: number;
+  end: number;
+  exact: boolean;
+}
+
+const CONTEXT_LENGTH = 32;
+const MAX_QUOTE_LENGTH = 1200;
+
+export function buildTextCommentAnchor(input: {
+  editor: InlineCommentEditor;
+  documentText: string;
+  start: number;
+  end: number;
+}): TextCommentAnchor | null {
+  const documentText = input.documentText || "";
+  let start = Math.max(0, Math.min(documentText.length, Math.trunc(input.start)));
+  let end = Math.max(start, Math.min(documentText.length, Math.trunc(input.end)));
+  const raw = documentText.slice(start, end);
+  if (!raw) return null;
+
+  const leading = raw.match(/^\s*/)?.[0].length || 0;
+  const trailing = raw.match(/\s*$/)?.[0].length || 0;
+  start += leading;
+  end -= trailing;
+  if (end <= start) return null;
+
+  const quote = documentText.slice(start, end);
+  if (!quote.trim()) return null;
+
+  return {
+    version: 1,
+    kind: "text",
+    editor: input.editor,
+    quote: quote.slice(0, MAX_QUOTE_LENGTH),
+    prefix: documentText.slice(Math.max(0, start - CONTEXT_LENGTH), start),
+    suffix: documentText.slice(end, Math.min(documentText.length, end + CONTEXT_LENGTH)),
+    start,
+    end,
+    createdAt: Date.now(),
+  };
+}
+
+export function parseTextCommentAnchor(value: unknown): TextCommentAnchor | null {
+  if (!value) return null;
+  let raw: unknown = value;
+  if (typeof value === "string") {
+    try {
+      raw = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw as Partial<TextCommentAnchor>;
+  if (data.kind !== "text" || data.version !== 1) return null;
+  if (data.editor !== "tiptap" && data.editor !== "markdown") return null;
+  if (typeof data.quote !== "string" || !data.quote.trim()) return null;
+  if (!Number.isFinite(data.start) || !Number.isFinite(data.end)) return null;
+  return {
+    version: 1,
+    kind: "text",
+    editor: data.editor,
+    quote: data.quote.slice(0, MAX_QUOTE_LENGTH),
+    prefix: typeof data.prefix === "string" ? data.prefix.slice(-CONTEXT_LENGTH) : "",
+    suffix: typeof data.suffix === "string" ? data.suffix.slice(0, CONTEXT_LENGTH) : "",
+    start: Math.max(0, Math.trunc(data.start as number)),
+    end: Math.max(0, Math.trunc(data.end as number)),
+    createdAt: Number.isFinite(data.createdAt) ? Math.trunc(data.createdAt as number) : 0,
+  };
+}
+
+function matchingSuffixLength(left: string, right: string): number {
+  const limit = Math.min(left.length, right.length);
+  let count = 0;
+  for (let i = 1; i <= limit; i += 1) {
+    if (left[left.length - i] !== right[right.length - i]) break;
+    count += 1;
+  }
+  return count;
+}
+
+function matchingPrefixLength(left: string, right: string): number {
+  const limit = Math.min(left.length, right.length);
+  let count = 0;
+  for (let i = 0; i < limit; i += 1) {
+    if (left[i] !== right[i]) break;
+    count += 1;
+  }
+  return count;
+}
+
+export function resolveTextCommentAnchor(
+  documentText: string,
+  anchor: TextCommentAnchor,
+): ResolvedTextCommentAnchor | null {
+  const text = documentText || "";
+  if (!anchor.quote || !text) return null;
+
+  const expectedStart = Math.max(0, Math.min(text.length, anchor.start));
+  const expectedEnd = expectedStart + anchor.quote.length;
+  if (expectedEnd <= text.length && text.slice(expectedStart, expectedEnd) === anchor.quote) {
+    return { start: expectedStart, end: expectedEnd, exact: true };
+  }
+
+  const candidates: Array<{ start: number; score: number }> = [];
+  let cursor = 0;
+  while (cursor <= text.length - anchor.quote.length) {
+    const found = text.indexOf(anchor.quote, cursor);
+    if (found === -1) break;
+    const before = text.slice(Math.max(0, found - CONTEXT_LENGTH), found);
+    const after = text.slice(found + anchor.quote.length, found + anchor.quote.length + CONTEXT_LENGTH);
+    const prefixScore = matchingSuffixLength(before, anchor.prefix);
+    const suffixScore = matchingPrefixLength(after, anchor.suffix);
+    const distancePenalty = Math.min(Math.abs(found - anchor.start), 10_000) / 10_000;
+    candidates.push({ start: found, score: prefixScore * 3 + suffixScore * 3 - distancePenalty });
+    cursor = found + Math.max(1, anchor.quote.length);
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.score - a.score || Math.abs(a.start - anchor.start) - Math.abs(b.start - anchor.start));
+  const best = candidates[0];
+  return {
+    start: best.start,
+    end: best.start + anchor.quote.length,
+    exact: false,
+  };
+}
+
+export function serializeTextCommentAnchor(anchor: TextCommentAnchor): string {
+  return JSON.stringify(anchor);
+}
+
+export function compactAnchorQuote(anchor: TextCommentAnchor, maxLength = 100): string {
+  const normalized = anchor.quote.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}…` : normalized;
+}

--- a/frontend/src/lib/inlineCommentEvents.ts
+++ b/frontend/src/lib/inlineCommentEvents.ts
@@ -1,0 +1,22 @@
+import type { TextCommentAnchor } from "@/lib/inlineCommentAnchor";
+
+export const OPEN_INLINE_COMMENT_PANEL_EVENT = "nowen:inline-comments:open";
+export const CLOSE_INLINE_COMMENT_PANEL_EVENT = "nowen:inline-comments:close";
+
+export interface OpenInlineCommentPanelDetail {
+  noteId: string;
+  noteTitle?: string;
+  anchor?: TextCommentAnchor | null;
+  onClose?: () => void;
+}
+
+export function openInlineCommentPanel(detail: OpenInlineCommentPanelDetail): void {
+  window.dispatchEvent(new CustomEvent<OpenInlineCommentPanelDetail>(
+    OPEN_INLINE_COMMENT_PANEL_EVENT,
+    { detail },
+  ));
+}
+
+export function closeInlineCommentPanel(): void {
+  window.dispatchEvent(new CustomEvent(CLOSE_INLINE_COMMENT_PANEL_EVENT));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -37,6 +37,7 @@ import RoundTripPermissionMappingCenter from "./components/RoundTripPermissionMa
 import RoundTripPermissionExportCenter from "./components/RoundTripPermissionExportCenter";
 import SiyuanImportProgressBridge from "./components/SiyuanImportProgressBridge";
 import SiyuanRichTextCalloutBridge from "./components/SiyuanRichTextCalloutBridge";
+import InlineCommentBridge from "./components/InlineCommentBridge";
 import "./index.css";
 import "./editor-list-markers.css";
 import "./code-block-wrap.css";
@@ -47,6 +48,7 @@ import "./sidebar-search-experience.css";
 import "./mobile-knowledge-tree-compact.css";
 import "./siyuan-rich-text-callout.css";
 import "./knowledge-tree-markdown-drop.css";
+import "./inline-comments.css";
 import { initCodeBlockTheme } from "./lib/codeBlockTheme";
 import { installAndroidNativeHttpBridge } from "./lib/androidNativeHttpBridge";
 import { installMobileStartupBridge } from "./lib/mobileStartupBridge";
@@ -180,6 +182,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <RoundTripPermissionExportCenter />
           <SiyuanImportProgressBridge />
           <SiyuanRichTextCalloutBridge />
+          <InlineCommentBridge />
           <App />
         </>
       )}


### PR DESCRIPTION
## 用户需求

参考腾讯文档，在正文选中文字或某一行后直接添加批注，并在右侧评论面板中查看、回复、解决和定位讨论。个人空间和工作区统一支持，同时遵循当前用户权限。

## 实现

- 新增全局 `InlineCommentBridge`，同时适配 Tiptap 富文本和 CodeMirror Markdown 编辑器
- 选中文字后显示浮动“添加批注”按钮
- 新增腾讯文档式右侧评论线程面板，保留整篇笔记评论入口
- 批注原文使用 CSS Custom Highlight 高亮，不向正文写入隐藏节点或 Markdown 标记
- 复用现有 `share_comments.anchorData` 和评论 API，不新增重复数据表
- 锚点采用 quote + prefix/suffix + start/end，在前文插入或文档轻微变化后可重新定位
- 点击高亮文字或评论引用可互相定位
- 支持评论回复、自己的评论删除、管理者解决/重新打开讨论
- 面板打开时轮询同步评论，切回窗口时刷新
- 移动端使用全宽抽屉并处理 safe area

## 权限矩阵

| 权限 | 查看 | 添加批注/回复 | 删除自己的评论 | 解决讨论/删除他人评论 |
|---|---:|---:|---:|---:|
| `read` / viewer | ✅ | ❌ | ❌ | ❌ |
| `comment` / commenter | ✅ | ✅ | ✅ | ❌ |
| `write` / editor | ✅ | ✅ | ✅ | ❌ |
| `manage` / owner/admin | ✅ | ✅ | ✅ | ✅ |
| 个人空间所有者 | ✅ | ✅ | ✅ | ✅ |

服务端继续通过 `resolveEffectiveNoteCapabilities` 强制校验，前端隐藏不可执行操作不是唯一防线。

## 数据与兼容性

- 不修改数据库结构
- 不修改笔记正文保存协议
- 不影响富文本/Markdown 互转
- 原 `CommentPanel` 保留为兼容入口，内部转发到新的统一面板
- 公开分享评论保持原逻辑，本次范围聚焦登录后的个人空间和工作区

## 验证

- ✅ Share Management 后端路由测试
- ✅ 现有分享安全权限回归
- ✅ 后端 TypeScript 构建
- ✅ 前端评论锚点恢复测试
- ✅ Share Management 前端回归
- ✅ 前端 TypeScript project build
- ✅ viewer / commenter / editor / manager 权限边界测试
- ✅ 锚点 `anchorData` 持久化测试

仓库原有 `Round-trip Permission Transfer V2 CI` 在本 PR 的连续提交上均因 `no such table: knowledge_tree_nodes` 失败；该工作流未运行本次评论相关文件，且其前端类型检查成功。本次相关的 Share Management CI 前后端均已通过。
