### PR TITLE
fix(siyuan): localize remote images for Markdown imports

### DIFF
--- a/.github/workflows/remote-image-localization-ci.yml
+++ b/.github/workflows/remote-image-localization-ci.yml
@@ -9,8 +9,11 @@ on:
       - "backend/src/lib/remote-image-localization.ts"
       - "backend/src/services/remote-image-import.ts"
       - "backend/src/services/remote-image-localization*.ts"
+      - "backend/src/services/siyuanImportedRemoteImages.ts"
+      - "backend/src/services/siyuanPackageImportLegacy.ts"
       - "backend/src/routes/remote-image-import.ts"
       - "backend/tests/remote-image-localization*.test.ts"
+      - "backend/tests/siyuan-markdown-remote-images.test.ts"
       - "frontend/src/lib/remoteImageLocalizationApi.ts"
       - "frontend/src/components/RemoteImageLocalizationPanel.tsx"
       - "frontend/src/components/TaskCenter.tsx"
@@ -20,8 +23,11 @@ on:
       - "backend/src/lib/remote-image-localization.ts"
       - "backend/src/services/remote-image-import.ts"
       - "backend/src/services/remote-image-localization*.ts"
+      - "backend/src/services/siyuanImportedRemoteImages.ts"
+      - "backend/src/services/siyuanPackageImportLegacy.ts"
       - "backend/src/routes/remote-image-import.ts"
       - "backend/tests/remote-image-localization*.test.ts"
+      - "backend/tests/siyuan-markdown-remote-images.test.ts"
       - "frontend/src/lib/remoteImageLocalizationApi.ts"
       - "frontend/src/components/RemoteImageLocalizationPanel.tsx"
       - "frontend/src/components/TaskCenter.tsx"
@@ -54,6 +60,8 @@ jobs:
         run: node --import tsx --test --test-concurrency=1 tests/remote-image-localization-service.test.ts
       - name: Authority, Yjs and rollback tests
         run: node --import tsx --test --test-concurrency=1 tests/remote-image-localization-authority.test.ts
+      - name: SiYuan Markdown remote image import tests
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test --test-concurrency=1 tests/siyuan-markdown-remote-images.test.ts
       - name: Build backend bundle
         run: npm run build
 

