### PR TITLE
fix(blocks): repair skipped block schema migrations

### DIFF
--- a/.github/workflows/block-schema-repair-ci.yml
+++ b/.github/workflows/block-schema-repair-ci.yml
@@ -1,0 +1,59 @@
+name: Block Schema Repair CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "backend/src/db/blockSchemaRepairMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/migrations.impl.ts"
+      - "backend/src/db/blockAuthorityMigration.ts"
+      - "backend/src/db/blockAuthorityStaleGuardMigration.ts"
+      - "backend/src/db/yjsSubdocumentsMigration.ts"
+      - "backend/src/db/yjsSubdocumentGenerationMigration.ts"
+      - "backend/src/lib/noteBlocks.ts"
+      - "backend/src/routes/blocks.ts"
+      - "backend/tests/block-schema-repair-migration.test.ts"
+      - "backend/tests/block-patch-route.test.ts"
+      - ".github/workflows/block-schema-repair-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/db/blockSchemaRepairMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/migrations.impl.ts"
+      - "backend/src/db/blockAuthorityMigration.ts"
+      - "backend/src/db/blockAuthorityStaleGuardMigration.ts"
+      - "backend/src/db/yjsSubdocumentsMigration.ts"
+      - "backend/src/db/yjsSubdocumentGenerationMigration.ts"
+      - "backend/src/lib/noteBlocks.ts"
+      - "backend/src/routes/blocks.ts"
+      - "backend/tests/block-schema-repair-migration.test.ts"
+      - "backend/tests/block-patch-route.test.ts"
+      - ".github/workflows/block-schema-repair-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Run historical block schema and legacy route regressions
+        run: >-
+          node --import tsx --test
+          tests/block-schema-repair-migration.test.ts
+          tests/block-patch-route.test.ts
+      - name: Backend typecheck
+        run: npm run build:tsc

--- a/backend/src/db/blockSchemaRepairMigration.ts
+++ b/backend/src/db/blockSchemaRepairMigration.ts
@@ -1,0 +1,54 @@
+import type Database from "better-sqlite3";
+import { ensureNoteBlockTables } from "../lib/noteBlocks.js";
+import { blockAuthorityMigration } from "./blockAuthorityMigration.js";
+import { blockAuthorityStaleGuardMigration } from "./blockAuthorityStaleGuardMigration.js";
+import {
+  MIGRATIONS as BASE_MIGRATIONS,
+  type Migration,
+} from "./migrations.impl.js";
+import { yjsSubdocumentGenerationMigration } from "./yjsSubdocumentGenerationMigration.js";
+import { yjsSubdocumentsMigration } from "./yjsSubdocumentsMigration.js";
+
+const LEGACY_BLOCK_SCHEMA_VERSION = 48;
+
+/**
+ * Repair the complete block-storage schema for databases that reached a newer
+ * schema version before the historical v48 migration was added to the registry.
+ *
+ * The old migration runner only compared MAX(schema_migrations.version), so a
+ * database already at v50+ could permanently skip v48. That leaves
+ * block_operations/note_blocks_index absent and makes the legacy createBlock
+ * route fail before its runtime table guard can run.
+ *
+ * Every operation below is intentionally idempotent. Reusing the published
+ * migration implementations keeps the repair aligned with the canonical schema
+ * instead of maintaining a second copy of the DDL.
+ */
+export function ensureBlockSchemaRepair(db: Database.Database): void {
+  const legacyBlockMigration = BASE_MIGRATIONS.find(
+    (migration) => migration.version === LEGACY_BLOCK_SCHEMA_VERSION,
+  );
+  if (!legacyBlockMigration) {
+    throw new Error(
+      `[block-schema-repair] missing canonical v${LEGACY_BLOCK_SCHEMA_VERSION} migration`,
+    );
+  }
+
+  legacyBlockMigration.up(db);
+  ensureNoteBlockTables(db);
+
+  // A database affected by the same out-of-order history can also be missing
+  // the later block authority and optional Yjs shadow tables. Re-applying these
+  // CREATE/ALTER/trigger migrations is safe and lets the next block write rebuild
+  // the materialized state normally.
+  blockAuthorityMigration.up(db);
+  yjsSubdocumentsMigration.up(db);
+  blockAuthorityStaleGuardMigration.up(db);
+  yjsSubdocumentGenerationMigration.up(db);
+}
+
+export const blockSchemaRepairMigration: Migration = {
+  version: 63,
+  name: "repair-skipped-block-schema",
+  up: ensureBlockSchemaRepair,
+};

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -22,6 +22,7 @@ import { tagScopeUniquenessMigration } from "./tagScopeUniquenessMigration.js";
 import { offlineSyncMigration } from "./offlineSyncMigration.js";
 import { newUserOnboardingMigration } from "./newUserOnboardingMigration.js";
 import { newUserOnboardingFirstLoginMigration } from "./newUserOnboardingFirstLoginMigration.js";
