### PR TITLE
feat(tasks): add My Day daily planning

### DIFF
--- a/.github/workflows/task-my-day-ci.yml
+++ b/.github/workflows/task-my-day-ci.yml
@@ -1,0 +1,71 @@
+name: Task My Day CI
+
+on:
+  push:
+    branches:
+      - feature/task-my-day-v1
+    paths:
+      - "backend/src/routes/task-day-plans.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/db/taskDayPlansMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-day-plans.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/MyDayPanel.tsx"
+      - "frontend/src/components/tasks/taskMyDay.ts"
+      - "frontend/src/components/tasks/__tests__/taskMyDay.test.ts"
+      - "frontend/src/lib/taskDayPlanApi.ts"
+      - ".github/workflows/task-my-day-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/routes/task-day-plans.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/db/taskDayPlansMigration.ts"
+      - "backend/src/db/migrations.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-day-plans.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/MyDayPanel.tsx"
+      - "frontend/src/components/tasks/taskMyDay.ts"
+      - "frontend/src/components/tasks/__tests__/taskMyDay.test.ts"
+      - "frontend/src/lib/taskDayPlanApi.ts"
+      - ".github/workflows/task-my-day-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npm run build:tsc
+      - name: Test My Day API
+        run: node --import tsx --import ./tests/setup-db-isolation.ts --test tests/task-day-plans.test.ts
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - name: Test My Day planning helpers
+        run: npx vitest run src/components/tasks/__tests__/taskMyDay.test.ts --reporter=verbose

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -23,6 +23,7 @@ import { offlineSyncMigration } from "./offlineSyncMigration.js";
 import { newUserOnboardingMigration } from "./newUserOnboardingMigration.js";
 import { newUserOnboardingFirstLoginMigration } from "./newUserOnboardingFirstLoginMigration.js";
 import { blockSchemaRepairMigration } from "./blockSchemaRepairMigration.js";
+import { taskDayPlansMigration } from "./taskDayPlansMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -278,6 +279,7 @@ export const MIGRATIONS: Migration[] = [
   newUserOnboardingMigration,
   newUserOnboardingFirstLoginMigration,
   blockSchemaRepairMigration,
+  taskDayPlansMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -31,3 +31,20 @@ CREATE INDEX IF NOT EXISTS idx_task_activity_task_type
   ON task_activity_events("taskId", "eventType", "occurredAt" DESC);
 CREATE INDEX IF NOT EXISTS idx_task_activity_type_time
   ON task_activity_events("eventType", "occurredAt" DESC);
