### PR TITLE
ci(pg): finalize knowledge-tree read runtime

### DIFF
--- a/.github/pg-knowledge-tree-read-final-trigger
+++ b/.github/pg-knowledge-tree-read-final-trigger
@@ -1,0 +1,1 @@
+final PostgreSQL knowledge-tree read migration at 2026-08-02


### PR DESCRIPTION
一次性执行 PostgreSQL Knowledge Tree 读取迁移最终门禁：统一列表 API 为无尾斜杠路径、保留后端兼容路由，补齐 `0015` 固定 migration 清单，并验证真实 PostgreSQL 16、权限继承、Schema parity、SQLite 边界、Bundle 与 migration 打包。该 PR 不合并。