### PR TITLE
feat(ui): add fixed all-notes entry to three-column sidebar

### DIFF
--- a/frontend/src/components/KnowledgeTreeCreateMenuRuntime.tsx
+++ b/frontend/src/components/KnowledgeTreeCreateMenuRuntime.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { FileCode, FileText, FileType2, Folder, Link2 } from "lucide-react";
+import { FileCode, Files, FileText, FileType2, Folder, Link2 } from "lucide-react";
 
 import KnowledgeTreePanelBase, {
   FOCUS_KNOWLEDGE_TREE_EVENT,
@@ -10,11 +10,14 @@ import KnowledgeTreePanelBase, {
   type KnowledgeTreePanelProps,
 } from "./KnowledgeTreePanel";
 import { type KnowledgeTreeInlineCreateKind } from "@/lib/knowledgeTreeInlineCreate";
+import { cn } from "@/lib/utils";
+import { useApp, useAppActions } from "@/store/AppContext";
 
 export { FOCUS_KNOWLEDGE_TREE_EVENT, KNOWLEDGE_TREE_CHANGED_EVENT };
 export type { KnowledgeTreePanelProps };
 
 const CREATE_SCOPE_ATTR = "data-nowen-create-scope";
+const ALL_NOTES_HOST_ATTR = "data-knowledge-tree-all-notes-host";
 const CREATE_MENU_WIDTH = 184;
 const CREATE_MENU_HEIGHT = 252;
 
@@ -57,6 +60,84 @@ function markCreateButtons(root: HTMLElement): void {
     button.setAttribute("aria-label", title ? `在“${title}”下新建` : "在当前节点下新建");
     button.setAttribute("aria-haspopup", "menu");
   }
+}
+
+function ensureAllNotesHost(root: HTMLElement): HTMLElement | null {
+  const panel = root.querySelector<HTMLElement>('[data-nowen-knowledge-tree="embedded"]');
+  if (!panel) return null;
+  const scroll = panel.querySelector<HTMLElement>('[data-swipe-blocker="knowledge-tree-scroll"]');
+  if (!scroll || scroll.parentElement !== panel) return null;
+
+  let host = panel.querySelector<HTMLElement>(`[${ALL_NOTES_HOST_ATTR}]`);
+  if (!host) {
+    host = document.createElement("div");
+    host.setAttribute(ALL_NOTES_HOST_ATTR, "");
+    host.className = "shrink-0 px-2 pb-1.5";
+    panel.insertBefore(host, scroll);
+  }
+  return host;
+}
+
+function AllNotesEntry({ variant }: { variant: "desktop" | "mobile" }) {
+  const { state } = useApp();
+  const actions = useAppActions();
+  const active = state.viewMode === "all"
+    && state.selectedNotebookId === null
+    && state.selectedTagIds.length === 0;
+  const allNotesCount = useMemo(() => {
+    const countedNotebooks = state.notebooks.filter(
+      (notebook) => typeof notebook.noteCount === "number",
+    );
+    if (countedNotebooks.length === state.notebooks.length) {
+      return countedNotebooks.reduce(
+        (total, notebook) => total + Math.max(0, notebook.noteCount || 0),
+        0,
+      );
+    }
+    return active ? state.notes.length : null;
+  }, [active, state.notebooks, state.notes.length]);
+
+  const openAllNotes = useCallback(() => {
+    actions.setSelectedNotebook(null);
+    actions.clearSelectedTags();
+    actions.setSearchQuery("");
+    actions.setViewMode("all");
+    actions.setMobileView("list");
+    if (variant === "desktop" && state.noteListCollapsed) {
+      actions.toggleNoteListCollapsed();
+    }
+    if (variant === "mobile") actions.setMobileSidebar(false);
+  }, [actions, state.noteListCollapsed, variant]);
+
+  return (
+    <button
+      type="button"
+      onClick={openAllNotes}
+      className={cn(
+        "group flex h-9 w-full items-center gap-2 rounded-lg border px-2.5 text-left text-xs font-medium transition-colors",
+        active
+          ? "border-accent-primary/15 bg-accent-primary/10 text-accent-primary"
+          : "border-transparent text-tx-secondary hover:bg-app-hover hover:text-tx-primary",
+      )}
+      aria-current={active ? "page" : undefined}
+      aria-label={allNotesCount === null ? "查看所有笔记" : `查看所有笔记，共 ${allNotesCount} 条`}
+      data-knowledge-tree-all-notes=""
+    >
+      <Files size={15} className="shrink-0 text-accent-primary" aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate">所有笔记</span>
+      {allNotesCount !== null && (
+        <span
+          className={cn(
+            "min-w-6 shrink-0 rounded-full px-1.5 text-center text-[10px] leading-5 tabular-nums",
+            active ? "bg-accent-primary/10 text-accent-primary" : "bg-app-hover text-tx-tertiary",
+          )}
+          data-knowledge-tree-all-notes-count=""
+        >
+          {allNotesCount}
+        </span>
+      )}
+    </button>
+  );
 }
 
 function menuPosition(anchor: DOMRect): React.CSSProperties {
@@ -174,13 +255,18 @@ export function KnowledgeTreePanel(props: KnowledgeTreePanelProps) {
   const [createMenu, setCreateMenu] = useState<KnowledgeTreeCreateMenuState | null>(null);
   const [createRequest, setCreateRequest] = useState<KnowledgeTreeInlineCreateRequest | undefined>();
   const [importRequest, setImportRequest] = useState<KnowledgeTreeImportRequest | undefined>();
+  const [allNotesHost, setAllNotesHost] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
-    const mark = () => markCreateButtons(root);
-    mark();
-    const observer = new MutationObserver(mark);
+    const syncRuntimeEnhancements = () => {
+      markCreateButtons(root);
+      const host = ensureAllNotesHost(root);
+      setAllNotesHost((current) => current === host ? current : host);
+    };
+    syncRuntimeEnhancements();
+    const observer = new MutationObserver(syncRuntimeEnhancements);
     observer.observe(root, { childList: true, subtree: true });
     return () => observer.disconnect();
   }, []);
