### PR TITLE
ci(pg): reconcile latest-main DB audit baseline

### DIFF
--- a/.github/pg-reconcile-audit-trigger
+++ b/.github/pg-reconcile-audit-trigger
@@ -1,0 +1,1 @@
+reconcile PostgreSQL migration audit baseline at 2026-08-02


### PR DESCRIPTION
一次性触发 PostgreSQL 迁移分支的 SQLite 直连审计基线校准。仅登记最新主线新增、已有明确归属的 #249/#251 临时边界，并运行精确上限检查后推送。该 PR 不合并。