### PR TITLE
feat(tasks): add estimates and personal time blocks

### DIFF
--- a/.github/workflows/task-time-planning-ci.yml
+++ b/.github/workflows/task-time-planning-ci.yml
@@ -1,0 +1,80 @@
+name: Task Time Planning CI
+
+on:
+  push:
+    branches:
+      - feature/task-time-planning-v1
+    paths:
+      - "backend/src/db/taskTimePlanningMigration.ts"
+      - "backend/src/runtime/task-time-planning-migration-bootstrap.ts"
+      - "backend/src/routes/task-time-blocks.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-time-planning.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/TaskTimePlanner.tsx"
+      - "frontend/src/components/tasks/taskTimePlanning.ts"
+      - "frontend/src/components/tasks/__tests__/taskTimePlanning.test.ts"
+      - "frontend/src/lib/taskTimePlanningApi.ts"
+      - "frontend/tsconfig.task-time-planning.json"
+      - ".github/workflows/task-time-planning-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/db/taskTimePlanningMigration.ts"
+      - "backend/src/runtime/task-time-planning-migration-bootstrap.ts"
+      - "backend/src/routes/task-time-blocks.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-time-planning.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/tasks/TaskTimePlanner.tsx"
+      - "frontend/src/components/tasks/taskTimePlanning.ts"
+      - "frontend/src/components/tasks/__tests__/taskTimePlanning.test.ts"
+      - "frontend/src/lib/taskTimePlanningApi.ts"
+      - "frontend/tsconfig.task-time-planning.json"
+      - ".github/workflows/task-time-planning-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Backend typecheck
+        run: npm run build:tsc
+      - name: Test task time planning API
+        run: node --import tsx --test tests/task-time-planning.test.ts
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Targeted TypeScript check
+        run: npx tsc -p tsconfig.task-time-planning.json
+      - name: Vite production bundle
+        run: npx vite build
+      - name: Test time planning helpers
+        run: npx vitest run src/components/tasks/__tests__/taskTimePlanning.test.ts --reporter=verbose

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -13,6 +13,8 @@ $$;
 
 \ir schema.base.sql
 
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS "estimatedMinutes" INTEGER;
+
 CREATE TABLE IF NOT EXISTS task_activity_events (
   id TEXT PRIMARY KEY,
   "taskId" TEXT,
@@ -96,3 +98,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_name
   ON task_saved_views("userId", "scopeKey", "normalizedName");
 CREATE INDEX IF NOT EXISTS idx_task_saved_views_user_scope_sort
   ON task_saved_views("userId", "scopeKey", "sortOrder", "createdAt");
+
+CREATE TABLE IF NOT EXISTS task_time_blocks (
+  id TEXT PRIMARY KEY,
+  "taskId" TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "workspaceId" TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+  "startAt" TIMESTAMPTZ NOT NULL,
+  "endAt" TIMESTAMPTZ NOT NULL,
+  "timeZone" TEXT NOT NULL DEFAULT 'UTC',
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK ("endAt" > "startAt")
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_time_blocks_user_scope_start
+  ON task_time_blocks("userId", "workspaceId", "startAt", "endAt");
+CREATE INDEX IF NOT EXISTS idx_task_time_blocks_task_user
+  ON task_time_blocks("taskId", "userId", "startAt");

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -116,3 +116,22 @@ CREATE INDEX IF NOT EXISTS idx_task_time_blocks_user_scope_start
   ON task_time_blocks("userId", "workspaceId", "startAt", "endAt");
 CREATE INDEX IF NOT EXISTS idx_task_time_blocks_task_user
   ON task_time_blocks("taskId", "userId", "startAt");
+
+CREATE OR REPLACE FUNCTION inherit_recurring_task_estimate()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."repeatGeneratedFromId" IS NOT NULL AND NEW."estimatedMinutes" IS NULL THEN
+    SELECT "estimatedMinutes"
+      INTO NEW."estimatedMinutes"
+      FROM tasks
+      WHERE id = NEW."repeatGeneratedFromId";
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS tasks_inherit_estimate_before_recurrence_insert ON tasks;
+CREATE TRIGGER tasks_inherit_estimate_before_recurrence_insert
+BEFORE INSERT ON tasks
+FOR EACH ROW
+EXECUTE FUNCTION inherit_recurring_task_estimate();

--- a/backend/src/db/taskTimePlanningMigration.ts
+++ b/backend/src/db/taskTimePlanningMigration.ts
@@ -28,6 +28,18 @@ export function ensureTaskTimePlanningSchema(db: Database.Database): void {
       ON task_time_blocks(userId, workspaceId, startAt, endAt);
     CREATE INDEX IF NOT EXISTS idx_task_time_blocks_task_user
       ON task_time_blocks(taskId, userId, startAt);
+
+    DROP TRIGGER IF EXISTS tasks_inherit_estimate_after_recurrence_insert;
+    CREATE TRIGGER tasks_inherit_estimate_after_recurrence_insert
+    AFTER INSERT ON tasks
+    WHEN NEW.repeatGeneratedFromId IS NOT NULL AND NEW.estimatedMinutes IS NULL
+    BEGIN
+      UPDATE tasks
+      SET estimatedMinutes = (
+        SELECT estimatedMinutes FROM tasks WHERE id = NEW.repeatGeneratedFromId
+      )
+      WHERE id = NEW.id;
+    END;
   `);
 }
 

--- a/backend/src/db/taskTimePlanningMigration.ts
+++ b/backend/src/db/taskTimePlanningMigration.ts
@@ -1,0 +1,38 @@
+import type Database from "better-sqlite3";
+import type { Migration } from "./migrations.impl.js";
+
+export function ensureTaskTimePlanningSchema(db: Database.Database): void {
+  const taskColumns = db.prepare("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
+  if (!taskColumns.some((column) => column.name === "estimatedMinutes")) {
+    db.prepare("ALTER TABLE tasks ADD COLUMN estimatedMinutes INTEGER").run();
+  }
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS task_time_blocks (
+      id TEXT PRIMARY KEY,
+      taskId TEXT NOT NULL,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      startAt TEXT NOT NULL,
+      endAt TEXT NOT NULL,
+      timeZone TEXT NOT NULL DEFAULT 'UTC',
+      createdAt TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updatedAt TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      CHECK (endAt > startAt),
+      FOREIGN KEY (taskId) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_task_time_blocks_user_scope_start
+      ON task_time_blocks(userId, workspaceId, startAt, endAt);
+    CREATE INDEX IF NOT EXISTS idx_task_time_blocks_task_user
+      ON task_time_blocks(taskId, userId, startAt);
+  `);
+}
+
+export const taskTimePlanningMigration: Migration = {
+  version: 72,
+  name: "task-estimates-and-time-blocks",
+  up: ensureTaskTimePlanningSchema,
+};

--- a/backend/src/index.hardened.ts
+++ b/backend/src/index.hardened.ts
@@ -3,6 +3,7 @@ import "./runtime/url-import-dns-compat.js";
 // Register feature migrations before any runtime imports can initialize the database.
 import "./runtime/knowledge-tree-migration-bootstrap.js";
 import "./runtime/task-metadata-migration-bootstrap.js";
+import "./runtime/task-time-planning-migration-bootstrap.js";
 // Permission routes import ACL services that may initialize database guards, so they must load
 // only after the feature migration list has been registered.
 import "./runtime/notebook-permission-management.js";

--- a/backend/src/routes/task-time-blocks.ts
+++ b/backend/src/routes/task-time-blocks.ts
@@ -1,6 +1,5 @@
 import crypto from "crypto";
 import { Hono } from "hono";
-import type { Context } from "hono";
 import { getDb } from "../db/schema";
 import { ensureTaskTimePlanningSchema } from "../db/taskTimePlanningMigration";
 import { canManageResource, getUserWorkspaceRole } from "../middleware/acl";
@@ -71,7 +70,12 @@ function normalizeTimeZone(value: unknown): string {
   if (!normalized || normalized.length > 100 || !/^[A-Za-z0-9_+\-/]+$/.test(normalized)) {
     return "UTC";
   }
-  return normalized;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(new Date());
+    return normalized;
+  } catch {
+    return "UTC";
+  }
 }
 
 function normalizeEstimate(value: unknown): number | null {
@@ -254,6 +258,11 @@ taskTimeBlocks.put("/:id", async (c) => {
     "SELECT * FROM task_time_blocks WHERE id = ? AND userId = ?",
   ).get(id, userId) as TimeBlockRow | undefined;
   if (!existing) return c.json({ error: "Time block not found", code: "TIME_BLOCK_NOT_FOUND" }, 404);
+
+  const task = getTask(existing.taskId);
+  if (!task || !canReadTask(task, userId)) {
+    return c.json({ error: "Time block not found", code: "TIME_BLOCK_NOT_FOUND" }, 404);
+  }
 
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const range = validateBlockRange(

--- a/backend/src/routes/task-time-blocks.ts
+++ b/backend/src/routes/task-time-blocks.ts
@@ -1,0 +1,298 @@
+import crypto from "crypto";
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { getDb } from "../db/schema";
+import { ensureTaskTimePlanningSchema } from "../db/taskTimePlanningMigration";
+import { canManageResource, getUserWorkspaceRole } from "../middleware/acl";
+
+const taskTimeBlocks = new Hono();
+const MIN_BLOCK_MINUTES = 5;
+const MAX_BLOCK_MINUTES = 24 * 60;
+const MAX_RANGE_DAYS = 93;
+const MAX_ESTIMATE_MINUTES = 7 * 24 * 60;
+let initializedDatabase: object | null = null;
+
+interface TaskRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  title: string;
+  estimatedMinutes: number | null;
+}
+
+interface TimeBlockRow {
+  id: string;
+  taskId: string;
+  userId: string;
+  workspaceId: string | null;
+  startAt: string;
+  endAt: string;
+  timeZone: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ResolvedScope {
+  workspaceId: string | null;
+  error?: string;
+}
+
+function ensureSchema(): void {
+  const db = getDb();
+  if (initializedDatabase === db) return;
+  ensureTaskTimePlanningSchema(db);
+  initializedDatabase = db;
+}
+
+function resolveScope(userId: string, rawWorkspaceId: unknown): ResolvedScope {
+  const workspaceId = typeof rawWorkspaceId === "string" ? rawWorkspaceId.trim() : "";
+  if (!workspaceId || workspaceId === "personal") return { workspaceId: null };
+  if (!getUserWorkspaceRole(workspaceId, userId)) {
+    return { workspaceId, error: "无权访问该工作区" };
+  }
+  return { workspaceId };
+}
+
+function canReadTask(task: TaskRow, userId: string): boolean {
+  if (task.workspaceId) return getUserWorkspaceRole(task.workspaceId, userId) !== null;
+  return task.userId === userId;
+}
+
+function normalizeIso(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeTimeZone(value: unknown): string {
+  if (typeof value !== "string") return "UTC";
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 100 || !/^[A-Za-z0-9_+\-/]+$/.test(normalized)) {
+    return "UTC";
+  }
+  return normalized;
+}
+
+function normalizeEstimate(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const minutes = Number(value);
+  if (!Number.isInteger(minutes) || minutes < 1 || minutes > MAX_ESTIMATE_MINUTES) {
+    throw new Error("INVALID_ESTIMATE");
+  }
+  return minutes;
+}
+
+function validateBlockRange(startAt: unknown, endAt: unknown):
+  | { startAt: string; endAt: string }
+  | { error: string; code: string } {
+  const normalizedStart = normalizeIso(startAt);
+  const normalizedEnd = normalizeIso(endAt);
+  if (!normalizedStart || !normalizedEnd) {
+    return { error: "startAt and endAt must be valid ISO date-times", code: "INVALID_TIME_BLOCK_RANGE" };
+  }
+  const durationMinutes = (Date.parse(normalizedEnd) - Date.parse(normalizedStart)) / 60_000;
+  if (durationMinutes < MIN_BLOCK_MINUTES || durationMinutes > MAX_BLOCK_MINUTES) {
+    return {
+      error: `Time block duration must be between ${MIN_BLOCK_MINUTES} and ${MAX_BLOCK_MINUTES} minutes`,
+      code: "INVALID_TIME_BLOCK_DURATION",
+    };
+  }
+  return { startAt: normalizedStart, endAt: normalizedEnd };
+}
+
+function getTask(taskId: string): TaskRow | undefined {
+  return getDb().prepare(
+    "SELECT id, userId, workspaceId, title, estimatedMinutes FROM tasks WHERE id = ?",
+  ).get(taskId) as TaskRow | undefined;
+}
+
+function serializeBlock(row: TimeBlockRow & Record<string, unknown>) {
+  return {
+    ...row,
+    workspaceId: row.workspaceId || "personal",
+  };
+}
+
+// GET /api/user-preferences/task-time-blocks?workspaceId=...&from=...&to=...
+taskTimeBlocks.get("/", (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const scope = resolveScope(userId, c.req.query("workspaceId"));
+  if (scope.error) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const now = new Date();
+  const defaultFrom = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+  const defaultTo = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 8).toISOString();
+  const from = normalizeIso(c.req.query("from")) || defaultFrom;
+  const to = normalizeIso(c.req.query("to")) || defaultTo;
+  if (Date.parse(to) <= Date.parse(from)) {
+    return c.json({ error: "to must be after from", code: "INVALID_TIME_BLOCK_RANGE" }, 400);
+  }
+  if ((Date.parse(to) - Date.parse(from)) / 86_400_000 > MAX_RANGE_DAYS) {
+    return c.json({ error: `Range cannot exceed ${MAX_RANGE_DAYS} days`, code: "TIME_BLOCK_RANGE_TOO_LARGE" }, 400);
+  }
+
+  const taskId = (c.req.query("taskId") || "").trim();
+  const params: unknown[] = [userId];
+  let sql = `
+    SELECT b.*, t.title AS taskTitle, t.priority, t.projectId, t.isCompleted,
+           t.estimatedMinutes
+    FROM task_time_blocks b
+    INNER JOIN tasks t ON t.id = b.taskId
+    WHERE b.userId = ?
+  `;
+  if (scope.workspaceId) {
+    sql += " AND b.workspaceId = ?";
+    params.push(scope.workspaceId);
+  } else {
+    sql += " AND b.workspaceId IS NULL";
+  }
+  sql += " AND b.endAt > ? AND b.startAt < ?";
+  params.push(from, to);
+  if (taskId) {
+    sql += " AND b.taskId = ?";
+    params.push(taskId);
+  }
+  sql += " ORDER BY b.startAt ASC, b.createdAt ASC";
+
+  const rows = getDb().prepare(sql).all(...params) as Array<TimeBlockRow & Record<string, unknown>>;
+  return c.json({
+    workspaceId: scope.workspaceId || "personal",
+    from,
+    to,
+    blocks: rows.map(serializeBlock),
+  });
+});
+
+// PUT /api/user-preferences/task-time-blocks/tasks/:taskId/estimate
+taskTimeBlocks.put("/tasks/:taskId/estimate", async (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const taskId = c.req.param("taskId");
+  const task = getTask(taskId);
+  if (!task) return c.json({ error: "Task not found", code: "TASK_NOT_FOUND" }, 404);
+  if (!canManageResource(task.userId, task.workspaceId, userId)) {
+    return c.json({ error: "无权修改该任务", code: "FORBIDDEN" }, 403);
+  }
+
+  const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
+  let estimatedMinutes: number | null;
+  try {
+    estimatedMinutes = normalizeEstimate(body?.estimatedMinutes);
+  } catch {
+    return c.json({
+      error: `estimatedMinutes must be an integer between 1 and ${MAX_ESTIMATE_MINUTES}`,
+      code: "INVALID_ESTIMATE",
+    }, 400);
+  }
+
+  getDb().prepare(
+    "UPDATE tasks SET estimatedMinutes = ?, updatedAt = datetime('now') WHERE id = ?",
+  ).run(estimatedMinutes, taskId);
+  return c.json({ taskId, estimatedMinutes });
+});
+
+// POST /api/user-preferences/task-time-blocks
+taskTimeBlocks.post("/", async (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
+  const taskId = typeof body?.taskId === "string" ? body.taskId.trim() : "";
+  if (!taskId) return c.json({ error: "taskId is required", code: "TASK_ID_REQUIRED" }, 400);
+
+  const task = getTask(taskId);
+  if (!task || !canReadTask(task, userId)) {
+    return c.json({ error: "Task not found", code: "TASK_NOT_FOUND" }, 404);
+  }
+
+  const range = validateBlockRange(body?.startAt, body?.endAt);
+  if ("error" in range) return c.json({ error: range.error, code: range.code }, 400);
+
+  const id = crypto.randomUUID();
+  const timeZone = normalizeTimeZone(body?.timeZone);
+  getDb().prepare(`
+    INSERT INTO task_time_blocks (
+      id, taskId, userId, workspaceId, startAt, endAt, timeZone, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    task.id,
+    userId,
+    task.workspaceId,
+    range.startAt,
+    range.endAt,
+    timeZone,
+    new Date().toISOString(),
+    new Date().toISOString(),
+  );
+
+  const row = getDb().prepare(`
+    SELECT b.*, t.title AS taskTitle, t.priority, t.projectId, t.isCompleted,
+           t.estimatedMinutes
+    FROM task_time_blocks b
+    INNER JOIN tasks t ON t.id = b.taskId
+    WHERE b.id = ?
+  `).get(id) as TimeBlockRow & Record<string, unknown>;
+  return c.json({ block: serializeBlock(row) }, 201);
+});
+
+// PUT /api/user-preferences/task-time-blocks/:id
+taskTimeBlocks.put("/:id", async (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const id = c.req.param("id");
+  const existing = getDb().prepare(
+    "SELECT * FROM task_time_blocks WHERE id = ? AND userId = ?",
+  ).get(id, userId) as TimeBlockRow | undefined;
+  if (!existing) return c.json({ error: "Time block not found", code: "TIME_BLOCK_NOT_FOUND" }, 404);
+
+  const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
+  const range = validateBlockRange(
+    body?.startAt ?? existing.startAt,
+    body?.endAt ?? existing.endAt,
+  );
+  if ("error" in range) return c.json({ error: range.error, code: range.code }, 400);
+  const timeZone = body && Object.prototype.hasOwnProperty.call(body, "timeZone")
+    ? normalizeTimeZone(body.timeZone)
+    : existing.timeZone;
+
+  getDb().prepare(`
+    UPDATE task_time_blocks
+    SET startAt = ?, endAt = ?, timeZone = ?, updatedAt = ?
+    WHERE id = ? AND userId = ?
+  `).run(range.startAt, range.endAt, timeZone, new Date().toISOString(), id, userId);
+
+  const row = getDb().prepare(`
+    SELECT b.*, t.title AS taskTitle, t.priority, t.projectId, t.isCompleted,
+           t.estimatedMinutes
+    FROM task_time_blocks b
+    INNER JOIN tasks t ON t.id = b.taskId
+    WHERE b.id = ? AND b.userId = ?
+  `).get(id, userId) as TimeBlockRow & Record<string, unknown>;
+  return c.json({ block: serializeBlock(row) });
+});
+
+taskTimeBlocks.delete("/:id", (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const result = getDb().prepare(
+    "DELETE FROM task_time_blocks WHERE id = ? AND userId = ?",
+  ).run(c.req.param("id"), userId);
+  if (result.changes === 0) {
+    return c.json({ error: "Time block not found", code: "TIME_BLOCK_NOT_FOUND" }, 404);
+  }
+  return c.json({ success: true });
+});
+
+export default taskTimeBlocks;

--- a/backend/src/routes/user-preferences.ts
+++ b/backend/src/routes/user-preferences.ts
@@ -5,6 +5,7 @@ import reliableAIRoutes from "./ai-reliable";
 import mobileBootstrapRoutes from "./mobile-bootstrap";
 import taskDayPlansRoutes from "./task-day-plans";
 import taskMetadataRoutes from "./task-metadata";
+import taskTimeBlocksRoutes from "./task-time-blocks";
 
 /**
  * Compatibility wrapper: existing user preference/profile endpoints stay at their
@@ -21,6 +22,10 @@ app.route("/task-day-plans", taskDayPlansRoutes);
 // Labels and saved views are task organization metadata. Labels may be shared in
 // a workspace, while each saved view remains account-scoped.
 app.route("/task-metadata", taskMetadataRoutes);
+
+// Time blocks are personal calendar allocations. Even inside a shared workspace,
+// every member owns an independent schedule for the same shared task.
+app.route("/task-time-blocks", taskTimeBlocksRoutes);
 
 // Root preference GET/PUT/PATCH must be mounted before the legacy router. The new
 // implementation keeps the old flat response fields while adding account-scoped

--- a/backend/src/runtime/task-time-planning-migration-bootstrap.ts
+++ b/backend/src/runtime/task-time-planning-migration-bootstrap.ts
@@ -1,0 +1,7 @@
+import { MIGRATIONS as BASE_MIGRATIONS } from "../db/migrations.impl.js";
+import { taskTimePlanningMigration } from "../db/taskTimePlanningMigration.js";
+
+if (!BASE_MIGRATIONS.some((migration) => migration.version === taskTimePlanningMigration.version)) {
+  BASE_MIGRATIONS.push(taskTimePlanningMigration);
+  BASE_MIGRATIONS.sort((a, b) => a.version - b.version);
+}

--- a/backend/tests/task-time-planning.test.ts
+++ b/backend/tests/task-time-planning.test.ts
@@ -56,6 +56,8 @@ test.beforeEach(() => {
   db.prepare("DELETE FROM task_reminders").run();
   db.prepare("DELETE FROM task_dependencies").run();
   db.prepare("DELETE FROM tasks").run();
+  db.prepare("DELETE FROM workspace_members").run();
+  db.prepare("DELETE FROM workspaces").run();
 });
 
 test.after(() => {
@@ -177,4 +179,53 @@ test("inherits the estimate when a recurring task generates its next instance", 
   assert.equal(toggled.status, 200);
   assert.ok(toggled.json.generatedTask?.id);
   assert.equal(toggled.json.generatedTask.estimatedMinutes, 45);
+});
+
+test("lets workspace members plan the same shared task in private schedules", async () => {
+  const db = getDb();
+  const workspaceId = "time-planning-workspace";
+  db.prepare(
+    "INSERT INTO workspaces (id, name, ownerId, enabledFeatures) VALUES (?, ?, ?, ?)"
+  ).run(workspaceId, "Time Planning", USER_A, "{}");
+  db.prepare(
+    "INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)"
+  ).run(workspaceId, USER_A, "owner");
+  db.prepare(
+    "INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, ?)"
+  ).run(workspaceId, USER_B, "editor");
+
+  const task = await requestJson(
+    USER_A,
+    "POST",
+    `/tasks?workspaceId=${workspaceId}`,
+    { title: "Shared launch task" },
+  );
+  assert.equal(task.status, 201);
+
+  const ownerBlock = await requestJson(USER_A, "POST", "/task-time-blocks", {
+    taskId: task.json.id,
+    startAt: "2026-08-03T01:00:00.000Z",
+    endAt: "2026-08-03T02:00:00.000Z",
+  });
+  const memberBlock = await requestJson(USER_B, "POST", "/task-time-blocks", {
+    taskId: task.json.id,
+    startAt: "2026-08-03T03:00:00.000Z",
+    endAt: "2026-08-03T04:00:00.000Z",
+  });
+  assert.equal(ownerBlock.status, 201);
+  assert.equal(memberBlock.status, 201);
+
+  const range = `workspaceId=${workspaceId}&from=2026-08-03T00%3A00%3A00.000Z&to=2026-08-04T00%3A00%3A00.000Z`;
+  const ownerSchedule = await requestJson(USER_A, "GET", `/task-time-blocks?${range}`);
+  const memberSchedule = await requestJson(USER_B, "GET", `/task-time-blocks?${range}`);
+  assert.deepEqual(ownerSchedule.json.blocks.map((block: { id: string }) => block.id), [ownerBlock.json.block.id]);
+  assert.deepEqual(memberSchedule.json.blocks.map((block: { id: string }) => block.id), [memberBlock.json.block.id]);
+
+  const memberCannotEditOwner = await requestJson(
+    USER_B,
+    "PUT",
+    `/task-time-blocks/${ownerBlock.json.block.id}`,
+    { startAt: "2026-08-03T05:00:00.000Z", endAt: "2026-08-03T06:00:00.000Z" },
+  );
+  assert.equal(memberCannotEditOwner.status, 404);
 });

--- a/backend/tests/task-time-planning.test.ts
+++ b/backend/tests/task-time-planning.test.ts
@@ -155,3 +155,26 @@ test("keeps personal estimates and blocks private to the task owner", async () =
   });
   assert.equal(otherBlock.status, 404);
 });
+
+test("inherits the estimate when a recurring task generates its next instance", async () => {
+  const task = await requestJson(USER_A, "POST", "/tasks", {
+    title: "Recurring focus session",
+    dueDate: "2026-08-03",
+    repeatRule: "daily",
+    repeatInterval: 1,
+  });
+  assert.equal(task.status, 201);
+
+  const estimate = await requestJson(
+    USER_A,
+    "PUT",
+    `/task-time-blocks/tasks/${task.json.id}/estimate`,
+    { estimatedMinutes: 45 },
+  );
+  assert.equal(estimate.status, 200);
+
+  const toggled = await requestJson(USER_A, "PATCH", `/tasks/${task.json.id}/toggle`);
+  assert.equal(toggled.status, 200);
+  assert.ok(toggled.json.generatedTask?.id);
+  assert.equal(toggled.json.generatedTask.estimatedMinutes, 45);
+});

--- a/backend/tests/task-time-planning.test.ts
+++ b/backend/tests/task-time-planning.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-task-time-planning-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+const USER_A = "time-planning-user-a";
+const USER_B = "time-planning-user-b";
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+async function requestJson(userId: string, method: string, url: string, body?: unknown) {
+  const response = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": userId,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, json: text ? JSON.parse(text) : null };
+}
+
+test.before(async () => {
+  const [tasksModule, planningModule, schemaModule, migrationModule] = await Promise.all([
+    import("../src/routes/tasks"),
+    import("../src/routes/task-time-blocks"),
+    import("../src/db/schema"),
+    import("../src/db/taskTimePlanningMigration"),
+  ]);
+  app = new Hono();
+  app.route("/tasks", tasksModule.default);
+  app.route("/task-time-blocks", planningModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+
+  const db = getDb();
+  migrationModule.taskTimePlanningMigration.up(db);
+  const insertUser = db.prepare(
+    "INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)",
+  );
+  insertUser.run(USER_A, USER_A, "hash");
+  insertUser.run(USER_B, USER_B, "hash");
+});
+
+test.beforeEach(() => {
+  const db = getDb();
+  db.prepare("DELETE FROM task_time_blocks").run();
+  db.prepare("DELETE FROM task_reminders").run();
+  db.prepare("DELETE FROM task_dependencies").run();
+  db.prepare("DELETE FROM tasks").run();
+});
+
+test.after(() => {
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("stores estimates and supports the full time block lifecycle", async () => {
+  const task = await requestJson(USER_A, "POST", "/tasks", {
+    title: "Plan focused implementation",
+    priority: 3,
+  });
+  assert.equal(task.status, 201);
+
+  const estimate = await requestJson(
+    USER_A,
+    "PUT",
+    `/task-time-blocks/tasks/${task.json.id}/estimate`,
+    { estimatedMinutes: 90 },
+  );
+  assert.equal(estimate.status, 200);
+  assert.equal(estimate.json.estimatedMinutes, 90);
+
+  const created = await requestJson(USER_A, "POST", "/task-time-blocks", {
+    taskId: task.json.id,
+    startAt: "2026-08-03T01:00:00.000Z",
+    endAt: "2026-08-03T02:30:00.000Z",
+    timeZone: "Asia/Shanghai",
+  });
+  assert.equal(created.status, 201);
+  assert.equal(created.json.block.taskId, task.json.id);
+  assert.equal(created.json.block.estimatedMinutes, 90);
+
+  const listed = await requestJson(
+    USER_A,
+    "GET",
+    "/task-time-blocks?workspaceId=personal&from=2026-08-03T00%3A00%3A00.000Z&to=2026-08-04T00%3A00%3A00.000Z",
+  );
+  assert.equal(listed.status, 200);
+  assert.equal(listed.json.blocks.length, 1);
+  assert.equal(listed.json.blocks[0].taskTitle, "Plan focused implementation");
+
+  const updated = await requestJson(USER_A, "PUT", `/task-time-blocks/${created.json.block.id}`, {
+    startAt: "2026-08-03T03:00:00.000Z",
+    endAt: "2026-08-03T04:00:00.000Z",
+  });
+  assert.equal(updated.status, 200);
+  assert.equal(updated.json.block.startAt, "2026-08-03T03:00:00.000Z");
+
+  const removed = await requestJson(USER_A, "DELETE", `/task-time-blocks/${created.json.block.id}`);
+  assert.equal(removed.status, 200);
+
+  const afterDelete = await requestJson(
+    USER_A,
+    "GET",
+    "/task-time-blocks?workspaceId=personal&from=2026-08-03T00%3A00%3A00.000Z&to=2026-08-04T00%3A00%3A00.000Z",
+  );
+  assert.deepEqual(afterDelete.json.blocks, []);
+});
+
+test("rejects invalid block durations", async () => {
+  const task = await requestJson(USER_A, "POST", "/tasks", { title: "Invalid duration" });
+
+  const tooShort = await requestJson(USER_A, "POST", "/task-time-blocks", {
+    taskId: task.json.id,
+    startAt: "2026-08-03T01:00:00.000Z",
+    endAt: "2026-08-03T01:01:00.000Z",
+  });
+  assert.equal(tooShort.status, 400);
+  assert.equal(tooShort.json.code, "INVALID_TIME_BLOCK_DURATION");
+
+  const badEstimate = await requestJson(
+    USER_A,
+    "PUT",
+    `/task-time-blocks/tasks/${task.json.id}/estimate`,
+    { estimatedMinutes: 0 },
+  );
+  assert.equal(badEstimate.status, 400);
+  assert.equal(badEstimate.json.code, "INVALID_ESTIMATE");
+});
+
+test("keeps personal estimates and blocks private to the task owner", async () => {
+  const task = await requestJson(USER_A, "POST", "/tasks", { title: "Private planning" });
+
+  const otherEstimate = await requestJson(
+    USER_B,
+    "PUT",
+    `/task-time-blocks/tasks/${task.json.id}/estimate`,
+    { estimatedMinutes: 30 },
+  );
+  assert.equal(otherEstimate.status, 403);
+
+  const otherBlock = await requestJson(USER_B, "POST", "/task-time-blocks", {
+    taskId: task.json.id,
+    startAt: "2026-08-03T01:00:00.000Z",
+    endAt: "2026-08-03T01:30:00.000Z",
+  });
+  assert.equal(otherBlock.status, 404);
+});

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
 import { MyDayPanel } from "./tasks/MyDayPanel";
 import { TaskMetadataWorkspace } from "./tasks/TaskMetadataWorkspace";
+import { TaskTimePlanner } from "./tasks/TaskTimePlanner";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
 
 export * from "./TaskCenterImpl";
@@ -25,7 +26,7 @@ export default function TaskCenter() {
 
   useEffect(() => {
     // Keep a long-running desktop/web session aligned with the local calendar day.
-    // Changing this key remounts only My Day; labels and saved views remain intact.
+    // Changing this key remounts only daily planning surfaces.
     const timer = window.setInterval(() => {
       const nextDayKey = new Date().toDateString();
       setLocalDayKey((current) => current === nextDayKey ? current : nextDayKey);
@@ -58,6 +59,7 @@ export default function TaskCenter() {
           key={`my-day-${workspaceGeneration}-${localDayKey}`}
           onTaskMutated={remountTaskWorkspace}
         />
+        <TaskTimePlanner key={`time-planner-${workspaceGeneration}-${localDayKey}`} />
         <div className="min-h-0 flex-1">
           <TaskCenterImpl />
         </div>

--- a/frontend/src/components/tasks/TaskTimePlanner.tsx
+++ b/frontend/src/components/tasks/TaskTimePlanner.tsx
@@ -1,0 +1,546 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarClock,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Clock3,
+  Loader2,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import type { Task } from "@/types";
+import {
+  createTaskTimeBlock,
+  deleteTaskTimeBlock,
+  getTaskTimeBlocks,
+  updateTaskEstimate,
+  updateTaskTimeBlock,
+  type TaskTimeBlock,
+} from "@/lib/taskTimePlanningApi";
+import { cn } from "@/lib/utils";
+import {
+  addMinutesIso,
+  combineLocalDateAndTime,
+  findConflictingBlockIds,
+  formatLocalDateKey,
+  formatMinutes,
+  localDayRange,
+  minutesBetween,
+  nextHalfHour,
+  occupiedMinutes,
+} from "./taskTimePlanning";
+
+type PlannedTask = Task & { estimatedMinutes?: number | null };
+
+const ESTIMATE_PRESETS = [15, 30, 45, 60, 90, 120, 180];
+const DAY_CAPACITY_MINUTES = 8 * 60;
+
+interface TaskTimePlannerProps {
+  onTaskMutated?: () => void;
+}
+
+function dateInputValue(date: Date): string {
+  return formatLocalDateKey(date);
+}
+
+function moveDate(dateKey: string, days: number): string {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return dateInputValue(new Date(year, month - 1, day + days));
+}
+
+function timeText(iso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(iso));
+}
+
+function dateLabel(dateKey: string, chinese: boolean): string {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat(chinese ? "zh-CN" : undefined, {
+    month: "short",
+    day: "numeric",
+    weekday: "short",
+  }).format(date);
+}
+
+export function TaskTimePlanner({ onTaskMutated }: TaskTimePlannerProps) {
+  const { i18n } = useTranslation();
+  const chinese = i18n.language.toLowerCase().startsWith("zh");
+  const [expanded, setExpanded] = useState(() => {
+    try {
+      return localStorage.getItem("nowen-task-time-planner-expanded") === "true";
+    } catch {
+      return false;
+    }
+  });
+  const [dateKey, setDateKey] = useState(() => formatLocalDateKey());
+  const [tasks, setTasks] = useState<PlannedTask[]>([]);
+  const [blocks, setBlocks] = useState<TaskTimeBlock[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [selectedTaskId, setSelectedTaskId] = useState("");
+  const [startTime, setStartTime] = useState(() => nextHalfHour());
+  const [durationMinutes, setDurationMinutes] = useState(30);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editStartTime, setEditStartTime] = useState("");
+  const [editDurationMinutes, setEditDurationMinutes] = useState(30);
+
+  const labels = useMemo(() => chinese ? {
+    title: "时间规划",
+    subtitle: "把任务放进日程，不修改截止时间",
+    today: "今天",
+    task: "选择任务",
+    chooseTask: "选择一个未完成任务…",
+    estimate: "预估时长",
+    clearEstimate: "清除预估",
+    start: "开始时间",
+    duration: "时间块",
+    add: "加入日程",
+    scheduled: "已安排",
+    capacity: "日容量",
+    conflicts: "时间冲突",
+    noBlocks: "这一天还没有安排时间块",
+    noTasks: "当前空间没有可安排的未完成任务",
+    loadFailed: "加载时间规划失败",
+    saveFailed: "保存时间规划失败",
+    estimateFailed: "更新预估时长失败",
+    deleteFailed: "删除时间块失败",
+    edit: "调整",
+    cancel: "取消",
+    save: "保存",
+    delete: "删除",
+    completed: "已完成",
+    overCapacity: "当天安排已超过 8 小时容量",
+    conflictHint: "存在重叠时间块，请调整安排",
+    refresh: "刷新",
+  } : {
+    title: "Time planning",
+    subtitle: "Schedule tasks without changing their deadlines",
+    today: "Today",
+    task: "Task",
+    chooseTask: "Choose an unfinished task…",
+    estimate: "Estimate",
+    clearEstimate: "Clear estimate",
+    start: "Start",
+    duration: "Time block",
+    add: "Schedule",
+    scheduled: "Scheduled",
+    capacity: "Daily capacity",
+    conflicts: "Conflicts",
+    noBlocks: "No time blocks scheduled for this day",
+    noTasks: "No unfinished tasks are available in this space",
+    loadFailed: "Failed to load time planning",
+    saveFailed: "Failed to save time planning",
+    estimateFailed: "Failed to update estimate",
+    deleteFailed: "Failed to delete time block",
+    edit: "Adjust",
+    cancel: "Cancel",
+    save: "Save",
+    delete: "Delete",
+    completed: "Completed",
+    overCapacity: "This day exceeds the 8-hour planning capacity",
+    conflictHint: "Some time blocks overlap",
+    refresh: "Refresh",
+  }, [chinese]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const range = localDayRange(dateKey);
+      const [taskRows, blockRows] = await Promise.all([
+        api.getTasks("all") as Promise<PlannedTask[]>,
+        getTaskTimeBlocks(range.from, range.to),
+      ]);
+      setTasks(taskRows);
+      setBlocks(blockRows.blocks);
+      setSelectedTaskId((current) => {
+        if (current && taskRows.some((task) => task.id === current && !task.isCompleted)) return current;
+        return taskRows.find((task) => !task.isCompleted)?.id || "";
+      });
+    } catch (error) {
+      console.error("[TaskTimePlanner] load failed", error);
+      toast.error(labels.loadFailed);
+    } finally {
+      setLoading(false);
+    }
+  }, [dateKey, labels.loadFailed]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("nowen-task-time-planner-expanded", String(expanded));
+    } catch {
+      // Keep the state in memory when storage is unavailable.
+    }
+  }, [expanded]);
+
+  const availableTasks = useMemo(() => tasks
+    .filter((task) => !task.isCompleted)
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return b.priority - a.priority;
+      return (a.dueAt || a.dueDate || "9999").localeCompare(b.dueAt || b.dueDate || "9999");
+    }), [tasks]);
+  const selectedTask = tasks.find((task) => task.id === selectedTaskId) || null;
+  const conflictIds = useMemo(() => findConflictingBlockIds(blocks), [blocks]);
+  const totalMinutes = useMemo(
+    () => blocks.reduce((sum, block) => sum + minutesBetween(block.startAt, block.endAt), 0),
+    [blocks],
+  );
+  const occupied = useMemo(() => occupiedMinutes(blocks), [blocks]);
+  const capacityPercent = Math.min(100, Math.round((totalMinutes / DAY_CAPACITY_MINUTES) * 100));
+  const timeZone = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    [],
+  );
+
+  const chooseTask = (taskId: string) => {
+    setSelectedTaskId(taskId);
+    const task = tasks.find((item) => item.id === taskId);
+    if (task?.estimatedMinutes) setDurationMinutes(task.estimatedMinutes);
+  };
+
+  const setEstimate = async (minutes: number | null) => {
+    if (!selectedTaskId) return;
+    try {
+      await updateTaskEstimate(selectedTaskId, minutes);
+      setTasks((current) => current.map((task) => (
+        task.id === selectedTaskId ? { ...task, estimatedMinutes: minutes } : task
+      )));
+      if (minutes) setDurationMinutes(minutes);
+      onTaskMutated?.();
+    } catch (error) {
+      console.error("[TaskTimePlanner] estimate update failed", error);
+      toast.error(labels.estimateFailed);
+    }
+  };
+
+  const addBlock = async () => {
+    if (!selectedTaskId || saving) return;
+    const startAt = combineLocalDateAndTime(dateKey, startTime);
+    const endAt = addMinutesIso(startAt, durationMinutes);
+    setSaving(true);
+    try {
+      const block = await createTaskTimeBlock({ selectedTaskId, taskId: selectedTaskId, startAt, endAt, timeZone } as {
+        taskId: string;
+        startAt: string;
+        endAt: string;
+        timeZone: string;
+      });
+      setBlocks((current) => [...current, block].sort((a, b) => a.startAt.localeCompare(b.startAt)));
+      setStartTime(timeText(endAt));
+    } catch (error) {
+      console.error("[TaskTimePlanner] create block failed", error);
+      toast.error(labels.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const beginEdit = (block: TaskTimeBlock) => {
+    setEditingId(block.id);
+    setEditStartTime(timeText(block.startAt));
+    setEditDurationMinutes(minutesBetween(block.startAt, block.endAt));
+  };
+
+  const saveEdit = async (block: TaskTimeBlock) => {
+    if (saving) return;
+    const startAt = combineLocalDateAndTime(dateKey, editStartTime);
+    const endAt = addMinutesIso(startAt, editDurationMinutes);
+    setSaving(true);
+    try {
+      const updated = await updateTaskTimeBlock(block.id, { startAt, endAt, timeZone });
+      setBlocks((current) => current
+        .map((item) => item.id === block.id ? updated : item)
+        .sort((a, b) => a.startAt.localeCompare(b.startAt)));
+      setEditingId(null);
+    } catch (error) {
+      console.error("[TaskTimePlanner] update block failed", error);
+      toast.error(labels.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeBlock = async (id: string) => {
+    try {
+      await deleteTaskTimeBlock(id);
+      setBlocks((current) => current.filter((block) => block.id !== id));
+      if (editingId === id) setEditingId(null);
+    } catch (error) {
+      console.error("[TaskTimePlanner] delete block failed", error);
+      toast.error(labels.deleteFailed);
+    }
+  };
+
+  return (
+    <section className="shrink-0 border-b border-app-border bg-app-surface">
+      <div className="flex items-center gap-3 px-4 md:px-5 py-2.5">
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 text-violet-500">
+            <CalendarClock size={17} />
+          </span>
+          <span className="min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-tx-primary">{labels.title}</span>
+              <span className="text-[10px] text-tx-tertiary">{dateLabel(dateKey, chinese)}</span>
+            </span>
+            <span className="hidden truncate text-[11px] text-tx-tertiary sm:block">{labels.subtitle}</span>
+          </span>
+        </button>
+
+        <div className="hidden items-center gap-2 text-[11px] sm:flex">
+          <span className={cn(
+            "rounded-full px-2 py-1",
+            totalMinutes > DAY_CAPACITY_MINUTES
+              ? "bg-red-500/10 text-red-500"
+              : "bg-app-elevated text-tx-secondary",
+          )}>
+            {labels.capacity} {formatMinutes(totalMinutes, chinese)} / 8h
+          </span>
+          {conflictIds.size > 0 && (
+            <span className="flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-amber-600 dark:text-amber-400">
+              <AlertTriangle size={11} /> {labels.conflicts} {conflictIds.size}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="rounded-md p-1 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+        >
+          {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-app-border/70 px-4 md:px-5 pb-4 pt-3">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-1 rounded-lg border border-app-border bg-app-bg p-1">
+              <button type="button" onClick={() => setDateKey((value) => moveDate(value, -1))} className="rounded p-1 text-tx-secondary hover:bg-app-hover">
+                <ChevronLeft size={15} />
+              </button>
+              <input
+                type="date"
+                value={dateKey}
+                onChange={(event) => setDateKey(event.target.value || formatLocalDateKey())}
+                className="bg-transparent px-1 text-xs text-tx-primary outline-none"
+              />
+              <button type="button" onClick={() => setDateKey((value) => moveDate(value, 1))} className="rounded p-1 text-tx-secondary hover:bg-app-hover">
+                <ChevronRight size={15} />
+              </button>
+              <button type="button" onClick={() => setDateKey(formatLocalDateKey())} className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-accent-primary hover:bg-accent-primary/10">
+                <RotateCcw size={11} /> {labels.today}
+              </button>
+            </div>
+            <button type="button" onClick={() => void load()} className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-tx-tertiary hover:bg-app-hover hover:text-tx-secondary">
+              <RotateCcw size={11} /> {labels.refresh}
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="flex h-24 items-center justify-center text-tx-tertiary">
+              <Loader2 size={18} className="animate-spin" />
+            </div>
+          ) : (
+            <div className="grid gap-4 xl:grid-cols-[minmax(280px,380px)_1fr]">
+              <div className="rounded-xl border border-app-border bg-app-bg p-3">
+                <div className="space-y-3">
+                  <label className="block">
+                    <span className="mb-1 block text-[11px] font-medium text-tx-tertiary">{labels.task}</span>
+                    <select
+                      value={selectedTaskId}
+                      onChange={(event) => chooseTask(event.target.value)}
+                      className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm text-tx-primary outline-none focus:border-accent-primary"
+                    >
+                      <option value="">{availableTasks.length ? labels.chooseTask : labels.noTasks}</option>
+                      {availableTasks.map((task) => (
+                        <option key={task.id} value={task.id}>
+                          {task.priority === 3 ? "● " : task.priority === 2 ? "• " : ""}{task.title}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <div>
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[11px] font-medium text-tx-tertiary">{labels.estimate}</span>
+                      {selectedTask?.estimatedMinutes ? (
+                        <button type="button" onClick={() => void setEstimate(null)} className="flex items-center gap-1 text-[10px] text-tx-tertiary hover:text-accent-danger">
+                          <X size={10} /> {labels.clearEstimate}
+                        </button>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {ESTIMATE_PRESETS.map((minutes) => (
+                        <button
+                          key={minutes}
+                          type="button"
+                          disabled={!selectedTaskId}
+                          onClick={() => void setEstimate(minutes)}
+                          className={cn(
+                            "rounded-full border px-2 py-1 text-[11px] transition-colors disabled:opacity-40",
+                            selectedTask?.estimatedMinutes === minutes
+                              ? "border-accent-primary bg-accent-primary/10 text-accent-primary"
+                              : "border-app-border text-tx-secondary hover:border-accent-primary/40",
+                          )}
+                        >
+                          {formatMinutes(minutes, chinese)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-2">
+                    <label>
+                      <span className="mb-1 block text-[11px] font-medium text-tx-tertiary">{labels.start}</span>
+                      <input
+                        type="time"
+                        value={startTime}
+                        onChange={(event) => setStartTime(event.target.value)}
+                        className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm text-tx-primary outline-none focus:border-accent-primary"
+                      />
+                    </label>
+                    <label>
+                      <span className="mb-1 block text-[11px] font-medium text-tx-tertiary">{labels.duration}</span>
+                      <select
+                        value={durationMinutes}
+                        onChange={(event) => setDurationMinutes(Number(event.target.value))}
+                        className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm text-tx-primary outline-none focus:border-accent-primary"
+                      >
+                        {[15, 30, 45, 60, 90, 120, 180, 240].map((minutes) => (
+                          <option key={minutes} value={minutes}>{formatMinutes(minutes, chinese)}</option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => void addBlock()}
+                    disabled={!selectedTaskId || saving}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+                  >
+                    {saving ? <Loader2 size={15} className="animate-spin" /> : <Plus size={15} />}
+                    {labels.add}
+                  </button>
+                </div>
+              </div>
+
+              <div className="min-w-0 rounded-xl border border-app-border bg-app-bg">
+                <div className="border-b border-app-border px-3 py-2.5">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <h3 className="text-sm font-semibold text-tx-primary">{labels.scheduled}</h3>
+                      <p className="text-[10px] text-tx-tertiary">
+                        {formatMinutes(totalMinutes, chinese)} · {blocks.length} {chinese ? "个时间块" : "blocks"}
+                        {occupied !== totalMinutes ? ` · ${chinese ? "实际占用" : "occupied"} ${formatMinutes(occupied, chinese)}` : ""}
+                      </p>
+                    </div>
+                    <div className="w-32">
+                      <div className="mb-1 flex justify-between text-[9px] text-tx-tertiary">
+                        <span>0h</span><span>8h</span>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-app-border">
+                        <div
+                          className={cn("h-full rounded-full", totalMinutes > DAY_CAPACITY_MINUTES ? "bg-red-500" : "bg-accent-primary")}
+                          style={{ width: `${capacityPercent}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  {totalMinutes > DAY_CAPACITY_MINUTES && (
+                    <p className="mt-2 flex items-center gap-1 text-[10px] text-red-500"><AlertTriangle size={11} />{labels.overCapacity}</p>
+                  )}
+                  {conflictIds.size > 0 && (
+                    <p className="mt-1 flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400"><AlertTriangle size={11} />{labels.conflictHint}</p>
+                  )}
+                </div>
+
+                <div className="max-h-[320px] space-y-2 overflow-y-auto p-3">
+                  {blocks.length === 0 ? (
+                    <div className="flex h-28 flex-col items-center justify-center gap-2 text-tx-tertiary">
+                      <Clock3 size={20} />
+                      <span className="text-xs">{labels.noBlocks}</span>
+                    </div>
+                  ) : blocks.map((block) => {
+                    const duration = minutesBetween(block.startAt, block.endAt);
+                    const isEditing = editingId === block.id;
+                    const conflicted = conflictIds.has(block.id);
+                    return (
+                      <div
+                        key={block.id}
+                        className={cn(
+                          "rounded-lg border bg-app-surface p-3",
+                          conflicted ? "border-amber-400/60" : "border-app-border",
+                          block.isCompleted ? "opacity-60" : "",
+                        )}
+                      >
+                        {isEditing ? (
+                          <div className="grid gap-2 sm:grid-cols-[110px_130px_1fr] sm:items-end">
+                            <label>
+                              <span className="mb-1 block text-[10px] text-tx-tertiary">{labels.start}</span>
+                              <input type="time" value={editStartTime} onChange={(event) => setEditStartTime(event.target.value)} className="w-full rounded-md border border-app-border bg-app-bg px-2 py-1.5 text-xs text-tx-primary outline-none" />
+                            </label>
+                            <label>
+                              <span className="mb-1 block text-[10px] text-tx-tertiary">{labels.duration}</span>
+                              <select value={editDurationMinutes} onChange={(event) => setEditDurationMinutes(Number(event.target.value))} className="w-full rounded-md border border-app-border bg-app-bg px-2 py-1.5 text-xs text-tx-primary outline-none">
+                                {[15, 30, 45, 60, 90, 120, 180, 240].map((minutes) => <option key={minutes} value={minutes}>{formatMinutes(minutes, chinese)}</option>)}
+                              </select>
+                            </label>
+                            <div className="flex justify-end gap-1">
+                              <button type="button" onClick={() => setEditingId(null)} className="flex items-center gap-1 rounded-md px-2 py-1.5 text-[11px] text-tx-secondary hover:bg-app-hover"><X size={12} />{labels.cancel}</button>
+                              <button type="button" onClick={() => void saveEdit(block)} className="flex items-center gap-1 rounded-md bg-accent-primary px-2 py-1.5 text-[11px] text-white"><Save size={12} />{labels.save}</button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex items-start gap-3">
+                            <div className="w-[92px] shrink-0">
+                              <div className="text-sm font-semibold text-tx-primary">{timeText(block.startAt)}</div>
+                              <div className="text-[10px] text-tx-tertiary">{timeText(block.endAt)} · {formatMinutes(duration, chinese)}</div>
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className={cn("truncate text-sm text-tx-primary", block.isCompleted ? "line-through" : "")}>{block.taskTitle}</div>
+                              <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[10px] text-tx-tertiary">
+                                {block.estimatedMinutes ? <span>{labels.estimate} {formatMinutes(block.estimatedMinutes, chinese)}</span> : null}
+                                {block.isCompleted ? <span>{labels.completed}</span> : null}
+                                {conflicted ? <span className="text-amber-600 dark:text-amber-400">{labels.conflicts}</span> : null}
+                              </div>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-1">
+                              <button type="button" onClick={() => beginEdit(block)} title={labels.edit} className="rounded-md p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-accent-primary"><Pencil size={13} /></button>
+                              <button type="button" onClick={() => void removeBlock(block.id)} title={labels.delete} className="rounded-md p-1.5 text-tx-tertiary hover:bg-red-500/10 hover:text-red-500"><Trash2 size={13} /></button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/tasks/TaskTimePlanner.tsx
+++ b/frontend/src/components/tasks/TaskTimePlanner.tsx
@@ -176,8 +176,9 @@ export function TaskTimePlanner({ onTaskMutated }: TaskTimePlannerProps) {
   }, [dateKey, labels.loadFailed]);
 
   useEffect(() => {
+    if (!expanded) return;
     void load();
-  }, [load]);
+  }, [expanded, load]);
 
   useEffect(() => {
     try {

--- a/frontend/src/components/tasks/TaskTimePlanner.tsx
+++ b/frontend/src/components/tasks/TaskTimePlanner.tsx
@@ -59,11 +59,8 @@ function moveDate(dateKey: string, days: number): string {
 }
 
 function timeText(iso: string): string {
-  return new Intl.DateTimeFormat(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(new Date(iso));
+  const date = new Date(iso);
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
 }
 
 function dateLabel(dateKey: string, chinese: boolean): string {
@@ -236,11 +233,11 @@ export function TaskTimePlanner({ onTaskMutated }: TaskTimePlannerProps) {
     const endAt = addMinutesIso(startAt, durationMinutes);
     setSaving(true);
     try {
-      const block = await createTaskTimeBlock({ selectedTaskId, taskId: selectedTaskId, startAt, endAt, timeZone } as {
-        taskId: string;
-        startAt: string;
-        endAt: string;
-        timeZone: string;
+      const block = await createTaskTimeBlock({
+        taskId: selectedTaskId,
+        startAt,
+        endAt,
+        timeZone,
       });
       setBlocks((current) => [...current, block].sort((a, b) => a.startAt.localeCompare(b.startAt)));
       setStartTime(timeText(endAt));

--- a/frontend/src/components/tasks/__tests__/taskTimePlanning.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskTimePlanning.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { TaskTimeBlock } from "@/lib/taskTimePlanningApi";
+import {
+  addMinutesIso,
+  findConflictingBlockIds,
+  formatMinutes,
+  minutesBetween,
+  occupiedMinutes,
+} from "../taskTimePlanning";
+
+function block(id: string, startAt: string, endAt: string): TaskTimeBlock {
+  return {
+    id,
+    taskId: `task-${id}`,
+    userId: "user-1",
+    workspaceId: "personal",
+    startAt,
+    endAt,
+    timeZone: "UTC",
+    createdAt: startAt,
+    updatedAt: startAt,
+    taskTitle: id,
+    priority: 2,
+    projectId: null,
+    isCompleted: 0,
+    estimatedMinutes: null,
+  };
+}
+
+describe("task time planning helpers", () => {
+  it("detects overlapping blocks without marking adjacent blocks", () => {
+    const blocks = [
+      block("a", "2026-08-03T01:00:00.000Z", "2026-08-03T02:00:00.000Z"),
+      block("b", "2026-08-03T01:30:00.000Z", "2026-08-03T02:30:00.000Z"),
+      block("c", "2026-08-03T02:30:00.000Z", "2026-08-03T03:00:00.000Z"),
+    ];
+
+    expect([...findConflictingBlockIds(blocks)].sort()).toEqual(["a", "b"]);
+  });
+
+  it("calculates occupied time as the union of overlapping ranges", () => {
+    const blocks = [
+      block("a", "2026-08-03T01:00:00.000Z", "2026-08-03T02:00:00.000Z"),
+      block("b", "2026-08-03T01:30:00.000Z", "2026-08-03T02:30:00.000Z"),
+      block("c", "2026-08-03T03:00:00.000Z", "2026-08-03T03:30:00.000Z"),
+    ];
+
+    expect(occupiedMinutes(blocks)).toBe(120);
+  });
+
+  it("adds and formats durations consistently", () => {
+    const start = "2026-08-03T01:00:00.000Z";
+    const end = addMinutesIso(start, 90);
+    expect(end).toBe("2026-08-03T02:30:00.000Z");
+    expect(minutesBetween(start, end)).toBe(90);
+    expect(formatMinutes(90, true)).toBe("1 小时 30 分钟");
+    expect(formatMinutes(90, false)).toBe("1h 30m");
+  });
+});

--- a/frontend/src/components/tasks/taskTimePlanning.ts
+++ b/frontend/src/components/tasks/taskTimePlanning.ts
@@ -1,0 +1,93 @@
+import type { TaskTimeBlock } from "@/lib/taskTimePlanningApi";
+
+export function formatLocalDateKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function localDayRange(dateKey: string): { from: string; to: string } {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const start = new Date(year, month - 1, day, 0, 0, 0, 0);
+  const end = new Date(year, month - 1, day + 1, 0, 0, 0, 0);
+  return { from: start.toISOString(), to: end.toISOString() };
+}
+
+export function combineLocalDateAndTime(dateKey: string, time: string): string {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const [hour, minute] = time.split(":").map(Number);
+  return new Date(year, month - 1, day, hour || 0, minute || 0, 0, 0).toISOString();
+}
+
+export function addMinutesIso(startAt: string, minutes: number): string {
+  return new Date(Date.parse(startAt) + minutes * 60_000).toISOString();
+}
+
+export function minutesBetween(startAt: string, endAt: string): number {
+  return Math.max(0, Math.round((Date.parse(endAt) - Date.parse(startAt)) / 60_000));
+}
+
+export function formatMinutes(minutes: number, chinese = true): string {
+  const normalized = Math.max(0, Math.round(minutes));
+  const hours = Math.floor(normalized / 60);
+  const remainder = normalized % 60;
+  if (hours === 0) return chinese ? `${remainder} 分钟` : `${remainder}m`;
+  if (remainder === 0) return chinese ? `${hours} 小时` : `${hours}h`;
+  return chinese ? `${hours} 小时 ${remainder} 分钟` : `${hours}h ${remainder}m`;
+}
+
+export function findConflictingBlockIds(blocks: TaskTimeBlock[]): Set<string> {
+  const conflicts = new Set<string>();
+  const ordered = [...blocks].sort((a, b) => Date.parse(a.startAt) - Date.parse(b.startAt));
+  for (let i = 0; i < ordered.length; i += 1) {
+    const current = ordered[i];
+    const currentEnd = Date.parse(current.endAt);
+    for (let j = i + 1; j < ordered.length; j += 1) {
+      const next = ordered[j];
+      if (Date.parse(next.startAt) >= currentEnd) break;
+      if (Date.parse(current.startAt) < Date.parse(next.endAt)) {
+        conflicts.add(current.id);
+        conflicts.add(next.id);
+      }
+    }
+  }
+  return conflicts;
+}
+
+export function occupiedMinutes(blocks: TaskTimeBlock[]): number {
+  const intervals = blocks
+    .map((block) => [Date.parse(block.startAt), Date.parse(block.endAt)] as const)
+    .filter(([start, end]) => Number.isFinite(start) && Number.isFinite(end) && end > start)
+    .sort((a, b) => a[0] - b[0]);
+  if (intervals.length === 0) return 0;
+
+  let total = 0;
+  let [rangeStart, rangeEnd] = intervals[0];
+  for (let i = 1; i < intervals.length; i += 1) {
+    const [start, end] = intervals[i];
+    if (start <= rangeEnd) {
+      rangeEnd = Math.max(rangeEnd, end);
+    } else {
+      total += rangeEnd - rangeStart;
+      rangeStart = start;
+      rangeEnd = end;
+    }
+  }
+  total += rangeEnd - rangeStart;
+  return Math.round(total / 60_000);
+}
+
+export function nextHalfHour(date = new Date()): string {
+  const next = new Date(date);
+  next.setSeconds(0, 0);
+  const minutes = next.getMinutes();
+  if (minutes === 0 || minutes === 30) {
+    next.setMinutes(minutes + 30);
+  } else if (minutes < 30) {
+    next.setMinutes(30);
+  } else {
+    next.setHours(next.getHours() + 1, 0, 0, 0);
+  }
+  return `${String(next.getHours()).padStart(2, "0")}:${String(next.getMinutes()).padStart(2, "0")}`;
+}

--- a/frontend/src/lib/taskTimePlanningApi.ts
+++ b/frontend/src/lib/taskTimePlanningApi.ts
@@ -1,0 +1,101 @@
+import { getBaseUrl, getCurrentWorkspace } from "./api";
+
+export interface TaskTimeBlock {
+  id: string;
+  taskId: string;
+  userId: string;
+  workspaceId: string;
+  startAt: string;
+  endAt: string;
+  timeZone: string;
+  createdAt: string;
+  updatedAt: string;
+  taskTitle: string;
+  priority: number;
+  projectId: string | null;
+  isCompleted: number;
+  estimatedMinutes: number | null;
+}
+
+export interface TaskTimeBlockList {
+  workspaceId: string;
+  from: string;
+  to: string;
+  blocks: TaskTimeBlock[];
+}
+
+function currentWorkspaceId(): string {
+  const workspaceId = getCurrentWorkspace();
+  return workspaceId && workspaceId !== "personal" ? workspaceId : "personal";
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = new Error(
+      typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
+    ) as Error & { code?: string; status?: number };
+    error.code = payload?.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
+export async function getTaskTimeBlocks(from: string, to: string): Promise<TaskTimeBlockList> {
+  const params = new URLSearchParams({
+    workspaceId: currentWorkspaceId(),
+    from,
+    to,
+  });
+  return request<TaskTimeBlockList>(`/user-preferences/task-time-blocks?${params.toString()}`);
+}
+
+export async function createTaskTimeBlock(input: {
+  taskId: string;
+  startAt: string;
+  endAt: string;
+  timeZone: string;
+}): Promise<TaskTimeBlock> {
+  const response = await request<{ block: TaskTimeBlock }>("/user-preferences/task-time-blocks", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return response.block;
+}
+
+export async function updateTaskTimeBlock(
+  id: string,
+  input: { startAt: string; endAt: string; timeZone?: string },
+): Promise<TaskTimeBlock> {
+  const response = await request<{ block: TaskTimeBlock }>(`/user-preferences/task-time-blocks/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+  return response.block;
+}
+
+export async function deleteTaskTimeBlock(id: string): Promise<void> {
+  await request<{ success: true }>(`/user-preferences/task-time-blocks/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function updateTaskEstimate(
+  taskId: string,
+  estimatedMinutes: number | null,
+): Promise<{ taskId: string; estimatedMinutes: number | null }> {
+  return request(`/user-preferences/task-time-blocks/tasks/${taskId}/estimate`, {
+    method: "PUT",
+    body: JSON.stringify({ estimatedMinutes }),
+  });
+}

--- a/frontend/tsconfig.task-time-planning.json
+++ b/frontend/tsconfig.task-time-planning.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.task-time-planning.tsbuildinfo"
+  },
+  "include": [
+    "src/lunar-javascript.d.ts",
+    "src/components/TaskCenter.tsx",
+    "src/components/tasks/TaskTimePlanner.tsx",
+    "src/components/tasks/taskTimePlanning.ts",
+    "src/lib/taskTimePlanningApi.ts"
+  ]
+}


### PR DESCRIPTION
## 背景

任务中心已经具备 My Day、标签和保存视图，但用户仍只能决定“今天做什么”，不能回答“具体什么时候做、需要多久”。

本 PR 新增任务预估时长与个人时间块，让任务截止日期、今日计划和实际日程保持独立语义。

## 产品边界

- `estimatedMinutes` 属于共享任务字段，沿用现有任务写权限：创建者本人或工作区管理员/所有者可维护
- `task_time_blocks` 属于当前用户：即使在同一工作区，每个成员也拥有独立日程，不互相覆盖
- 时间块不会修改任务截止日期、开始日期或 My Day 计划
- 一个任务可以拆分成多个时间块
- 重叠时间块允许保存，但前端会明确提示冲突

## 实现内容

### 数据与接口

- SQLite 正式 v72 `task-estimates-and-time-blocks` 迁移
- `tasks` 增加可空 `estimatedMinutes`
- 新增 `task_time_blocks` 表和范围查询索引
- 新增个人时间块 API：
  - 按日期范围读取
  - 创建时间块
  - 调整时间与时长
  - 删除时间块
  - 更新任务预估时长
- 时间统一以 UTC ISO 保存，同时记录经过校验的 IANA 时区
- 时间块限制 5 分钟至 24 小时；任务预估最多 7 天
- 循环任务生成下一次实例时自动继承预估时长
- PostgreSQL Pilot schema 与循环任务继承触发器同步

### 前端交互

- 任务中心新增可折叠「时间规划」区域，默认折叠
- 折叠状态下不额外请求任务和时间块，首次展开时再懒加载
- 支持前一天、后一天、日期选择和回到今天
- 支持为任务设置 15 分钟至 3 小时常用预估时长
- 支持选择任务、开始时间和时间块长度后加入日程
- 支持调整和删除已有时间块
- 展示当日安排总量、8 小时容量进度和去重后的实际占用时长
- 自动识别重叠时间块并标记冲突
- 工作区切换和跨午夜时自动重载对应空间与日期
- 使用本地时分生成输入值，避免部分浏览器在午夜返回 `24:00`

## 权限与安全

- 个人任务只能由任务所有者规划
- 工作区成员可以把可见的共享任务安排进自己的私人日程
- 同一共享任务可被不同成员分别安排，成员只能读取和修改自己的时间块
- 编辑时间块前会重新校验任务可见性；成员退出工作区后，旧时间块 ID 不会泄露任务标题
- 删除任务后，关联时间块通过外键级联清理

## 数据兼容性

- 不修改现有任务截止时间语义
- 不改变 My Day、标签、保存视图、看板、月历和甘特图
- 当前生产运行时仍使用 SQLite；本 PR 不引入生产 PostgreSQL 切换
- 分支完全基于当前 `main`，无合并冲突

## 自动验证

### Task Time Planning CI

- ✅ 后端 TypeScript 编译
- ✅ 真实 Hono API / SQLite 持久化测试
- ✅ 个人任务权限测试
- ✅ 工作区共享任务、个人日程隔离测试
- ✅ 循环任务预估继承测试
- ✅ 前端定向 TypeScript 检查
- ✅ Vite 生产打包
- ✅ 时间冲突、区间合并与时长计算单测

### 组合回归

- ✅ Task My Day CI：前后端构建、API 与规划逻辑通过
- ✅ Task Metadata CI：标签、保存视图、前后端构建与筛选逻辑通过

> `Block Patch CI` 的一次失败来自其并行路由测试中的 `SQLITE_BUSY_SNAPSHOT / database is locked`，与本 PR 的任务规划文件无关；本 PR 专用后端测试及其他任务模块回归均已通过。

## 仍需人工体验确认

- 桌面端折叠区域的信息密度
- 移动端日期与任务选择表单
- 不同时区跨设备查看同一时间块
- 连续安排超过 8 小时时的容量提示
