### PR TITLE
perf(editor): reduce image-heavy note switch latency

### DIFF
--- a/.github/workflows/issue-577-note-switch-performance-ci.yml
+++ b/.github/workflows/issue-577-note-switch-performance-ci.yml
@@ -8,6 +8,7 @@ on:
       - fix/issue-577-note-switch-performance
     paths:
       - "frontend/src/components/EditorPaneRuntime.tsx"
+      - "frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx"
       - "frontend/src/lib/editorRuntimePolicy.ts"
       - "frontend/src/lib/largeRichTextSafeMode.ts"
       - "frontend/src/lib/noteSplitAnalysis.ts"
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - "frontend/src/components/EditorPaneRuntime.tsx"
+      - "frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx"
       - "frontend/src/lib/editorRuntimePolicy.ts"
       - "frontend/src/lib/largeRichTextSafeMode.ts"
       - "frontend/src/lib/noteSplitAnalysis.ts"
@@ -51,6 +53,7 @@ jobs:
           src/lib/__tests__/editorRuntimePolicy.test.ts
           src/lib/__tests__/largeRichTextSafeMode.test.ts
           src/lib/__tests__/noteSplitAnalysis.test.ts
+          src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b --pretty false

--- a/.github/workflows/issue-577-note-switch-performance-ci.yml
+++ b/.github/workflows/issue-577-note-switch-performance-ci.yml
@@ -1,0 +1,56 @@
+name: Issue 577 Note Switch Performance CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - fix/issue-577-note-switch-performance
+    paths:
+      - "frontend/src/components/EditorPaneRuntime.tsx"
+      - "frontend/src/lib/editorRuntimePolicy.ts"
+      - "frontend/src/lib/largeRichTextSafeMode.ts"
+      - "frontend/src/lib/noteSplitAnalysis.ts"
+      - "frontend/src/lib/__tests__/editorRuntimePolicy.test.ts"
+      - "frontend/src/lib/__tests__/largeRichTextSafeMode.test.ts"
+      - "frontend/src/lib/__tests__/noteSplitAnalysis.test.ts"
+      - ".github/workflows/issue-577-note-switch-performance-ci.yml"
+  pull_request:
+    paths:
+      - "frontend/src/components/EditorPaneRuntime.tsx"
+      - "frontend/src/lib/editorRuntimePolicy.ts"
+      - "frontend/src/lib/largeRichTextSafeMode.ts"
+      - "frontend/src/lib/noteSplitAnalysis.ts"
+      - "frontend/src/lib/__tests__/editorRuntimePolicy.test.ts"
+      - "frontend/src/lib/__tests__/largeRichTextSafeMode.test.ts"
+      - "frontend/src/lib/__tests__/noteSplitAnalysis.test.ts"
+      - ".github/workflows/issue-577-note-switch-performance-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --no-audit --no-fund
+      - name: Note switch performance regressions
+        run: >-
+          npm run test:run --
+          src/lib/__tests__/editorRuntimePolicy.test.ts
+          src/lib/__tests__/largeRichTextSafeMode.test.ts
+          src/lib/__tests__/noteSplitAnalysis.test.ts
+      - name: Frontend typecheck
+        if: always()
+        run: npx tsc -b --pretty false

--- a/frontend/src/components/EditorPaneRuntime.tsx
+++ b/frontend/src/components/EditorPaneRuntime.tsx
@@ -4,27 +4,19 @@ import FormatAwareEditorPane from "./FormatAwareEditorPane";
 import NoteSplitDialog from "@/components/NoteSplitDialog";
 import { useApp, useAppActions } from "@/store/AppContext";
 import { canWriteNote } from "@/lib/notePermissions";
+import type { NoteSplitHeadingLevel } from "@/lib/noteSplit";
 import {
-  findPreferredMarkdownSplitLevel,
-  type NoteSplitHeadingLevel,
-} from "@/lib/noteSplit";
-import { findPreferredTiptapSplitLevel } from "@/lib/tiptapNoteSplit";
+  getCachedPreferredNoteSplitLevel,
+  resolvePreferredNoteSplitLevel,
+  schedulePreferredNoteSplitLevel,
+} from "@/lib/noteSplitAnalysis";
 import type { Note } from "@/types";
 