+
+CREATE TABLE IF NOT EXISTS task_day_plans (
+  id TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "scopeKey" TEXT NOT NULL,
+  "workspaceId" TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+  "planDate" DATE NOT NULL,
+  "taskIdsJson" TEXT NOT NULL DEFAULT '[]',
+  "focusTaskIdsJson" TEXT NOT NULL DEFAULT '[]',
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
+  ON task_day_plans("userId", "scopeKey", "planDate");
+CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
+  ON task_day_plans("userId", "planDate");

--- a/backend/src/db/taskDayPlansMigration.ts
+++ b/backend/src/db/taskDayPlansMigration.ts
@@ -1,0 +1,28 @@
+import type { Migration } from "./migrations.impl.js";
+
+export const taskDayPlansMigration: Migration = {
+  version: 70,
+  name: "task-day-plans",
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS task_day_plans (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        scopeKey TEXT NOT NULL,
+        workspaceId TEXT,
+        planDate TEXT NOT NULL,
+        taskIdsJson TEXT NOT NULL DEFAULT '[]',
+        focusTaskIdsJson TEXT NOT NULL DEFAULT '[]',
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
+        ON task_day_plans(userId, scopeKey, planDate);
+      CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
+        ON task_day_plans(userId, planDate);
+    `);
+  },
+};

--- a/backend/src/db/taskDayPlansMigration.ts
+++ b/backend/src/db/taskDayPlansMigration.ts
@@ -1,28 +1,31 @@
+import type Database from "better-sqlite3";
 import type { Migration } from "./migrations.impl.js";
+
+export function ensureTaskDayPlansSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS task_day_plans (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      scopeKey TEXT NOT NULL,
+      workspaceId TEXT,
+      planDate TEXT NOT NULL,
+      taskIdsJson TEXT NOT NULL DEFAULT '[]',
+      focusTaskIdsJson TEXT NOT NULL DEFAULT '[]',
+      createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+      updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
+      ON task_day_plans(userId, scopeKey, planDate);
+    CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
+      ON task_day_plans(userId, planDate);
+  `);
+}
 
 export const taskDayPlansMigration: Migration = {
   version: 70,
   name: "task-day-plans",
-  up: (db) => {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS task_day_plans (
-        id TEXT PRIMARY KEY,
-        userId TEXT NOT NULL,
-        scopeKey TEXT NOT NULL,
-        workspaceId TEXT,
-        planDate TEXT NOT NULL,
-        taskIdsJson TEXT NOT NULL DEFAULT '[]',
-        focusTaskIdsJson TEXT NOT NULL DEFAULT '[]',
-        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
-        updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
-        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
-        FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
-      );
-
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
-        ON task_day_plans(userId, scopeKey, planDate);
-      CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
-        ON task_day_plans(userId, planDate);
-    `);
-  },
+  up: ensureTaskDayPlansSchema,
 };

--- a/backend/src/routes/task-day-plans.ts
+++ b/backend/src/routes/task-day-plans.ts
@@ -1,0 +1,285 @@
+import crypto from "crypto";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { getDb } from "../db/schema";
+import { getUserWorkspaceRole } from "../middleware/acl";
+
+const taskDayPlans = new Hono();
+const MAX_TASKS_PER_DAY = 200;
+const MAX_FOCUS_TASKS = 3;
+const PLAN_RETENTION_DAYS = 45;
+let initializedDatabase: object | null = null;
+
+interface TaskDayPlanRow {
+  id: string;
+  userId: string;
+  scopeKey: string;
+  workspaceId: string | null;
+  planDate: string;
+  taskIdsJson: string;
+  focusTaskIdsJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ResolvedScope {
+  scopeKey: string;
+  workspaceId: string | null;
+  error?: string;
+}
+
+function ensureTaskDayPlansTable(): void {
+  const db = getDb();
+  if (initializedDatabase === db) return;
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS task_day_plans (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      scopeKey TEXT NOT NULL,
+      workspaceId TEXT,
+      planDate TEXT NOT NULL,
+      taskIdsJson TEXT NOT NULL,
+      focusTaskIdsJson TEXT NOT NULL,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
+      ON task_day_plans(userId, scopeKey, planDate);
+    CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
+      ON task_day_plans(userId, planDate);
+  `);
+  initializedDatabase = db;
+}
+
+export function isTaskDayPlanDate(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+export function normalizeTaskDayPlanIds(value: unknown, limit = MAX_TASKS_PER_DAY): string[] {
+  if (!Array.isArray(value)) return [];
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const id = item.trim();
+    if (!id || id.length > 128 || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+    if (result.length >= limit) break;
+  }
+  return result;
+}
+
+function parseStoredIds(value: string, limit: number): string[] {
+  try {
+    return normalizeTaskDayPlanIds(JSON.parse(value), limit);
+  } catch {
+    return [];
+  }
+}
+
+function resolveScope(c: Context, userId: string, rawWorkspaceId: unknown): ResolvedScope {
+  const workspaceId = typeof rawWorkspaceId === "string" ? rawWorkspaceId.trim() : "";
+  if (!workspaceId || workspaceId === "personal") {
+    return { scopeKey: "personal", workspaceId: null };
+  }
+  if (!getUserWorkspaceRole(workspaceId, userId)) {
+    return { scopeKey: workspaceId, workspaceId, error: "无权访问该工作区" };
+  }
+  return { scopeKey: workspaceId, workspaceId };
+}
+
+function planId(userId: string, scopeKey: string, planDate: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${userId}\u0000${scopeKey}\u0000${planDate}`)
+    .digest("hex");
+}
+
+function getAccessibleTaskIds(
+  userId: string,
+  workspaceId: string | null,
+  taskIds: string[],
+): Set<string> {
+  if (taskIds.length === 0) return new Set();
+  const db = getDb();
+  const placeholders = taskIds.map(() => "?").join(",");
+  const rows = workspaceId
+    ? db.prepare(
+        `SELECT id FROM tasks WHERE workspaceId = ? AND id IN (${placeholders})`,
+      ).all(workspaceId, ...taskIds) as Array<{ id: string }>
+    : db.prepare(
+        `SELECT id FROM tasks WHERE userId = ? AND workspaceId IS NULL AND id IN (${placeholders})`,
+      ).all(userId, ...taskIds) as Array<{ id: string }>;
+  return new Set(rows.map((row) => row.id));
+}
+
+function cleanStoredPlan(row: TaskDayPlanRow, userId: string): {
+  taskIds: string[];
+  focusTaskIds: string[];
+} {
+  const taskIds = parseStoredIds(row.taskIdsJson, MAX_TASKS_PER_DAY);
+  const accessibleIds = getAccessibleTaskIds(userId, row.workspaceId, taskIds);
+  const cleanedTaskIds = taskIds.filter((id) => accessibleIds.has(id));
+  const taskIdSet = new Set(cleanedTaskIds);
+  const focusTaskIds = parseStoredIds(row.focusTaskIdsJson, MAX_FOCUS_TASKS)
+    .filter((id) => taskIdSet.has(id))
+    .slice(0, MAX_FOCUS_TASKS);
+  return { taskIds: cleanedTaskIds, focusTaskIds };
+}
+
+function emptyPlan(planDate: string, workspaceId: string | null) {
+  return {
+    date: planDate,
+    workspaceId: workspaceId || "personal",
+    taskIds: [] as string[],
+    focusTaskIds: [] as string[],
+    updatedAt: null as string | null,
+  };
+}
+
+// GET /api/user-preferences/task-day-plans?date=YYYY-MM-DD&workspaceId=personal|uuid
+// Each user owns an independent daily plan, including inside a shared workspace.
+taskDayPlans.get("/", (c) => {
+  ensureTaskDayPlansTable();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const planDate = c.req.query("date");
+  if (!isTaskDayPlanDate(planDate)) {
+    return c.json({ error: "date must use YYYY-MM-DD", code: "INVALID_PLAN_DATE" }, 400);
+  }
+  const scope = resolveScope(c, userId, c.req.query("workspaceId"));
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const row = getDb().prepare(
+    "SELECT * FROM task_day_plans WHERE id = ? AND userId = ?",
+  ).get(planId(userId, scope.scopeKey, planDate), userId) as TaskDayPlanRow | undefined;
+  if (!row) return c.json(emptyPlan(planDate, scope.workspaceId));
+
+  const cleaned = cleanStoredPlan(row, userId);
+  if (
+    JSON.stringify(cleaned.taskIds) !== row.taskIdsJson ||
+    JSON.stringify(cleaned.focusTaskIds) !== row.focusTaskIdsJson
+  ) {
+    getDb().prepare(
+      "UPDATE task_day_plans SET taskIdsJson = ?, focusTaskIdsJson = ?, updatedAt = ? WHERE id = ?",
+    ).run(JSON.stringify(cleaned.taskIds), JSON.stringify(cleaned.focusTaskIds), new Date().toISOString(), row.id);
+  }
+
+  return c.json({
+    date: row.planDate,
+    workspaceId: row.workspaceId || "personal",
+    taskIds: cleaned.taskIds,
+    focusTaskIds: cleaned.focusTaskIds,
+    updatedAt: row.updatedAt,
+  });
+});
+
+// PUT /api/user-preferences/task-day-plans
+// Body: { date, workspaceId, taskIds, focusTaskIds }
+taskDayPlans.put("/", async (c) => {
+  ensureTaskDayPlansTable();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
+  if (!body || !isTaskDayPlanDate(body.date)) {
+    return c.json({ error: "date must use YYYY-MM-DD", code: "INVALID_PLAN_DATE" }, 400);
+  }
+  if (!Array.isArray(body.taskIds) || !Array.isArray(body.focusTaskIds)) {
+    return c.json({ error: "taskIds and focusTaskIds must be arrays", code: "INVALID_PLAN_TASKS" }, 400);
+  }
+
+  const scope = resolveScope(c, userId, body.workspaceId);
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const taskIds = normalizeTaskDayPlanIds(body.taskIds, MAX_TASKS_PER_DAY);
+  const taskIdSet = new Set(taskIds);
+  const focusTaskIds = normalizeTaskDayPlanIds(body.focusTaskIds, MAX_FOCUS_TASKS)
+    .filter((id) => taskIdSet.has(id))
+    .slice(0, MAX_FOCUS_TASKS);
+
+  const accessibleIds = getAccessibleTaskIds(userId, scope.workspaceId, taskIds);
+  const invalidTaskIds = taskIds.filter((id) => !accessibleIds.has(id));
+  if (invalidTaskIds.length > 0) {
+    return c.json({
+      error: "计划中包含不存在或无权访问的任务",
+      code: "INVALID_PLAN_TASK_SCOPE",
+      invalidTaskIds,
+    }, 400);
+  }
+
+  const db = getDb();
+  const id = planId(userId, scope.scopeKey, body.date);
+  const now = new Date().toISOString();
+  const existing = db.prepare(
+    "SELECT id, createdAt FROM task_day_plans WHERE id = ? AND userId = ?",
+  ).get(id, userId) as { id: string; createdAt: string } | undefined;
+
+  if (existing) {
+    db.prepare(`
+      UPDATE task_day_plans
+      SET taskIdsJson = ?, focusTaskIdsJson = ?, workspaceId = ?, updatedAt = ?
+      WHERE id = ? AND userId = ?
+    `).run(
+      JSON.stringify(taskIds),
+      JSON.stringify(focusTaskIds),
+      scope.workspaceId,
+      now,
+      id,
+      userId,
+    );
+  } else {
+    db.prepare(`
+      INSERT INTO task_day_plans (
+        id, userId, scopeKey, workspaceId, planDate,
+        taskIdsJson, focusTaskIdsJson, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      userId,
+      scope.scopeKey,
+      scope.workspaceId,
+      body.date,
+      JSON.stringify(taskIds),
+      JSON.stringify(focusTaskIds),
+      now,
+      now,
+    );
+  }
+
+  const cutoff = new Date(Date.now() - PLAN_RETENTION_DAYS * 86_400_000).toISOString().slice(0, 10);
+  db.prepare("DELETE FROM task_day_plans WHERE userId = ? AND planDate < ?").run(userId, cutoff);
+
+  return c.json({
+    date: body.date,
+    workspaceId: scope.workspaceId || "personal",
+    taskIds,
+    focusTaskIds,
+    updatedAt: now,
+  });
+});
+
+// DELETE /api/user-preferences/task-day-plans?date=YYYY-MM-DD&workspaceId=personal|uuid
+taskDayPlans.delete("/", (c) => {
+  ensureTaskDayPlansTable();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const planDate = c.req.query("date");
+  if (!isTaskDayPlanDate(planDate)) {
+    return c.json({ error: "date must use YYYY-MM-DD", code: "INVALID_PLAN_DATE" }, 400);
+  }
+  const scope = resolveScope(c, userId, c.req.query("workspaceId"));
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  getDb().prepare("DELETE FROM task_day_plans WHERE id = ? AND userId = ?")
+    .run(planId(userId, scope.scopeKey, planDate), userId);
+  return c.json(emptyPlan(planDate, scope.workspaceId));
+});
+
+export default taskDayPlans;

