### PR TITLE
ci(pg): trigger latest main synchronization

### DIFF
--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,1 +1,1 @@
-sync main into pg-migration-unified at 2026-08-02
+sync main into pg-migration-unified at 2026-08-02 retry 2

--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,1 +1,1 @@
-sync main into pg-migration-unified at 2026-08-02 retry 2
+run PostgreSQL knowledge-tree read migration at 2026-08-02

--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,0 +1,1 @@
+sync main into pg-migration-unified at 2026-08-02


### PR DESCRIPTION
一次性触发默认分支上的 PostgreSQL latest-main 同步命令。工作流会检出 `pg-migration-unified`，合并最新 `main`，解决已知入口冲突并推送回迁移分支。该 PR 不合并。