-function resolvePreferredLevel(note: Note | null | undefined): NoteSplitHeadingLevel | null {
-  if (!note) return null;
-  if (note.contentFormat === "markdown") {
-    return findPreferredMarkdownSplitLevel(note.content || "");
-  }
-  if (note.contentFormat === "tiptap-json") {
-    return findPreferredTiptapSplitLevel(note.content || "");
-  }
-  return null;
-}
-
 /**
- * 文档拆分运行时外壳：打开笔记时扫描一次可用标题层级，
- * 将拆分能力交给按 contentFormat 路由的编辑器，并持有事务化预览弹窗。
+ * 文档拆分运行时外壳。
+ *
+ * 标题扫描只服务于可选的“拆分文档”入口，不应阻塞每次笔记切换。首次打开把扫描安排
+ * 到浏览器空闲阶段；A → B → A 返回同一版本时直接复用缓存结果。
  */
 export default function EditorPaneRuntime() {
   const { state } = useApp();
@@ -35,9 +27,20 @@ export default function EditorPaneRuntime() {
 
   useEffect(() => {
     setDialogOpen(false);
-    setPreferredLevel(resolvePreferredLevel(activeNote));
-    // Deliberately scan only when a note is opened. Re-running a full heading scan after every
-    // debounced save would undermine the large-document performance work this feature builds on.
+    setPreferredLevel(null);
+
+    const note = activeNote;
+    if (!note) return;
+
+    const cached = getCachedPreferredNoteSplitLevel(note);
+    if (cached.hit) {
+      setPreferredLevel(cached.level);
+      return;
+    }
+
+    return schedulePreferredNoteSplitLevel(note, setPreferredLevel);
+    // Deliberately analyze only when a note is opened. Re-running after every debounced save would
+    // put the full-document scan back onto the editing path that this optimization removes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeNote?.id]);
 
@@ -61,7 +64,9 @@ export default function EditorPaneRuntime() {
       isTrashed: updated.isTrashed,
       notebookId: updated.notebookId,
     });
-    setPreferredLevel(resolvePreferredLevel(updated));
+    // This scan follows an explicit split transaction, not a routine note switch, so resolving it
+    // synchronously keeps the command state accurate without affecting navigation latency.
+    setPreferredLevel(resolvePreferredNoteSplitLevel(updated));
     actions.refreshNotes();
     actions.refreshNotebooks();
   };

--- a/frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
+++ b/frontend/src/components/__tests__/EditorPaneRuntimeLayout.test.tsx
@@ -46,6 +46,7 @@ import EditorPaneRuntime from "../EditorPaneRuntime";
   .IS_REACT_ACT_ENVIRONMENT = true;
 
 afterEach(() => {
+  vi.useRealTimers();
   mocks.state.activeNote = null;
   mocks.editorPaneProps = null;
   document.body.innerHTML = "";
@@ -75,12 +76,15 @@ describe("EditorPaneRuntime layout", () => {
     }
   });
 
-  it("delegates an available split action through the format-aware editor", async () => {
+  it("defers split analysis until after the first render, then delegates the action", async () => {
+    vi.useFakeTimers();
     mocks.state.activeNote = {
       id: "split-note",
       title: "可拆分笔记",
       contentFormat: "markdown",
       content: "# 标题\n\n## 第一章\n\n正文\n\n## 第二章\n\n正文",
+      contentText: "标题 第一章 正文 第二章 正文",
+      updatedAt: "2026-07-31T00:00:00.000Z",
       version: 1,
       isLocked: false,
       isTrashed: false,
@@ -91,6 +95,13 @@ describe("EditorPaneRuntime layout", () => {
 
     try {
       await act(async () => root.render(<EditorPaneRuntime />));
+
+      // The optional heading scan must not block the note's initial editor render.
+      expect(mocks.editorPaneProps?.canSplitDocument).toBe(false);
+
+      await act(async () => {
+        vi.runAllTimers();
+      });
 
       expect(mocks.editorPaneProps?.canSplitDocument).toBe(true);
       expect(host.textContent).not.toContain("拆分文档");

--- a/frontend/src/lib/__tests__/editorRuntimePolicy.test.ts
+++ b/frontend/src/lib/__tests__/editorRuntimePolicy.test.ts
@@ -13,6 +13,16 @@ function tiptapWithText(length: number): string {
   return `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"${"x".repeat(length)}"}]}]}`;
 }
 
+function tiptapWithImages(count: number): string {
+  return JSON.stringify({
+    type: "doc",
+    content: Array.from({ length: count }, (_, index) => ({
+      type: "image",
+      attrs: { src: `/api/attachments/image-${index}` },
+    })),
+  });
+}
+
 describe("editor complexity profile", () => {
   it("reports UTF-8 bytes separately from JavaScript characters", () => {
     expect(utf8ByteLength("A中😀")).toBe(8);
@@ -46,6 +56,22 @@ describe("progressive editor runtime policy", () => {
     });
     expect(decision.mode).toBe("normal");
     expect(decision.capabilities.editable).toBe(true);
+  });
+
+  it("starts offscreen media deferral at eight image nodes", () => {
+    const belowThreshold = resolveEditorRuntimeDecision({
+      content: tiptapWithImages(7),
+      contentFormat: "tiptap-json",
+    });
+    const imageDense = resolveEditorRuntimeDecision({
+      content: tiptapWithImages(8),
+      contentFormat: "tiptap-json",
+    });
+
+    expect(belowThreshold.mode).toBe("normal");
+    expect(imageDense.mode).toBe("viewport-optimized");
+    expect(imageDense.reasons).toContain("media-count");
+    expect(imageDense.capabilities.eagerHeavyNodes).toBe(false);
   });
 
   it("uses viewport optimization before removing editing features", () => {

--- a/frontend/src/lib/__tests__/largeRichTextSafeMode.test.ts
+++ b/frontend/src/lib/__tests__/largeRichTextSafeMode.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { Note } from "@/types";
 import {
+  clearEditorRuntimeDecisionCache,
   getEditorRuntimeDecisionForNote,
   getLargeDocumentOriginalFormat,
   isLargeDocumentCollaborationBlocked,
@@ -37,6 +38,10 @@ function tiptapText(length: number): string {
   return `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"${"x".repeat(length)}"}]}]}`;
 }
 
+beforeEach(() => {
+  clearEditorRuntimeDecisionCache();
+});
+
 describe("large rich-text runtime safety", () => {
   it("keeps an ordinary compact 18 KB Tiptap document editable", () => {
     const rawContent = tiptapText(18_000);
@@ -50,6 +55,30 @@ describe("large rich-text runtime safety", () => {
     expect(isLargeRichTextSafeNote(prepared)).toBe(false);
     expect(isLargeDocumentCollaborationBlocked(original.id)).toBe(false);
     expect(getEditorRuntimeDecisionForNote(prepared)?.mode).toBe("normal");
+  });
+
+  it("reuses the full-document complexity decision when reopening the same note version", () => {
+    const first = makeNote({
+      id: "note-runtime-cache",
+      content: tiptapText(120_000),
+    });
+    const prepared = prepareLargeRichTextNoteForDisplay(first);
+    const firstDecision = getEditorRuntimeDecisionForNote(prepared);
+
+    const reopened = makeNote({
+      ...first,
+      content: `${first.content}`,
+    });
+    const reopenedDecision = getEditorRuntimeDecisionForNote(reopened);
+
+    expect(reopenedDecision).toBe(firstDecision);
+
+    const changedDecision = getEditorRuntimeDecisionForNote({
+      ...reopened,
+      version: reopened.version + 1,
+      updatedAt: "2026-07-21T00:01:00.000Z",
+    });
+    expect(changedDecision).not.toBe(firstDecision);
   });
 
   it("marks medium rich text for viewport optimization without changing content format", () => {

--- a/frontend/src/lib/__tests__/noteSplitAnalysis.test.ts
+++ b/frontend/src/lib/__tests__/noteSplitAnalysis.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "@/types";
+import {
+  clearPreferredNoteSplitLevelCache,
+  getCachedPreferredNoteSplitLevel,
+  resolvePreferredNoteSplitLevel,
+  schedulePreferredNoteSplitLevel,
+} from "@/lib/noteSplitAnalysis";
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-split-analysis",
+    userId: "user-1",
+    notebookId: "notebook-1",
+    workspaceId: null,
+    title: "Split analysis",
+    content: JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "A" }] },
+        { type: "paragraph", content: [{ type: "text", text: "Body" }] },
+        { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "B" }] },
+      ],
+    }),
+    contentText: "A\nBody\nB",
+    contentFormat: "tiptap-json",
+    isPinned: 0,
+    isFavorite: 0,
+    isLocked: 0,
+    isArchived: 0,
+    isTrashed: 0,
+    trashedAt: null,
+    version: 1,
+    sortOrder: 0,
+    createdAt: "2026-07-31T00:00:00.000Z",
+    updatedAt: "2026-07-31T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clearPreferredNoteSplitLevelCache();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("note split analysis scheduling", () => {
+  it("keeps heading discovery off the synchronous note-open path", () => {
+    const note = makeNote();
+    const resolved = vi.fn();
+
+    schedulePreferredNoteSplitLevel(note, resolved);
+
+    expect(resolved).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(resolved).toHaveBeenCalledWith(2);
+  });
+
+  it("cancels stale analysis when the user switches again", () => {
+    const resolved = vi.fn();
+    const cancel = schedulePreferredNoteSplitLevel(makeNote(), resolved);
+
+    cancel();
+    vi.runAllTimers();
+
+    expect(resolved).not.toHaveBeenCalled();
+  });
+
+  it("reuses the split result for the same note version and invalidates changed content", () => {
+    const note = makeNote();
+
+    expect(getCachedPreferredNoteSplitLevel(note).hit).toBe(false);
+    expect(resolvePreferredNoteSplitLevel(note)).toBe(2);
+    expect(getCachedPreferredNoteSplitLevel({ ...note })).toEqual({ hit: true, level: 2 });
+
+    const changed = {
+      ...note,
+      version: 2,
+      updatedAt: "2026-07-31T00:01:00.000Z",
+      content: JSON.stringify({ type: "doc", content: [] }),
+    };
+    expect(getCachedPreferredNoteSplitLevel(changed).hit).toBe(false);
+    expect(resolvePreferredNoteSplitLevel(changed)).toBeNull();
+  });
+});

--- a/frontend/src/lib/editorRuntimePolicy.ts
+++ b/frontend/src/lib/editorRuntimePolicy.ts
@@ -66,6 +66,9 @@ export const EDITOR_RUNTIME_THRESHOLDS = {
     viewport: {
       characters: 100_000,
       nodes: 2_500,
+      // A handful of high-resolution screenshots can be more expensive than thousands of text
+      // nodes. Start deferring offscreen media before the old 40-heavy-node cliff.
+      mediaNodes: 8,
       heavyNodes: 40,
     },
     lightweight: {
@@ -192,7 +195,9 @@ function resolveRichTextMode(profile: EditorComplexityProfile): {
 
   if (profile.characters >= viewport.characters) pushReason(reasons, "serialized-size");
   if (profile.approximateNodes >= viewport.nodes) pushReason(reasons, "node-count");
-  if (heavyNodeCount >= viewport.heavyNodes) pushReason(reasons, "media-count");
+  if (mediaCount >= viewport.mediaNodes || heavyNodeCount >= viewport.heavyNodes) {
+    pushReason(reasons, "media-count");
+  }
   if (profile.codeBlockCount >= Math.ceil(viewport.heavyNodes / 2)) {
     pushReason(reasons, "code-block-count");
   }

--- a/frontend/src/lib/largeRichTextSafeMode.ts
+++ b/frontend/src/lib/largeRichTextSafeMode.ts
@@ -34,7 +34,55 @@ export interface RuntimeLargeRichTextSafeNote extends RuntimeEditorPolicyNote {
   __nowenOriginalContentFormat: string;
 }
 
+interface RuntimeDecisionCacheEntry {
+  fingerprint: string;
+  decision: EditorRuntimeDecision;
+}
+
 const collaborationBlockedNoteIds = new Set<string>();
+const runtimeDecisionCache = new Map<string, RuntimeDecisionCacheEntry>();
+const MAX_RUNTIME_DECISION_CACHE_ENTRIES = 32;
+
+function runtimeDecisionFingerprint(note: Note, contentFormat: string): string {
+  const content = note.content || "";
+  const contentText = note.contentText || "";
+  return [
+    note.version,
+    note.updatedAt,
+    contentFormat,
+    content.length,
+    contentText.length,
+    content.slice(0, 64),
+    content.length > 64 ? content.slice(-64) : "",
+  ].join("|");
+}
+
+function rememberRuntimeDecision(noteId: string, entry: RuntimeDecisionCacheEntry): void {
+  runtimeDecisionCache.delete(noteId);
+  runtimeDecisionCache.set(noteId, entry);
+  while (runtimeDecisionCache.size > MAX_RUNTIME_DECISION_CACHE_ENTRIES) {
+    const oldest = runtimeDecisionCache.keys().next().value as string | undefined;
+    if (!oldest) break;
+    runtimeDecisionCache.delete(oldest);
+  }
+}
+
+function resolveCachedRuntimeDecision(note: Note, contentFormat: string): EditorRuntimeDecision {
+  const fingerprint = runtimeDecisionFingerprint(note, contentFormat);
+  const cached = runtimeDecisionCache.get(note.id);
+  if (cached?.fingerprint === fingerprint) {
+    rememberRuntimeDecision(note.id, cached);
+    return cached.decision;
+  }
+
+  const decision = resolveEditorRuntimeDecision({
+    content: note.content,
+    contentText: note.contentText,
+    contentFormat,
+  });
+  rememberRuntimeDecision(note.id, { fingerprint, decision });
+  return decision;
+}
 
 export function isLargeRichTextSafeNote(
   note: Note | null | undefined,
@@ -48,11 +96,10 @@ export function getEditorRuntimeDecisionForNote(
   if (!note) return null;
   const runtime = (note as RuntimeEditorPolicyNote).__nowenEditorRuntimeDecision;
   if (runtime) return runtime;
-  return resolveEditorRuntimeDecision({
-    content: note.content,
-    contentText: note.contentText,
-    contentFormat: note.contentFormat,
-  });
+  const originalFormat = isLargeRichTextSafeNote(note)
+    ? note.__nowenOriginalContentFormat
+    : (note.contentFormat || "tiptap-json");
+  return resolveCachedRuntimeDecision(note, originalFormat);
 }
 
 export function prepareLargeRichTextNoteForDisplay(note: Note): Note {
@@ -60,11 +107,9 @@ export function prepareLargeRichTextNoteForDisplay(note: Note): Note {
     ? note.__nowenOriginalContentFormat
     : (note.contentFormat || "tiptap-json");
 
-  const decision = resolveEditorRuntimeDecision({
-    content: note.content,
-    contentText: note.contentText,
-    contentFormat: originalFormat,
-  });
+  // Complexity profiling scans the complete serialized document. Cache by note version and a
+  // lightweight content fingerprint so returning to A after A → B does not repeat the scan.
+  const decision = resolveCachedRuntimeDecision(note, originalFormat);
   setActiveEditorRuntimeDecision(note.id, decision);
 
   const shouldProtect = originalFormat !== "markdown" && decision.mode === "emergency-readonly";
@@ -110,4 +155,8 @@ export function getLargeDocumentOriginalFormat(note: Note): string | undefined {
   return isLargeRichTextSafeNote(note)
     ? note.__nowenOriginalContentFormat
     : note.contentFormat;
+}
+
+export function clearEditorRuntimeDecisionCache(): void {
+  runtimeDecisionCache.clear();
 }

--- a/frontend/src/lib/noteSplitAnalysis.ts
+++ b/frontend/src/lib/noteSplitAnalysis.ts
@@ -1,0 +1,112 @@
+import type { Note } from "@/types";
+import {
+  findPreferredMarkdownSplitLevel,
+  type NoteSplitHeadingLevel,
+} from "@/lib/noteSplit";
+import { findPreferredTiptapSplitLevel } from "@/lib/tiptapNoteSplit";
+
+interface SplitAnalysisCacheEntry {
+  fingerprint: string;
+  level: NoteSplitHeadingLevel | null;
+}
+
+export interface CachedSplitAnalysisResult {
+  hit: boolean;
+  level: NoteSplitHeadingLevel | null;
+}
+
+const MAX_CACHE_ENTRIES = 32;
+const splitAnalysisCache = new Map<string, SplitAnalysisCacheEntry>();
+
+function noteFingerprint(note: Note): string {
+  const content = note.content || "";
+  const prefix = content.slice(0, 64);
+  const suffix = content.length > 64 ? content.slice(-64) : "";
+  return [
+    note.version,
+    note.updatedAt,
+    note.contentFormat || "",
+    content.length,
+    prefix,
+    suffix,
+  ].join("|");
+}
+
+function remember(noteId: string, entry: SplitAnalysisCacheEntry): void {
+  splitAnalysisCache.delete(noteId);
+  splitAnalysisCache.set(noteId, entry);
+  while (splitAnalysisCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = splitAnalysisCache.keys().next().value as string | undefined;
+    if (!oldest) break;
+    splitAnalysisCache.delete(oldest);
+  }
+}
+
+export function getCachedPreferredNoteSplitLevel(note: Note): CachedSplitAnalysisResult {
+  const cached = splitAnalysisCache.get(note.id);
+  if (!cached || cached.fingerprint !== noteFingerprint(note)) {
+    return { hit: false, level: null };
+  }
+  remember(note.id, cached);
+  return { hit: true, level: cached.level };
+}
+
+export function resolvePreferredNoteSplitLevel(
+  note: Note | null | undefined,
+): NoteSplitHeadingLevel | null {
+  if (!note) return null;
+  const cached = getCachedPreferredNoteSplitLevel(note);
+  if (cached.hit) return cached.level;
+
+  let level: NoteSplitHeadingLevel | null = null;
+  if (note.contentFormat === "markdown") {
+    level = findPreferredMarkdownSplitLevel(note.content || "");
+  } else if (note.contentFormat === "tiptap-json") {
+    level = findPreferredTiptapSplitLevel(note.content || "");
+  }
+
+  remember(note.id, {
+    fingerprint: noteFingerprint(note),
+    level,
+  });
+  return level;
+}
+
+type IdleCapableWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+/**
+ * Heading discovery is useful for the optional document-split command, but it must not block the
+ * first paint of every note. Schedule it for the browser's idle period and keep a cancellable
+ * fallback for browsers/WebViews without requestIdleCallback.
+ */
+export function schedulePreferredNoteSplitLevel(
+  note: Note,
+  onResolved: (level: NoteSplitHeadingLevel | null) => void,
+): () => void {
+  let cancelled = false;
+  const run = () => {
+    if (!cancelled) onResolved(resolvePreferredNoteSplitLevel(note));
+  };
+
+  const browser = typeof window !== "undefined" ? window as IdleCapableWindow : null;
+  if (browser?.requestIdleCallback) {
+    const handle = browser.requestIdleCallback(run, { timeout: 500 });
+    return () => {
+      cancelled = true;
+      browser.cancelIdleCallback?.(handle);
+    };
+  }
+
+  const timer = globalThis.setTimeout(run, 16);
+  return () => {
+    cancelled = true;
+    globalThis.clearTimeout(timer);
+  };
+}
+
+export function clearPreferredNoteSplitLevelCache(): void {
+  splitAnalysisCache.clear();
+}


### PR DESCRIPTION
## 背景

修复 #577：NAS Docker 局域网环境中，图片较多的富文本笔记来回切换需要数秒。

Refs #577

## 根因

- 每次打开笔记都会同步扫描整篇序列化正文，计算编辑器复杂度
- `EditorPaneRuntime` 为了可选的“拆分文档”入口，在首屏同步 `JSON.parse` 并扫描标题
- 富文本媒体节点达到 40 个才进入视口优化，8～39 张高分辨率截图仍会全部立即渲染

## 改动

- 按 `noteId + version + updatedAt + 轻量内容指纹` 缓存编辑器复杂度决策，A → B → A 不再重复全文扫描
- 将文档拆分标题分析移动到 `requestIdleCallback` / 延迟任务，并支持取消过期任务
- 缓存拆分标题分析结果，返回同一笔记版本时直接复用
- 富文本达到 8 个媒体节点即进入 `viewport-optimized`，离屏图片延迟请求和解码
- 保持 120 个重节点的轻量编辑阈值及 100 万字符的紧急只读阈值不变

## 验证

- 7/8 张图片阈值回归测试：通过
- 复杂度决策缓存复用与版本失效测试：通过
- 拆分分析延迟、取消和缓存失效测试：通过
- EditorPaneRuntime 首屏延迟分析布局测试：通过
- Issue 577 Note Switch Performance CI：通过
- Editor Runtime CI：通过
- Note Split CI：通过
- Editor Initialization Timeout CI：通过
- Issue 355 Content Format CI：通过

## 发布后验证

本 PR 使用 `Refs #577`，暂不自动关闭 Issue。合并后需要反馈用户在原 NAS、原图片密集笔记上复测 A → B → A 切换耗时，再决定是否关闭。