### PR TITLE
fix(ui): make Web three-column mode actually switch layouts

### DIFF
--- a/.github/workflows/knowledge-tree-p0-ci.yml
+++ b/.github/workflows/knowledge-tree-p0-ci.yml
@@ -7,24 +7,32 @@ on:
       - "frontend/src/App.tsx"
       - "frontend/src/components/EditorSplitView.tsx"
       - "frontend/src/components/common/CommandPalette.tsx"
+      - "frontend/src/components/MobileDrawerUxBridge.tsx"
       - "frontend/src/components/NoteWorkspaceLayoutController.tsx"
+      - "frontend/src/components/__tests__/MobileDrawerUxBridge.layout.test.tsx"
       - "frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx"
       - "frontend/src/lib/editorWorkspaceLayout.ts"
       - "frontend/src/lib/noteWorkspaceLayout.ts"
+      - "frontend/src/lib/unifiedTreeOnlyLayout.ts"
       - "frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts"
       - "frontend/src/lib/__tests__/noteWorkspaceLayout.test.ts"
+      - "frontend/src/lib/__tests__/unifiedTreeOnlyLayout.test.ts"
       - ".github/workflows/knowledge-tree-p0-ci.yml"
   pull_request:
     paths:
       - "frontend/src/App.tsx"
       - "frontend/src/components/EditorSplitView.tsx"
       - "frontend/src/components/common/CommandPalette.tsx"
+      - "frontend/src/components/MobileDrawerUxBridge.tsx"
       - "frontend/src/components/NoteWorkspaceLayoutController.tsx"
+      - "frontend/src/components/__tests__/MobileDrawerUxBridge.layout.test.tsx"
       - "frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx"
       - "frontend/src/lib/editorWorkspaceLayout.ts"
       - "frontend/src/lib/noteWorkspaceLayout.ts"
+      - "frontend/src/lib/unifiedTreeOnlyLayout.ts"
       - "frontend/src/lib/__tests__/editorWorkspaceLayout.test.ts"
       - "frontend/src/lib/__tests__/noteWorkspaceLayout.test.ts"
+      - "frontend/src/lib/__tests__/unifiedTreeOnlyLayout.test.ts"
       - ".github/workflows/knowledge-tree-p0-ci.yml"
 
 permissions:
@@ -46,7 +54,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - name: Workspace layout tests
-        run: npm run test:run -- src/lib/__tests__/editorWorkspaceLayout.test.ts src/lib/__tests__/noteWorkspaceLayout.test.ts src/components/__tests__/NoteWorkspaceLayoutController.test.tsx
+        run: npm run test:run -- src/lib/__tests__/editorWorkspaceLayout.test.ts src/lib/__tests__/noteWorkspaceLayout.test.ts src/lib/__tests__/unifiedTreeOnlyLayout.test.ts src/components/__tests__/NoteWorkspaceLayoutController.test.tsx src/components/__tests__/MobileDrawerUxBridge.layout.test.tsx
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b

--- a/frontend/src/components/MobileDrawerUxBridge.tsx
+++ b/frontend/src/components/MobileDrawerUxBridge.tsx
@@ -3,10 +3,7 @@ import KnowledgeTreeDrawer from "@/components/KnowledgeTreeDrawer";
 import ShortcutHelpCenter from "@/components/ShortcutHelpCenter";
 import ShortcutRuntimeBridge from "@/components/ShortcutRuntimeBridge";
 import { useApp, useAppActions } from "@/store/AppContext";
-import {
-  shouldCollapseLegacyNoteList,
-  usesFunctionalNoteList,
-} from "@/lib/unifiedTreeOnlyLayout";
+import { usesFunctionalNoteList } from "@/lib/unifiedTreeOnlyLayout";
 
 export const MOBILE_DRAWER_SEARCH_BLUR_DELAY_MS = 160;
 
@@ -120,9 +117,10 @@ export const ANDROID_DRAWER_SAFE_AREA_CSS = `
 }
 `;
 
-const UNIFIED_TREE_ONLY_CSS = `
-/* Legacy notebook-list layout controls are retired. Runtime state is enforced below,
-   and these selectors prevent stale large components from exposing a dead control. */
+const LEGACY_NOTE_LIST_CONTROL_CSS = `
+/* The canonical standard/three-column/focus selector lives in the knowledge-tree
+   header. Hide older direct expand/collapse controls so two independent layout
+   controls cannot compete for the same panel state. */
 button[title="展开笔记列表"],
 button[title="收起笔记列表"],
 button[aria-label="展开笔记列表"],
