### PR TITLE
feat(ui): enable three-column mode on Web

### DIFF
--- a/frontend/src/components/NoteWorkspaceLayoutController.tsx
+++ b/frontend/src/components/NoteWorkspaceLayoutController.tsx
@@ -11,9 +11,11 @@ import { useTranslation } from "react-i18next";
 
 import { useApp, useAppActions } from "@/store/AppContext";
 import {
+  detectNoteWorkspaceSurface,
   getAutomaticCollapseReason,
   loadNoteWorkspaceLayoutMode,
   persistNoteWorkspaceLayoutMode,
+  supportsWideNoteWorkspaceLayout,
   type NoteWorkspaceLayoutMode,
 } from "@/lib/noteWorkspaceLayout";
 import { cn } from "@/lib/utils";
@@ -28,7 +30,7 @@ interface LayoutChoice {
   previewColumns: number;
 }
 
-const DESKTOP_SIDEBAR_HEADER_SELECTOR =
+const WIDE_SIDEBAR_HEADER_SELECTOR =
   '[data-unified-sidebar][data-sidebar-variant="desktop"] > header';
 const NON_NOTE_WORKSPACE_VIEWS = new Set([
   "tasks",
@@ -39,23 +41,28 @@ const NON_NOTE_WORKSPACE_VIEWS = new Set([
   "shares",
 ]);
 
-function findDesktopHeader(): HTMLElement | null {
+function findWideSidebarHeader(): HTMLElement | null {
   if (typeof document === "undefined") return null;
-  return document.querySelector<HTMLElement>(DESKTOP_SIDEBAR_HEADER_SELECTOR);
+  return document.querySelector<HTMLElement>(WIDE_SIDEBAR_HEADER_SELECTOR);
 }
 
 export default function NoteWorkspaceLayoutController() {
   const { state } = useApp();
   const actions = useAppActions();
   const { t } = useTranslation();
-  const noteWorkspaceActive = !NON_NOTE_WORKSPACE_VIEWS.has(state.viewMode);
+  const [surface] = useState(() => detectNoteWorkspaceSurface());
+  const wideLayoutSupported = supportsWideNoteWorkspaceLayout(surface);
+  const noteWorkspaceActive = wideLayoutSupported
+    && !NON_NOTE_WORKSPACE_VIEWS.has(state.viewMode);
   const [preferredMode, setPreferredMode] = useState<NoteWorkspaceLayoutMode>(() =>
     loadNoteWorkspaceLayoutMode(state.noteListCollapsed),
   );
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window === "undefined" ? 1920 : window.innerWidth,
   );
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(() => findDesktopHeader());
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(() =>
+    wideLayoutSupported ? findWideSidebarHeader() : null,
+  );
   const [open, setOpen] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ left: 8, top: 44 });
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -103,18 +110,20 @@ export default function NoteWorkspaceLayoutController() {
   ], [t]);
 
   useEffect(() => {
+    if (!wideLayoutSupported) return;
     const update = () => setViewportWidth(window.innerWidth);
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
-  }, []);
+  }, [wideLayoutSupported]);
 
   useEffect(() => {
-    const updateTarget = () => setPortalTarget(findDesktopHeader());
+    if (!wideLayoutSupported) return;
+    const updateTarget = () => setPortalTarget(findWideSidebarHeader());
     updateTarget();
     const observer = new MutationObserver(updateTarget);
     observer.observe(document.body, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, []);
+  }, [wideLayoutSupported]);
 
   useEffect(() => {
     if (!portalTarget || !noteWorkspaceActive) return;
@@ -234,6 +243,7 @@ export default function NoteWorkspaceLayoutController() {
       aria-haspopup="menu"
       aria-expanded={open}
       data-testid="note-workspace-layout-trigger"
+      data-note-workspace-surface={surface}
     >
       {currentMode === "focus" ? (
         <Maximize2 size={15} />
@@ -262,6 +272,7 @@ export default function NoteWorkspaceLayoutController() {
           className="fixed z-[100] w-[304px] overflow-hidden rounded-xl border border-app-border bg-app-elevated p-1.5 shadow-2xl"
           style={menuPosition}
           data-testid="note-workspace-layout-menu"
+          data-note-workspace-surface={surface}
         >
           <div className="px-2.5 pb-1.5 pt-1 text-[11px] font-semibold uppercase tracking-wide text-tx-tertiary">
             {t("workspaceLayout.title", { defaultValue: "布局模式" })}

--- a/frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx
+++ b/frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx
@@ -60,6 +60,8 @@ describe("NoteWorkspaceLayoutController", () => {
     state.viewMode = "all";
     actions.toggleNoteListCollapsed.mockClear();
     actions.setEditorFullscreen.mockClear();
+    delete (window as any).nowenDesktop;
+    delete (window as any).Capacitor;
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1600 });
 
     class StaticMutationObserver {
@@ -86,10 +88,13 @@ describe("NoteWorkspaceLayoutController", () => {
     vi.unstubAllGlobals();
   });
 
-  it("switches among standard, three-column and focus modes", () => {
+  it("exposes standard, three-column and focus modes in the Web browser", () => {
     act(() => root.render(<NoteWorkspaceLayoutController />));
 
-    act(() => click(document.querySelector('[data-testid="note-workspace-layout-trigger"]')));
+    const trigger = document.querySelector('[data-testid="note-workspace-layout-trigger"]');
+    expect(trigger?.getAttribute("data-note-workspace-surface")).toBe("web");
+
+    act(() => click(trigger));
     act(() => click(findMenuChoice("标准模式")));
     expect(actions.toggleNoteListCollapsed).toHaveBeenCalledTimes(1);
     expect(state.noteListCollapsed).toBe(true);
@@ -107,6 +112,25 @@ describe("NoteWorkspaceLayoutController", () => {
     act(() => click(findMenuChoice("专注模式")));
     expect(actions.setEditorFullscreen).toHaveBeenLastCalledWith(true);
     expect(localStorage.getItem(NOTE_WORKSPACE_LAYOUT_STORAGE_KEY)).toBe("three-column");
+  });
+
+  it("keeps the same layout entry in Electron", () => {
+    (window as any).nowenDesktop = { isDesktop: true };
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+
+    const trigger = document.querySelector('[data-testid="note-workspace-layout-trigger"]');
+    expect(trigger?.getAttribute("data-note-workspace-surface")).toBe("desktop");
+  });
+
+  it("does not replace native mobile progressive navigation with a wide layout", () => {
+    (window as any).Capacitor = {
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+    };
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+
+    expect(document.querySelector('[data-testid="note-workspace-layout-trigger"]')).toBeNull();
+    expect(actions.toggleNoteListCollapsed).not.toHaveBeenCalled();
   });
 
   it("restores three-column mode after right split and still accepts a manual collapse", () => {

--- a/frontend/src/lib/__tests__/noteWorkspaceLayout.test.ts
+++ b/frontend/src/lib/__tests__/noteWorkspaceLayout.test.ts
@@ -2,14 +2,36 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   NOTE_WORKSPACE_LAYOUT_STORAGE_KEY,
   THREE_COLUMN_MIN_VIEWPORT_WIDTH,
+  detectNoteWorkspaceSurface,
   getAutomaticCollapseReason,
   loadNoteWorkspaceLayoutMode,
   persistNoteWorkspaceLayoutMode,
   resolveNoteWorkspaceVisibility,
+  supportsWideNoteWorkspaceLayout,
 } from "@/lib/noteWorkspaceLayout";
 
 describe("note workspace layout", () => {
   beforeEach(() => localStorage.clear());
+
+  it("supports wide layouts in Web and Electron but not native mobile", () => {
+    const webWindow = {} as Window;
+    const desktopWindow = {
+      nowenDesktop: { isDesktop: true },
+    } as unknown as Window;
+    const nativeWindow = {
+      Capacitor: {
+        isNativePlatform: () => true,
+        getPlatform: () => "android",
+      },
+    } as unknown as Window;
+
+    expect(detectNoteWorkspaceSurface(webWindow)).toBe("web");
+    expect(detectNoteWorkspaceSurface(desktopWindow)).toBe("desktop");
+    expect(detectNoteWorkspaceSurface(nativeWindow)).toBe("native-mobile");
+    expect(supportsWideNoteWorkspaceLayout("web")).toBe(true);
+    expect(supportsWideNoteWorkspaceLayout("desktop")).toBe(true);
+    expect(supportsWideNoteWorkspaceLayout("native-mobile")).toBe(false);
+  });
 
   it("migrates the previous note-list collapsed preference", () => {
     expect(loadNoteWorkspaceLayoutMode(true)).toBe("standard");

--- a/frontend/src/lib/noteWorkspaceLayout.ts
+++ b/frontend/src/lib/noteWorkspaceLayout.ts
@@ -1,4 +1,5 @@
 export type NoteWorkspaceLayoutMode = "standard" | "three-column";
+export type NoteWorkspaceSurface = "web" | "desktop" | "native-mobile";
 
 export const NOTE_WORKSPACE_LAYOUT_STORAGE_KEY = "nowen-note-workspace-layout";
 export const THREE_COLUMN_MIN_VIEWPORT_WIDTH = 1120;
@@ -16,6 +17,39 @@ export interface NoteWorkspaceVisibilityInput {
 export interface NoteWorkspaceVisibility {
   showNoteList: boolean;
   autoCollapseReason: NoteWorkspaceAutoCollapseReason;
+}
+
+/**
+ * The React workspace is shared by the browser Web app and Electron.
+ * Keep the distinction explicit so future native-only checks cannot
+ * accidentally hide wide-screen layout controls from Web users.
+ */
+export function detectNoteWorkspaceSurface(
+  runtimeWindow: Window | undefined = typeof window === "undefined" ? undefined : window,
+): NoteWorkspaceSurface {
+  if (!runtimeWindow) return "web";
+
+  const runtime = runtimeWindow as Window & {
+    nowenDesktop?: { isDesktop?: boolean };
+    Capacitor?: {
+      isNativePlatform?: () => boolean;
+      platform?: string;
+      getPlatform?: () => string;
+    };
+  };
+
+  const capacitorPlatform = runtime.Capacitor?.getPlatform?.()
+    || runtime.Capacitor?.platform;
+  const nativeMobile = runtime.Capacitor?.isNativePlatform?.()
+    || (!!capacitorPlatform && capacitorPlatform !== "web");
+
+  if (nativeMobile) return "native-mobile";
+  if (runtime.nowenDesktop?.isDesktop) return "desktop";
+  return "web";
+}
+
+export function supportsWideNoteWorkspaceLayout(surface: NoteWorkspaceSurface): boolean {
+  return surface === "web" || surface === "desktop";
 }
 
 export function loadNoteWorkspaceLayoutMode(


### PR DESCRIPTION
## 目标

将现有三栏笔记工作区正式扩展到浏览器 Web 端，并明确区分 Web、Electron 与原生移动端运行时。

## 已实现

- 普通浏览器明确识别为 `web`，显示标准 / 三栏 / 专注布局入口
- Electron 继续识别为 `desktop`，保持现有行为
- Capacitor Android / iOS 识别为 `native-mobile`，继续使用目录 → 列表 → 编辑器逐级导航
- Web 与 Electron 共用同一布局状态机、响应式降级、左右分屏降级和本地偏好
- 布局入口增加运行端标记，避免后续端判断误把 Web 入口隐藏
- 将原先桌面专用命名收敛为宽屏工作区语义

## 验证

- Web 浏览器三种布局切换测试
- Electron 布局入口兼容测试
- 原生移动端不显示宽屏布局测试
- Web / Electron / native-mobile 运行端识别测试
- 原有布局迁移、持久化、窄窗口和分屏降级测试
- 前端 TypeScript 类型检查