--- a/backend/src/services/siyuanImportedRemoteImages.ts
+++ b/backend/src/services/siyuanImportedRemoteImages.ts
@@ -1,0 +1,322 @@
+import crypto from "node:crypto";
+import { getDb } from "../db/schema";
+import { syncNoteBlocks } from "../lib/noteBlocks";
+import { scanRemoteImages } from "../lib/remote-image-localization";
+import {
+    downloadRemoteImage,
+    RemoteImageError,
+    type DownloadedRemoteImage,
+} from "./remote-image-import";
+import {
+    applyLocalizedContent,
+    currentWriteState,
+    rollbackLocalizedAttachments,
+    saveLocalizedAttachment,
+    type CreatedAttachment,
+} from "./remote-image-localization-mutation";
+import { readNote, type NoteRow } from "./remote-image-localization-core";
+import { yDestroyDoc } from "./yjs";
+
+interface ImportedNoteRef {
+    id: string;
+    title: string;
+    version: number;
+}
+
+interface ImportedMarkdownNoteScan {
+    note: ImportedNoteRef;
+    remoteUrls: string[];
+}
+
+export interface SiyuanImportedRemoteImageResult {
+    warnings: string[];
+    noteVersions: Record<string, number>;
+    uniqueRemoteUrls: number;
+    localizedUrls: number;
+    localizedReferences: number;
+    deduplicatedAttachments: number;
+    failedUrls: number;
+    skippedUrls: number;
+}
+
+const DEFAULT_MAX_REMOTE_IMAGES = 5_000;
+const DEFAULT_MAX_REMOTE_TOTAL_BYTES = 500 * 1024 * 1024;
+const DEFAULT_DOWNLOAD_CONCURRENCY = 4;
+const MAX_DETAIL_WARNINGS = 20;
+
+function readPositiveEnv(name: string, fallback: number, max: number): number {
+    const value = Number.parseInt(process.env[name] || "", 10);
+    return Number.isFinite(value) && value > 0 ? Math.min(value, max) : fallback;
+}
+
+function getLimits() {
+    return {
+        maxImages: readPositiveEnv(
+            "SIYUAN_IMPORT_MAX_REMOTE_IMAGES",
+            DEFAULT_MAX_REMOTE_IMAGES,
+            50_000,
+        ),
+        maxTotalBytes: readPositiveEnv(
+            "SIYUAN_IMPORT_MAX_REMOTE_IMAGE_MB",
+            DEFAULT_MAX_REMOTE_TOTAL_BYTES / 1024 / 1024,
+            10_000,
+        ) * 1024 * 1024,
+        concurrency: readPositiveEnv(
+            "SIYUAN_IMPORT_REMOTE_IMAGE_CONCURRENCY",
+            DEFAULT_DOWNLOAD_CONCURRENCY,
+            8,
+        ),
+    };
+}
+
+function safeUrlLabel(raw: string): string {
+    try {
+        const parsed = new URL(raw);
+        return `${parsed.origin}${parsed.pathname}`.slice(0, 240);
+    } catch {
+        return raw.slice(0, 240);
+    }
+}
+
+function errorMessage(error: unknown): string {
+    if (error instanceof RemoteImageError) return `${error.code}: ${error.message}`;
+    return error instanceof Error ? error.message : String(error);
+}
+
+async function runWithConcurrency<T>(
+    values: T[],
+    concurrency: number,
+    worker: (value: T) => Promise<void>,
+): Promise<void> {
+    let nextIndex = 0;
+    const workers = Array.from(
+        { length: Math.min(Math.max(1, concurrency), values.length) },
+        async () => {
+            while (nextIndex < values.length) {
+                const index = nextIndex;
+                nextIndex += 1;
+                await worker(values[index]);
+            }
+        },
+    );
+    await Promise.all(workers);
+}
+
+/**
+ * Materialize Nowen's Markdown block identifiers before image localization.
+ *
+ * `syncNoteBlocks()` may add hidden block IDs and write the normalized Markdown
+ * back to `notes.content`. The generic localization mutation later uses exact
+ * content equality as an optimistic-lock guard, so it must start from this
+ * normalized source rather than the pre-index import text.
+ */
+function normalizeImportedMarkdownNote(noteId: string): NoteRow | undefined {
+    const current = readNote(noteId);
+    if (!current || current.contentFormat !== "markdown") return current;
+    syncNoteBlocks(getDb(), current.id, current.content || "", current.contentFormat);
+    return readNote(noteId);
+}
+
+/**
+ * Localize HTTP(S) image references created by a SiYuan Markdown import.
+ *
+ * ZIP-local assets are already handled by the transaction-oriented importer. This
+ * post-import pass covers image-bed URLs that intentionally remain remote during
+ * `.sy` conversion. Failures are isolated per URL: the note keeps its original URL
+ * and the successful part of the import is still returned to the user.
+ */
+export async function localizeSiyuanImportedMarkdownImages(args: {
+    userId: string;
+    notes: ImportedNoteRef[];
+}): Promise<SiyuanImportedRemoteImageResult> {
+    const limits = getLimits();
+    const scans: ImportedMarkdownNoteScan[] = [];
+    const orderedUniqueUrls: string[] = [];
+    const seenUrls = new Set<string>();
+    const warnings: string[] = [];
+
+    for (const note of args.notes) {
+        const current = normalizeImportedMarkdownNote(note.id);
+        if (!current || current.contentFormat !== "markdown") continue;
+        const scan = scanRemoteImages(current.content || "", current.contentFormat);
+        if (scan.parseError) {
+            warnings.push(`思源 Markdown：${note.title} 的网络图片扫描失败，已保留原地址。`);
+            continue;
+        }
+        if (scan.remoteUrls.length === 0) continue;
+        scans.push({ note, remoteUrls: scan.remoteUrls });
+        for (const url of scan.remoteUrls) {
+            if (seenUrls.has(url)) continue;
+            seenUrls.add(url);
+            orderedUniqueUrls.push(url);
+        }
+    }
+
+    const allowedUrls = new Set(orderedUniqueUrls.slice(0, limits.maxImages));
+    const skippedByLimit = Math.max(0, orderedUniqueUrls.length - allowedUrls.size);
+    if (skippedByLimit > 0) {
+        warnings.push(
+            `思源 Markdown：网络图片唯一地址超过 ${limits.maxImages} 个，本次跳过 ${skippedByLimit} 个并保留原地址。`,
+        );
+    }
+
+    const remainingUses = new Map<string, number>();
+    for (const scan of scans) {
+        for (const url of scan.remoteUrls) {
+            if (!allowedUrls.has(url)) continue;
+            remainingUses.set(url, (remainingUses.get(url) || 0) + 1);
+        }
+    }
+
+    const downloadCache = new Map<string, Promise<DownloadedRemoteImage>>();
+    let downloadedBytes = 0;
+    let localizedUrls = 0;
+    let localizedReferences = 0;
+    let deduplicatedAttachments = 0;
+    let failedUrls = 0;
+    let skippedUrls = skippedByLimit;
+    let detailWarningCount = 0;
+    const noteVersions: Record<string, number> = {};
+    const importJobId = `siyuan-${crypto.randomUUID()}`;
+
+    const getDownloaded = (url: string): Promise<DownloadedRemoteImage> => {
+        const cached = downloadCache.get(url);
+        if (cached) return cached;
+        const promise = downloadRemoteImage(url).then((downloaded) => {
+            const nextBytes = downloadedBytes + downloaded.buffer.byteLength;
+            if (nextBytes > limits.maxTotalBytes) {
+                throw new Error(
+                    `思源网络图片下载总量超过 ${Math.round(limits.maxTotalBytes / 1024 / 1024)}MB 限制`,
+                );
+            }
+            downloadedBytes = nextBytes;
+            return downloaded;
+        });
+        downloadCache.set(url, promise);
+        return promise;
+    };
+
+    const releaseDownload = (url: string) => {
+        const remaining = (remainingUses.get(url) || 1) - 1;
+        if (remaining <= 0) {
+            remainingUses.delete(url);
+            downloadCache.delete(url);
+        } else {
+            remainingUses.set(url, remaining);
+        }
+    };
+
+    for (const scan of scans) {
+        const current = readNote(scan.note.id);
+        if (!current || current.contentFormat !== "markdown") {
+            skippedUrls += scan.remoteUrls.filter((url) => allowedUrls.has(url)).length;
+            for (const url of scan.remoteUrls) if (allowedUrls.has(url)) releaseDownload(url);
+            continue;
+        }
+
+        const urls = scan.remoteUrls.filter((url) => allowedUrls.has(url));
+        const replacements = new Map<string, string>();
+        const createdAttachments: CreatedAttachment[] = [];
+        let savedUrls = 0;
+        let savedDeduplicated = 0;
+
+        await runWithConcurrency(urls, limits.concurrency, async (url) => {
+            try {
+                const downloaded = await getDownloaded(url);
+                const state = currentWriteState(args.userId, current.id, current.version, current.content);
+                if (!state) throw new Error("下载期间笔记内容、版本或权限已变化");
+                const saved = await saveLocalizedAttachment({
+                    jobId: importJobId,
+                    userId: args.userId,
+                    noteId: current.id,
+                    workspaceId: state.workspaceId,
+                    sourceUrl: url,
+                    downloaded,
+                });
+                replacements.set(url, saved.imported.url);
+                if (saved.created) createdAttachments.push(saved.created);
+                savedUrls += 1;
+                if (saved.imported.deduplicated) savedDeduplicated += 1;
+            } catch (error) {
+                failedUrls += 1;
+                if (detailWarningCount < MAX_DETAIL_WARNINGS) {
+                    warnings.push(
+                        `思源 Markdown：网络图片本地化失败（${safeUrlLabel(url)}）：${errorMessage(error)}`,
+                    );
+                    detailWarningCount += 1;
+                }
+            } finally {
+                releaseDownload(url);
+            }
+        });
+
+        if (replacements.size === 0) continue;
+
+        try {
+            const latest = readNote(current.id);
+            if (!latest || latest.contentFormat !== "markdown") {
+                await rollbackLocalizedAttachments(createdAttachments);
+                skippedUrls += savedUrls;
+                warnings.push(`思源 Markdown：${current.title} 在写回前已不可用，已保留原地址。`);
+                continue;
+            }
+
+            const applied = applyLocalizedContent({
+                userId: args.userId,
+                noteId: latest.id,
+                scannedVersion: latest.version,
+                scannedContent: latest.content,
+                contentFormat: latest.contentFormat,
+                replacements,
+            });
+            if (applied.conflict) {
+                await rollbackLocalizedAttachments(createdAttachments);
+                skippedUrls += savedUrls;
+                warnings.push(`思源 Markdown：${latest.title} 在写回网络图片时发生冲突，已保留原地址。`);
+                continue;
+            }
+            if (!applied.updated) {
+                await rollbackLocalizedAttachments(createdAttachments);
+                skippedUrls += savedUrls;
+                warnings.push(`思源 Markdown：${latest.title} 未找到可替换的网络图片引用，已保留原地址。`);
+                continue;
+            }
+            localizedUrls += savedUrls;
+            localizedReferences += applied.replacedCount;
+            deduplicatedAttachments += savedDeduplicated;
+            noteVersions[latest.id] = applied.finalVersion || latest.version;
+            warnings.push(...applied.warnings);
+            // yReplaceContentAsUpdate persists the canonical update before returning.
+            // This imported note has not been exposed to clients yet, so release the
+            // temporary room immediately instead of retaining its 5-minute idle timer.
+            try { yDestroyDoc(latest.id); } catch {}
+        } catch (error) {
+            await rollbackLocalizedAttachments(createdAttachments);
+            skippedUrls += savedUrls;
+            warnings.push(`思源 Markdown：${current.title} 的网络图片写回失败，已保留原地址：${errorMessage(error)}`);
+        }
+    }
+
+    if (localizedUrls > 0) {
+        warnings.push(
+            `思源 Markdown：已将 ${localizedReferences} 个网络图片引用下载到文件管理（${localizedUrls} 个唯一地址，复用 ${deduplicatedAttachments} 个附件）。`,
+        );
+    }
+    if (failedUrls > 0) {
+        const omitted = Math.max(0, failedUrls - detailWarningCount);
+        warnings.push(
+            `思源 Markdown：${failedUrls} 个网络图片下载失败，已保留原地址${omitted > 0 ? `；另有 ${omitted} 条详情未展开` : ""}。`,
+        );
+    }
+
+    return {
+        warnings,
+        noteVersions,
+        uniqueRemoteUrls: orderedUniqueUrls.length,
+        localizedUrls,
+        localizedReferences,
+        deduplicatedAttachments,
+        failedUrls,
+        skippedUrls,
+    };
+}