@@ -147,27 +145,22 @@ export default function MobileDrawerUxBridge() {
   }, [state.mobileSidebarOpen]);
 
   /**
-   * Unified content tree is the only everyday hierarchy on desktop and mobile.
-   * Favorites, tags, Trash and legacy persistent-search results remain dedicated
-   * list surfaces because they are cross-tree result sets, not notebook navigation.
+   * This bridge owns progressive mobile navigation only. Wide Web/Electron
+   * note-list visibility is owned exclusively by NoteWorkspaceLayoutController.
+   *
+   * The previous implementation also forced noteListCollapsed for every view.
+   * That legacy rule immediately undid a user's three-column selection, making
+   * the Web layout menu appear unresponsive.
    */
   useLayoutEffect(() => {
-    document.documentElement.setAttribute("data-unified-tree-only", "");
-
-    const collapse = shouldCollapseLegacyNoteList(state.viewMode);
-    if (state.noteListCollapsed !== collapse) {
-      actions.toggleNoteListCollapsed();
-    }
-
     const functionalList = usesFunctionalNoteList(state.viewMode);
     const viewChanged = previousViewModeRef.current !== state.viewMode;
 
     if (functionalList) {
       if (viewChanged && state.mobileView !== "list") actions.setMobileView("list");
     } else if (state.mobileView !== "editor") {
-      // The retired note-list route now maps to the editor shell. On phones, open the
-      // unified tree immediately on first boot as well as after a later Android-back
-      // navigation, so users never have to press Back once just to reach their notebooks.
+      // Ordinary note navigation uses the unified tree drawer on phones. The
+      // desktop-width middle list remains controlled by the workspace mode.
       actions.setMobileView("editor");
       if (typeof window !== "undefined" && isMobileDrawerViewport(window.innerWidth)) {
         actions.setMobileSidebar(true);
@@ -175,7 +168,7 @@ export default function MobileDrawerUxBridge() {
     }
 
     previousViewModeRef.current = state.viewMode;
-  }, [actions, state.mobileView, state.noteListCollapsed, state.viewMode]);
+  }, [actions, state.mobileView, state.viewMode]);
 
   useEffect(() => {
     const clearBlurTimer = () => {
@@ -230,7 +223,7 @@ export default function MobileDrawerUxBridge() {
   return (
     <>
       <style data-mobile-drawer-ux="">{ANDROID_DRAWER_SAFE_AREA_CSS}</style>
-      <style data-unified-tree-only-layout="">{UNIFIED_TREE_ONLY_CSS}</style>
+      <style data-note-workspace-layout-controls="">{LEGACY_NOTE_LIST_CONTROL_CSS}</style>
       <KnowledgeTreeDrawer />
       <ShortcutHelpCenter />
       <ShortcutRuntimeBridge />

--- a/frontend/src/components/NoteWorkspaceLayoutController.tsx
+++ b/frontend/src/components/NoteWorkspaceLayoutController.tsx
@@ -18,6 +18,7 @@ import {
   supportsWideNoteWorkspaceLayout,
   type NoteWorkspaceLayoutMode,
 } from "@/lib/noteWorkspaceLayout";
+import { usesFunctionalNoteList } from "@/lib/unifiedTreeOnlyLayout";
 import { cn } from "@/lib/utils";
 
 type DisplayLayoutMode = NoteWorkspaceLayoutMode | "focus";
@@ -54,6 +55,7 @@ export default function NoteWorkspaceLayoutController() {
   const wideLayoutSupported = supportsWideNoteWorkspaceLayout(surface);
   const noteWorkspaceActive = wideLayoutSupported
     && !NON_NOTE_WORKSPACE_VIEWS.has(state.viewMode);
+  const functionalListView = usesFunctionalNoteList(state.viewMode);
   const [preferredMode, setPreferredMode] = useState<NoteWorkspaceLayoutMode>(() =>
     loadNoteWorkspaceLayoutMode(state.noteListCollapsed),
   );
@@ -70,7 +72,10 @@ export default function NoteWorkspaceLayoutController() {
   const observedCollapsedRef = useRef(state.noteListCollapsed);
   const expectedCollapsedRef = useRef<boolean | null>(null);
 
-  const automaticCollapseReason = noteWorkspaceActive
+  // Favorites, tags, search and Trash are result-set surfaces. They require the
+  // middle list even when the saved everyday workspace mode is "standard".
+  // Leaving those views restores the user's standard/three-column preference.
+  const automaticCollapseReason = noteWorkspaceActive && !functionalListView
     ? getAutomaticCollapseReason({
       editorFullscreen: state.editorFullscreen,
       viewportWidth,
@@ -160,13 +165,16 @@ export default function NoteWorkspaceLayoutController() {
   useEffect(() => {
     if (!noteWorkspaceActive) return;
     const automatic = automaticCollapseReason !== null;
+    const forceExpanded = functionalListView;
     const collapsedChanged = observedCollapsedRef.current !== state.noteListCollapsed;
 
     if (collapsedChanged) {
       observedCollapsedRef.current = state.noteListCollapsed;
       if (expectedCollapsedRef.current === state.noteListCollapsed) {
         expectedCollapsedRef.current = null;
-      } else if (!automatic) {
+      } else if (!automatic && !forceExpanded) {
+        // A change not requested by this controller is treated as the user's
+        // legacy expand/collapse action and becomes the new saved base mode.
         const inferredMode: NoteWorkspaceLayoutMode = state.noteListCollapsed
           ? "standard"
           : "three-column";
@@ -178,7 +186,9 @@ export default function NoteWorkspaceLayoutController() {
       }
     }
 
-    const desiredCollapsed = automatic || preferredMode === "standard";
+    const desiredCollapsed = forceExpanded
+      ? false
+      : automatic || preferredMode === "standard";
     if (
       state.noteListCollapsed !== desiredCollapsed
       && expectedCollapsedRef.current !== desiredCollapsed
@@ -189,6 +199,7 @@ export default function NoteWorkspaceLayoutController() {
   }, [
     actions,
     automaticCollapseReason,
+    functionalListView,
     noteWorkspaceActive,
     preferredMode,
     state.noteListCollapsed,

--- a/frontend/src/components/__tests__/MobileDrawerUxBridge.layout.test.tsx
+++ b/frontend/src/components/__tests__/MobileDrawerUxBridge.layout.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  mobileSidebarOpen: false,
+  mobileView: "editor" as "list" | "editor",
+  noteListCollapsed: false,
+  viewMode: "all",
+}));
+
+const actions = vi.hoisted(() => ({
+  toggleNoteListCollapsed: vi.fn(),
+  setMobileView: vi.fn((value: "list" | "editor") => {
+    state.mobileView = value;
+  }),
+  setMobileSidebar: vi.fn((value: boolean) => {
+    state.mobileSidebarOpen = value;
+  }),
+}));
+
+vi.mock("@/store/AppContext", () => ({
+  useApp: () => ({ state }),
+  useAppActions: () => actions,
+}));
+vi.mock("@/components/KnowledgeTreeDrawer", () => ({ default: () => null }));
+vi.mock("@/components/ShortcutHelpCenter", () => ({ default: () => null }));
+vi.mock("@/components/ShortcutRuntimeBridge", () => ({ default: () => null }));
+
+import MobileDrawerUxBridge from "@/components/MobileDrawerUxBridge";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MobileDrawerUxBridge layout ownership", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    state.mobileSidebarOpen = false;
+    state.mobileView = "editor";
+    state.noteListCollapsed = false;
+    state.viewMode = "all";
+    actions.toggleNoteListCollapsed.mockClear();
+    actions.setMobileView.mockClear();
+    actions.setMobileSidebar.mockClear();
+
+    class StaticMutationObserver {
+      observe() {}
+      disconnect() {}
+      takeRecords() { return []; }
+    }
+    vi.stubGlobal("MutationObserver", StaticMutationObserver);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1600 });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("does not collapse an ordinary Web three-column workspace", () => {
+    act(() => root.render(<MobileDrawerUxBridge />));
+
+    expect(actions.toggleNoteListCollapsed).not.toHaveBeenCalled();
+    expect(state.noteListCollapsed).toBe(false);
+  });
+
+  it("keeps mobile progressive navigation for functional result views without changing desktop layout", () => {
+    act(() => root.render(<MobileDrawerUxBridge />));
+    state.viewMode = "favorites";
+    act(() => root.render(<MobileDrawerUxBridge />));
+
+    expect(actions.setMobileView).toHaveBeenCalledWith("list");
+    expect(actions.toggleNoteListCollapsed).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx
+++ b/frontend/src/components/__tests__/NoteWorkspaceLayoutController.test.tsx
@@ -156,6 +156,25 @@ describe("NoteWorkspaceLayoutController", () => {
     expect(actions.toggleNoteListCollapsed).toHaveBeenCalledTimes(2);
   });
 
+  it("forces functional result lists open and restores the saved base mode afterwards", () => {
+    localStorage.setItem(NOTE_WORKSPACE_LAYOUT_STORAGE_KEY, "standard");
+    state.noteListCollapsed = true;
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+
+    state.viewMode = "favorites";
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+    expect(actions.toggleNoteListCollapsed).toHaveBeenCalledTimes(1);
+    expect(state.noteListCollapsed).toBe(false);
+    expect(localStorage.getItem(NOTE_WORKSPACE_LAYOUT_STORAGE_KEY)).toBe("standard");
+
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+    state.viewMode = "all";
+    act(() => root.render(<NoteWorkspaceLayoutController />));
+    expect(actions.toggleNoteListCollapsed).toHaveBeenCalledTimes(2);
+    expect(state.noteListCollapsed).toBe(true);
+    expect(localStorage.getItem(NOTE_WORKSPACE_LAYOUT_STORAGE_KEY)).toBe("standard");
+  });
+
   it("does not expose note layout controls in non-note modules", () => {
     state.viewMode = "tasks";
     act(() => root.render(<NoteWorkspaceLayoutController />));

--- a/frontend/src/lib/__tests__/unifiedTreeOnlyLayout.test.ts
+++ b/frontend/src/lib/__tests__/unifiedTreeOnlyLayout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   LEGACY_NOTEBOOK_TREE_SORT_KEY,
   LEGACY_NOTE_LIST_COLLAPSED_KEY,
+  NOTE_WORKSPACE_LAYOUT_KEY,
   migrateUnifiedTreeOnlyLayout,
   shouldCollapseLegacyNoteList,
   usesFunctionalNoteList,
@@ -20,21 +21,19 @@ function createStorage(initial: Record<string, string> = {}): StorageLike & { va
 }
 
 describe("unifiedTreeOnlyLayout", () => {
-  it("collapses the retired notebook list for normal tree navigation", () => {
+  it("identifies ordinary tree navigation and functional result lists", () => {
     for (const mode of ["all", "notebook", "tasks", "files", "diary", "mindmaps", "ai-chat", "shares"]) {
       expect(usesFunctionalNoteList(mode)).toBe(false);
       expect(shouldCollapseLegacyNoteList(mode)).toBe(true);
     }
-  });
 
-  it("keeps dedicated cross-tree result lists available", () => {
     for (const mode of ["favorites", "trash", "tag", "search"]) {
       expect(usesFunctionalNoteList(mode)).toBe(true);
       expect(shouldCollapseLegacyNoteList(mode)).toBe(false);
     }
   });
 
-  it("overrides old user layout caches before AppContext initializes", () => {
+  it("defaults users without an explicit workspace preference to standard mode", () => {
     const storage = createStorage({
       [LEGACY_NOTE_LIST_COLLAPSED_KEY]: "0",
       [LEGACY_NOTEBOOK_TREE_SORT_KEY]: JSON.stringify({ by: "name", dir: "asc" }),
@@ -44,6 +43,28 @@ describe("unifiedTreeOnlyLayout", () => {
 
     expect(storage.getItem(LEGACY_NOTE_LIST_COLLAPSED_KEY)).toBe("1");
     expect(storage.getItem(LEGACY_NOTEBOOK_TREE_SORT_KEY)).toBeNull();
+  });
+
+  it("keeps an explicit three-column preference expanded before AppContext initializes", () => {
+    const storage = createStorage({
+      [NOTE_WORKSPACE_LAYOUT_KEY]: "three-column",
+      [LEGACY_NOTE_LIST_COLLAPSED_KEY]: "1",
+    });
+
+    migrateUnifiedTreeOnlyLayout(storage);
+
+    expect(storage.getItem(LEGACY_NOTE_LIST_COLLAPSED_KEY)).toBe("0");
+  });
+
+  it("keeps an explicit standard preference collapsed before AppContext initializes", () => {
+    const storage = createStorage({
+      [NOTE_WORKSPACE_LAYOUT_KEY]: "standard",
+      [LEGACY_NOTE_LIST_COLLAPSED_KEY]: "0",
+    });
+
+    migrateUnifiedTreeOnlyLayout(storage);
+
+    expect(storage.getItem(LEGACY_NOTE_LIST_COLLAPSED_KEY)).toBe("1");
   });
 
   it("does not throw when storage is restricted", () => {

--- a/frontend/src/lib/unifiedTreeOnlyLayout.ts
+++ b/frontend/src/lib/unifiedTreeOnlyLayout.ts
@@ -1,5 +1,6 @@
 export const LEGACY_NOTE_LIST_COLLAPSED_KEY = "nowen-notelist-collapsed";
 export const LEGACY_NOTEBOOK_TREE_SORT_KEY = "nowen.notebookTree.sort";
+export const NOTE_WORKSPACE_LAYOUT_KEY = "nowen-note-workspace-layout";
 
 const FUNCTIONAL_NOTE_LIST_VIEWS = new Set([
   "favorites",
@@ -15,33 +16,46 @@ export interface StorageLike {
 }
 
 /**
- * The unified content tree is the only everyday note-navigation hierarchy.
- * These exceptional views still need a dedicated list because they represent
- * cross-tree result sets or batch-management surfaces rather than a notebook
- * directory.
+ * Cross-tree result sets and batch-management surfaces still require a
+ * dedicated note list even when the ordinary notebook workspace uses the
+ * unified knowledge tree directly.
  */
 export function usesFunctionalNoteList(viewMode: string): boolean {
   return FUNCTIONAL_NOTE_LIST_VIEWS.has(viewMode);
 }
 
+/**
+ * Compatibility helper retained for older callers and tests. New wide-screen
+ * layout code must use the explicit workspace layout preference instead of
+ * enforcing this result at runtime.
+ */
 export function shouldCollapseLegacyNoteList(viewMode: string): boolean {
   return !usesFunctionalNoteList(viewMode);
 }
 
 /**
- * Runs before AppContext reads its legacy layout cache. Existing users who
- * saved the old three-column notebook-directory layout are migrated to the
- * unified-tree layout without a one-frame flash on startup.
+ * Runs before AppContext reads the old note-list cache.
+ *
+ * The previous unified-tree migration always wrote `collapsed=1` on every
+ * startup. That became incorrect once standard/three-column modes were added:
+ * a saved three-column preference would start collapsed and then compete with
+ * the layout controller. Keep the old cache aligned with the explicit layout
+ * preference instead, while preserving standard mode for users who have never
+ * chosen a workspace layout.
  */
 export function migrateUnifiedTreeOnlyLayout(
   storage: StorageLike | null | undefined = typeof window === "undefined" ? null : window.localStorage,
 ): void {
   if (!storage) return;
   try {
-    storage.setItem(LEGACY_NOTE_LIST_COLLAPSED_KEY, "1");
+    const explicitLayout = storage.getItem(NOTE_WORKSPACE_LAYOUT_KEY);
+    storage.setItem(
+      LEGACY_NOTE_LIST_COLLAPSED_KEY,
+      explicitLayout === "three-column" ? "0" : "1",
+    );
     storage.removeItem(LEGACY_NOTEBOOK_TREE_SORT_KEY);
   } catch {
     // Privacy mode and restricted WebViews may reject storage writes. Runtime
-    // enforcement still applies after AppContext mounts.
+    // layout reconciliation still runs after AppContext mounts.
   }
 }


### PR DESCRIPTION
## 问题

Web 端布局菜单可以打开，但点击“三栏模式”后中间笔记列表没有出现。

## 根因

`NoteWorkspaceLayoutController` 展开中间列表后，旧的 `MobileDrawerUxBridge` 仍按“统一知识树单栏”规则在 `useLayoutEffect` 中强制把普通笔记视图的 `noteListCollapsed` 改回折叠。两个组件争用同一个状态，导致三栏模式看起来点击无反应。

## 修复

- 移除 MobileDrawerUxBridge 对桌面宽屏 `noteListCollapsed` 的强制控制
- 明确由 NoteWorkspaceLayoutController 独占 Web/Electron 中间笔记列表状态
- 保留移动端目录 → 列表 → 编辑器的逐级导航
- 收藏、标签、搜索、回收站等功能型结果页面强制展示中间列表，离开后恢复用户保存的标准/三栏偏好
- 启动迁移不再每次无条件写入折叠状态；明确选择三栏时，AppContext 初始化前保持展开
- 旧的直接展开/收起按钮继续隐藏，避免与统一布局菜单形成第二个状态入口

## 验证结果

- 布局与状态所有权测试：24 项通过
- Web 标准 / 三栏 / 专注切换：通过
- MobileDrawer 不覆盖 Web 三栏状态：通过
- 功能型列表进入时展开、离开时恢复：通过
- 三栏偏好刷新启动后保持展开：通过
- Electron 与原生移动端运行时兼容：通过
- Knowledge Tree 前端回归：通过
- 前端 TypeScript 类型检查：通过
- 分支相对 main：behind 0

## 已知主线问题

Knowledge Tree CI 的后端 SQLite 测试因现有迁移编号重复失败：`v60` 后再次出现 `v60 (offline-workspace-sync-feed)`。该问题存在于当前 main 的后端迁移序列，与本 PR 的 7 个前端布局文件无关；同一工作流中的 PostgreSQL schema、后端类型检查和全部前端检查均通过。