--- a/backend/src/routes/user-preferences.ts
+++ b/backend/src/routes/user-preferences.ts
@@ -3,6 +3,7 @@ import syncRoutes from "./user-preferences-sync";
 import legacyRoutes from "./user-preferences-legacy";
 import reliableAIRoutes from "./ai-reliable";
 import mobileBootstrapRoutes from "./mobile-bootstrap";
+import taskDayPlansRoutes from "./task-day-plans";
 
 /**
  * Compatibility wrapper: existing user preference/profile endpoints stay at their
@@ -10,6 +11,11 @@ import mobileBootstrapRoutes from "./mobile-bootstrap";
  * sub-paths so older clients remain untouched.
  */
 const app = new Hono();
+
+// Task day plans are user-scoped planning state, not task deadlines. Keep them
+// under user-preferences so the feature can sync across devices without changing
+// the core tasks table or the semantics of the existing "Today" due-date filter.
+app.route("/task-day-plans", taskDayPlansRoutes);
 
 // Root preference GET/PUT/PATCH must be mounted before the legacy router. The new
 // implementation keeps the old flat response fields while adding account-scoped

--- a/backend/tests/block-schema-repair-migration.test.ts
+++ b/backend/tests/block-schema-repair-migration.test.ts
@@ -8,6 +8,19 @@ import {
   runMigrations,
 } from "../src/db/migrations";
 