--- a/backend/src/services/siyuanPackageImportLegacy.ts
+++ b/backend/src/services/siyuanPackageImportLegacy.ts
@@ -6,6 +6,7 @@ import {
     SiyuanZipBudgetError,
     type SiyuanPackageImportResult,
 } from "./siyuanPackageImportLegacyCore";
+import { localizeSiyuanImportedMarkdownImages } from "./siyuanImportedRemoteImages";
 
 interface ImportParams {
     userId: string;
@@ -30,6 +31,7 @@ interface ImportedRichTextRow {
 
 const NOTE_BATCH_SIZE = 400;
 const MAX_TAG_NAME_LENGTH = 30;
+const REMOTE_ASSET_MISSING_WARNING_RE = /^Siyuan asset not found:\s*(?:https?:|\/\/|data:)/i;
 
 export { SiyuanZipBudgetError };
 export type { SiyuanPackageImportResult };
@@ -44,6 +46,22 @@ function chunks<T>(values: T[], size: number): T[][] {
     const out: T[][] = [];
     for (let index = 0; index < values.length; index += size) out.push(values.slice(index, index + size));
     return out;
+}
+
+function readImportedNoteVersions(noteIds: string[]): Map<string, number> {
+    const versions = new Map<string, number>();
+    if (noteIds.length === 0) return versions;
+    const db = getDb();
+    for (const batch of chunks(noteIds, NOTE_BATCH_SIZE)) {
+        const placeholders = batch.map(() => "?").join(", ");
+        const rows = db.prepare(`
+            SELECT id, version
+            FROM notes
+            WHERE id IN (${placeholders})
+        `).all(...batch) as Array<{ id: string; version: number }>;
+        for (const row of rows) versions.set(row.id, Number(row.version) || 1);
+    }
+    return versions;
 }
 
 function tagsSupportWorkspaceId(): boolean {
@@ -190,8 +208,33 @@ export async function importSiyuanPackageFromZipFile(
         console.error("[siyuan-import] rich-text post-processing failed", error);
         richTextWarnings = ["思源富文本后处理失败，已保留基础转换结果；请查看服务端日志并重新导入。"];
     }
+
+    let remoteImageWarnings: string[] = [];
+    try {
+        const localized = await localizeSiyuanImportedMarkdownImages({
+            userId: params.userId,
+            notes: result.notes,
+        });
+        remoteImageWarnings = localized.warnings;
+    } catch (error) {
+        console.error("[siyuan-import] Markdown remote image localization failed", error);
+        remoteImageWarnings = ["思源 Markdown 网络图片本地化失败，已保留原图床地址；请查看服务端日志后重试。"];
+    }
+
+    const currentVersions = readImportedNoteVersions(noteIds);
+    const coreWarnings = result.warnings.filter((warning) => !REMOTE_ASSET_MISSING_WARNING_RE.test(warning));
+
     return {
         ...result,
-        warnings: uniqueSorted([...result.warnings, ...cleanupWarnings, ...richTextWarnings]),
+        notes: result.notes.map((note) => ({
+            ...note,
+            version: currentVersions.get(note.id) ?? note.version,
+        })),
+        warnings: uniqueSorted([
+            ...coreWarnings,
+            ...cleanupWarnings,
+            ...richTextWarnings,
+            ...remoteImageWarnings,
+        ]),
     };
 }

--- a/backend/tests/siyuan-markdown-remote-images.test.ts
+++ b/backend/tests/siyuan-markdown-remote-images.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-siyuan-remote-images-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+process.env.ELECTRON_USER_DATA = tmpDir;
+process.env.SIYUAN_IMPORT_REMOTE_IMAGE_CONCURRENCY = "2";
+
+const USER_ID = "siyuan-remote-image-user";
+const NOTEBOOK_ID = "siyuan-remote-image-notebook";
+const REMOTE_IMAGE_URL = "http://93.184.216.34/image-bed/pixel.png";
+const FAILED_REMOTE_IMAGE_URL = "http://93.184.216.34/image-bed/missing.png";
+const PNG_BYTES = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9ZQ3sAAAAASUVORK5CYII=",
+    "base64",
+);
+
+let closeDb: () => void;
+let getDb: () => import("better-sqlite3").Database;
+let importSiyuanPackageFromZipFile: typeof import("../src/services/siyuanPackageImport").importSiyuanPackageFromZipFile;
+const originalFetch = globalThis.fetch;
+
+function syDoc(id: string, title: string, children: any[] = []) {
+    return {
+        ID: id,
+        Type: "NodeDocument",
+        Properties: { title },
+        updated: "20260731120000",
+        Children: children,
+    };
+}
+
+function image(src: string, alt: string) {
+    return {
+        Type: "NodeImage",
+        Children: [
+            { Type: "NodeLinkText", Data: alt },
+            { Type: "NodeLinkDest", Data: src },
+        ],
+    };
+}
+
+async function writeZip(name: string, title: string, remoteUrl: string) {
+    const zip = new JSZip();
+    zip.file(
+        "doc.sy",
+        JSON.stringify(syDoc(name, title, [{
+            Type: "NodeParagraph",
+            Children: [
+                { Type: "NodeText", Data: "远程图片一 " },
+                image(remoteUrl, "图床图片一"),
+                { Type: "NodeText", Data: " 远程图片二 " },
+                image(remoteUrl, "图床图片二"),
+            ],
+        }])),
+    );
+    const zipPath = path.join(tmpDir, `${name}.zip`);
+    fs.writeFileSync(zipPath, await zip.generateAsync({ type: "nodebuffer" }));
+    return zipPath;
+}
+
+function getNote(title: string) {
+    return getDb().prepare(`
+        SELECT id, title, content, contentFormat, version
+        FROM notes WHERE title = ? ORDER BY createdAt DESC LIMIT 1
+    `).get(title) as {
+        id: string;
+        title: string;
+        content: string;
+        contentFormat: string;
+        version: number;
+    } | undefined;
+}
+
+function listAttachments(noteId: string) {
+    return getDb().prepare(`
+        SELECT id, noteId, filename, mimeType, size, path, uploadSource
+        FROM attachments WHERE noteId = ? ORDER BY id
+    `).all(noteId) as Array<{
+        id: string;
+        noteId: string;
+        filename: string;
+        mimeType: string;
+        size: number;
+        path: string;
+        uploadSource: string;
+    }>;
+}
+
+test.before(async () => {
+    const [schemaModule, importerModule] = await Promise.all([
+        import("../src/db/schema"),
+        import("../src/services/siyuanPackageImport"),
+    ]);
+    closeDb = schemaModule.closeDb;
+    getDb = schemaModule.getDb;
+    importSiyuanPackageFromZipFile = importerModule.importSiyuanPackageFromZipFile;
+
+    const db = getDb();
+    db.prepare("INSERT INTO users (id, username, passwordHash) VALUES (?, ?, ?)")
+        .run(USER_ID, USER_ID, "hash");
+    db.prepare("INSERT INTO notebooks (id, userId, parentId, name, icon, workspaceId) VALUES (?, ?, NULL, ?, ?, NULL)")
+        .run(NOTEBOOK_ID, USER_ID, "思源远程图片", "📥");
+});
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test.after(() => {
+    globalThis.fetch = originalFetch;
+    closeDb();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("Markdown target downloads SiYuan image-bed images into file management", { concurrency: false }, async () => {
+    let fetchCount = 0;
+    globalThis.fetch = async (input) => {
+        fetchCount += 1;
+        assert.equal(String(input), REMOTE_IMAGE_URL);
+        return new Response(PNG_BYTES, {
+            status: 200,
+            headers: {
+                "Content-Type": "image/png",
+                "Content-Length": String(PNG_BYTES.byteLength),
+                "Content-Disposition": 'inline; filename="pixel.png"',
+            },
+        });
+    };
+
+    const zipPath = await writeZip("remote-success", "图床图片导入成功", REMOTE_IMAGE_URL);
+    const result = await importSiyuanPackageFromZipFile(zipPath, {
+        userId: USER_ID,
+        workspaceId: null,
+        targetNotebookId: NOTEBOOK_ID,
+        contentFormat: "markdown",
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.count, 1);
+    assert.equal(fetchCount, 1, "the same image-bed URL should only be downloaded once");
+    assert.equal(
+        result.notes[0].version,
+        2,
+        `localization writes the imported Markdown as version 2; warnings=${JSON.stringify(result.warnings)}`,
+    );
+    assert.ok(result.warnings.some((warning) => warning.includes("下载到文件管理")));
+    assert.ok(!result.warnings.some((warning) => warning.includes(`Siyuan asset not found: ${REMOTE_IMAGE_URL}`)));
+
+    const note = getNote("图床图片导入成功");
+    assert.ok(note);
+    assert.equal(note.contentFormat, "markdown");
+    assert.equal(note.version, 2);
+    assert.doesNotMatch(note.content, new RegExp(REMOTE_IMAGE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    const localReferences = note.content.match(/\/api\/attachments\/[0-9a-f-]+/g) || [];
+    assert.equal(localReferences.length, 2, "all repeated Markdown image references should be rewritten");
+
+    const attachments = listAttachments(note.id);
+    assert.equal(attachments.length, 1, "the localized image should appear once in file management");
+    assert.equal(attachments[0].mimeType, "image/png");
+    assert.equal(attachments[0].filename, "pixel.png");
+    assert.equal(attachments[0].size, PNG_BYTES.byteLength);
+    assert.match(attachments[0].uploadSource, /^historical-localization:siyuan-/);
+    assert.ok(note.content.includes(`/api/attachments/${attachments[0].id}`));
+
+    const referenceCount = getDb().prepare(
+        "SELECT COUNT(*) AS count FROM attachment_references WHERE noteId = ? AND attachmentId = ?",
+    ).get(note.id, attachments[0].id) as { count: number };
+    assert.equal(referenceCount.count, 1);
+});
+
+test("failed image-bed downloads keep the original Markdown URL without failing the import", { concurrency: false }, async () => {
+    globalThis.fetch = async () => new Response("upstream failed", { status: 502 });
+
+    const zipPath = await writeZip("remote-failure", "图床图片导入失败降级", FAILED_REMOTE_IMAGE_URL);
+    const result = await importSiyuanPackageFromZipFile(zipPath, {
+        userId: USER_ID,
+        workspaceId: null,
+        targetNotebookId: NOTEBOOK_ID,
+        contentFormat: "markdown",
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.notes[0].version, 1);
+    assert.ok(result.warnings.some((warning) => warning.includes("网络图片下载失败")));
+    assert.ok(!result.warnings.some((warning) => warning.includes(`Siyuan asset not found: ${FAILED_REMOTE_IMAGE_URL}`)));
+
+    const note = getNote("图床图片导入失败降级");
+    assert.ok(note);
+    assert.equal(note.version, 1);
+    assert.ok(note.content.includes(FAILED_REMOTE_IMAGE_URL));
+    assert.equal(listAttachments(note.id).length, 0);
+});


### PR DESCRIPTION
## 背景

思源导入选择 Markdown 目标格式时，ZIP 内 `assets/*` 已能进入附件管理，但 Markdown 中的 HTTP/HTTPS 图床图片仍保留远程地址，导致文件管理中没有对应图片。

Closes #567

## 改动

- 在思源导入完成后扫描本次导入的 Markdown 笔记
- 使用现有安全下载器处理 HTTP/HTTPS 图片（SSRF、类型、大小、超时校验保持不变）
- 图片写入附件存储和 `attachments`，正文替换为 `/api/attachments/<id>`
- 同步 `attachment_references`，重复 URL 只下载一次并复用附件去重
- 单张下载失败不终止整次导入，保留原图床地址并返回警告
- 增加导入级图片数量、总容量和并发环境变量保护

## 配置

- `SIYUAN_IMPORT_MAX_REMOTE_IMAGES`：默认 5000
- `SIYUAN_IMPORT_MAX_REMOTE_IMAGE_MB`：默认 500MB
- `SIYUAN_IMPORT_REMOTE_IMAGE_CONCURRENCY`：默认 4，最大 8

## 测试

新增回归测试覆盖：

- Markdown 图床图片下载到文件管理
- 重复 URL 只下载一次，正文全部替换
- 附件引用关系同步
- 下载失败时导入仍成功并保留原 URL
