### PR TITLE
feat(tasks): add labels and saved views

### DIFF
--- a/.github/workflows/task-metadata-ci.yml
+++ b/.github/workflows/task-metadata-ci.yml
@@ -1,0 +1,81 @@
+name: Task Metadata CI
+
+on:
+  push:
+    branches:
+      - feature/task-labels-saved-views-v1
+      - feature/task-labels-saved-views-rebase
+    paths:
+      - "backend/src/db/taskMetadataMigration.ts"
+      - "backend/src/runtime/task-metadata-migration-bootstrap.ts"
+      - "backend/src/routes/task-metadata.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-metadata.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/TaskMetadataWorkspace.tsx"
+      - "frontend/src/components/tasks/taskSavedViewFilter.ts"
+      - "frontend/src/components/tasks/__tests__/taskSavedViewFilter.test.ts"
+      - "frontend/src/lib/taskMetadataApi.ts"
+      - "frontend/tsconfig.task-metadata.json"
+      - ".github/workflows/task-metadata-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/db/taskMetadataMigration.ts"
+      - "backend/src/runtime/task-metadata-migration-bootstrap.ts"
+      - "backend/src/routes/task-metadata.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-metadata.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/TaskMetadataWorkspace.tsx"
+      - "frontend/src/components/tasks/taskSavedViewFilter.ts"
+      - "frontend/src/components/tasks/__tests__/taskSavedViewFilter.test.ts"
+      - "frontend/src/lib/taskMetadataApi.ts"
+      - "frontend/tsconfig.task-metadata.json"
+      - ".github/workflows/task-metadata-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Backend typecheck
+        run: npm run build:tsc
+      - name: Test task metadata API
+        run: node --import tsx --test tests/task-metadata.test.ts
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Targeted TypeScript check
+        run: npx tsc -p tsconfig.task-metadata.json
+      - name: Vite production bundle
+        run: npx vite build
+      - name: Test saved view filtering
+        run: npx vitest run src/components/tasks/__tests__/taskSavedViewFilter.test.ts --reporter=verbose

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -48,3 +48,51 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_task_day_plans_user_scope_date
   ON task_day_plans("userId", "scopeKey", "planDate");
 CREATE INDEX IF NOT EXISTS idx_task_day_plans_user_date
   ON task_day_plans("userId", "planDate");