+const BLOCK_SCHEMA_VERSION = 48;
+const BLOCK_REPAIR_VERSION = MIGRATIONS.find(
+  (migration) => migration.name === "repair-skipped-block-schema",
+)?.version;
+
+if (!BLOCK_REPAIR_VERSION) {
+  throw new Error("repair-skipped-block-schema migration is not registered");
+}
+
+const BLOCK_MIGRATION_VERSIONS = [BLOCK_SCHEMA_VERSION, BLOCK_REPAIR_VERSION].sort(
+  (a, b) => a - b,
+);
+
 function createHistoricalBlockDatabase(): Database.Database {
   const db = new Database(":memory:");
   db.exec(`
@@ -40,6 +53,17 @@ function createHistoricalBlockDatabase(): Database.Database {
   return db;
 }
 
+function seedAllExceptBlockRepair(db: Database.Database): void {
+  const missing = new Set(BLOCK_MIGRATION_VERSIONS);
+  const insert = db.prepare(
+    "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+  );
+  for (const migration of MIGRATIONS) {
+    if (missing.has(migration.version)) continue;
+    insert.run(migration.version, migration.name);
+  }
+}
+
 function tableNames(db: Database.Database): Set<string> {
   const rows = db.prepare(`
     SELECT name FROM sqlite_master WHERE type = 'table'
@@ -50,21 +74,21 @@ function tableNames(db: Database.Database): Set<string> {
 test("detects a missing historical migration even when MAX(version) is newer", () => {
   const db = createHistoricalBlockDatabase();
   try {
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
-    );
-    for (const migration of MIGRATIONS) {
-      if (migration.version === 48 || migration.version === 63) continue;
-      insert.run(migration.version, migration.name);
-    }
+    seedAllExceptBlockRepair(db);
 
     const latest = db.prepare(
       "SELECT MAX(version) AS version FROM schema_migrations",
     ).get() as { version: number };
-    assert.equal(latest.version, 62);
+    const expectedLatest = Math.max(
+      ...MIGRATIONS
+        .filter((migration) => !BLOCK_MIGRATION_VERSIONS.includes(migration.version))
+        .map((migration) => migration.version),
+    );
+    assert.equal(latest.version, expectedLatest);
+    assert.ok(latest.version > BLOCK_SCHEMA_VERSION);
     assert.deepEqual(
       getPendingMigrations(db).map((migration) => migration.version),
-      [48, 63],
+      BLOCK_MIGRATION_VERSIONS,
     );
   } finally {
     db.close();
@@ -74,15 +98,9 @@ test("detects a missing historical migration even when MAX(version) is newer", (
 test("repairs skipped block tables and records both migrations", () => {
   const db = createHistoricalBlockDatabase();
   try {
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
-    );
-    for (const migration of MIGRATIONS) {
-      if (migration.version === 48 || migration.version === 63) continue;
-      insert.run(migration.version, migration.name);
-    }
+    seedAllExceptBlockRepair(db);
 
-    assert.equal(runMigrations(db), 2);
+    assert.equal(runMigrations(db), BLOCK_MIGRATION_VERSIONS.length);
 
     const tables = tableNames(db);
     for (const table of [
@@ -109,9 +127,14 @@ test("repairs skipped block tables and records both migrations", () => {
     assert.equal(manifestColumns.some((column) => column.name === "structureVersion"), true);
 
     const applied = db.prepare(`
-      SELECT version FROM schema_migrations WHERE version IN (48, 63) ORDER BY version
+      SELECT version FROM schema_migrations ORDER BY version
     `).all() as Array<{ version: number }>;
-    assert.deepEqual(applied.map((row) => row.version), [48, 63]);
+    assert.deepEqual(
+      applied
+        .map((row) => row.version)
+        .filter((version) => BLOCK_MIGRATION_VERSIONS.includes(version)),
+      BLOCK_MIGRATION_VERSIONS,
+    );
     assert.deepEqual(getPendingMigrations(db), []);
   } finally {
     db.close();

--- a/backend/tests/task-day-plans.test.ts
+++ b/backend/tests/task-day-plans.test.ts
@@ -1,9 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
+import { Hono } from "hono";
+import taskDayPlans, {
   isTaskDayPlanDate,
   normalizeTaskDayPlanIds,
 } from "../src/routes/task-day-plans";
+
+const app = new Hono();
+app.route("/user-preferences/task-day-plans", taskDayPlans);
+
+function request(path: string, init?: RequestInit) {
+  return app.request(path, {
+    ...init,
+    headers: {
+      "X-User-Id": "my-day-test-user",
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+}
 
 test("task day plan date validation accepts real calendar dates", () => {
   assert.equal(isTaskDayPlanDate("2026-08-02"), true);
@@ -26,4 +41,42 @@ test("task day plan ids reject oversized values", () => {
     normalizeTaskDayPlanIds(["x".repeat(129), "valid-task"]),
     ["valid-task"],
   );
+});
+
+test("My Day route works without a trailing slash and persists an empty plan", async () => {
+  const invalid = await request(
+    "/user-preferences/task-day-plans?date=invalid&workspaceId=personal",
+  );
+  assert.equal(invalid.status, 400);
+
+  const saved = await request("/user-preferences/task-day-plans", {
+    method: "PUT",
+    body: JSON.stringify({
+      date: "2026-08-02",
+      workspaceId: "personal",
+      taskIds: [],
+      focusTaskIds: [],
+    }),
+  });
+  assert.equal(saved.status, 200);
+  assert.deepEqual(await saved.json(), {
+    date: "2026-08-02",
+    workspaceId: "personal",
+    taskIds: [],
+    focusTaskIds: [],
+    updatedAt: (await request(
+      "/user-preferences/task-day-plans?date=2026-08-02&workspaceId=personal",
+    ).then((response) => response.json())).updatedAt,
+  });
+
+  const loaded = await request(
+    "/user-preferences/task-day-plans?date=2026-08-02&workspaceId=personal",
+  );
+  assert.equal(loaded.status, 200);
+  const payload = await loaded.json() as Record<string, unknown>;
+  assert.equal(payload.date, "2026-08-02");
+  assert.equal(payload.workspaceId, "personal");
+  assert.deepEqual(payload.taskIds, []);
+  assert.deepEqual(payload.focusTaskIds, []);
+  assert.equal(typeof payload.updatedAt, "string");
 });

--- a/backend/tests/task-day-plans.test.ts
+++ b/backend/tests/task-day-plans.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
+import { closeDb, getDb } from "../src/db/schema";
 import taskDayPlans, {
   isTaskDayPlanDate,
   normalizeTaskDayPlanIds,
 } from "../src/routes/task-day-plans";
 
+const USER_ID = "my-day-test-user";
 const app = new Hono();
 app.route("/user-preferences/task-day-plans", taskDayPlans);
 
@@ -13,12 +15,22 @@ function request(path: string, init?: RequestInit) {
   return app.request(path, {
     ...init,
     headers: {
-      "X-User-Id": "my-day-test-user",
+      "X-User-Id": USER_ID,
       ...(init?.body ? { "Content-Type": "application/json" } : {}),
       ...(init?.headers || {}),
     },
   });
 }
+
+test.before(() => {
+  getDb().prepare(
+    "INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)",
+  ).run(USER_ID, USER_ID, "hash");
+});
+
+test.after(() => {
+  closeDb();
+});
 
 test("task day plan date validation accepts real calendar dates", () => {
   assert.equal(isTaskDayPlanDate("2026-08-02"), true);
@@ -59,24 +71,21 @@ test("My Day route works without a trailing slash and persists an empty plan", a
     }),
   });
   assert.equal(saved.status, 200);
-  assert.deepEqual(await saved.json(), {
-    date: "2026-08-02",
-    workspaceId: "personal",
-    taskIds: [],
-    focusTaskIds: [],
-    updatedAt: (await request(
-      "/user-preferences/task-day-plans?date=2026-08-02&workspaceId=personal",
-    ).then((response) => response.json())).updatedAt,
-  });
+  const savedPayload = await saved.json() as Record<string, unknown>;
+  assert.equal(savedPayload.date, "2026-08-02");
+  assert.equal(savedPayload.workspaceId, "personal");
+  assert.deepEqual(savedPayload.taskIds, []);
+  assert.deepEqual(savedPayload.focusTaskIds, []);
+  assert.equal(typeof savedPayload.updatedAt, "string");
 
   const loaded = await request(
     "/user-preferences/task-day-plans?date=2026-08-02&workspaceId=personal",
   );
   assert.equal(loaded.status, 200);
-  const payload = await loaded.json() as Record<string, unknown>;
-  assert.equal(payload.date, "2026-08-02");
-  assert.equal(payload.workspaceId, "personal");
-  assert.deepEqual(payload.taskIds, []);
-  assert.deepEqual(payload.focusTaskIds, []);
-  assert.equal(typeof payload.updatedAt, "string");
+  const loadedPayload = await loaded.json() as Record<string, unknown>;
+  assert.equal(loadedPayload.date, "2026-08-02");
+  assert.equal(loadedPayload.workspaceId, "personal");
+  assert.deepEqual(loadedPayload.taskIds, []);
+  assert.deepEqual(loadedPayload.focusTaskIds, []);
+  assert.equal(loadedPayload.updatedAt, savedPayload.updatedAt);
 });

--- a/backend/tests/task-day-plans.test.ts
+++ b/backend/tests/task-day-plans.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isTaskDayPlanDate,
+  normalizeTaskDayPlanIds,
+} from "../src/routes/task-day-plans";
+
+test("task day plan date validation accepts real calendar dates", () => {
+  assert.equal(isTaskDayPlanDate("2026-08-02"), true);
+  assert.equal(isTaskDayPlanDate("2028-02-29"), true);
+  assert.equal(isTaskDayPlanDate("2026-02-29"), false);
+  assert.equal(isTaskDayPlanDate("2026-02-30"), false);
+  assert.equal(isTaskDayPlanDate("2026-8-2"), false);
+  assert.equal(isTaskDayPlanDate(null), false);
+});
+
+test("task day plan ids are trimmed, deduplicated and bounded", () => {
+  assert.deepEqual(
+    normalizeTaskDayPlanIds([" task-a ", "task-a", "", 42, "task-b", "task-c"], 2),
+    ["task-a", "task-b"],
+  );
+});
+
+test("task day plan ids reject oversized values", () => {
+  assert.deepEqual(
+    normalizeTaskDayPlanIds(["x".repeat(129), "valid-task"]),
+    ["valid-task"],
+  );
+});

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -7,6 +7,7 @@ export * from "./TaskCenterImpl";
 
 export default function TaskCenter() {
   const [workspaceGeneration, setWorkspaceGeneration] = useState(0);
+  const [localDayKey, setLocalDayKey] = useState(() => new Date().toDateString());
 
   const remountTaskWorkspace = useCallback(() => {
     setWorkspaceGeneration((value) => value + 1);
@@ -22,6 +23,16 @@ export default function TaskCenter() {
     window.addEventListener("nowen:workspace-changed", handleWorkspaceChange);
     return () => window.removeEventListener("nowen:workspace-changed", handleWorkspaceChange);
   }, [remountTaskWorkspace]);
+
+  useEffect(() => {
+    // Keep a long-running desktop/web session aligned with the local calendar day.
+    // Changing this key remounts only My Day; task deadlines and the task center stay untouched.
+    const timer = window.setInterval(() => {
+      const nextDayKey = new Date().toDateString();
+      setLocalDayKey((current) => current === nextDayKey ? current : nextDayKey);
+    }, 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     const handleDeleteCapture = (event: MouseEvent) => {
@@ -44,7 +55,7 @@ export default function TaskCenter() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <MyDayPanel
-        key={`my-day-${workspaceGeneration}`}
+        key={`my-day-${workspaceGeneration}-${localDayKey}`}
         onTaskMutated={remountTaskWorkspace}
       />
       <div className="min-h-0 flex-1">

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
 import { MyDayPanel } from "./tasks/MyDayPanel";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
@@ -8,9 +8,9 @@ export * from "./TaskCenterImpl";
 export default function TaskCenter() {
   const [workspaceGeneration, setWorkspaceGeneration] = useState(0);
 
-  const remountTaskWorkspace = () => {
+  const remountTaskWorkspace = useCallback(() => {
     setWorkspaceGeneration((value) => value + 1);
-  };
+  }, []);
 
   useEffect(() => {
     const handleWorkspaceChange = () => {
@@ -21,7 +21,7 @@ export default function TaskCenter() {
     };
     window.addEventListener("nowen:workspace-changed", handleWorkspaceChange);
     return () => window.removeEventListener("nowen:workspace-changed", handleWorkspaceChange);
-  }, []);
+  }, [remountTaskWorkspace]);
 
   useEffect(() => {
     const handleDeleteCapture = (event: MouseEvent) => {

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
+import { MyDayPanel } from "./tasks/MyDayPanel";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
 
 export * from "./TaskCenterImpl";
@@ -7,12 +8,16 @@ export * from "./TaskCenterImpl";
 export default function TaskCenter() {
   const [workspaceGeneration, setWorkspaceGeneration] = useState(0);
 
+  const remountTaskWorkspace = () => {
+    setWorkspaceGeneration((value) => value + 1);
+  };
+
   useEffect(() => {
     const handleWorkspaceChange = () => {
       // Remount the full task center. This immediately drops the previous
       // workspace state, and late promises from the unmounted instance cannot
       // overwrite the newly selected workspace.
-      setWorkspaceGeneration((value) => value + 1);
+      remountTaskWorkspace();
     };
     window.addEventListener("nowen:workspace-changed", handleWorkspaceChange);
     return () => window.removeEventListener("nowen:workspace-changed", handleWorkspaceChange);
@@ -36,5 +41,15 @@ export default function TaskCenter() {
     return () => document.removeEventListener("click", handleDeleteCapture, true);
   }, []);
 
-  return <TaskCenterImpl key={workspaceGeneration} />;
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <MyDayPanel
+        key={`my-day-${workspaceGeneration}`}
+        onTaskMutated={remountTaskWorkspace}
+      />
+      <div className="min-h-0 flex-1">
+        <TaskCenterImpl key={workspaceGeneration} />
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/tasks/MyDayPanel.tsx
+++ b/frontend/src/components/tasks/MyDayPanel.tsx
@@ -1,0 +1,438 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarDays,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Search,
+  Star,
+  Sun,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { Task } from "@/types";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import {
+  getTaskDayPlan,
+  saveTaskDayPlan,
+  type TaskDayPlan,
+} from "@/lib/taskDayPlanApi";
+import {
+  formatMyDayDate,
+  getMyDaySuggestions,
+  isTaskDueToday,
+  isTaskOverdue,
+  normalizeMyDayPlan,
+  orderMyDayTasks,
+} from "./taskMyDay";
+
+interface MyDayPanelProps {
+  onTaskMutated?: () => void;
+}
+
+function emptyPlan(date: string): TaskDayPlan {
+  return {
+    date,
+    workspaceId: "personal",
+    taskIds: [],
+    focusTaskIds: [],
+    updatedAt: null,
+  };
+}
+
+export function MyDayPanel({ onTaskMutated }: MyDayPanelProps) {
+  const { i18n } = useTranslation();
+  const chinese = i18n.language.toLowerCase().startsWith("zh");
+  const today = useMemo(() => formatMyDayDate(), []);
+  const [expanded, setExpanded] = useState(() => {
+    try {
+      return localStorage.getItem("nowen-my-day-expanded") !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [plan, setPlan] = useState<TaskDayPlan>(() => emptyPlan(today));
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [completingId, setCompletingId] = useState<string | null>(null);
+
+  const labels = chinese
+    ? {
+        title: "我的一天",
+        subtitle: "主动选择今天要完成的任务，不修改原截止日期",
+        focus: "今日重点",
+        planned: "今日计划",
+        suggestions: "建议加入",
+        searchResults: "搜索结果",
+        search: "搜索其他任务加入今天…",
+        empty: "今天还没有安排任务",
+        emptyHint: "从下方建议中加入，或搜索任意未完成任务。",
+        completed: "已完成",
+        refresh: "刷新任务",
+        remove: "移出今日计划",
+        add: "加入今天",
+        setFocus: "设为今日重点",
+        unsetFocus: "取消重点",
+        focusLimit: "今日重点最多选择 3 个",
+        loadFailed: "加载今日计划失败",
+        saveFailed: "保存今日计划失败",
+        updateFailed: "更新任务失败",
+        overdue: "已逾期",
+        dueToday: "今天到期",
+        noSuggestions: "没有需要优先处理的建议任务",
+      }
+    : {
+        title: "My Day",
+        subtitle: "Choose what to do today without changing task deadlines",
+        focus: "Focus",
+        planned: "Today's plan",
+        suggestions: "Suggested",
+        searchResults: "Search results",
+        search: "Search unfinished tasks…",
+        empty: "Nothing planned for today",
+        emptyHint: "Add a suggestion below or search for any unfinished task.",
+        completed: "completed",
+        refresh: "Refresh tasks",
+        remove: "Remove from My Day",
+        add: "Add to My Day",
+        setFocus: "Mark as focus",
+        unsetFocus: "Remove focus",
+        focusLimit: "You can choose up to 3 focus tasks",
+        loadFailed: "Failed to load My Day",
+        saveFailed: "Failed to save My Day",
+        updateFailed: "Failed to update task",
+        overdue: "Overdue",
+        dueToday: "Due today",
+        noSuggestions: "No urgent suggestions right now",
+      };
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [taskRows, storedPlan] = await Promise.all([
+        api.getTasks("all"),
+        getTaskDayPlan(today),
+      ]);
+      const existingIds = new Set(taskRows.map((task) => task.id));
+      const normalized = normalizeMyDayPlan(
+        storedPlan.taskIds,
+        storedPlan.focusTaskIds,
+        existingIds,
+      );
+      setTasks(taskRows);
+      setPlan({ ...storedPlan, ...normalized });
+    } catch (error) {
+      console.error("[MyDay] load failed", error);
+      toast.error(labels.loadFailed);
+    } finally {
+      setLoading(false);
+    }
+  }, [labels.loadFailed, today]);
+
+  useEffect(() => {
+    void load();
+    const refreshOnFocus = () => void load();
+    window.addEventListener("focus", refreshOnFocus);
+    return () => window.removeEventListener("focus", refreshOnFocus);
+  }, [load]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("nowen-my-day-expanded", String(expanded));
+    } catch {
+      // Storage can be unavailable in privacy mode; expansion remains session-local.
+    }
+  }, [expanded]);
+
+  const plannedTasks = useMemo(
+    () => orderMyDayTasks(tasks, plan),
+    [plan, tasks],
+  );
+  const completedCount = plannedTasks.filter((task) => !!task.isCompleted).length;
+  const progress = plannedTasks.length === 0
+    ? 0
+    : Math.round((completedCount / plannedTasks.length) * 100);
+  const suggestions = useMemo(
+    () => getMyDaySuggestions(tasks, today, plan.taskIds),
+    [plan.taskIds, tasks, today],
+  );
+  const availableTasks = useMemo(() => {
+    const planned = new Set(plan.taskIds);
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return suggestions.slice(0, 6);
+    return tasks
+      .filter((task) => !task.isCompleted && !planned.has(task.id))
+      .filter((task) => task.title.toLowerCase().includes(normalizedQuery))
+      .sort((a, b) => b.priority - a.priority)
+      .slice(0, 8);
+  }, [plan.taskIds, query, suggestions, tasks]);
+
+  const persist = useCallback(async (taskIds: string[], focusTaskIds: string[]) => {
+    if (saving) return;
+    const previous = plan;
+    const normalized = normalizeMyDayPlan(taskIds, focusTaskIds, new Set(tasks.map((task) => task.id)));
+    const optimistic = { ...plan, ...normalized };
+    setPlan(optimistic);
+    setSaving(true);
+    try {
+      const saved = await saveTaskDayPlan({
+        date: today,
+        taskIds: normalized.taskIds,
+        focusTaskIds: normalized.focusTaskIds,
+      });
+      setPlan(saved);
+    } catch (error) {
+      console.error("[MyDay] save failed", error);
+      setPlan(previous);
+      toast.error(labels.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  }, [labels.saveFailed, plan, saving, tasks, today]);
+
+  const addTask = (taskId: string) => {
+    void persist([...plan.taskIds, taskId], plan.focusTaskIds);
+    setQuery("");
+  };
+
+  const removeTask = (taskId: string) => {
+    void persist(
+      plan.taskIds.filter((id) => id !== taskId),
+      plan.focusTaskIds.filter((id) => id !== taskId),
+    );
+  };
+
+  const toggleFocus = (taskId: string) => {
+    if (plan.focusTaskIds.includes(taskId)) {
+      void persist(plan.taskIds, plan.focusTaskIds.filter((id) => id !== taskId));
+      return;
+    }
+    if (plan.focusTaskIds.length >= 3) {
+      toast.error(labels.focusLimit);
+      return;
+    }
+    void persist(plan.taskIds, [...plan.focusTaskIds, taskId]);
+  };
+
+  const toggleComplete = async (task: Task) => {
+    if (completingId) return;
+    setCompletingId(task.id);
+    try {
+      const updated = await api.updateTask(task.id, {
+        isCompleted: task.isCompleted ? 0 : 1,
+      });
+      setTasks((current) => current.map((item) => item.id === task.id ? updated : item));
+      onTaskMutated?.();
+    } catch (error) {
+      console.error("[MyDay] update task failed", error);
+      toast.error(labels.updateFailed);
+    } finally {
+      setCompletingId(null);
+    }
+  };
+
+  const dateLabel = useMemo(() => new Intl.DateTimeFormat(
+    chinese ? "zh-CN" : "en-US",
+    { month: "long", day: "numeric", weekday: "short" },
+  ).format(new Date(`${today}T12:00:00`)), [chinese, today]);
+
+  return (
+    <section className="shrink-0 border-b border-border bg-background/95 backdrop-blur">
+      <div className="flex min-h-14 items-center gap-3 px-3 py-2 sm:px-5">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+        >
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
+            <Sun size={19} />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-2">
+              <strong className="truncate text-sm text-foreground">{labels.title}</strong>
+              <span className="shrink-0 text-xs text-muted-foreground">{dateLabel}</span>
+            </span>
+            <span className="mt-1 flex items-center gap-2">
+              <span className="h-1.5 min-w-16 flex-1 overflow-hidden rounded-full bg-muted">
+                <span
+                  className="block h-full rounded-full bg-amber-500 transition-[width]"
+                  style={{ width: `${progress}%` }}
+                />
+              </span>
+              <span className="shrink-0 text-[11px] text-muted-foreground">
+                {completedCount}/{plannedTasks.length} {labels.completed}
+              </span>
+            </span>
+          </span>
+          {expanded ? <ChevronUp size={17} /> : <ChevronDown size={17} />}
+        </button>
+
+        <button
+          type="button"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          onClick={() => void load()}
+          disabled={loading}
+          title={labels.refresh}
+        >
+          <RefreshCw size={15} className={loading ? "animate-spin" : ""} />
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="max-h-[42vh] overflow-y-auto border-t border-border/60 px-3 py-3 sm:px-5">
+          <p className="mb-3 text-xs text-muted-foreground">{labels.subtitle}</p>
+
+          {loading ? (
+            <div className="flex h-24 items-center justify-center text-muted-foreground">
+              <Loader2 size={20} className="animate-spin" />
+            </div>
+          ) : (
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(280px,0.42fr)]">
+              <div className="min-w-0">
+                <div className="mb-2 flex items-center justify-between">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {labels.planned}
+                  </h3>
+                  {plan.focusTaskIds.length > 0 && (
+                    <span className="inline-flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-300">
+                      <Star size={12} fill="currentColor" />
+                      {labels.focus} {plan.focusTaskIds.length}/3
+                    </span>
+                  )}
+                </div>
+
+                {plannedTasks.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-border px-4 py-6 text-center">
+                    <CalendarDays size={22} className="mx-auto mb-2 text-muted-foreground" />
+                    <p className="text-sm font-medium text-foreground">{labels.empty}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{labels.emptyHint}</p>
+                  </div>
+                ) : (
+                  <div className="space-y-1.5">
+                    {plannedTasks.map((task) => {
+                      const focused = plan.focusTaskIds.includes(task.id);
+                      const overdue = isTaskOverdue(task, today);
+                      const dueToday = isTaskDueToday(task, today);
+                      return (
+                        <div
+                          key={task.id}
+                          className="group flex items-center gap-2 rounded-xl border border-border/70 bg-card px-2.5 py-2 shadow-sm"
+                        >
+                          <button
+                            type="button"
+                            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors ${
+                              task.isCompleted
+                                ? "border-emerald-500 bg-emerald-500 text-white"
+                                : "border-muted-foreground/50 hover:border-emerald-500"
+                            }`}
+                            onClick={() => void toggleComplete(task)}
+                            disabled={completingId === task.id}
+                            aria-label={task.title}
+                          >
+                            {completingId === task.id
+                              ? <Loader2 size={12} className="animate-spin" />
+                              : task.isCompleted ? <Check size={12} strokeWidth={3} /> : null}
+                          </button>
+
+                          <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 items-center gap-1.5">
+                              <span className={`truncate text-sm ${task.isCompleted ? "text-muted-foreground line-through" : "text-foreground"}`}>
+                                {task.title}
+                              </span>
+                              {focused && <Star size={12} className="shrink-0 text-amber-500" fill="currentColor" />}
+                            </div>
+                            {(overdue || dueToday) && (
+                              <span className={`mt-0.5 inline-flex items-center gap-1 text-[10px] ${overdue ? "text-destructive" : "text-muted-foreground"}`}>
+                                {overdue ? <AlertTriangle size={10} /> : <CalendarDays size={10} />}
+                                {overdue ? labels.overdue : labels.dueToday}
+                              </span>
+                            )}
+                          </div>
+
+                          <button
+                            type="button"
+                            className={`inline-flex h-7 w-7 items-center justify-center rounded-lg transition-colors ${
+                              focused
+                                ? "text-amber-500 hover:bg-amber-500/10"
+                                : "text-muted-foreground opacity-60 hover:bg-muted hover:text-amber-500 group-hover:opacity-100"
+                            }`}
+                            onClick={() => toggleFocus(task.id)}
+                            disabled={saving}
+                            title={focused ? labels.unsetFocus : labels.setFocus}
+                          >
+                            <Star size={14} fill={focused ? "currentColor" : "none"} />
+                          </button>
+                          <button
+                            type="button"
+                            className="inline-flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground opacity-60 hover:bg-muted hover:text-destructive group-hover:opacity-100"
+                            onClick={() => removeTask(task.id)}
+                            disabled={saving}
+                            title={labels.remove}
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className="min-w-0">
+                <label className="relative block">
+                  <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder={labels.search}
+                    className="h-9 w-full rounded-xl border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
+                  />
+                </label>
+                <h3 className="mb-2 mt-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {query.trim() ? labels.searchResults : labels.suggestions}
+                </h3>
+
+                {availableTasks.length === 0 ? (
+                  <p className="rounded-xl bg-muted/50 px-3 py-4 text-center text-xs text-muted-foreground">
+                    {labels.noSuggestions}
+                  </p>
+                ) : (
+                  <div className="space-y-1">
+                    {availableTasks.map((task) => (
+                      <button
+                        key={task.id}
+                        type="button"
+                        className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left hover:bg-muted disabled:opacity-50"
+                        onClick={() => addTask(task.id)}
+                        disabled={saving}
+                        title={labels.add}
+                      >
+                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                          <Plus size={13} />
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-sm text-foreground">{task.title}</span>
+                        {isTaskOverdue(task, today) && (
+                          <AlertTriangle size={12} className="shrink-0 text-destructive" />
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default MyDayPanel;

--- a/frontend/src/components/tasks/MyDayPanel.tsx
+++ b/frontend/src/components/tasks/MyDayPanel.tsx
@@ -225,10 +225,10 @@ export function MyDayPanel({ onTaskMutated }: MyDayPanelProps) {
     if (completingId) return;
     setCompletingId(task.id);
     try {
-      const updated = await api.updateTask(task.id, {
+      const result = await api.updateTask(task.id, {
         isCompleted: task.isCompleted ? 0 : 1,
       });
-      setTasks((current) => current.map((item) => item.id === task.id ? updated : item));
+      setTasks((current) => current.map((item) => item.id === task.id ? result.task : item));
       onTaskMutated?.();
     } catch (error) {
       console.error("[MyDay] update task failed", error);

--- a/frontend/src/components/tasks/MyDayPanel.tsx
+++ b/frontend/src/components/tasks/MyDayPanel.tsx
@@ -63,7 +63,7 @@ export function MyDayPanel({ onTaskMutated }: MyDayPanelProps) {
   const [saving, setSaving] = useState(false);
   const [completingId, setCompletingId] = useState<string | null>(null);
 
-  const labels = chinese
+  const labels = useMemo(() => chinese
     ? {
         title: "我的一天",
         subtitle: "主动选择今天要完成的任务，不修改原截止日期",
@@ -111,7 +111,7 @@ export function MyDayPanel({ onTaskMutated }: MyDayPanelProps) {
         overdue: "Overdue",
         dueToday: "Due today",
         noSuggestions: "No urgent suggestions right now",
-      };
+      }, [chinese]);
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/frontend/src/components/tasks/__tests__/taskMyDay.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskMyDay.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/types";
+import {
+  getMyDaySuggestions,
+  normalizeMyDayPlan,
+  orderMyDayTasks,
+} from "../taskMyDay";
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: overrides.id || "task-1",
+    userId: "user-1",
+    workspaceId: null,
+    title: overrides.title || "Task",
+    description: "",
+    isCompleted: 0,
+    priority: 2,
+    dueDate: null,
+    dueAt: null,
+    startDate: null,
+    noteId: null,
+    parentId: null,
+    sortOrder: 0,
+    projectId: null,
+    status: "todo",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("taskMyDay", () => {
+  it("normalizes task ids and limits focus to three planned tasks", () => {
+    const normalized = normalizeMyDayPlan(
+      ["a", "a", "b", "c", "d", "missing"],
+      ["missing", "d", "c", "b", "a"],
+      new Set(["a", "b", "c", "d"]),
+    );
+
+    expect(normalized.taskIds).toEqual(["a", "b", "c", "d"]);
+    expect(normalized.focusTaskIds).toEqual(["d", "c", "b"]);
+  });
+
+  it("suggests overdue and due-today tasks while excluding planned and completed tasks", () => {
+    const tasks = [
+      task({ id: "planned", dueDate: "2026-08-02" }),
+      task({ id: "overdue", dueDate: "2026-08-01", priority: 1 }),
+      task({ id: "today", dueDate: "2026-08-02", priority: 3 }),
+      task({ id: "starting", startDate: "2026-08-02" }),
+      task({ id: "future", dueDate: "2026-08-03" }),
+      task({ id: "done", dueDate: "2026-08-01", isCompleted: 1, status: "done" }),
+    ];
+
+    expect(getMyDaySuggestions(tasks, "2026-08-02", ["planned"]).map((item) => item.id))
+      .toEqual(["overdue", "today", "starting"]);
+  });
+
+  it("orders focus tasks first and completed tasks last within each group", () => {
+    const tasks = [
+      task({ id: "a" }),
+      task({ id: "b", isCompleted: 1, status: "done" }),
+      task({ id: "c" }),
+    ];
+
+    expect(orderMyDayTasks(tasks, {
+      taskIds: ["a", "b", "c"],
+      focusTaskIds: ["c"],
+    }).map((item) => item.id)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/frontend/src/components/tasks/taskMyDay.ts
+++ b/frontend/src/components/tasks/taskMyDay.ts
@@ -1,0 +1,84 @@
+import type { Task } from "@/types";
+
+export interface MyDayPlanState {
+  taskIds: string[];
+  focusTaskIds: string[];
+}
+
+export function formatMyDayDate(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function taskDateKey(task: Task): string | null {
+  if (task.dueAt) return task.dueAt.slice(0, 10);
+  return task.dueDate || null;
+}
+
+export function isTaskDueToday(task: Task, today: string): boolean {
+  return !task.isCompleted && taskDateKey(task) === today;
+}
+
+export function isTaskOverdue(task: Task, today: string): boolean {
+  const date = taskDateKey(task);
+  return !task.isCompleted && !!date && date < today;
+}
+
+export function isTaskStartingToday(task: Task, today: string): boolean {
+  return !task.isCompleted && task.startDate === today;
+}
+
+export function normalizeMyDayPlan(
+  taskIds: string[],
+  focusTaskIds: string[],
+  existingTaskIds?: Set<string>,
+): MyDayPlanState {
+  const uniqueTaskIds = Array.from(new Set(taskIds.filter(Boolean)))
+    .filter((id) => !existingTaskIds || existingTaskIds.has(id))
+    .slice(0, 200);
+  const taskIdSet = new Set(uniqueTaskIds);
+  const uniqueFocusIds = Array.from(new Set(focusTaskIds.filter(Boolean)))
+    .filter((id) => taskIdSet.has(id))
+    .slice(0, 3);
+  return { taskIds: uniqueTaskIds, focusTaskIds: uniqueFocusIds };
+}
+
+export function getMyDaySuggestions(
+  tasks: Task[],
+  today: string,
+  plannedTaskIds: string[],
+): Task[] {
+  const planned = new Set(plannedTaskIds);
+  return tasks
+    .filter((task) => {
+      if (task.isCompleted || planned.has(task.id)) return false;
+      return isTaskOverdue(task, today) || isTaskDueToday(task, today) || isTaskStartingToday(task, today);
+    })
+    .sort((a, b) => {
+      const aOverdue = isTaskOverdue(a, today) ? 1 : 0;
+      const bOverdue = isTaskOverdue(b, today) ? 1 : 0;
+      if (aOverdue !== bOverdue) return bOverdue - aOverdue;
+      if (a.priority !== b.priority) return b.priority - a.priority;
+      return (taskDateKey(a) || "9999-12-31").localeCompare(taskDateKey(b) || "9999-12-31");
+    });
+}
+
+export function orderMyDayTasks(
+  tasks: Task[],
+  plan: MyDayPlanState,
+): Task[] {
+  const byId = new Map(tasks.map((task) => [task.id, task]));
+  const focus = new Set(plan.focusTaskIds);
+  return plan.taskIds
+    .map((id) => byId.get(id))
+    .filter((task): task is Task => !!task)
+    .sort((a, b) => {
+      const aFocus = focus.has(a.id) ? 1 : 0;
+      const bFocus = focus.has(b.id) ? 1 : 0;
+      if (aFocus !== bFocus) return bFocus - aFocus;
+      if (a.isCompleted !== b.isCompleted) return a.isCompleted - b.isCompleted;
+      return plan.taskIds.indexOf(a.id) - plan.taskIds.indexOf(b.id);
+    });
+}

--- a/frontend/src/lib/taskDayPlanApi.ts
+++ b/frontend/src/lib/taskDayPlanApi.ts
@@ -1,0 +1,66 @@
+import { getBaseUrl, getCurrentWorkspace } from "./api";
+
+export interface TaskDayPlan {
+  date: string;
+  workspaceId: string;
+  taskIds: string[];
+  focusTaskIds: string[];
+  updatedAt: string | null;
+}
+
+function currentWorkspaceId(): string {
+  const workspaceId = getCurrentWorkspace();
+  return workspaceId && workspaceId !== "personal" ? workspaceId : "personal";
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = new Error(
+      typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
+    ) as Error & { code?: string; status?: number };
+    error.code = payload?.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
+export async function getTaskDayPlan(date: string): Promise<TaskDayPlan> {
+  const params = new URLSearchParams({
+    date,
+    workspaceId: currentWorkspaceId(),
+  });
+  return request<TaskDayPlan>(`/user-preferences/task-day-plans?${params.toString()}`);
+}
+
+export async function saveTaskDayPlan(
+  plan: Pick<TaskDayPlan, "date" | "taskIds" | "focusTaskIds">,
+): Promise<TaskDayPlan> {
+  return request<TaskDayPlan>("/user-preferences/task-day-plans", {
+    method: "PUT",
+    body: JSON.stringify({
+      ...plan,
+      workspaceId: currentWorkspaceId(),
+    }),
+  });
+}
+
+export async function clearTaskDayPlan(date: string): Promise<TaskDayPlan> {
+  const params = new URLSearchParams({
+    date,
+    workspaceId: currentWorkspaceId(),
+  });
+  return request<TaskDayPlan>(`/user-preferences/task-day-plans?${params.toString()}`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## 背景

当前“今天”筛选只表示今天到期的任务，无法表达用户主动选择“今天准备做什么”。本 PR 新增独立的「我的一天 / My Day」计划层，不修改任务原始截止日期。

## 实现内容

- 新增按 `用户 + 工作区 + 日期` 隔离的今日计划 API
- 今日计划与任务截止日期解耦
- 支持从逾期、今天到期、今天开始的任务中智能建议
- 支持搜索任意未完成任务加入今天
- 支持最多 3 个“今日重点”
- 支持在面板内完成/恢复任务
- 支持移出今日计划
- 支持个人空间与工作区独立计划
- 支持跨设备同步
- 长时间运行时跨午夜自动切换到新一天
- 自动清理 45 天以前的计划数据

## 数据与兼容性

- 不修改 `tasks` 表，不改变现有 Today 筛选语义
- SQLite 增加正式 v70 `task-day-plans` 迁移
- 路由保留幂等建表兜底，避免异常迁移历史导致运行时报错
- PostgreSQL pilot schema 同步增加 `task_day_plans` 表和索引
- 当前生产运行时仍使用 SQLite；本 PR 不引入 `DB_DRIVER` 或生产切库逻辑
- 不影响看板、日历、Gantt、循环任务和提醒

## 自动验证结果

- ✅ 后端 TypeScript 编译
- ✅ My Day API 真实路由与持久化测试
- ✅ 前端完整生产构建
- ✅ My Day 前端逻辑测试
- ✅ Block Schema Repair 历史迁移回归

## 测试覆盖

- 前端 My Day 规划纯逻辑单元测试
- 后端日期、ID 归一化测试
- 后端真实 Hono 路由与持久化测试（含无尾斜杠路径）
- 新增 `Task My Day CI`，后续改动会自动重复上述验证

## 仍需人工体验确认

- 个人空间与工作区切换观感
- 移动端高度与滚动布局
- 跨午夜自动切换新一天的实际桌面端体验
