### PR TITLE
ci(pg): validate knowledge-tree read runtime

### DIFF
--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,1 +1,1 @@
-run PostgreSQL knowledge-tree read migration at 2026-08-02
+run PostgreSQL knowledge-tree read migration at 2026-08-02 retry 2

--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,0 +1,1 @@
+run PostgreSQL knowledge-tree read migration at 2026-08-02

--- a/.github/pg-sync-latest-main-trigger
+++ b/.github/pg-sync-latest-main-trigger
@@ -1,1 +1,1 @@
-run PostgreSQL knowledge-tree read migration at 2026-08-02 retry 2
+run PostgreSQL knowledge-tree read migration at 2026-08-02 retry 3


### PR DESCRIPTION
一次性触发 PostgreSQL Knowledge Tree 读取迁移命令。工作流会在 `pg-migration-unified` 上生成正式 `0015` migration、实现跨驱动读取 Repository、挂载只读 Runtime 路由，并在真实 PostgreSQL 16 上验证后推送。该 PR 不合并。