+
+CREATE TABLE IF NOT EXISTS task_labels (
+  id TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "workspaceId" TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+  "scopeKey" TEXT NOT NULL,
+  name TEXT NOT NULL,
+  "normalizedName" TEXT NOT NULL,
+  color TEXT NOT NULL DEFAULT '#6366f1',
+  "sortOrder" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_labels_scope_name
+  ON task_labels("scopeKey", "normalizedName");
+CREATE INDEX IF NOT EXISTS idx_task_labels_workspace_sort
+  ON task_labels("workspaceId", "sortOrder", "createdAt");
+CREATE INDEX IF NOT EXISTS idx_task_labels_user_sort
+  ON task_labels("userId", "sortOrder", "createdAt");
+
+CREATE TABLE IF NOT EXISTS task_label_links (
+  "taskId" TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  "labelId" TEXT NOT NULL REFERENCES task_labels(id) ON DELETE CASCADE,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY ("taskId", "labelId")
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_label_links_label
+  ON task_label_links("labelId", "taskId");
+
+CREATE TABLE IF NOT EXISTS task_saved_views (
+  id TEXT PRIMARY KEY,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "workspaceId" TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+  "scopeKey" TEXT NOT NULL,
+  name TEXT NOT NULL,
+  "normalizedName" TEXT NOT NULL,
+  "filtersJson" TEXT NOT NULL DEFAULT '{}',
+  "sortOrder" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_name
+  ON task_saved_views("userId", "scopeKey", "normalizedName");
+CREATE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_sort
+  ON task_saved_views("userId", "scopeKey", "sortOrder", "createdAt");

--- a/backend/src/db/taskMetadataMigration.ts
+++ b/backend/src/db/taskMetadataMigration.ts
@@ -1,0 +1,69 @@
+import type { Migration } from "./migrations.impl.js";
+
+/**
+ * TASK-METADATA-01
+ *
+ * v70 belongs to My Day. Task labels and saved views start at v71 so the
+ * features retain independent schema ownership.
+ */
+export const taskMetadataMigration: Migration = {
+  version: 71,
+  name: "task-labels-and-saved-views",
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS task_labels (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        workspaceId TEXT,
+        scopeKey TEXT NOT NULL,
+        name TEXT NOT NULL,
+        normalizedName TEXT NOT NULL,
+        color TEXT NOT NULL DEFAULT '#6366f1',
+        sortOrder INTEGER NOT NULL DEFAULT 0,
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_labels_scope_name
+        ON task_labels(scopeKey, normalizedName);
+      CREATE INDEX IF NOT EXISTS idx_task_labels_workspace_sort
+        ON task_labels(workspaceId, sortOrder, createdAt);
+      CREATE INDEX IF NOT EXISTS idx_task_labels_user_sort
+        ON task_labels(userId, sortOrder, createdAt);
+
+      CREATE TABLE IF NOT EXISTS task_label_links (
+        taskId TEXT NOT NULL,
+        labelId TEXT NOT NULL,
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (taskId, labelId),
+        FOREIGN KEY (taskId) REFERENCES tasks(id) ON DELETE CASCADE,
+        FOREIGN KEY (labelId) REFERENCES task_labels(id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_task_label_links_label
+        ON task_label_links(labelId, taskId);
+
+      CREATE TABLE IF NOT EXISTS task_saved_views (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        workspaceId TEXT,
+        scopeKey TEXT NOT NULL,
+        name TEXT NOT NULL,
+        normalizedName TEXT NOT NULL,
+        filtersJson TEXT NOT NULL DEFAULT '{}',
+        sortOrder INTEGER NOT NULL DEFAULT 0,
+        createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+        updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_name
+        ON task_saved_views(userId, scopeKey, normalizedName);
+      CREATE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_sort
+        ON task_saved_views(userId, scopeKey, sortOrder, createdAt);
+    `);
+  },
+};

--- a/backend/src/index.hardened.ts
+++ b/backend/src/index.hardened.ts
@@ -2,6 +2,7 @@
 import "./runtime/url-import-dns-compat.js";
 // Register feature migrations before any runtime imports can initialize the database.
 import "./runtime/knowledge-tree-migration-bootstrap.js";
+import "./runtime/task-metadata-migration-bootstrap.js";
 // Permission routes import ACL services that may initialize database guards, so they must load
 // only after the feature migration list has been registered.
 import "./runtime/notebook-permission-management.js";

--- a/backend/src/routes/task-metadata.ts
+++ b/backend/src/routes/task-metadata.ts
@@ -1,0 +1,614 @@
+import crypto from "crypto";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { getDb } from "../db/schema";
+import { taskMetadataMigration } from "../db/taskMetadataMigration";
+import {
+  canManageResource,
+  getUserWorkspaceRole,
+  hasPermission,
+  roleToPermission,
+  type WorkspaceRole,
+} from "../middleware/acl";
+
+const taskMetadata = new Hono();
+const MAX_LABELS_PER_SCOPE = 100;
+const MAX_LABELS_PER_TASK = 20;
+const MAX_VIEWS_PER_SCOPE = 30;
+const LABEL_COLORS: readonly string[] = [
+  "#6366f1",
+  "#ef4444",
+  "#f59e0b",
+  "#10b981",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+  "#6b7280",
+];
+let initializedDatabase: object | null = null;
+
+type TaskStatus = "todo" | "doing" | "blocked" | "done";
+type TaskViewDue = "all" | "pending" | "today" | "week" | "overdue" | "completed";
+type LabelMode = "any" | "all";
+
+export interface TaskSavedViewFilters {
+  labelIds: string[];
+  labelMode: LabelMode;
+  priorities: number[];
+  statuses: TaskStatus[];
+  due: TaskViewDue;
+  keyword: string;
+  projectId?: string | null;
+}
+
+interface ResolvedScope {
+  workspaceId: string | null;
+  scopeKey: string;
+  role: WorkspaceRole | null;
+  error?: string;
+}
+
+interface TaskLabelRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  scopeKey: string;
+  name: string;
+  normalizedName: string;
+  color: string;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  taskCount?: number;
+}
+
+interface TaskSavedViewRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  scopeKey: string;
+  name: string;
+  normalizedName: string;
+  filtersJson: string;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function ensureTaskMetadataTables(): void {
+  const db = getDb();
+  if (initializedDatabase === db) return;
+  taskMetadataMigration.up(db);
+  initializedDatabase = db;
+}
+
+function normalizeName(value: unknown, max = 40): string {
+  return typeof value === "string"
+    ? value.trim().replace(/\s+/g, " ").slice(0, max)
+    : "";
+}
+
+function normalizedName(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase();
+}
+
+function normalizeColor(value: unknown, fallback: string = LABEL_COLORS[0]): string {
+  if (typeof value !== "string") return fallback;
+  const color = value.trim().toLowerCase();
+  return /^#[0-9a-f]{6}$/.test(color) ? color : fallback;
+}
+
+export function normalizeTaskMetadataIds(
+  value: unknown,
+  limit = MAX_LABELS_PER_TASK,
+): string[] {
+  if (!Array.isArray(value)) return [];
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of value) {
+    if (typeof raw !== "string") continue;
+    const id = raw.trim();
+    if (!id || id.length > 128 || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+    if (result.length >= limit) break;
+  }
+  return result;
+}
+
+export function normalizeTaskSavedViewFilters(input: unknown): TaskSavedViewFilters {
+  const raw = input && typeof input === "object" && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : {};
+  const validStatuses = new Set<TaskStatus>(["todo", "doing", "blocked", "done"]);
+  const validDue = new Set<TaskViewDue>([
+    "all",
+    "pending",
+    "today",
+    "week",
+    "overdue",
+    "completed",
+  ]);
+  const priorities = Array.isArray(raw.priorities)
+    ? Array.from(new Set(
+        raw.priorities
+          .map(Number)
+          .filter((value) => value === 1 || value === 2 || value === 3),
+      ))
+    : [];
+  const statuses = Array.isArray(raw.statuses)
+    ? Array.from(new Set(
+        raw.statuses.filter(
+          (value): value is TaskStatus =>
+            typeof value === "string" && validStatuses.has(value as TaskStatus),
+        ),
+      ))
+    : [];
+  const projectId = typeof raw.projectId === "string"
+    ? raw.projectId.trim().slice(0, 128)
+    : raw.projectId === null
+      ? null
+      : undefined;
+
+  return {
+    labelIds: normalizeTaskMetadataIds(raw.labelIds),
+    labelMode: raw.labelMode === "all" ? "all" : "any",
+    priorities,
+    statuses,
+    due: typeof raw.due === "string" && validDue.has(raw.due as TaskViewDue)
+      ? raw.due as TaskViewDue
+      : "all",
+    keyword: typeof raw.keyword === "string" ? raw.keyword.trim().slice(0, 80) : "",
+    ...(projectId !== undefined ? { projectId } : {}),
+  };
+}
+
+function resolveScope(userId: string, rawWorkspaceId: unknown): ResolvedScope {
+  const workspaceId = typeof rawWorkspaceId === "string" ? rawWorkspaceId.trim() : "";
+  if (!workspaceId || workspaceId === "personal") {
+    return {
+      workspaceId: null,
+      scopeKey: `personal:${userId}`,
+      role: null,
+    };
+  }
+  const role = getUserWorkspaceRole(workspaceId, userId);
+  if (!role) {
+    return {
+      workspaceId,
+      scopeKey: `workspace:${workspaceId}`,
+      role: null,
+      error: "无权访问该工作区",
+    };
+  }
+  return {
+    workspaceId,
+    scopeKey: `workspace:${workspaceId}`,
+    role,
+  };
+}
+
+function resolveRequestScope(
+  c: Context,
+  userId: string,
+  body?: Record<string, unknown>,
+): ResolvedScope {
+  return resolveScope(userId, body?.workspaceId ?? c.req.query("workspaceId"));
+}
+
+function canWriteScope(scope: ResolvedScope): boolean {
+  if (!scope.workspaceId) return true;
+  return !!scope.role && hasPermission(roleToPermission(scope.role), "write");
+}
+
+function getScopeLabelIds(userId: string, scope: ResolvedScope): Set<string> {
+  const rows = scope.workspaceId
+    ? getDb()
+        .prepare("SELECT id FROM task_labels WHERE workspaceId = ?")
+        .all(scope.workspaceId)
+    : getDb()
+        .prepare("SELECT id FROM task_labels WHERE userId = ? AND workspaceId IS NULL")
+        .all(userId);
+  return new Set((rows as Array<{ id: string }>).map((row) => row.id));
+}
+
+function validateProjectScope(
+  userId: string,
+  scope: ResolvedScope,
+  projectId: string | null | undefined,
+): boolean {
+  if (projectId === undefined || projectId === null || projectId === "") return true;
+  const row = getDb()
+    .prepare("SELECT userId, workspaceId FROM task_projects WHERE id = ?")
+    .get(projectId) as { userId: string; workspaceId: string | null } | undefined;
+  if (!row) return false;
+  if (scope.workspaceId) return row.workspaceId === scope.workspaceId;
+  return row.userId === userId && row.workspaceId === null;
+}
+
+function cleanFiltersForScope(
+  userId: string,
+  scope: ResolvedScope,
+  input: unknown,
+): TaskSavedViewFilters {
+  const filters = normalizeTaskSavedViewFilters(input);
+  const allowedLabels = getScopeLabelIds(userId, scope);
+  const projectIsValid = validateProjectScope(userId, scope, filters.projectId);
+  return {
+    ...filters,
+    labelIds: filters.labelIds.filter((id) => allowedLabels.has(id)),
+    ...(!projectIsValid ? { projectId: undefined } : {}),
+  };
+}
+
+function parseFilters(
+  row: TaskSavedViewRow,
+  userId: string,
+  scope: ResolvedScope,
+): TaskSavedViewFilters {
+  try {
+    return cleanFiltersForScope(userId, scope, JSON.parse(row.filtersJson));
+  } catch {
+    return normalizeTaskSavedViewFilters({});
+  }
+}
+
+function publicLabel(row: TaskLabelRow) {
+  return {
+    id: row.id,
+    userId: row.userId,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    color: row.color,
+    sortOrder: row.sortOrder,
+    taskCount: Number(row.taskCount || 0),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function publicView(
+  row: TaskSavedViewRow,
+  userId: string,
+  scope: ResolvedScope,
+) {
+  return {
+    id: row.id,
+    userId: row.userId,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    filters: parseFilters(row, userId, scope),
+    sortOrder: row.sortOrder,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function isConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("UNIQUE constraint") || message.includes("SQLITE_CONSTRAINT");
+}
+
+function readBody(c: Context): Promise<Record<string, unknown>> {
+  return c.req.json().catch(() => ({})) as Promise<Record<string, unknown>>;
+}
+
+taskMetadata.get("/", (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const scope = resolveRequestScope(c, userId);
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const labels = (scope.workspaceId
+    ? getDb().prepare(`
+        SELECT l.*,
+          (SELECT COUNT(*) FROM task_label_links link WHERE link.labelId = l.id) AS taskCount
+        FROM task_labels l
+        WHERE l.workspaceId = ?
+        ORDER BY l.sortOrder ASC, l.createdAt ASC
+      `).all(scope.workspaceId)
+    : getDb().prepare(`
+        SELECT l.*,
+          (SELECT COUNT(*) FROM task_label_links link WHERE link.labelId = l.id) AS taskCount
+        FROM task_labels l
+        WHERE l.userId = ? AND l.workspaceId IS NULL
+        ORDER BY l.sortOrder ASC, l.createdAt ASC
+      `).all(userId)) as TaskLabelRow[];
+
+  const links = (scope.workspaceId
+    ? getDb().prepare(`
+        SELECT link.taskId, link.labelId
+        FROM task_label_links link
+        JOIN tasks task ON task.id = link.taskId
+        JOIN task_labels label ON label.id = link.labelId
+        WHERE task.workspaceId = ? AND label.workspaceId = ?
+      `).all(scope.workspaceId, scope.workspaceId)
+    : getDb().prepare(`
+        SELECT link.taskId, link.labelId
+        FROM task_label_links link
+        JOIN tasks task ON task.id = link.taskId
+        JOIN task_labels label ON label.id = link.labelId
+        WHERE task.userId = ? AND task.workspaceId IS NULL
+          AND label.userId = ? AND label.workspaceId IS NULL
+      `).all(userId, userId)) as Array<{ taskId: string; labelId: string }>;
+
+  const assignments: Record<string, string[]> = {};
+  for (const link of links) (assignments[link.taskId] ||= []).push(link.labelId);
+
+  const views = (scope.workspaceId
+    ? getDb().prepare(`
+        SELECT * FROM task_saved_views
+        WHERE userId = ? AND workspaceId = ?
+        ORDER BY sortOrder ASC, createdAt ASC
+      `).all(userId, scope.workspaceId)
+    : getDb().prepare(`
+        SELECT * FROM task_saved_views
+        WHERE userId = ? AND workspaceId IS NULL
+        ORDER BY sortOrder ASC, createdAt ASC
+      `).all(userId)) as TaskSavedViewRow[];
+
+  return c.json({
+    workspaceId: scope.workspaceId || "personal",
+    labels: labels.map(publicLabel),
+    assignments,
+    views: views.map((view) => publicView(view, userId, scope)),
+  });
+});
+
+taskMetadata.post("/labels", async (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const body = await readBody(c);
+  const scope = resolveRequestScope(c, userId, body);
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+  if (!canWriteScope(scope)) {
+    return c.json({ error: "当前角色不能创建任务标签", code: "FORBIDDEN" }, 403);
+  }
+
+  const name = normalizeName(body.name);
+  if (!name) {
+    return c.json({ error: "标签名称不能为空", code: "INVALID_LABEL_NAME" }, 400);
+  }
+  const countRow = (scope.workspaceId
+    ? getDb().prepare("SELECT COUNT(*) AS count FROM task_labels WHERE workspaceId = ?").get(scope.workspaceId)
+    : getDb().prepare("SELECT COUNT(*) AS count FROM task_labels WHERE userId = ? AND workspaceId IS NULL").get(userId)) as { count: number };
+  if (Number(countRow.count) >= MAX_LABELS_PER_SCOPE) {
+    return c.json({
+      error: `每个空间最多创建 ${MAX_LABELS_PER_SCOPE} 个任务标签`,
+      code: "LABEL_LIMIT",
+    }, 400);
+  }
+
+  const now = new Date().toISOString();
+  const row: TaskLabelRow = {
+    id: crypto.randomUUID(),
+    userId,
+    workspaceId: scope.workspaceId,
+    scopeKey: scope.scopeKey,
+    name,
+    normalizedName: normalizedName(name),
+    color: normalizeColor(body.color),
+    sortOrder: Number.isInteger(body.sortOrder) ? Number(body.sortOrder) : 0,
+    createdAt: now,
+    updatedAt: now,
+    taskCount: 0,
+  };
+  try {
+    getDb().prepare(`
+      INSERT INTO task_labels (
+        id, userId, workspaceId, scopeKey, name, normalizedName,
+        color, sortOrder, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      row.id, row.userId, row.workspaceId, row.scopeKey, row.name,
+      row.normalizedName, row.color, row.sortOrder, row.createdAt, row.updatedAt,
+    );
+  } catch (error) {
+    if (isConstraintError(error)) {
+      return c.json({ error: "当前空间已存在同名标签", code: "LABEL_NAME_CONFLICT" }, 409);
+    }
+    throw error;
+  }
+  return c.json({ label: publicLabel(row) }, 201);
+});
+
+taskMetadata.put("/labels/:id", async (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const id = c.req.param("id");
+  const existing = getDb().prepare("SELECT * FROM task_labels WHERE id = ?").get(id) as TaskLabelRow | undefined;
+  if (!existing) return c.json({ error: "任务标签不存在", code: "LABEL_NOT_FOUND" }, 404);
+  if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
+    return c.json({ error: "无权修改该任务标签", code: "FORBIDDEN" }, 403);
+  }
+
+  const body = await readBody(c);
+  const name = body.name === undefined ? existing.name : normalizeName(body.name);
+  if (!name) return c.json({ error: "标签名称不能为空", code: "INVALID_LABEL_NAME" }, 400);
+  const color = body.color === undefined ? existing.color : normalizeColor(body.color, existing.color);
+  const sortOrder = Number.isInteger(body.sortOrder) ? Number(body.sortOrder) : existing.sortOrder;
+  const now = new Date().toISOString();
+  try {
+    getDb().prepare(`
+      UPDATE task_labels
+      SET name = ?, normalizedName = ?, color = ?, sortOrder = ?, updatedAt = ?
+      WHERE id = ?
+    `).run(name, normalizedName(name), color, sortOrder, now, id);
+  } catch (error) {
+    if (isConstraintError(error)) {
+      return c.json({ error: "当前空间已存在同名标签", code: "LABEL_NAME_CONFLICT" }, 409);
+    }
+    throw error;
+  }
+  const updated = getDb().prepare(`
+    SELECT l.*,
+      (SELECT COUNT(*) FROM task_label_links link WHERE link.labelId = l.id) AS taskCount
+    FROM task_labels l WHERE l.id = ?
+  `).get(id) as TaskLabelRow;
+  return c.json({ label: publicLabel(updated) });
+});
+
+taskMetadata.delete("/labels/:id", (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const id = c.req.param("id");
+  const existing = getDb().prepare("SELECT userId, workspaceId FROM task_labels WHERE id = ?").get(id) as
+    | { userId: string; workspaceId: string | null }
+    | undefined;
+  if (!existing) return c.json({ success: true });
+  if (!canManageResource(existing.userId, existing.workspaceId, userId)) {
+    return c.json({ error: "无权删除该任务标签", code: "FORBIDDEN" }, 403);
+  }
+  getDb().prepare("DELETE FROM task_labels WHERE id = ?").run(id);
+  return c.json({ success: true });
+});
+
+taskMetadata.put("/tasks/:taskId/labels", async (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const taskId = c.req.param("taskId");
+  const task = getDb().prepare("SELECT userId, workspaceId FROM tasks WHERE id = ?").get(taskId) as
+    | { userId: string; workspaceId: string | null }
+    | undefined;
+  if (!task) return c.json({ error: "任务不存在", code: "TASK_NOT_FOUND" }, 404);
+  if (!canManageResource(task.userId, task.workspaceId, userId)) {
+    return c.json({ error: "无权修改该任务的标签", code: "FORBIDDEN" }, 403);
+  }
+
+  const body = await readBody(c);
+  if (!Array.isArray(body.labelIds)) {
+    return c.json({ error: "labelIds 必须是数组", code: "INVALID_LABEL_IDS" }, 400);
+  }
+  const labelIds = normalizeTaskMetadataIds(body.labelIds);
+  const taskScope = resolveScope(userId, task.workspaceId || "personal");
+  if (taskScope.error) return c.json({ error: taskScope.error, code: "FORBIDDEN" }, 403);
+  const allowed = getScopeLabelIds(task.workspaceId ? userId : task.userId, taskScope);
+  const invalid = labelIds.filter((id) => !allowed.has(id));
+  if (invalid.length > 0) {
+    return c.json({
+      error: "包含不存在或跨空间的任务标签",
+      code: "INVALID_LABEL_SCOPE",
+      invalidLabelIds: invalid,
+    }, 400);
+  }
+
+  const db = getDb();
+  db.transaction(() => {
+    db.prepare("DELETE FROM task_label_links WHERE taskId = ?").run(taskId);
+    const insert = db.prepare("INSERT INTO task_label_links (taskId, labelId, createdAt) VALUES (?, ?, ?)");
+    const now = new Date().toISOString();
+    for (const labelId of labelIds) insert.run(taskId, labelId, now);
+  })();
+  return c.json({ taskId, labelIds });
+});
+
+taskMetadata.post("/views", async (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const body = await readBody(c);
+  const scope = resolveRequestScope(c, userId, body);
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+  const name = normalizeName(body.name, 60);
+  if (!name) return c.json({ error: "视图名称不能为空", code: "INVALID_VIEW_NAME" }, 400);
+
+  const countRow = (scope.workspaceId
+    ? getDb().prepare("SELECT COUNT(*) AS count FROM task_saved_views WHERE userId = ? AND workspaceId = ?").get(userId, scope.workspaceId)
+    : getDb().prepare("SELECT COUNT(*) AS count FROM task_saved_views WHERE userId = ? AND workspaceId IS NULL").get(userId)) as { count: number };
+  if (Number(countRow.count) >= MAX_VIEWS_PER_SCOPE) {
+    return c.json({
+      error: `每个空间最多保存 ${MAX_VIEWS_PER_SCOPE} 个视图`,
+      code: "VIEW_LIMIT",
+    }, 400);
+  }
+
+  const rawFilters = normalizeTaskSavedViewFilters(body.filters);
+  if (!validateProjectScope(userId, scope, rawFilters.projectId)) {
+    return c.json({ error: "项目不属于当前空间", code: "INVALID_PROJECT_SCOPE" }, 400);
+  }
+  const filters = cleanFiltersForScope(userId, scope, rawFilters);
+  const now = new Date().toISOString();
+  const row: TaskSavedViewRow = {
+    id: crypto.randomUUID(),
+    userId,
+    workspaceId: scope.workspaceId,
+    scopeKey: scope.scopeKey,
+    name,
+    normalizedName: normalizedName(name),
+    filtersJson: JSON.stringify(filters),
+    sortOrder: Number.isInteger(body.sortOrder) ? Number(body.sortOrder) : 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  try {
+    getDb().prepare(`
+      INSERT INTO task_saved_views (
+        id, userId, workspaceId, scopeKey, name, normalizedName,
+        filtersJson, sortOrder, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      row.id, row.userId, row.workspaceId, row.scopeKey, row.name,
+      row.normalizedName, row.filtersJson, row.sortOrder, row.createdAt, row.updatedAt,
+    );
+  } catch (error) {
+    if (isConstraintError(error)) {
+      return c.json({ error: "当前空间已存在同名视图", code: "VIEW_NAME_CONFLICT" }, 409);
+    }
+    throw error;
+  }
+  return c.json({ view: publicView(row, userId, scope) }, 201);
+});
+
+taskMetadata.put("/views/:id", async (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const id = c.req.param("id");
+  const existing = getDb().prepare("SELECT * FROM task_saved_views WHERE id = ? AND userId = ?").get(id, userId) as TaskSavedViewRow | undefined;
+  if (!existing) return c.json({ error: "保存视图不存在", code: "VIEW_NOT_FOUND" }, 404);
+  const scope = resolveScope(userId, existing.workspaceId || "personal");
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const body = await readBody(c);
+  const name = body.name === undefined ? existing.name : normalizeName(body.name, 60);
+  if (!name) return c.json({ error: "视图名称不能为空", code: "INVALID_VIEW_NAME" }, 400);
+  const rawFilters = body.filters === undefined
+    ? parseFilters(existing, userId, scope)
+    : normalizeTaskSavedViewFilters(body.filters);
+  if (!validateProjectScope(userId, scope, rawFilters.projectId)) {
+    return c.json({ error: "项目不属于当前空间", code: "INVALID_PROJECT_SCOPE" }, 400);
+  }
+  const filters = cleanFiltersForScope(userId, scope, rawFilters);
+  const sortOrder = Number.isInteger(body.sortOrder) ? Number(body.sortOrder) : existing.sortOrder;
+  const now = new Date().toISOString();
+  try {
+    getDb().prepare(`
+      UPDATE task_saved_views
+      SET name = ?, normalizedName = ?, filtersJson = ?, sortOrder = ?, updatedAt = ?
+      WHERE id = ? AND userId = ?
+    `).run(name, normalizedName(name), JSON.stringify(filters), sortOrder, now, id, userId);
+  } catch (error) {
+    if (isConstraintError(error)) {
+      return c.json({ error: "当前空间已存在同名视图", code: "VIEW_NAME_CONFLICT" }, 409);
+    }
+    throw error;
+  }
+  const updated = getDb().prepare("SELECT * FROM task_saved_views WHERE id = ?").get(id) as TaskSavedViewRow;
+  return c.json({ view: publicView(updated, userId, scope) });
+});
+
+taskMetadata.delete("/views/:id", (c) => {
+  ensureTaskMetadataTables();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const id = c.req.param("id");
+  getDb().prepare("DELETE FROM task_saved_views WHERE id = ? AND userId = ?").run(id, userId);
+  return c.json({ success: true });
+});
+
+export default taskMetadata;

--- a/backend/src/routes/user-preferences.ts
+++ b/backend/src/routes/user-preferences.ts
@@ -4,6 +4,7 @@ import legacyRoutes from "./user-preferences-legacy";
 import reliableAIRoutes from "./ai-reliable";
 import mobileBootstrapRoutes from "./mobile-bootstrap";
 import taskDayPlansRoutes from "./task-day-plans";
+import taskMetadataRoutes from "./task-metadata";
 
 /**
  * Compatibility wrapper: existing user preference/profile endpoints stay at their
@@ -16,6 +17,10 @@ const app = new Hono();
 // under user-preferences so the feature can sync across devices without changing
 // the core tasks table or the semantics of the existing "Today" due-date filter.
 app.route("/task-day-plans", taskDayPlansRoutes);
+
+// Labels and saved views are task organization metadata. Labels may be shared in
+// a workspace, while each saved view remains account-scoped.
+app.route("/task-metadata", taskMetadataRoutes);
 
 // Root preference GET/PUT/PATCH must be mounted before the legacy router. The new
 // implementation keeps the old flat response fields while adding account-scoped

--- a/backend/src/runtime/task-metadata-migration-bootstrap.ts
+++ b/backend/src/runtime/task-metadata-migration-bootstrap.ts
@@ -1,0 +1,10 @@
+import { taskMetadataMigration } from "../db/taskMetadataMigration.js";
+import { MIGRATIONS as BASE_MIGRATIONS } from "../db/migrations.impl.js";
+
+// Register before schema.ts imports migrations.ts. This mirrors the knowledge-tree
+// feature bootstrap and avoids editing the historical migration wrapper from a
+// feature branch.
+if (!BASE_MIGRATIONS.some((migration) => migration.version === taskMetadataMigration.version)) {
+  BASE_MIGRATIONS.push(taskMetadataMigration);
+  BASE_MIGRATIONS.sort((a, b) => a.version - b.version);
+}

--- a/backend/tests/task-metadata.test.ts
+++ b/backend/tests/task-metadata.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-task-metadata-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+const USER_ID = "task-metadata-user";
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+async function requestJson(method: string, url: string, body?: unknown) {
+  const response = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": USER_ID,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, json: text ? JSON.parse(text) : null };
+}
+
+test.before(async () => {
+  const [tasksModule, metadataModule, schemaModule] = await Promise.all([
+    import("../src/routes/tasks"),
+    import("../src/routes/task-metadata"),
+    import("../src/db/schema"),
+  ]);
+  app = new Hono();
+  app.route("/tasks", tasksModule.default);
+  app.route("/task-metadata", metadataModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+  getDb().prepare(
+    "INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)",
+  ).run(USER_ID, USER_ID, "hash");
+});
+
+test.beforeEach(() => {
+  const db = getDb();
+  db.prepare("DELETE FROM task_label_links").run();
+  db.prepare("DELETE FROM task_saved_views").run();
+  db.prepare("DELETE FROM task_labels").run();
+  db.prepare("DELETE FROM task_reminders").run();
+  db.prepare("DELETE FROM task_dependencies").run();
+  db.prepare("DELETE FROM tasks").run();
+});
+
+test.after(() => {
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("creates labels, assigns them to a task and persists a saved view", async () => {
+  const task = await requestJson("POST", "/tasks", { title: "Ship task labels", priority: 3 });
+  assert.equal(task.status, 201);
+
+  const label = await requestJson("POST", "/task-metadata/labels", {
+    name: "Release",
+    color: "#10b981",
+  });
+  assert.equal(label.status, 201);
+
+  const assignment = await requestJson(
+    "PUT",
+    `/task-metadata/tasks/${task.json.id}/labels`,
+    { labelIds: [label.json.label.id] },
+  );
+  assert.equal(assignment.status, 200);
+  assert.deepEqual(assignment.json.labelIds, [label.json.label.id]);
+
+  const view = await requestJson("POST", "/task-metadata/views", {
+    name: "Release focus",
+    filters: {
+      labelIds: [label.json.label.id],
+      labelMode: "all",
+      priorities: [3],
+      statuses: ["todo", "doing"],
+      due: "pending",
+      keyword: "ship",
+    },
+  });
+  assert.equal(view.status, 201);
+  assert.deepEqual(view.json.view.filters.labelIds, [label.json.label.id]);
+
+  const snapshot = await requestJson("GET", "/task-metadata");
+  assert.equal(snapshot.status, 200);
+  assert.equal(snapshot.json.labels[0].taskCount, 1);
+  assert.deepEqual(snapshot.json.assignments[task.json.id], [label.json.label.id]);
+  assert.equal(snapshot.json.views[0].name, "Release focus");
+});
+
+test("rejects duplicate label names after case normalization", async () => {
+  const first = await requestJson("POST", "/task-metadata/labels", { name: "Urgent" });
+  assert.equal(first.status, 201);
+
+  const duplicate = await requestJson("POST", "/task-metadata/labels", { name: " urgent " });
+  assert.equal(duplicate.status, 409);
+  assert.equal(duplicate.json.code, "LABEL_NAME_CONFLICT");
+});
+
+test("deleting a label removes task links and prunes saved view filters", async () => {
+  const task = await requestJson("POST", "/tasks", { title: "Clean metadata" });
+  const label = await requestJson("POST", "/task-metadata/labels", { name: "Cleanup" });
+  await requestJson("PUT", `/task-metadata/tasks/${task.json.id}/labels`, {
+    labelIds: [label.json.label.id],
+  });
+  await requestJson("POST", "/task-metadata/views", {
+    name: "Cleanup view",
+    filters: { labelIds: [label.json.label.id] },
+  });
+
+  const removed = await requestJson("DELETE", `/task-metadata/labels/${label.json.label.id}`);
+  assert.equal(removed.status, 200);
+
+  const snapshot = await requestJson("GET", "/task-metadata");
+  assert.deepEqual(snapshot.json.labels, []);
+  assert.deepEqual(snapshot.json.assignments, {});
+  assert.deepEqual(snapshot.json.views[0].filters.labelIds, []);
+});

--- a/backend/tests/task-metadata.test.ts
+++ b/backend/tests/task-metadata.test.ts
@@ -28,17 +28,23 @@ async function requestJson(method: string, url: string, body?: unknown) {
 }
 
 test.before(async () => {
-  const [tasksModule, metadataModule, schemaModule] = await Promise.all([
+  const [tasksModule, metadataModule, schemaModule, migrationModule] = await Promise.all([
     import("../src/routes/tasks"),
     import("../src/routes/task-metadata"),
     import("../src/db/schema"),
+    import("../src/db/taskMetadataMigration"),
   ]);
   app = new Hono();
   app.route("/tasks", tasksModule.default);
   app.route("/task-metadata", metadataModule.default);
   getDb = schemaModule.getDb;
   closeDb = schemaModule.closeDb;
-  getDb().prepare(
+
+  const db = getDb();
+  // The route also installs the schema lazily on first request. Tests clean the
+  // tables in beforeEach, so initialize v71 explicitly before that hook runs.
+  migrationModule.taskMetadataMigration.up(db);
+  db.prepare(
     "INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)",
   ).run(USER_ID, USER_ID, "hash");
 });

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
 import { MyDayPanel } from "./tasks/MyDayPanel";
+import { TaskMetadataWorkspace } from "./tasks/TaskMetadataWorkspace";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
 
 export * from "./TaskCenterImpl";
@@ -15,9 +16,7 @@ export default function TaskCenter() {
 
   useEffect(() => {
     const handleWorkspaceChange = () => {
-      // Remount the full task center. This immediately drops the previous
-      // workspace state, and late promises from the unmounted instance cannot
-      // overwrite the newly selected workspace.
+      // Remount planning state, smart views and the legacy task center together.
       remountTaskWorkspace();
     };
     window.addEventListener("nowen:workspace-changed", handleWorkspaceChange);
@@ -26,7 +25,7 @@ export default function TaskCenter() {
 
   useEffect(() => {
     // Keep a long-running desktop/web session aligned with the local calendar day.
-    // Changing this key remounts only My Day; task deadlines and the task center stay untouched.
+    // Changing this key remounts only My Day; labels and saved views remain intact.
     const timer = window.setInterval(() => {
       const nextDayKey = new Date().toDateString();
       setLocalDayKey((current) => current === nextDayKey ? current : nextDayKey);
@@ -53,14 +52,16 @@ export default function TaskCenter() {
   }, []);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <MyDayPanel
-        key={`my-day-${workspaceGeneration}-${localDayKey}`}
-        onTaskMutated={remountTaskWorkspace}
-      />
-      <div className="min-h-0 flex-1">
-        <TaskCenterImpl key={workspaceGeneration} />
+    <TaskMetadataWorkspace key={workspaceGeneration}>
+      <div className="flex h-full min-h-0 flex-col">
+        <MyDayPanel
+          key={`my-day-${workspaceGeneration}-${localDayKey}`}
+          onTaskMutated={remountTaskWorkspace}
+        />
+        <div className="min-h-0 flex-1">
+          <TaskCenterImpl />
+        </div>
       </div>
-    </div>
+    </TaskMetadataWorkspace>
   );
 }

--- a/frontend/src/components/tasks/TaskMetadataWorkspace.tsx
+++ b/frontend/src/components/tasks/TaskMetadataWorkspace.tsx
@@ -1,0 +1,730 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Bookmark,
+  BookmarkPlus,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  Filter,
+  Flag,
+  FolderOpen,
+  Loader2,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Search,
+  Tag,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import type { Task, TaskProject } from "@/types";
+import {
+  createTaskLabel,
+  createTaskSavedView,
+  deleteTaskLabel,
+  deleteTaskSavedView,
+  EMPTY_TASK_SAVED_VIEW_FILTERS,
+  getTaskMetadata,
+  setTaskLabels,
+  updateTaskLabel,
+  updateTaskSavedView,
+  type TaskLabel,
+  type TaskMetadataDue,
+  type TaskMetadataSnapshot,
+  type TaskMetadataStatus,
+  type TaskSavedViewFilters,
+} from "@/lib/taskMetadataApi";
+import {
+  countTaskSavedViewFilters,
+  filterTasksBySavedView,
+  hasTaskSavedViewFilters,
+} from "./taskSavedViewFilter";
+
+const COLORS = [
+  "#6366f1",
+  "#ef4444",
+  "#f59e0b",
+  "#10b981",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+  "#6b7280",
+];
+
+function emptyFilters(): TaskSavedViewFilters {
+  return {
+    ...EMPTY_TASK_SAVED_VIEW_FILTERS,
+    labelIds: [],
+    priorities: [],
+    statuses: [],
+  };
+}
+
+function emptySnapshot(): TaskMetadataSnapshot {
+  return { workspaceId: "personal", labels: [], assignments: {}, views: [] };
+}
+
+function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    if (a.isCompleted !== b.isCompleted) return a.isCompleted - b.isCompleted;
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    const aDate = a.dueAt || a.dueDate || "9999-12-31";
+    const bDate = b.dueAt || b.dueDate || "9999-12-31";
+    return aDate.localeCompare(bDate) || a.sortOrder - b.sortOrder;
+  });
+}
+
+function taskDate(task: Task): string {
+  return (task.dueAt || task.dueDate || "").slice(0, 16).replace("T", " ");
+}
+
+function Dialog({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/45 p-4"
+      onMouseDown={onClose}
+    >
+      <div
+        className="max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-xl border border-app-border bg-app-surface shadow-2xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function TaskMetadataWorkspace({ children }: { children: React.ReactNode }) {
+  const { i18n } = useTranslation();
+  const zh = i18n.language.toLowerCase().startsWith("zh");
+  const copy = useMemo(() => zh ? {
+    smart: "智能视图",
+    filter: "筛选",
+    saved: "保存的视图",
+    noSaved: "暂无保存视图",
+    labels: "任务标签",
+    manageLabels: "管理标签",
+    assignLabels: "标注任务",
+    saveView: "保存视图",
+    saveAs: "另存视图",
+    updateView: "更新视图",
+    clear: "清除筛选",
+    any: "任一标签",
+    all: "全部标签",
+    due: "时间范围",
+    project: "项目",
+    keyword: "关键词",
+    anyProject: "全部项目",
+    noProject: "无项目",
+    priority: "优先级",
+    status: "状态",
+    pending: "未完成",
+    today: "今天到期",
+    week: "未来 7 天",
+    overdue: "已逾期",
+    completed: "已完成",
+    todo: "待处理",
+    doing: "进行中",
+    blocked: "已阻塞",
+    done: "已完成",
+    high: "高",
+    medium: "中",
+    low: "低",
+    results: "条任务",
+    noResults: "没有符合当前条件的任务",
+    normal: "返回普通任务中心",
+    newLabel: "新建标签",
+    labelName: "标签名称",
+    viewName: "视图名称",
+    taskSearch: "搜索任务…",
+    create: "创建",
+    save: "保存",
+    cancel: "取消",
+    close: "关闭",
+    edit: "编辑",
+    remove: "删除",
+    loadFailed: "加载任务标签和保存视图失败",
+    updateFailed: "更新失败",
+    workspaceHint: "工作区标签为共享资源；保存视图仅属于当前账号。",
+  } : {
+    smart: "Smart views",
+    filter: "Filters",
+    saved: "Saved views",
+    noSaved: "No saved views",
+    labels: "Task labels",
+    manageLabels: "Manage labels",
+    assignLabels: "Label tasks",
+    saveView: "Save view",
+    saveAs: "Save as",
+    updateView: "Update view",
+    clear: "Clear filters",
+    any: "Match any",
+    all: "Match all",
+    due: "Due range",
+    project: "Project",
+    keyword: "Keyword",
+    anyProject: "Any project",
+    noProject: "No project",
+    priority: "Priority",
+    status: "Status",
+    pending: "Pending",
+    today: "Due today",
+    week: "Next 7 days",
+    overdue: "Overdue",
+    completed: "Completed",
+    todo: "To do",
+    doing: "Doing",
+    blocked: "Blocked",
+    done: "Done",
+    high: "High",
+    medium: "Medium",
+    low: "Low",
+    results: "tasks",
+    noResults: "No tasks match these filters",
+    normal: "Return to task center",
+    newLabel: "New label",
+    labelName: "Label name",
+    viewName: "View name",
+    taskSearch: "Search tasks…",
+    create: "Create",
+    save: "Save",
+    cancel: "Cancel",
+    close: "Close",
+    edit: "Edit",
+    remove: "Delete",
+    loadFailed: "Failed to load task labels and saved views",
+    updateFailed: "Update failed",
+    workspaceHint: "Workspace labels are shared; saved views belong to your account.",
+  }, [zh]);
+
+  const [snapshot, setSnapshot] = useState<TaskMetadataSnapshot>(emptySnapshot);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [projects, setProjects] = useState<TaskProject[]>([]);
+  const [filters, setFilters] = useState<TaskSavedViewFilters>(emptyFilters);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [loadingMetadata, setLoadingMetadata] = useState(true);
+  const [loadingTasks, setLoadingTasks] = useState(false);
+  const [tasksLoaded, setTasksLoaded] = useState(false);
+  const [labelDialog, setLabelDialog] = useState(false);
+  const [assignDialog, setAssignDialog] = useState(false);
+  const [viewDialog, setViewDialog] = useState(false);
+  const [viewName, setViewName] = useState("");
+  const [newLabelName, setNewLabelName] = useState("");
+  const [newLabelColor, setNewLabelColor] = useState(COLORS[0]);
+  const [editingLabel, setEditingLabel] = useState<TaskLabel | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editingColor, setEditingColor] = useState(COLORS[0]);
+  const [taskQuery, setTaskQuery] = useState("");
+  const [assigningTaskId, setAssigningTaskId] = useState<string | null>(null);
+
+  const smartActive = hasTaskSavedViewFilters(filters);
+  const filterCount = countTaskSavedViewFilters(filters);
+
+  const loadMetadata = useCallback(async () => {
+    setLoadingMetadata(true);
+    try {
+      const [metadata, projectRows] = await Promise.all([
+        getTaskMetadata(),
+        api.getTaskProjects(),
+      ]);
+      setSnapshot(metadata);
+      setProjects(projectRows);
+    } catch (error) {
+      console.error("task metadata load failed", error);
+      toast.error(copy.loadFailed);
+    } finally {
+      setLoadingMetadata(false);
+    }
+  }, [copy.loadFailed]);
+
+  const loadTasks = useCallback(async () => {
+    if (loadingTasks) return;
+    setLoadingTasks(true);
+    try {
+      setTasks(await api.getTasks("all"));
+      setTasksLoaded(true);
+    } catch (error) {
+      console.error("task metadata task load failed", error);
+      toast.error(copy.loadFailed);
+      setTasksLoaded(true);
+    } finally {
+      setLoadingTasks(false);
+    }
+  }, [copy.loadFailed, loadingTasks]);
+
+  useEffect(() => { void loadMetadata(); }, [loadMetadata]);
+  useEffect(() => {
+    if (smartActive && !tasksLoaded && !loadingTasks) void loadTasks();
+  }, [loadTasks, loadingTasks, smartActive, tasksLoaded]);
+
+  const labelMap = useMemo(
+    () => new Map(snapshot.labels.map((label) => [label.id, label])),
+    [snapshot.labels],
+  );
+  const projectMap = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects],
+  );
+  const filteredTasks = useMemo(
+    () => sortTasks(filterTasksBySavedView(tasks, filters, snapshot.assignments)),
+    [filters, snapshot.assignments, tasks],
+  );
+
+  const patchFilters = (patch: Partial<TaskSavedViewFilters>) => {
+    setFilters((current) => ({ ...current, ...patch }));
+  };
+  const toggleValue = <T,>(values: T[], value: T): T[] => (
+    values.includes(value) ? values.filter((item) => item !== value) : [...values, value]
+  );
+
+  const clearFilters = () => {
+    setFilters(emptyFilters());
+    setActiveViewId(null);
+    setFilterOpen(false);
+  };
+
+  const applyView = (id: string) => {
+    const view = snapshot.views.find((item) => item.id === id);
+    if (!view) return;
+    setFilters({
+      ...view.filters,
+      labelIds: [...view.filters.labelIds],
+      priorities: [...view.filters.priorities],
+      statuses: [...view.filters.statuses],
+    });
+    setActiveViewId(id);
+    setFilterOpen(false);
+  };
+
+  const createLabel = async () => {
+    if (!newLabelName.trim()) return;
+    try {
+      await createTaskLabel({ name: newLabelName, color: newLabelColor });
+      setNewLabelName("");
+      await loadMetadata();
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const saveLabel = async () => {
+    if (!editingLabel || !editingName.trim()) return;
+    try {
+      await updateTaskLabel(editingLabel.id, { name: editingName, color: editingColor });
+      setEditingLabel(null);
+      await loadMetadata();
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const removeLabel = async (label: TaskLabel) => {
+    const confirmed = window.confirm(
+      zh ? `删除标签「${label.name}」？任务不会被删除。` : `Delete “${label.name}”? Tasks will remain.`,
+    );
+    if (!confirmed) return;
+    try {
+      await deleteTaskLabel(label.id);
+      setFilters((current) => ({
+        ...current,
+        labelIds: current.labelIds.filter((id) => id !== label.id),
+      }));
+      await loadMetadata();
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const openAssignments = async (task?: Task) => {
+    setAssignDialog(true);
+    setTaskQuery(task?.title || "");
+    if (!tasksLoaded) await loadTasks();
+  };
+
+  const toggleTaskLabel = async (taskId: string, labelId: string) => {
+    if (assigningTaskId) return;
+    const previous = snapshot.assignments[taskId] || [];
+    const next = previous.includes(labelId)
+      ? previous.filter((id) => id !== labelId)
+      : [...previous, labelId];
+    setAssigningTaskId(taskId);
+    setSnapshot((current) => ({
+      ...current,
+      assignments: { ...current.assignments, [taskId]: next },
+    }));
+    try {
+      await setTaskLabels(taskId, next);
+      await loadMetadata();
+    } catch (error) {
+      setSnapshot((current) => ({
+        ...current,
+        assignments: { ...current.assignments, [taskId]: previous },
+      }));
+      toast.error((error as Error).message || copy.updateFailed);
+    } finally {
+      setAssigningTaskId(null);
+    }
+  };
+
+  const createView = async () => {
+    if (!viewName.trim() || !smartActive) return;
+    try {
+      const result = await createTaskSavedView({ name: viewName, filters });
+      setViewName("");
+      setViewDialog(false);
+      await loadMetadata();
+      setActiveViewId(result.view.id);
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const updateView = async () => {
+    if (!activeViewId) return;
+    try {
+      await updateTaskSavedView(activeViewId, { filters });
+      await loadMetadata();
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const removeView = async (id: string) => {
+    const view = snapshot.views.find((item) => item.id === id);
+    const confirmed = window.confirm(
+      zh ? `删除视图「${view?.name || ""}」？` : `Delete view “${view?.name || ""}”?`,
+    );
+    if (!confirmed) return;
+    try {
+      await deleteTaskSavedView(id);
+      if (activeViewId === id) clearFilters();
+      await loadMetadata();
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const toggleComplete = async (task: Task) => {
+    try {
+      const result = await api.updateTask(task.id, {
+        isCompleted: task.isCompleted === 1 ? 0 : 1,
+      });
+      setTasks((current) => current.map((item) => item.id === task.id ? result.task : item));
+    } catch (error) {
+      toast.error((error as Error).message || copy.updateFailed);
+    }
+  };
+
+  const visibleAssignmentTasks = useMemo(() => {
+    const query = taskQuery.trim().toLocaleLowerCase();
+    return (query
+      ? tasks.filter((task) => `${task.title}\n${task.description || ""}`.toLocaleLowerCase().includes(query))
+      : tasks
+    ).slice(0, 100);
+  }, [taskQuery, tasks]);
+
+  const dueOptions: Array<{ value: TaskMetadataDue; label: string }> = [
+    { value: "all", label: zh ? "全部" : "All" },
+    { value: "pending", label: copy.pending },
+    { value: "today", label: copy.today },
+    { value: "week", label: copy.week },
+    { value: "overdue", label: copy.overdue },
+    { value: "completed", label: copy.completed },
+  ];
+  const statusOptions: Array<{ value: TaskMetadataStatus; label: string }> = [
+    { value: "todo", label: copy.todo },
+    { value: "doing", label: copy.doing },
+    { value: "blocked", label: copy.blocked },
+    { value: "done", label: copy.done },
+  ];
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col bg-app-bg">
+      <div className="shrink-0 border-b border-app-border bg-app-surface">
+        <div className="flex min-h-11 items-center gap-2 px-3 md:px-4">
+          <Bookmark size={15} className="shrink-0 text-accent-primary" />
+          <span className="hidden shrink-0 text-sm font-semibold text-tx-primary sm:inline">{copy.smart}</span>
+          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-1 [scrollbar-width:none]">
+            {snapshot.views.length === 0 ? (
+              <span className="hidden text-xs text-tx-tertiary md:inline">{copy.noSaved}</span>
+            ) : snapshot.views.map((view) => (
+              <div key={view.id} className="group flex shrink-0 items-center rounded-full border border-app-border bg-app-bg">
+                <button
+                  onClick={() => applyView(view.id)}
+                  className={cn(
+                    "max-w-40 truncate px-2.5 py-1 text-xs",
+                    activeViewId === view.id ? "font-medium text-accent-primary" : "text-tx-secondary hover:text-tx-primary",
+                  )}
+                >{view.name}</button>
+                <button
+                  onClick={() => void removeView(view.id)}
+                  className="mr-1 hidden rounded-full p-0.5 text-tx-tertiary hover:bg-app-hover hover:text-red-500 group-hover:inline-flex"
+                  title={copy.remove}
+                ><X size={10} /></button>
+              </div>
+            ))}
+          </div>
+
+          <button
+            onClick={() => setFilterOpen((value) => !value)}
+            className={cn(
+              "flex shrink-0 items-center gap-1 rounded-md px-2 py-1.5 text-xs",
+              filterOpen || smartActive ? "bg-accent-primary/10 text-accent-primary" : "text-tx-secondary hover:bg-app-hover",
+            )}
+          >
+            <Filter size={13} />
+            <span className="hidden sm:inline">{copy.filter}</span>
+            {filterCount > 0 && <span className="rounded-full bg-accent-primary px-1.5 text-[9px] text-white">{filterCount}</span>}
+            <ChevronDown size={11} className={cn("transition-transform", filterOpen && "rotate-180")} />
+          </button>
+          <button onClick={() => setLabelDialog(true)} className="rounded-md p-1.5 text-tx-secondary hover:bg-app-hover hover:text-accent-primary" title={copy.manageLabels}>
+            <Tag size={14} />
+          </button>
+          <button onClick={() => void openAssignments()} className="hidden items-center gap-1 rounded-md px-2 py-1.5 text-xs text-tx-secondary hover:bg-app-hover hover:text-accent-primary md:flex">
+            <Pencil size={13} /> {copy.assignLabels}
+          </button>
+          {smartActive && (
+            <>
+              {activeViewId && (
+                <button onClick={() => void updateView()} className="hidden items-center gap-1 rounded-md px-2 py-1.5 text-xs text-accent-primary hover:bg-accent-primary/10 md:flex">
+                  <Check size={13} /> {copy.updateView}
+                </button>
+              )}
+              <button onClick={() => setViewDialog(true)} className="hidden items-center gap-1 rounded-md px-2 py-1.5 text-xs text-accent-primary hover:bg-accent-primary/10 md:flex">
+                <BookmarkPlus size={13} /> {activeViewId ? copy.saveAs : copy.saveView}
+              </button>
+              <button onClick={clearFilters} className="rounded-md p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary" title={copy.clear}>
+                <RotateCcw size={14} />
+              </button>
+            </>
+          )}
+        </div>
+
+        {filterOpen && (
+          <div className="space-y-3 border-t border-app-border px-3 py-3 md:px-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="w-20 text-xs font-medium text-tx-secondary">{copy.labels}</span>
+              <div className="flex flex-1 flex-wrap gap-1.5">
+                {snapshot.labels.map((label) => {
+                  const active = filters.labelIds.includes(label.id);
+                  return (
+                    <button
+                      key={label.id}
+                      onClick={() => patchFilters({ labelIds: toggleValue(filters.labelIds, label.id) })}
+                      className={cn(
+                        "flex items-center gap-1 rounded-full border px-2 py-1 text-xs",
+                        active ? "border-transparent text-white" : "border-app-border text-tx-secondary hover:bg-app-hover",
+                      )}
+                      style={active ? { backgroundColor: label.color } : undefined}
+                    >
+                      <span className="h-2 w-2 rounded-full" style={{ backgroundColor: label.color }} />
+                      {label.name}
+                    </button>
+                  );
+                })}
+                {snapshot.labels.length === 0 && (
+                  <button onClick={() => setLabelDialog(true)} className="text-xs text-accent-primary hover:underline">{copy.newLabel}</button>
+                )}
+              </div>
+              {filters.labelIds.length > 1 && (
+                <div className="flex overflow-hidden rounded-md border border-app-border text-[10px]">
+                  <button onClick={() => patchFilters({ labelMode: "any" })} className={cn("px-2 py-1", filters.labelMode === "any" ? "bg-accent-primary text-white" : "text-tx-tertiary")}>{copy.any}</button>
+                  <button onClick={() => patchFilters({ labelMode: "all" })} className={cn("px-2 py-1", filters.labelMode === "all" ? "bg-accent-primary text-white" : "text-tx-tertiary")}>{copy.all}</button>
+                </div>
+              )}
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <label className="space-y-1">
+                <span className="text-xs font-medium text-tx-secondary">{copy.due}</span>
+                <select value={filters.due} onChange={(event) => patchFilters({ due: event.target.value as TaskMetadataDue })} className="w-full rounded-md border border-app-border bg-app-bg px-2 py-1.5 text-xs text-tx-primary focus:border-accent-primary focus:outline-none">
+                  {dueOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+              <label className="space-y-1">
+                <span className="text-xs font-medium text-tx-secondary">{copy.project}</span>
+                <select
+                  value={filters.projectId === undefined ? "__any__" : filters.projectId === null ? "__none__" : filters.projectId}
+                  onChange={(event) => patchFilters({
+                    projectId: event.target.value === "__any__" ? undefined : event.target.value === "__none__" ? null : event.target.value,
+                  })}
+                  className="w-full rounded-md border border-app-border bg-app-bg px-2 py-1.5 text-xs text-tx-primary focus:border-accent-primary focus:outline-none"
+                >
+                  <option value="__any__">{copy.anyProject}</option>
+                  <option value="__none__">{copy.noProject}</option>
+                  {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+                </select>
+              </label>
+              <label className="space-y-1 md:col-span-2">
+                <span className="text-xs font-medium text-tx-secondary">{copy.keyword}</span>
+                <div className="flex items-center rounded-md border border-app-border bg-app-bg px-2">
+                  <Search size={12} className="text-tx-tertiary" />
+                  <input value={filters.keyword} onChange={(event) => patchFilters({ keyword: event.target.value })} className="w-full bg-transparent px-2 py-1.5 text-xs text-tx-primary focus:outline-none" />
+                </div>
+              </label>
+            </div>
+
+            <div className="flex flex-wrap gap-x-6 gap-y-2">
+              <div className="flex items-center gap-1.5">
+                <span className="mr-1 text-xs font-medium text-tx-secondary">{copy.priority}</span>
+                {[
+                  { value: 3, label: copy.high, color: "text-red-500" },
+                  { value: 2, label: copy.medium, color: "text-amber-500" },
+                  { value: 1, label: copy.low, color: "text-blue-500" },
+                ].map((option) => (
+                  <button key={option.value} onClick={() => patchFilters({ priorities: toggleValue(filters.priorities, option.value) })} className={cn("flex items-center gap-1 rounded-md border px-2 py-1 text-xs", filters.priorities.includes(option.value) ? "border-accent-primary bg-accent-primary/10" : "border-app-border hover:bg-app-hover", option.color)}>
+                    <Flag size={11} /> {option.label}
+                  </button>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span className="mr-1 text-xs font-medium text-tx-secondary">{copy.status}</span>
+                {statusOptions.map((option) => (
+                  <button key={option.value} onClick={() => patchFilters({ statuses: toggleValue(filters.statuses, option.value) })} className={cn("rounded-md border px-2 py-1 text-xs", filters.statuses.includes(option.value) ? "border-accent-primary bg-accent-primary/10 text-accent-primary" : "border-app-border text-tx-tertiary hover:bg-app-hover")}>{option.label}</button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 border-t border-app-border pt-2 md:hidden">
+              {smartActive && activeViewId && <button onClick={() => void updateView()} className="text-xs text-accent-primary">{copy.updateView}</button>}
+              {smartActive && <button onClick={() => setViewDialog(true)} className="text-xs text-accent-primary">{copy.saveView}</button>}
+              <button onClick={() => void openAssignments()} className="text-xs text-accent-primary">{copy.assignLabels}</button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {!smartActive ? children : (
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex shrink-0 items-center justify-between border-b border-app-border px-4 py-2.5 md:px-6">
+              <div>
+                <div className="flex items-center gap-2 text-sm font-semibold text-tx-primary">
+                  <Filter size={14} className="text-accent-primary" />
+                  {activeViewId ? snapshot.views.find((view) => view.id === activeViewId)?.name || copy.smart : copy.smart}
+                </div>
+                <p className="mt-0.5 text-[11px] text-tx-tertiary">{copy.workspaceHint}</p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-tx-tertiary">{filteredTasks.length} {copy.results}</span>
+                <button onClick={clearFilters} className="text-xs text-accent-primary hover:underline">{copy.normal}</button>
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3 md:px-6">
+              {loadingTasks ? (
+                <div className="flex h-40 items-center justify-center"><Loader2 size={20} className="animate-spin text-tx-tertiary" /></div>
+              ) : filteredTasks.length === 0 ? (
+                <div className="flex h-40 flex-col items-center justify-center gap-2 text-sm text-tx-tertiary"><Filter size={24} />{copy.noResults}</div>
+              ) : (
+                <div className="mx-auto max-w-5xl space-y-2">
+                  {filteredTasks.map((task) => (
+                    <div key={task.id} className={cn("group flex items-start gap-3 rounded-lg border border-app-border bg-app-elevated px-3 py-2.5 hover:border-accent-primary/30", task.isCompleted === 1 && "opacity-60") }>
+                      <button onClick={() => void toggleComplete(task)} className="mt-0.5 shrink-0">
+                        {task.isCompleted === 1 ? <CheckCircle2 size={19} className="text-accent-primary" /> : <Circle size={19} className="text-tx-tertiary hover:text-accent-primary" />}
+                      </button>
+                      <div className="min-w-0 flex-1">
+                        <div className={cn("text-sm text-tx-primary", task.isCompleted === 1 && "line-through text-tx-tertiary")}>{task.title}</div>
+                        {task.description && <p className="mt-0.5 line-clamp-1 text-xs text-tx-tertiary">{task.description}</p>}
+                        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                          {task.projectId && projectMap.get(task.projectId) && (
+                            <span className="flex items-center gap-1 rounded-full bg-app-hover px-2 py-0.5 text-[10px] text-tx-secondary">
+                              <FolderOpen size={9} style={{ color: projectMap.get(task.projectId)?.color }} />
+                              {projectMap.get(task.projectId)?.name}
+                            </span>
+                          )}
+                          {(snapshot.assignments[task.id] || []).map((labelId) => {
+                            const label = labelMap.get(labelId);
+                            return label ? <span key={label.id} className="rounded-full px-2 py-0.5 text-[10px] text-white" style={{ backgroundColor: label.color }}>{label.name}</span> : null;
+                          })}
+                          {taskDate(task) && <span className="text-[10px] text-tx-tertiary">{taskDate(task)}</span>}
+                        </div>
+                      </div>
+                      <Flag size={13} className={task.priority === 3 ? "text-red-500" : task.priority === 2 ? "text-amber-500" : "text-blue-500"} />
+                      <button onClick={() => void openAssignments(task)} className="rounded-md p-1 text-tx-tertiary opacity-0 hover:bg-app-hover hover:text-accent-primary group-hover:opacity-100" title={copy.assignLabels}><Tag size={14} /></button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {labelDialog && (
+        <Dialog onClose={() => setLabelDialog(false)}>
+          <div className="flex items-center justify-between border-b border-app-border px-5 py-3">
+            <div><h3 className="text-sm font-semibold text-tx-primary">{copy.manageLabels}</h3><p className="mt-0.5 text-[11px] text-tx-tertiary">{copy.workspaceHint}</p></div>
+            <button onClick={() => setLabelDialog(false)} className="rounded p-1 text-tx-tertiary hover:bg-app-hover"><X size={16} /></button>
+          </div>
+          <div className="max-h-[72vh] space-y-4 overflow-y-auto p-5">
+            <div className="rounded-lg border border-app-border bg-app-bg p-3">
+              <div className="flex gap-2">
+                <input value={newLabelName} onChange={(event) => setNewLabelName(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void createLabel(); }} placeholder={copy.labelName} className="min-w-0 flex-1 rounded-md border border-app-border bg-app-surface px-3 py-2 text-sm text-tx-primary focus:border-accent-primary focus:outline-none" />
+                <button onClick={() => void createLabel()} className="flex items-center gap-1 rounded-md bg-accent-primary px-3 py-2 text-xs text-white"><Plus size={13} />{copy.create}</button>
+              </div>
+              <div className="mt-2 flex gap-1.5">{COLORS.map((color) => <button key={color} onClick={() => setNewLabelColor(color)} className={cn("h-5 w-5 rounded-full border-2", newLabelColor === color ? "border-tx-primary" : "border-transparent")} style={{ backgroundColor: color }} />)}</div>
+            </div>
+            <div className="space-y-2">
+              {snapshot.labels.map((label) => (
+                <div key={label.id} className="rounded-lg border border-app-border bg-app-elevated p-3">
+                  {editingLabel?.id === label.id ? (
+                    <div className="space-y-2">
+                      <input value={editingName} onChange={(event) => setEditingName(event.target.value)} className="w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-primary focus:border-accent-primary focus:outline-none" />
+                      <div className="flex items-center justify-between">
+                        <div className="flex gap-1.5">{COLORS.map((color) => <button key={color} onClick={() => setEditingColor(color)} className={cn("h-5 w-5 rounded-full border-2", editingColor === color ? "border-tx-primary" : "border-transparent")} style={{ backgroundColor: color }} />)}</div>
+                        <div className="flex gap-2"><button onClick={() => setEditingLabel(null)} className="text-xs text-tx-tertiary">{copy.cancel}</button><button onClick={() => void saveLabel()} className="rounded-md bg-accent-primary px-3 py-1.5 text-xs text-white">{copy.save}</button></div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-3">
+                      <span className="h-3 w-3 rounded-full" style={{ backgroundColor: label.color }} />
+                      <div className="min-w-0 flex-1"><div className="truncate text-sm text-tx-primary">{label.name}</div><div className="text-[10px] text-tx-tertiary">{label.taskCount} {copy.results}</div></div>
+                      <button onClick={() => { setEditingLabel(label); setEditingName(label.name); setEditingColor(label.color); }} className="rounded p-1 text-tx-tertiary hover:bg-app-hover hover:text-accent-primary" title={copy.edit}><Pencil size={14} /></button>
+                      <button onClick={() => void removeLabel(label)} className="rounded p-1 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500" title={copy.remove}><Trash2 size={14} /></button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </Dialog>
+      )}
+
+      {assignDialog && (
+        <Dialog onClose={() => setAssignDialog(false)}>
+          <div className="flex items-center justify-between border-b border-app-border px-5 py-3">
+            <div><h3 className="text-sm font-semibold text-tx-primary">{copy.assignLabels}</h3><p className="mt-0.5 text-[11px] text-tx-tertiary">{copy.workspaceHint}</p></div>
+            <button onClick={() => setAssignDialog(false)} className="rounded p-1 text-tx-tertiary hover:bg-app-hover"><X size={16} /></button>
+          </div>
+          <div className="border-b border-app-border p-4"><div className="flex items-center rounded-md border border-app-border bg-app-bg px-3"><Search size={14} className="text-tx-tertiary" /><input value={taskQuery} onChange={(event) => setTaskQuery(event.target.value)} placeholder={copy.taskSearch} className="w-full bg-transparent px-2 py-2 text-sm text-tx-primary focus:outline-none" /></div></div>
+          <div className="max-h-[65vh] space-y-2 overflow-y-auto p-4">
+            {loadingTasks ? <div className="flex h-24 items-center justify-center"><Loader2 size={18} className="animate-spin text-tx-tertiary" /></div> : snapshot.labels.length === 0 ? <button onClick={() => { setAssignDialog(false); setLabelDialog(true); }} className="w-full py-10 text-sm text-accent-primary">{copy.newLabel}</button> : visibleAssignmentTasks.map((task) => (
+              <div key={task.id} className="rounded-lg border border-app-border bg-app-elevated p-3">
+                <div className="flex items-center gap-2"><span className={cn("min-w-0 flex-1 truncate text-sm text-tx-primary", task.isCompleted === 1 && "line-through text-tx-tertiary")}>{task.title}</span>{assigningTaskId === task.id && <Loader2 size={13} className="animate-spin text-accent-primary" />}</div>
+                <div className="mt-2 flex flex-wrap gap-1.5">{snapshot.labels.map((label) => {
+                  const active = (snapshot.assignments[task.id] || []).includes(label.id);
+                  return <button key={label.id} disabled={!!assigningTaskId} onClick={() => void toggleTaskLabel(task.id, label.id)} className={cn("flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] disabled:opacity-50", active ? "border-transparent text-white" : "border-app-border text-tx-secondary hover:bg-app-hover")} style={active ? { backgroundColor: label.color } : undefined}>{active && <Check size={10} />}{label.name}</button>;
+                })}</div>
+              </div>
+            ))}
+          </div>
+        </Dialog>
+      )}
+
+      {viewDialog && (
+        <Dialog onClose={() => setViewDialog(false)}>
+          <div className="flex items-center justify-between border-b border-app-border px-5 py-3"><h3 className="text-sm font-semibold text-tx-primary">{copy.saveView}</h3><button onClick={() => setViewDialog(false)} className="rounded p-1 text-tx-tertiary hover:bg-app-hover"><X size={16} /></button></div>
+          <div className="space-y-4 p-5"><input autoFocus value={viewName} onChange={(event) => setViewName(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void createView(); }} placeholder={copy.viewName} className="w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-sm text-tx-primary focus:border-accent-primary focus:outline-none" /><div className="flex justify-end gap-2"><button onClick={() => setViewDialog(false)} className="rounded-md px-3 py-2 text-xs text-tx-secondary hover:bg-app-hover">{copy.cancel}</button><button onClick={() => void createView()} className="rounded-md bg-accent-primary px-3 py-2 text-xs text-white">{copy.save}</button></div></div>
+        </Dialog>
+      )}
+
+      {loadingMetadata && <div className="pointer-events-none absolute right-3 top-3"><Loader2 size={14} className="animate-spin text-tx-tertiary" /></div>}
+    </div>
+  );
+}

--- a/frontend/src/components/tasks/__tests__/taskSavedViewFilter.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskSavedViewFilter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/types";
+import type { TaskSavedViewFilters } from "@/lib/taskMetadataApi";
+import {
+  countTaskSavedViewFilters,
+  filterTasksBySavedView,
+  hasTaskSavedViewFilters,
+} from "../taskSavedViewFilter";
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: overrides.id || "task-1",
+    userId: "user-1",
+    workspaceId: null,
+    title: "Default task",
+    description: "",
+    isCompleted: 0,
+    priority: 2,
+    dueDate: null,
+    dueAt: null,
+    noteId: null,
+    parentId: null,
+    sortOrder: 0,
+    projectId: null,
+    status: "todo",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function filters(overrides: Partial<TaskSavedViewFilters>): TaskSavedViewFilters {
+  return {
+    labelIds: [],
+    labelMode: "any",
+    priorities: [],
+    statuses: [],
+    due: "all",
+    keyword: "",
+    ...overrides,
+  };
+}
+
+const tasks = [
+  task({ id: "urgent", title: "Ship release", description: "Prepare changelog", priority: 3, dueDate: "2026-08-02", projectId: "project-a" }),
+  task({ id: "blocked", title: "Wait for review", dueDate: "2026-08-01", status: "blocked" }),
+  task({ id: "done", title: "Write tests", priority: 1, dueDate: "2026-08-04", status: "done", isCompleted: 1 }),
+  task({ id: "later", title: "Plan roadmap", dueDate: "2026-08-08" }),
+];
+
+const assignments = {
+  urgent: ["release", "work"],
+  blocked: ["work"],
+  done: ["quality"],
+  later: ["planning"],
+};
+
+describe("task saved view filters", () => {
+  it("combines label, priority, project and keyword filters", () => {
+    const result = filterTasksBySavedView(tasks, filters({
+      labelIds: ["release", "work"],
+      labelMode: "all",
+      priorities: [3],
+      projectId: "project-a",
+      keyword: "changelog",
+    }), assignments, "2026-08-02");
+    expect(result.map((item) => item.id)).toEqual(["urgent"]);
+  });
+
+  it("supports any-label matching and no-project filtering", () => {
+    expect(filterTasksBySavedView(tasks, filters({
+      labelIds: ["release", "quality"],
+      labelMode: "any",
+    }), assignments, "2026-08-02").map((item) => item.id)).toEqual(["urgent", "done"]);
+
+    expect(filterTasksBySavedView(tasks, filters({ projectId: null }), assignments, "2026-08-02")
+      .map((item) => item.id)).toEqual(["blocked", "done", "later"]);
+  });
+
+  it("handles due ranges", () => {
+    expect(filterTasksBySavedView(tasks, filters({ due: "overdue" }), assignments, "2026-08-02").map((item) => item.id)).toEqual(["blocked"]);
+    expect(filterTasksBySavedView(tasks, filters({ due: "today" }), assignments, "2026-08-02").map((item) => item.id)).toEqual(["urgent"]);
+    expect(filterTasksBySavedView(tasks, filters({ due: "week" }), assignments, "2026-08-02").map((item) => item.id)).toEqual(["urgent", "later"]);
+    expect(filterTasksBySavedView(tasks, filters({ due: "completed" }), assignments, "2026-08-02").map((item) => item.id)).toEqual(["done"]);
+  });
+
+  it("reports active filter groups", () => {
+    expect(hasTaskSavedViewFilters(filters({}))).toBe(false);
+    const configured = filters({ labelIds: ["work"], due: "pending", keyword: "release" });
+    expect(hasTaskSavedViewFilters(configured)).toBe(true);
+    expect(countTaskSavedViewFilters(configured)).toBe(3);
+  });
+});

--- a/frontend/src/components/tasks/taskSavedViewFilter.ts
+++ b/frontend/src/components/tasks/taskSavedViewFilter.ts
@@ -1,0 +1,91 @@
+import type { Task } from "@/types";
+import type { TaskSavedViewFilters } from "@/lib/taskMetadataApi";
+
+function dateKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(value: string, days: number): string {
+  const [year, month, day] = value.split("-").map(Number);
+  return dateKey(new Date(year, month - 1, day + days));
+}
+
+function dueKey(task: Task): string | null {
+  const match = (task.dueAt || task.dueDate || "").match(/^(\d{4}-\d{2}-\d{2})/);
+  return match?.[1] || null;
+}
+
+function statusOf(task: Task): "todo" | "doing" | "blocked" | "done" {
+  if (task.isCompleted === 1) return "done";
+  return task.status || "todo";
+}
+
+function matchesDue(task: Task, due: TaskSavedViewFilters["due"], today: string): boolean {
+  if (due === "all") return true;
+  if (due === "completed") return task.isCompleted === 1;
+  if (due === "pending") return task.isCompleted !== 1;
+  if (task.isCompleted === 1) return false;
+  const value = dueKey(task);
+  if (!value) return false;
+  if (due === "today") return value === today;
+  if (due === "overdue") return value < today;
+  if (due === "week") return value >= today && value <= addDays(today, 6);
+  return true;
+}
+
+export function hasTaskSavedViewFilters(filters: TaskSavedViewFilters): boolean {
+  return filters.labelIds.length > 0
+    || filters.priorities.length > 0
+    || filters.statuses.length > 0
+    || filters.due !== "all"
+    || !!filters.keyword.trim()
+    || filters.projectId !== undefined;
+}
+
+export function filterTasksBySavedView(
+  tasks: Task[],
+  filters: TaskSavedViewFilters,
+  assignments: Record<string, string[]>,
+  today = dateKey(),
+): Task[] {
+  const keyword = filters.keyword.trim().toLocaleLowerCase();
+  const priorities = new Set(filters.priorities);
+  const statuses = new Set(filters.statuses);
+
+  return tasks.filter((task) => {
+    if (!matchesDue(task, filters.due, today)) return false;
+    if (priorities.size > 0 && !priorities.has(task.priority)) return false;
+    if (statuses.size > 0 && !statuses.has(statusOf(task))) return false;
+
+    if (filters.projectId !== undefined) {
+      if (filters.projectId === null && task.projectId !== null) return false;
+      if (typeof filters.projectId === "string" && task.projectId !== filters.projectId) return false;
+    }
+
+    if (filters.labelIds.length > 0) {
+      const taskLabels = new Set(assignments[task.id] || []);
+      const matches = filters.labelMode === "all"
+        ? filters.labelIds.every((id) => taskLabels.has(id))
+        : filters.labelIds.some((id) => taskLabels.has(id));
+      if (!matches) return false;
+    }
+
+    if (keyword) {
+      const haystack = `${task.title}\n${task.description || ""}`.toLocaleLowerCase();
+      if (!haystack.includes(keyword)) return false;
+    }
+    return true;
+  });
+}
+
+export function countTaskSavedViewFilters(filters: TaskSavedViewFilters): number {
+  return Number(filters.labelIds.length > 0)
+    + Number(filters.priorities.length > 0)
+    + Number(filters.statuses.length > 0)
+    + Number(filters.due !== "all")
+    + Number(!!filters.keyword.trim())
+    + Number(filters.projectId !== undefined);
+}

--- a/frontend/src/lib/taskMetadataApi.ts
+++ b/frontend/src/lib/taskMetadataApi.ts
@@ -1,0 +1,143 @@
+import { getBaseUrl, getCurrentWorkspace } from "./api";
+
+export type TaskMetadataStatus = "todo" | "doing" | "blocked" | "done";
+export type TaskMetadataDue = "all" | "pending" | "today" | "week" | "overdue" | "completed";
+export type TaskLabelMode = "any" | "all";
+
+export interface TaskLabel {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  color: string;
+  sortOrder: number;
+  taskCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskSavedViewFilters {
+  labelIds: string[];
+  labelMode: TaskLabelMode;
+  priorities: number[];
+  statuses: TaskMetadataStatus[];
+  due: TaskMetadataDue;
+  keyword: string;
+  projectId?: string | null;
+}
+
+export interface TaskSavedView {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  name: string;
+  filters: TaskSavedViewFilters;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskMetadataSnapshot {
+  workspaceId: string;
+  labels: TaskLabel[];
+  assignments: Record<string, string[]>;
+  views: TaskSavedView[];
+}
+
+export const EMPTY_TASK_SAVED_VIEW_FILTERS: TaskSavedViewFilters = {
+  labelIds: [],
+  labelMode: "any",
+  priorities: [],
+  statuses: [],
+  due: "all",
+  keyword: "",
+};
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}/user-preferences/task-metadata${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+  const text = await response.text();
+  let payload: any = null;
+  if (text) {
+    try { payload = JSON.parse(text); } catch { payload = text; }
+  }
+  if (!response.ok) {
+    const error = new Error(
+      typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
+    ) as Error & { code?: string; status?: number };
+    error.code = payload?.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
+function workspaceId(): string {
+  return getCurrentWorkspace() || "personal";
+}
+
+export function getTaskMetadata(): Promise<TaskMetadataSnapshot> {
+  return request(`?workspaceId=${encodeURIComponent(workspaceId())}`);
+}
+
+export function createTaskLabel(input: { name: string; color?: string }): Promise<{ label: TaskLabel }> {
+  return request("/labels", {
+    method: "POST",
+    body: JSON.stringify({ ...input, workspaceId: workspaceId() }),
+  });
+}
+
+export function updateTaskLabel(
+  id: string,
+  input: { name?: string; color?: string; sortOrder?: number },
+): Promise<{ label: TaskLabel }> {
+  return request(`/labels/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
+export function deleteTaskLabel(id: string): Promise<{ success: boolean }> {
+  return request(`/labels/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+export function setTaskLabels(
+  taskId: string,
+  labelIds: string[],
+): Promise<{ taskId: string; labelIds: string[] }> {
+  return request(`/tasks/${encodeURIComponent(taskId)}/labels`, {
+    method: "PUT",
+    body: JSON.stringify({ labelIds }),
+  });
+}
+
+export function createTaskSavedView(input: {
+  name: string;
+  filters: TaskSavedViewFilters;
+}): Promise<{ view: TaskSavedView }> {
+  return request("/views", {
+    method: "POST",
+    body: JSON.stringify({ ...input, workspaceId: workspaceId() }),
+  });
+}
+
+export function updateTaskSavedView(
+  id: string,
+  input: { name?: string; filters?: TaskSavedViewFilters; sortOrder?: number },
+): Promise<{ view: TaskSavedView }> {
+  return request(`/views/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
+export function deleteTaskSavedView(id: string): Promise<{ success: boolean }> {
+  return request(`/views/${encodeURIComponent(id)}`, { method: "DELETE" });
+}

--- a/frontend/tsconfig.task-metadata.json
+++ b/frontend/tsconfig.task-metadata.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.task-metadata.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.d.ts",
+    "src/components/TaskCenter.tsx",
+    "src/components/tasks/TaskMetadataWorkspace.tsx",
+    "src/components/tasks/taskSavedViewFilter.ts",
+    "src/lib/taskMetadataApi.ts"
+  ]
+}


### PR DESCRIPTION
## 背景

任务中心已有固定时间筛选、项目分类和「我的一天」，但仍缺少跨项目语义组织能力，也无法把一组常用筛选条件保存为可复用视图。

本 PR 新增独立的任务标签和保存视图能力，不复用笔记标签、不复制任务数据，并已重放到包含 My Day 的最新 `main`。

## 实现内容

### 任务标签

- 个人空间标签仅属于当前用户
- 工作区标签为工作区共享资源
- 支持名称、颜色、编辑、删除和任务数量统计
- 任务与标签为多对多关系，每个任务最多 20 个标签
- 删除任务或标签时自动级联清理关联
- 支持搜索任务并批量维护其标签

### 保存视图

保存视图属于当前账号，并按空间隔离，可组合保存：

- 标签：匹配任一 / 匹配全部
- 优先级
- 任务状态
- 时间范围：未完成、今天、未来 7 天、逾期、已完成
- 项目 / 无项目
- 标题与描述关键词

### 任务中心交互

- 顶部新增轻量智能视图工具栏
- 未启用高级筛选时，原任务中心和 My Day 保持不变
- 启用筛选后进入聚焦任务列表
- 聚焦列表中可直接完成/恢复任务、查看项目与标签、定位任务并修改标签
- 已保存视图支持应用、更新、另存和删除
- 工作区切换时，My Day、智能视图和原任务中心同步重置到新空间

## 数据与兼容性

- 任务标签独立于笔记标签，避免权限和业务语义混用
- 保存视图仅保存筛选条件，不生成任务副本
- SQLite 增加正式 v71 `task-labels-and-saved-views` 迁移
- v70 My Day 迁移与路由完整保留
- PostgreSQL Pilot schema 同步增加任务标签、关联表和保存视图表
- 当前生产运行时仍使用 SQLite；本 PR 不引入生产切库逻辑
- 分支已基于合入 My Day 后的最新 `main` 重放，当前无合并冲突

## 自动验证

新增 `Task Metadata CI`：

- 后端 TypeScript 编译
- 任务标签与保存视图真实 Hono API / SQLite 持久化测试
- 前端本功能定向 TypeScript 检查
- Vite 生产打包
- 保存视图纯逻辑单元测试

同时会触发 `Task My Day CI`，验证两个任务功能组合后的入口与构建回归。

> 当前仓库完整 `npm run build` 仍会命中 `MobileKnowledgeTreePanel.tsx` 的主分支既有类型债务，因此本 PR 使用本功能定向 TypeScript 检查，并单独执行完整 Vite 生产打包。

## 当前状态

- ✅ 实现完成
- ✅ 已重放到最新主分支
- ✅ PR 无合并冲突
- ⏳ GitHub Actions 当前整体排队，PR 暂保留草稿状态

## 仍需人工体验确认

- 桌面端智能筛选栏信息密度
- 移动端横向滚动和弹窗高度
- 工作区不同角色下的标签管理提示