+import { blockSchemaRepairMigration } from "./blockSchemaRepairMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -276,6 +277,7 @@ export const MIGRATIONS: Migration[] = [
   offlineSyncMigration,
   newUserOnboardingMigration,
   newUserOnboardingFirstLoginMigration,
+  blockSchemaRepairMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(
@@ -293,6 +295,33 @@ function ensureMigrationsTable(db: Database.Database): void {
   `);
 }
 
+function validateMigrationRegistry(): void {
+  const seen = new Map<number, string>();
+  for (const migration of MIGRATIONS) {
+    const existing = seen.get(migration.version);
+    if (existing) {
+      throw new Error(
+        `[migrations] 重复版本号 v${migration.version}: ${existing}, ${migration.name}`,
+      );
+    }
+    seen.set(migration.version, migration.name);
+  }
+}
+
+function getAppliedMigrationVersions(db: Database.Database): Set<number> {
+  ensureMigrationsTable(db);
+  const rows = db.prepare("SELECT version FROM schema_migrations").all() as Array<{ version: number }>;
+  return new Set(rows.map((row) => row.version));
+}
+
+export function getPendingMigrations(db: Database.Database): Migration[] {
+  validateMigrationRegistry();
+  const applied = getAppliedMigrationVersions(db);
+  return MIGRATIONS
+    .filter((migration) => !applied.has(migration.version))
+    .sort((a, b) => a.version - b.version);
+}
+
 export function getCurrentSchemaVersion(db: Database.Database): number {
   ensureMigrationsTable(db);
   const row = db
@@ -303,6 +332,8 @@ export function getCurrentSchemaVersion(db: Database.Database): number {
 
 export function runMigrations(db: Database.Database): number {
   ensureMigrationsTable(db);
+  validateMigrationRegistry();
+
   const current = getCurrentSchemaVersion(db);
   if (current > CURRENT_SCHEMA_VERSION) {
     throw new Error(
@@ -311,20 +342,11 @@ export function runMigrations(db: Database.Database): number {
     );
   }
 
-  const pending = MIGRATIONS
-    .filter((migration) => migration.version > current)
-    .sort((a, b) => a.version - b.version);
+  // schema_migrations is an applied-migration ledger, not a single cursor.
+  // Looking only at MAX(version) permanently skips a migration added later with
+  // a lower historical version (the v48 block schema was affected by this).
+  const pending = getPendingMigrations(db);
   if (pending.length === 0) return 0;
-
-  let previous = current;
-  for (const migration of pending) {
-    if (migration.version <= previous) {
-      throw new Error(
-        `[migrations] 版本号必须严格递增：v${previous} 之后是 v${migration.version}（${migration.name}）`,
-      );
-    }
-    previous = migration.version;
-  }
 
   const insert = db.prepare(
     "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",

--- a/backend/tests/block-schema-repair-migration.test.ts
+++ b/backend/tests/block-schema-repair-migration.test.ts
@@ -58,10 +58,10 @@ test("detects a missing historical migration even when MAX(version) is newer", (
       insert.run(migration.version, migration.name);
     }
 
-    assert.equal(
-      db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get().version,
-      62,
-    );
+    const latest = db.prepare(
+      "SELECT MAX(version) AS version FROM schema_migrations",
+    ).get() as { version: number };
+    assert.equal(latest.version, 62);
     assert.deepEqual(
       getPendingMigrations(db).map((migration) => migration.version),
       [48, 63],

--- a/backend/tests/block-schema-repair-migration.test.ts
+++ b/backend/tests/block-schema-repair-migration.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+
+import {
+  MIGRATIONS,
+  getPendingMigrations,
+  runMigrations,
+} from "../src/db/migrations";
+
+function createHistoricalBlockDatabase(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE notes (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL DEFAULT '',
+      contentFormat TEXT NOT NULL DEFAULT 'markdown',
+      version INTEGER NOT NULL DEFAULT 1
+    );
+
+    -- Simulate the pre-v48 link schema. targetBlockId already existed in v38,
+    -- while sourceBlockId and all generic block tables are intentionally absent.
+    CREATE TABLE note_links (
+      id TEXT PRIMARY KEY,
+      sourceNoteId TEXT NOT NULL,
+      targetNoteId TEXT NOT NULL,
+      targetBlockId TEXT
+    );
+
+    CREATE TABLE schema_migrations (
+      version INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      appliedAt TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+}
+
+function tableNames(db: Database.Database): Set<string> {
+  const rows = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type = 'table'
+  `).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+test("detects a missing historical migration even when MAX(version) is newer", () => {
+  const db = createHistoricalBlockDatabase();
+  try {
+    const insert = db.prepare(
+      "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+    );
+    for (const migration of MIGRATIONS) {
+      if (migration.version === 48 || migration.version === 63) continue;
+      insert.run(migration.version, migration.name);
+    }
+
+    assert.equal(
+      db.prepare("SELECT MAX(version) AS version FROM schema_migrations").get().version,
+      62,
+    );
+    assert.deepEqual(
+      getPendingMigrations(db).map((migration) => migration.version),
+      [48, 63],
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test("repairs skipped block tables and records both migrations", () => {
+  const db = createHistoricalBlockDatabase();
+  try {
+    const insert = db.prepare(
+      "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+    );
+    for (const migration of MIGRATIONS) {
+      if (migration.version === 48 || migration.version === 63) continue;
+      insert.run(migration.version, migration.name);
+    }
+
+    assert.equal(runMigrations(db), 2);
+
+    const tables = tableNames(db);
+    for (const table of [
+      "note_blocks_index",
+      "block_operations",
+      "note_block_documents",
+      "note_block_records",
+      "note_block_operations",
+      "note_block_attachment_refs",
+      "note_y_subdocument_manifests",
+      "note_y_subdocuments",
+      "note_y_subdocument_updates",
+    ]) {
+      assert.equal(tables.has(table), true, `missing repaired table: ${table}`);
+    }
+
+    const linkColumns = db.prepare("PRAGMA table_info(note_links)").all() as Array<{ name: string }>;
+    assert.equal(linkColumns.some((column) => column.name === "sourceBlockId"), true);
+
+    const manifestColumns = db.prepare(
+      "PRAGMA table_info(note_y_subdocument_manifests)",
+    ).all() as Array<{ name: string }>;
+    assert.equal(manifestColumns.some((column) => column.name === "generation"), true);
+    assert.equal(manifestColumns.some((column) => column.name === "structureVersion"), true);
+
+    const applied = db.prepare(`
+      SELECT version FROM schema_migrations WHERE version IN (48, 63) ORDER BY version
+    `).all() as Array<{ version: number }>;
+    assert.deepEqual(applied.map((row) => row.version), [48, 63]);
+    assert.deepEqual(getPendingMigrations(db), []);
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
## 问题

历史数据库可能已经记录到 schema v50+，但 v48 通用块迁移是在更高版本之后补入。旧迁移器只比较 `MAX(schema_migrations.version)`，因此会永久跳过 v48，导致 `block_operations` / `note_blocks_index` 缺失，`POST /api/blocks/:noteId` 在参数校验通过后返回 500。

## 修复

- 将迁移判断从“最大版本游标”改为“已执行版本集合”，自动执行缺失的历史迁移。
- 新增 v63 补偿迁移，幂等修复：
  - v48 通用块索引与幂等操作表
  - Block Authority 表和保护触发器
  - Yjs 子文档表与版本字段
- 增加历史数据库升级回归测试，模拟数据库已到 v62、但缺失 v48 的真实场景。
- 新增 Block Schema Repair 专项 CI，同时回归旧 `createBlock` 路由。

## 验证结果

- Block Schema Repair CI：通过
  - 历史数据库迁移缺口测试：通过
  - 旧块写入路由回归：通过
  - 后端 TypeScript：通过
- Tag Idempotency CI：通过
- New User Onboarding CI：通过
- Search Regression：通过
- Round-trip Import Batch CI：通过
- 分支相对 `main`：behind 0

Closes #592