@@ -227,11 +313,14 @@ export function KnowledgeTreePanel(props: KnowledgeTreePanelProps) {
     setCreateMenu((current) => current?.parentId === parentId ? null : { parentId, anchor });
   }, []);
 
+  const variant = props.variant ?? "desktop";
+
   return (
     <>
       <div ref={rootRef} className="contents" onClickCapture={handleClickCapture}>
         <KnowledgeTreePanelBase {...props} createRequest={createRequest} importRequest={importRequest} />
       </div>
+      {allNotesHost && createPortal(<AllNotesEntry variant={variant} />, allNotesHost)}
       <KnowledgeTreeCreateDropdown
         menu={createMenu}
         onClose={() => setCreateMenu(null)}

--- a/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeSidebarContract.test.ts
@@ -63,6 +63,21 @@ describe("knowledge tree sidebar contract", () => {
     expect(menu).toContain("onNotePatched(node.id, patch)");
   });
 
+  it("renders all notes as a fixed first-level navigation entry", () => {
+    const runtime = source("../../components/KnowledgeTreeCreateMenuRuntime.tsx");
+
+    expect(runtime).toContain('data-knowledge-tree-all-notes=""');
+    expect(runtime).toContain('data-knowledge-tree-all-notes-count=""');
+    expect(runtime).toContain("panel.insertBefore(host, scroll)");
+    expect(runtime).toContain('actions.setViewMode("all")');
+    expect(runtime).toContain("actions.setSelectedNotebook(null)");
+    expect(runtime).toContain("actions.clearSelectedTags()");
+    expect(runtime).toContain('actions.setSearchQuery("")');
+    expect(runtime).toContain("notebook.noteCount");
+    expect(runtime).toContain("state.noteListCollapsed");
+    expect(runtime).toContain("actions.toggleNoteListCollapsed()");
+  });
+
   it("applies an unmistakably compact mobile density with a safe fallback", () => {
     const main = source("../../main.tsx");
     const compactCss = source("../../mobile-knowledge-tree-compact.css");


### PR DESCRIPTION
## 目标

在三栏模式的知识树栏中增加清晰、固定的“所有笔记”一级入口，让用户不需要猜测标题或菜单即可随时返回全部笔记列表。

## 实现

- 入口固定在知识树搜索栏下方、滚动目录树上方，不随目录滚动；
- 使用独立的 `Files` 图标、文字和笔记总数；
- `all` 视图使用更明确的主题色选中态；
- 点击后复用现有 `viewMode = "all"`，清除目录、标签和搜索筛选；
- 标准模式下点击会展开中间笔记列表，三栏模式保持原布局；
- 总数复用现有笔记本统计，不为展示数字重复请求完整笔记列表；
- 保留当前正在编辑的笔记，不清空编辑器内容；
- 增加知识树侧栏契约测试，覆盖固定位置、状态切换和数量来源。

## 验证

- Knowledge Tree Sidebar contract
- Frontend TypeScript
- 现有知识树与三栏布局回归
