### PR TITLE
ci(pg): validate PostgreSQL view schema parity

### DIFF
--- a/.github/pg-schema-view-parity-trigger
+++ b/.github/pg-schema-view-parity-trigger
@@ -1,0 +1,1 @@
+recognize PostgreSQL views in schema parity at 2026-08-02


### PR DESCRIPTION
一次性触发 PostgreSQL schema parity 工具修复：把普通视图和物化视图纳入可查询关系扫描，避免 `files` 等兼容视图被误判为缺表。验证通过后推送到 `pg-migration-unified`。该 PR 不合并。