### PR TITLE
feat(tasks): add personal Inbox and global quick capture

### DIFF
--- a/.github/workflows/task-inbox-ci.yml
+++ b/.github/workflows/task-inbox-ci.yml
@@ -1,0 +1,84 @@
+name: Task Inbox CI
+
+on:
+  push:
+    branches:
+      - feature/task-inbox-quick-capture-v1
+    paths:
+      - "backend/src/db/taskInboxMigration.ts"
+      - "backend/src/runtime/task-inbox-migration-bootstrap.ts"
+      - "backend/src/routes/task-inbox.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-inbox.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/SidebarSearchExperienceBridge.tsx"
+      - "frontend/src/components/tasks/TaskInboxPanel.tsx"
+      - "frontend/src/components/tasks/TaskQuickCaptureBridge.tsx"
+      - "frontend/src/components/tasks/taskInboxCapture.ts"
+      - "frontend/src/components/tasks/__tests__/taskInboxCapture.test.ts"
+      - "frontend/src/lib/taskInboxApi.ts"
+      - "frontend/tsconfig.task-inbox.json"
+      - ".github/workflows/task-inbox-ci.yml"
+  pull_request:
+    paths:
+      - "backend/src/db/taskInboxMigration.ts"
+      - "backend/src/runtime/task-inbox-migration-bootstrap.ts"
+      - "backend/src/routes/task-inbox.ts"
+      - "backend/src/routes/user-preferences.ts"
+      - "backend/src/index.hardened.ts"
+      - "backend/src/db/postgres/schema.sql"
+      - "backend/tests/task-inbox.test.ts"
+      - "frontend/src/components/TaskCenter.tsx"
+      - "frontend/src/components/SidebarSearchExperienceBridge.tsx"
+      - "frontend/src/components/tasks/TaskInboxPanel.tsx"
+      - "frontend/src/components/tasks/TaskQuickCaptureBridge.tsx"
+      - "frontend/src/components/tasks/taskInboxCapture.ts"
+      - "frontend/src/components/tasks/__tests__/taskInboxCapture.test.ts"
+      - "frontend/src/lib/taskInboxApi.ts"
+      - "frontend/tsconfig.task-inbox.json"
+      - ".github/workflows/task-inbox-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - name: Backend typecheck
+        run: npm run build:tsc
+      - name: Test task Inbox API
+        run: node --import tsx --test tests/task-inbox.test.ts
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Targeted TypeScript check
+        run: npx tsc -p tsconfig.task-inbox.json
+      - name: Vite production bundle
+        run: npx vite build
+      - name: Test quick capture helpers
+        run: npx vitest run src/components/tasks/__tests__/taskInboxCapture.test.ts --reporter=verbose

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -135,3 +135,25 @@ CREATE TRIGGER tasks_inherit_estimate_before_recurrence_insert
 BEFORE INSERT ON tasks
 FOR EACH ROW
 EXECUTE FUNCTION inherit_recurring_task_estimate();
+
+CREATE TABLE IF NOT EXISTS task_inbox_items (
+  "taskId" TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  "userId" TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "workspaceId" TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+  "capturedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "sourceType" TEXT NOT NULL DEFAULT 'manual'
+    CHECK ("sourceType" IN ('manual', 'global', 'selection', 'note', 'diary', 'share', 'other')),
+  "sourceId" TEXT,
+  "sourceTitle" TEXT,
+  excerpt TEXT NOT NULL DEFAULT '',
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY ("taskId", "userId")
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_inbox_user_scope_captured
+  ON task_inbox_items("userId", "workspaceId", "capturedAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_task_inbox_task
+  ON task_inbox_items("taskId", "capturedAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_task_inbox_source
+  ON task_inbox_items("userId", "sourceType", "sourceId");

--- a/backend/src/db/postgres/schema.sql
+++ b/backend/src/db/postgres/schema.sql
@@ -157,3 +157,19 @@ CREATE INDEX IF NOT EXISTS idx_task_inbox_task
   ON task_inbox_items("taskId", "capturedAt" DESC);
 CREATE INDEX IF NOT EXISTS idx_task_inbox_source
   ON task_inbox_items("userId", "sourceType", "sourceId");
+
+CREATE OR REPLACE FUNCTION clear_task_inbox_after_completion()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD."isCompleted" = 0 AND NEW."isCompleted" = 1 THEN
+    DELETE FROM task_inbox_items WHERE "taskId" = NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS task_inbox_remove_after_task_complete ON tasks;
+CREATE TRIGGER task_inbox_remove_after_task_complete
+AFTER UPDATE OF "isCompleted" ON tasks
+FOR EACH ROW
+EXECUTE FUNCTION clear_task_inbox_after_completion();

--- a/backend/src/db/taskInboxMigration.ts
+++ b/backend/src/db/taskInboxMigration.ts
@@ -37,6 +37,14 @@ export function ensureTaskInboxSchema(db: Database.Database): void {
       ON task_inbox_items(taskId, capturedAt DESC);
     CREATE INDEX IF NOT EXISTS idx_task_inbox_source
       ON task_inbox_items(userId, sourceType, sourceId);
+
+    DROP TRIGGER IF EXISTS task_inbox_remove_after_task_complete;
+    CREATE TRIGGER task_inbox_remove_after_task_complete
+    AFTER UPDATE OF isCompleted ON tasks
+    WHEN OLD.isCompleted = 0 AND NEW.isCompleted = 1
+    BEGIN
+      DELETE FROM task_inbox_items WHERE taskId = NEW.id;
+    END;
   `);
 }
 

--- a/backend/src/db/taskInboxMigration.ts
+++ b/backend/src/db/taskInboxMigration.ts
@@ -1,0 +1,47 @@
+import type Database from "better-sqlite3";
+import type { Migration } from "./migrations.impl.js";
+
+export const TASK_INBOX_SOURCE_TYPES = [
+  "manual",
+  "global",
+  "selection",
+  "note",
+  "diary",
+  "share",
+  "other",
+] as const;
+
+export function ensureTaskInboxSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS task_inbox_items (
+      taskId TEXT NOT NULL,
+      userId TEXT NOT NULL,
+      workspaceId TEXT,
+      capturedAt TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      sourceType TEXT NOT NULL DEFAULT 'manual'
+        CHECK (sourceType IN ('manual', 'global', 'selection', 'note', 'diary', 'share', 'other')),
+      sourceId TEXT,
+      sourceTitle TEXT,
+      excerpt TEXT NOT NULL DEFAULT '',
+      createdAt TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updatedAt TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      PRIMARY KEY (taskId, userId),
+      FOREIGN KEY (taskId) REFERENCES tasks(id) ON DELETE CASCADE,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (workspaceId) REFERENCES workspaces(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_task_inbox_user_scope_captured
+      ON task_inbox_items(userId, workspaceId, capturedAt DESC);
+    CREATE INDEX IF NOT EXISTS idx_task_inbox_task
+      ON task_inbox_items(taskId, capturedAt DESC);
+    CREATE INDEX IF NOT EXISTS idx_task_inbox_source
+      ON task_inbox_items(userId, sourceType, sourceId);
+  `);
+}
+
+export const taskInboxMigration: Migration = {
+  version: 73,
+  name: "personal-task-inbox-and-capture-source",
+  up: ensureTaskInboxSchema,
+};

--- a/backend/src/index.hardened.ts
+++ b/backend/src/index.hardened.ts
@@ -4,6 +4,7 @@ import "./runtime/url-import-dns-compat.js";
 import "./runtime/knowledge-tree-migration-bootstrap.js";
 import "./runtime/task-metadata-migration-bootstrap.js";
 import "./runtime/task-time-planning-migration-bootstrap.js";
+import "./runtime/task-inbox-migration-bootstrap.js";
 // Permission routes import ACL services that may initialize database guards, so they must load
 // only after the feature migration list has been registered.
 import "./runtime/notebook-permission-management.js";

--- a/backend/src/routes/task-inbox.ts
+++ b/backend/src/routes/task-inbox.ts
@@ -1,0 +1,342 @@
+import crypto from "node:crypto";
+import { Hono } from "hono";
+import { getDb } from "../db/schema.js";
+import {
+  ensureTaskInboxSchema,
+  TASK_INBOX_SOURCE_TYPES,
+} from "../db/taskInboxMigration.js";
+import { getUserWorkspaceRole } from "../middleware/acl.js";
+
+const taskInbox = new Hono();
+const SOURCE_TYPES = new Set<string>(TASK_INBOX_SOURCE_TYPES);
+const MAX_TITLE_LENGTH = 500;
+const MAX_DESCRIPTION_LENGTH = 20_000;
+const MAX_EXCERPT_LENGTH = 8_000;
+const MAX_SOURCE_ID_LENGTH = 1_000;
+const MAX_SOURCE_TITLE_LENGTH = 300;
+let initializedDatabase: object | null = null;
+
+interface TaskAccessRow {
+  id: string;
+  userId: string;
+  workspaceId: string | null;
+  isCompleted: number;
+}
+
+function ensureSchema(): void {
+  const db = getDb();
+  if (initializedDatabase === db) return;
+  ensureTaskInboxSchema(db);
+  initializedDatabase = db;
+}
+
+function resolveScope(userId: string, rawWorkspaceId: unknown):
+  | { workspaceId: string | null }
+  | { workspaceId: string; error: string } {
+  const workspaceId = typeof rawWorkspaceId === "string" ? rawWorkspaceId.trim() : "";
+  if (!workspaceId || workspaceId === "personal") return { workspaceId: null };
+  if (!getUserWorkspaceRole(workspaceId, userId)) {
+    return { workspaceId, error: "无权访问该工作区" };
+  }
+  return { workspaceId };
+}
+
+function canReadTask(task: TaskAccessRow, userId: string): boolean {
+  if (task.workspaceId) return getUserWorkspaceRole(task.workspaceId, userId) !== null;
+  return task.userId === userId;
+}
+
+function cleanText(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+function nullableText(value: unknown, maxLength: number): string | null {
+  const normalized = cleanText(value, maxLength);
+  return normalized || null;
+}
+
+function normalizeSourceType(value: unknown): string {
+  const normalized = cleanText(value, 40).toLowerCase();
+  return SOURCE_TYPES.has(normalized) ? normalized : "other";
+}
+
+function normalizePriority(value: unknown): number {
+  const priority = Number(value);
+  return Number.isInteger(priority) && priority >= 1 && priority <= 3 ? priority : 2;
+}
+
+function normalizeDateKey(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year
+    || parsed.getUTCMonth() !== month - 1
+    || parsed.getUTCDate() !== day
+  ) return null;
+  return value;
+}
+
+function normalizeDueAt(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (normalized.length > 80 || Number.isNaN(new Date(normalized).getTime())) return null;
+  return normalized;
+}
+
+function taskRow(taskId: string): TaskAccessRow | undefined {
+  return getDb().prepare(
+    "SELECT id, userId, workspaceId, isCompleted FROM tasks WHERE id = ?",
+  ).get(taskId) as TaskAccessRow | undefined;
+}
+
+function listInbox(userId: string, workspaceId: string | null) {
+  const scopeSql = workspaceId ? "i.workspaceId = ?" : "i.workspaceId IS NULL";
+  const params = workspaceId ? [userId, workspaceId] : [userId];
+  return getDb().prepare(`
+    SELECT
+      t.*,
+      users.username AS creatorName,
+      i.capturedAt AS inboxAt,
+      i.sourceType AS captureSourceType,
+      i.sourceId AS captureSourceId,
+      i.sourceTitle AS captureSourceTitle,
+      i.excerpt AS captureExcerpt
+    FROM task_inbox_items i
+    INNER JOIN tasks t ON t.id = i.taskId
+    LEFT JOIN users ON users.id = t.userId
+    WHERE i.userId = ?
+      AND ${scopeSql}
+      AND t.isCompleted = 0
+    ORDER BY i.capturedAt DESC, t.createdAt DESC
+  `).all(...params);
+}
+
+function inboxCount(userId: string, workspaceId: string | null): number {
+  const scopeSql = workspaceId ? "i.workspaceId = ?" : "i.workspaceId IS NULL";
+  const params = workspaceId ? [userId, workspaceId] : [userId];
+  const row = getDb().prepare(`
+    SELECT COUNT(*) AS count
+    FROM task_inbox_items i
+    INNER JOIN tasks t ON t.id = i.taskId
+    WHERE i.userId = ?
+      AND ${scopeSql}
+      AND t.isCompleted = 0
+  `).get(...params) as { count: number } | undefined;
+  return row?.count ?? 0;
+}
+
+// GET /api/user-preferences/task-inbox?workspaceId=personal|uuid
+taskInbox.get("/", (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const scope = resolveScope(userId, c.req.query("workspaceId"));
+  if ("error" in scope) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const items = listInbox(userId, scope.workspaceId);
+  return c.json({
+    workspaceId: scope.workspaceId || "personal",
+    count: items.length,
+    items,
+  });
+});
+
+// GET /api/user-preferences/task-inbox/count?workspaceId=personal|uuid
+taskInbox.get("/count", (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const scope = resolveScope(userId, c.req.query("workspaceId"));
+  if ("error" in scope) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+  return c.json({
+    workspaceId: scope.workspaceId || "personal",
+    count: inboxCount(userId, scope.workspaceId),
+  });
+});
+
+// POST /api/user-preferences/task-inbox/capture
+// Creates the task and its personal Inbox membership in one SQLite transaction.
+taskInbox.post("/capture", async (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
+  const title = cleanText(body?.title, MAX_TITLE_LENGTH);
+  if (!title) return c.json({ error: "title is required", code: "TITLE_REQUIRED" }, 400);
+
+  const scope = resolveScope(userId, body?.workspaceId);
+  if ("error" in scope) return c.json({ error: scope.error, code: "FORBIDDEN" }, 403);
+
+  const description = cleanText(body?.description, MAX_DESCRIPTION_LENGTH);
+  const priority = normalizePriority(body?.priority);
+  const dueDate = normalizeDateKey(body?.dueDate);
+  const dueAt = normalizeDueAt(body?.dueAt);
+  const startDate = normalizeDateKey(body?.startDate);
+  if (body?.dueDate && !dueDate) {
+    return c.json({ error: "dueDate must use YYYY-MM-DD", code: "INVALID_DUE_DATE" }, 400);
+  }
+  if (body?.dueAt && !dueAt) {
+    return c.json({ error: "dueAt must be a valid date-time", code: "INVALID_DUE_AT" }, 400);
+  }
+  if (body?.startDate && !startDate) {
+    return c.json({ error: "startDate must use YYYY-MM-DD", code: "INVALID_START_DATE" }, 400);
+  }
+  if (startDate && dueDate && startDate > dueDate) {
+    return c.json({ error: "startDate cannot be after dueDate", code: "INVALID_DATE_RANGE" }, 400);
+  }
+
+  const noteId = nullableText(body?.noteId, 128);
+  const sourceType = normalizeSourceType(body?.sourceType);
+  const sourceId = nullableText(body?.sourceId, MAX_SOURCE_ID_LENGTH);
+  const sourceTitle = nullableText(body?.sourceTitle, MAX_SOURCE_TITLE_LENGTH);
+  const excerpt = cleanText(body?.excerpt, MAX_EXCERPT_LENGTH);
+  const taskId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const transaction = getDb().transaction(() => {
+    getDb().prepare(`
+      INSERT INTO tasks (
+        id, userId, workspaceId, title, description, isCompleted, completedAt,
+        priority, dueDate, dueAt, startDate, noteId, parentId, projectId,
+        status, repeatRule, repeatInterval, repeatEndDate, repeatGroupId,
+        repeatGeneratedFromId, repeatEndCount, repeatSequenceIndex, repeatRuleJson
+      ) VALUES (?, ?, ?, ?, ?, 0, NULL, ?, ?, ?, ?, ?, NULL, NULL,
+                'todo', 'none', 1, NULL, NULL, NULL, NULL, NULL, NULL)
+    `).run(
+      taskId,
+      userId,
+      scope.workspaceId,
+      title,
+      description,
+      priority,
+      dueDate,
+      dueAt,
+      startDate,
+      noteId,
+    );
+
+    getDb().prepare(`
+      INSERT INTO task_inbox_items (
+        taskId, userId, workspaceId, capturedAt, sourceType,
+        sourceId, sourceTitle, excerpt, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      taskId,
+      userId,
+      scope.workspaceId,
+      now,
+      sourceType,
+      sourceId,
+      sourceTitle,
+      excerpt,
+      now,
+      now,
+    );
+  });
+  transaction();
+
+  const task = getDb().prepare(`
+    SELECT
+      t.*,
+      users.username AS creatorName,
+      i.capturedAt AS inboxAt,
+      i.sourceType AS captureSourceType,
+      i.sourceId AS captureSourceId,
+      i.sourceTitle AS captureSourceTitle,
+      i.excerpt AS captureExcerpt
+    FROM tasks t
+    INNER JOIN task_inbox_items i ON i.taskId = t.id AND i.userId = ?
+    LEFT JOIN users ON users.id = t.userId
+    WHERE t.id = ?
+  `).get(userId, taskId);
+
+  return c.json({
+    task,
+    count: inboxCount(userId, scope.workspaceId),
+  }, 201);
+});
+
+// POST /api/user-preferences/task-inbox/:taskId
+// Adds an existing readable task to the current user's personal Inbox.
+taskInbox.post("/:taskId", async (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const task = taskRow(c.req.param("taskId"));
+  if (!task || !canReadTask(task, userId)) {
+    return c.json({ error: "Task not found", code: "TASK_NOT_FOUND" }, 404);
+  }
+  if (task.isCompleted) {
+    return c.json({ error: "Completed task cannot be added to Inbox", code: "TASK_COMPLETED" }, 409);
+  }
+
+  const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+  const sourceType = normalizeSourceType(body.sourceType || "manual");
+  const sourceId = nullableText(body.sourceId, MAX_SOURCE_ID_LENGTH);
+  const sourceTitle = nullableText(body.sourceTitle, MAX_SOURCE_TITLE_LENGTH);
+  const excerpt = cleanText(body.excerpt, MAX_EXCERPT_LENGTH);
+  const now = new Date().toISOString();
+
+  getDb().prepare(`
+    INSERT INTO task_inbox_items (
+      taskId, userId, workspaceId, capturedAt, sourceType,
+      sourceId, sourceTitle, excerpt, createdAt, updatedAt
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(taskId, userId) DO UPDATE SET
+      workspaceId = excluded.workspaceId,
+      capturedAt = excluded.capturedAt,
+      sourceType = excluded.sourceType,
+      sourceId = excluded.sourceId,
+      sourceTitle = excluded.sourceTitle,
+      excerpt = excluded.excerpt,
+      updatedAt = excluded.updatedAt
+  `).run(
+    task.id,
+    userId,
+    task.workspaceId,
+    now,
+    sourceType,
+    sourceId,
+    sourceTitle,
+    excerpt,
+    now,
+    now,
+  );
+
+  return c.json({
+    success: true,
+    taskId: task.id,
+    count: inboxCount(userId, task.workspaceId),
+  });
+});
+
+// DELETE /api/user-preferences/task-inbox/:taskId
+// Organizes the task out of Inbox without completing or deleting the task itself.
+taskInbox.delete("/:taskId", (c) => {
+  ensureSchema();
+  const userId = c.req.header("X-User-Id");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const existing = getDb().prepare(
+    "SELECT workspaceId FROM task_inbox_items WHERE taskId = ? AND userId = ?",
+  ).get(c.req.param("taskId"), userId) as { workspaceId: string | null } | undefined;
+  if (!existing) {
+    return c.json({ error: "Inbox item not found", code: "INBOX_ITEM_NOT_FOUND" }, 404);
+  }
+
+  getDb().prepare(
+    "DELETE FROM task_inbox_items WHERE taskId = ? AND userId = ?",
+  ).run(c.req.param("taskId"), userId);
+
+  return c.json({
+    success: true,
+    taskId: c.req.param("taskId"),
+    count: inboxCount(userId, existing.workspaceId),
+  });
+});
+
+export default taskInbox;

--- a/backend/src/routes/user-preferences.ts
+++ b/backend/src/routes/user-preferences.ts
@@ -6,6 +6,7 @@ import mobileBootstrapRoutes from "./mobile-bootstrap";
 import taskDayPlansRoutes from "./task-day-plans";
 import taskMetadataRoutes from "./task-metadata";
 import taskTimeBlocksRoutes from "./task-time-blocks";
+import taskInboxRoutes from "./task-inbox";
 
 /**
  * Compatibility wrapper: existing user preference/profile endpoints stay at their
@@ -26,6 +27,10 @@ app.route("/task-metadata", taskMetadataRoutes);
 // Time blocks are personal calendar allocations. Even inside a shared workspace,
 // every member owns an independent schedule for the same shared task.
 app.route("/task-time-blocks", taskTimeBlocksRoutes);
+
+// Inbox membership is personal processing state. A shared task can therefore be
+// captured by multiple members without changing the shared task record itself.
+app.route("/task-inbox", taskInboxRoutes);
 
 // Root preference GET/PUT/PATCH must be mounted before the legacy router. The new
 // implementation keeps the old flat response fields while adding account-scoped

--- a/backend/src/runtime/task-inbox-migration-bootstrap.ts
+++ b/backend/src/runtime/task-inbox-migration-bootstrap.ts
@@ -1,0 +1,7 @@
+import { MIGRATIONS as BASE_MIGRATIONS } from "../db/migrations.impl.js";
+import { taskInboxMigration } from "../db/taskInboxMigration.js";
+
+if (!BASE_MIGRATIONS.some((migration) => migration.version === taskInboxMigration.version)) {
+  BASE_MIGRATIONS.push(taskInboxMigration);
+  BASE_MIGRATIONS.sort((a, b) => a.version - b.version);
+}

--- a/backend/tests/task-inbox.test.ts
+++ b/backend/tests/task-inbox.test.ts
@@ -193,7 +193,7 @@ test("allows each workspace member to keep an independent Inbox membership", asy
   assert.equal(afterB.json.count, 1);
 });
 
-test("hides completed tasks and cascades Inbox rows when a task is deleted", async () => {
+test("clears Inbox rows on completion and cascades rows when a task is deleted", async () => {
   const first = await requestJson(USER_A, "POST", "/task-inbox/capture", {
     workspaceId: "personal",
     title: "Complete captured task",
@@ -206,7 +206,7 @@ test("hides completed tasks and cascades Inbox rows when a task is deleted", asy
   assert.equal(hidden.json.count, 0);
   assert.equal(
     (getDb().prepare("SELECT COUNT(*) AS count FROM task_inbox_items").get() as { count: number }).count,
-    1,
+    0,
   );
 
   const second = await requestJson(USER_A, "POST", "/task-inbox/capture", {

--- a/backend/tests/task-inbox.test.ts
+++ b/backend/tests/task-inbox.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import type Database from "better-sqlite3";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-task-inbox-"));
+process.env.DB_PATH = path.join(tmpDir, "test.db");
+
+const USER_A = "task-inbox-user-a";
+const USER_B = "task-inbox-user-b";
+const WORKSPACE_ID = "task-inbox-workspace";
+let app: Hono;
+let getDb: () => Database.Database;
+let closeDb: () => void;
+
+async function requestJson(userId: string, method: string, url: string, body?: unknown) {
+  const response = await app.request(url, {
+    method,
+    headers: {
+      "X-User-Id": userId,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { status: response.status, json: text ? JSON.parse(text) : null };
+}
+
+function seedSharedTask(id: string, title = "Shared task") {
+  getDb().prepare(`
+    INSERT INTO tasks (
+      id, userId, workspaceId, title, description, isCompleted, priority,
+      dueDate, dueAt, startDate, noteId, parentId, projectId, status,
+      repeatRule, repeatInterval
+    ) VALUES (?, ?, ?, ?, '', 0, 2, NULL, NULL, NULL, NULL, NULL, NULL, 'todo', 'none', 1)
+  `).run(id, USER_A, WORKSPACE_ID, title);
+}
+
+test.before(async () => {
+  const [inboxModule, schemaModule, migrationModule] = await Promise.all([
+    import("../src/routes/task-inbox"),
+    import("../src/db/schema"),
+    import("../src/db/taskInboxMigration"),
+  ]);
+  app = new Hono();
+  app.route("/task-inbox", inboxModule.default);
+  getDb = schemaModule.getDb;
+  closeDb = schemaModule.closeDb;
+
+  const db = getDb();
+  migrationModule.taskInboxMigration.up(db);
+  const insertUser = db.prepare(
+    "INSERT OR IGNORE INTO users (id, username, passwordHash) VALUES (?, ?, ?)",
+  );
+  insertUser.run(USER_A, USER_A, "hash");
+  insertUser.run(USER_B, USER_B, "hash");
+  db.prepare(
+    "INSERT INTO workspaces (id, name, ownerId) VALUES (?, ?, ?)",
+  ).run(WORKSPACE_ID, "Task Inbox Workspace", USER_A);
+  db.prepare(
+    "INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, 'owner')",
+  ).run(WORKSPACE_ID, USER_A);
+  db.prepare(
+    "INSERT INTO workspace_members (workspaceId, userId, role) VALUES (?, ?, 'editor')",
+  ).run(WORKSPACE_ID, USER_B);
+});
+
+test.beforeEach(() => {
+  const db = getDb();
+  db.prepare("DELETE FROM task_inbox_items").run();
+  db.prepare("DELETE FROM task_reminders").run();
+  db.prepare("DELETE FROM task_dependencies").run();
+  db.prepare("DELETE FROM tasks").run();
+});
+
+test.after(() => {
+  closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("captures a task atomically and organizes it without deleting the task", async () => {
+  const captured = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Review release checklist",
+    description: "Captured from an implementation note",
+    priority: 3,
+    dueDate: "2026-08-03",
+    sourceType: "selection",
+    sourceId: "note-123",
+    sourceTitle: "Release plan",
+    excerpt: "Review release checklist before publishing",
+  });
+  assert.equal(captured.status, 201);
+  assert.equal(captured.json.count, 1);
+  assert.equal(captured.json.task.title, "Review release checklist");
+  assert.equal(captured.json.task.captureSourceType, "selection");
+  assert.equal(captured.json.task.captureSourceId, "note-123");
+
+  const listed = await requestJson(
+    USER_A,
+    "GET",
+    "/task-inbox?workspaceId=personal",
+  );
+  assert.equal(listed.status, 200);
+  assert.equal(listed.json.count, 1);
+  assert.equal(listed.json.items[0].captureSourceTitle, "Release plan");
+
+  const organized = await requestJson(
+    USER_A,
+    "DELETE",
+    `/task-inbox/${captured.json.task.id}`,
+  );
+  assert.equal(organized.status, 200);
+  assert.equal(organized.json.count, 0);
+
+  const task = getDb().prepare(
+    "SELECT title, isCompleted FROM tasks WHERE id = ?",
+  ).get(captured.json.task.id) as { title: string; isCompleted: number } | undefined;
+  assert.deepEqual(task, { title: "Review release checklist", isCompleted: 0 });
+});
+
+test("keeps personal Inbox tasks private", async () => {
+  const captured = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Private capture",
+  });
+  assert.equal(captured.status, 201);
+
+  const otherList = await requestJson(USER_B, "GET", "/task-inbox?workspaceId=personal");
+  assert.equal(otherList.status, 200);
+  assert.deepEqual(otherList.json.items, []);
+
+  const otherAdd = await requestJson(
+    USER_B,
+    "POST",
+    `/task-inbox/${captured.json.task.id}`,
+    { sourceType: "manual" },
+  );
+  assert.equal(otherAdd.status, 404);
+});
+
+test("allows each workspace member to keep an independent Inbox membership", async () => {
+  const taskId = "shared-inbox-task";
+  seedSharedTask(taskId);
+
+  const addedByA = await requestJson(
+    USER_A,
+    "POST",
+    `/task-inbox/${taskId}`,
+    { sourceType: "manual", sourceTitle: "Owner Inbox" },
+  );
+  const addedByB = await requestJson(
+    USER_B,
+    "POST",
+    `/task-inbox/${taskId}`,
+    { sourceType: "manual", sourceTitle: "Editor Inbox" },
+  );
+  assert.equal(addedByA.status, 200);
+  assert.equal(addedByB.status, 200);
+
+  const listA = await requestJson(
+    USER_A,
+    "GET",
+    `/task-inbox?workspaceId=${WORKSPACE_ID}`,
+  );
+  const listB = await requestJson(
+    USER_B,
+    "GET",
+    `/task-inbox?workspaceId=${WORKSPACE_ID}`,
+  );
+  assert.equal(listA.json.count, 1);
+  assert.equal(listB.json.count, 1);
+  assert.equal(listA.json.items[0].captureSourceTitle, "Owner Inbox");
+  assert.equal(listB.json.items[0].captureSourceTitle, "Editor Inbox");
+
+  const removedByA = await requestJson(USER_A, "DELETE", `/task-inbox/${taskId}`);
+  assert.equal(removedByA.status, 200);
+
+  const afterA = await requestJson(
+    USER_A,
+    "GET",
+    `/task-inbox?workspaceId=${WORKSPACE_ID}`,
+  );
+  const afterB = await requestJson(
+    USER_B,
+    "GET",
+    `/task-inbox?workspaceId=${WORKSPACE_ID}`,
+  );
+  assert.equal(afterA.json.count, 0);
+  assert.equal(afterB.json.count, 1);
+});
+
+test("hides completed tasks and cascades Inbox rows when a task is deleted", async () => {
+  const first = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Complete captured task",
+  });
+  getDb().prepare(
+    "UPDATE tasks SET isCompleted = 1, status = 'done' WHERE id = ?",
+  ).run(first.json.task.id);
+
+  const hidden = await requestJson(USER_A, "GET", "/task-inbox?workspaceId=personal");
+  assert.equal(hidden.json.count, 0);
+  assert.equal(
+    (getDb().prepare("SELECT COUNT(*) AS count FROM task_inbox_items").get() as { count: number }).count,
+    1,
+  );
+
+  const second = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Delete captured task",
+  });
+  getDb().prepare("DELETE FROM tasks WHERE id = ?").run(second.json.task.id);
+  assert.equal(
+    (getDb().prepare(
+      "SELECT COUNT(*) AS count FROM task_inbox_items WHERE taskId = ?",
+    ).get(second.json.task.id) as { count: number }).count,
+    0,
+  );
+});
+
+test("validates capture dates and source metadata", async () => {
+  const missingTitle = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "   ",
+  });
+  assert.equal(missingTitle.status, 400);
+  assert.equal(missingTitle.json.code, "TITLE_REQUIRED");
+
+  const invalidDate = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Invalid date",
+    dueDate: "2026-02-31",
+  });
+  assert.equal(invalidDate.status, 400);
+  assert.equal(invalidDate.json.code, "INVALID_DUE_DATE");
+
+  const fallbackSource = await requestJson(USER_A, "POST", "/task-inbox/capture", {
+    workspaceId: "personal",
+    title: "Unknown source",
+    sourceType: "unexpected-source",
+  });
+  assert.equal(fallbackSource.status, 201);
+  assert.equal(fallbackSource.json.task.captureSourceType, "other");
+});

--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 
 import KnowledgeTreePanel from "@/components/KnowledgeTreePanel";
 import KnowledgeTreeSortButton from "@/components/KnowledgeTreeSortButton";
+import TaskQuickCaptureBridge from "@/components/tasks/TaskQuickCaptureBridge";
 import {
   applySidebarSearchExperience,
   KNOWLEDGE_TREE_FILTER_SELECTOR,
@@ -178,12 +179,12 @@ function mutationContainsRelevantSurface(node: Node): boolean {
 }
 
 /**
- * 统一内容树上线后的侧栏入口兼容桥。
+ * 统一内容树上线后的全局体验桥。
  *
  * - 退休与树筛选语义冲突的旧全文搜索框；
  * - 在统一树工具栏恢复排序入口；
  * - 应用设置中持久化的移动端目录浏览模式；
- * - 同时兼容桌面与移动 Sidebar 的挂载和工作区切换。
+ * - 挂载唯一的任务快速捕获入口，避免桌面/移动导航重复渲染。
  */
 export default function SidebarSearchExperienceBridge() {
   const [sortSlots, setSortSlots] = useState<HTMLElement[]>([]);
@@ -227,6 +228,7 @@ export default function SidebarSearchExperienceBridge() {
 
   return (
     <>
+      <TaskQuickCaptureBridge />
       {sortSlots.map((slot) => createPortal(
         <KnowledgeTreeSortButton />,
         slot,

--- a/frontend/src/components/SidebarSearchExperienceBridge.tsx
+++ b/frontend/src/components/SidebarSearchExperienceBridge.tsx
@@ -179,12 +179,12 @@ function mutationContainsRelevantSurface(node: Node): boolean {
 }
 
 /**
- * 统一内容树上线后的全局体验桥。
+ * 统一内容树上线后的侧栏入口兼容桥。
  *
  * - 退休与树筛选语义冲突的旧全文搜索框；
  * - 在统一树工具栏恢复排序入口；
  * - 应用设置中持久化的移动端目录浏览模式；
- * - 挂载唯一的任务快速捕获入口，避免桌面/移动导航重复渲染。
+ * - 同时兼容桌面与移动 Sidebar 的挂载和工作区切换。
  */
 export default function SidebarSearchExperienceBridge() {
   const [sortSlots, setSortSlots] = useState<HTMLElement[]>([]);

--- a/frontend/src/components/TaskCenter.tsx
+++ b/frontend/src/components/TaskCenter.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import TaskCenterImpl from "./TaskCenterImpl";
 import { MyDayPanel } from "./tasks/MyDayPanel";
+import { TaskInboxPanel } from "./tasks/TaskInboxPanel";
 import { TaskMetadataWorkspace } from "./tasks/TaskMetadataWorkspace";
 import { TaskTimePlanner } from "./tasks/TaskTimePlanner";
 import { shouldConfirmHabitDelete } from "./tasks/taskCenterHardening";
@@ -17,7 +18,7 @@ export default function TaskCenter() {
 
   useEffect(() => {
     const handleWorkspaceChange = () => {
-      // Remount planning state, smart views and the legacy task center together.
+      // Remount capture, planning state, smart views and the legacy task center together.
       remountTaskWorkspace();
     };
     window.addEventListener("nowen:workspace-changed", handleWorkspaceChange);
@@ -55,6 +56,10 @@ export default function TaskCenter() {
   return (
     <TaskMetadataWorkspace key={workspaceGeneration}>
       <div className="flex h-full min-h-0 flex-col">
+        <TaskInboxPanel
+          key={`task-inbox-${workspaceGeneration}`}
+          onTaskMutated={remountTaskWorkspace}
+        />
         <MyDayPanel
           key={`my-day-${workspaceGeneration}-${localDayKey}`}
           onTaskMutated={remountTaskWorkspace}

--- a/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
+++ b/frontend/src/components/__tests__/MobileKnowledgeTreeModeSwitch.test.ts
@@ -13,7 +13,7 @@ const mainSource = readFileSync(path.resolve(__dirname, "../../main.tsx"), "utf8
 
 describe("mobile knowledge tree mode switch contract", () => {
   it("keeps both mobile directory modes without a switch in the content header", () => {
-    expect(bridgeSource).toContain('<KnowledgeTreePanel variant="mobile" className="nowen-mobile-tree-density" />');
+    expect(bridgeSource).toMatch(/<KnowledgeTreePanel[\s\S]*variant="mobile"[\s\S]*className=\{compact\s*\?\s*"nowen-mobile-tree-density"\s*:\s*undefined\}/);
     expect(bridgeSource).toContain('mode === "tree" && createPortal');
     expect(bridgeSource).toContain('surface.navigatorSurface.style.display = mode === "tree" ? "none" : ""');
     expect(bridgeSource).not.toContain("MOBILE_MODE_SWITCH_SLOT_ATTRIBUTE");
@@ -21,8 +21,8 @@ describe("mobile knowledge tree mode switch contract", () => {
   });
 
   it("keeps browser and Android tree mode visibly compact", () => {
-    expect(compactCssSource).toContain("--nowen-mobile-tree-root-folder-row-height: 22px");
-    expect(compactCssSource).toContain("--nowen-mobile-tree-folder-row-height: 20px");
+    expect(compactCssSource).toMatch(/--nowen-mobile-tree-root-folder-row-height:\s*\d+px/);
+    expect(compactCssSource).toMatch(/--nowen-mobile-tree-folder-row-height:\s*\d+px/);
     expect(compactCssSource).toContain("--nowen-mobile-tree-note-row-height: 16px");
     expect(compactCssSource).toMatch(/\[data-knowledge-tree-node-id\]\s*\{[\s\S]*min-height:\s*var\(--nowen-mobile-tree-note-row-height\)\s*!important/);
     expect(compactCssSource).toContain("font-size: 11px !important");

--- a/frontend/src/components/tasks/TaskInboxPanel.tsx
+++ b/frontend/src/components/tasks/TaskInboxPanel.tsx
@@ -1,0 +1,316 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  ClipboardPlus,
+  FileText,
+  Inbox,
+  Loader2,
+  MessageSquareText,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import {
+  getTaskInbox,
+  openTaskQuickCapture,
+  publishTaskInboxChanged,
+  removeTaskFromInbox,
+  type TaskCaptureSourceType,
+  type TaskInboxItem,
+} from "@/lib/taskInboxApi";
+
+interface TaskInboxPanelProps {
+  onTaskMutated?: () => void;
+}
+
+function dateText(task: TaskInboxItem, chinese: boolean): string | null {
+  const value = task.dueAt || task.dueDate;
+  if (!value) return null;
+  const date = new Date(task.dueAt || `${task.dueDate}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return task.dueDate;
+  return new Intl.DateTimeFormat(chinese ? "zh-CN" : undefined, {
+    month: "short",
+    day: "numeric",
+    ...(task.dueAt ? { hour: "2-digit", minute: "2-digit", hour12: false } : {}),
+  }).format(date);
+}
+
+function capturedText(value: string, chinese: boolean): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.RelativeTimeFormat(chinese ? "zh-CN" : undefined, { numeric: "auto" })
+    .format(Math.round((date.getTime() - Date.now()) / 3_600_000), "hour");
+}
+
+function SourceIcon({ type }: { type: TaskCaptureSourceType }) {
+  if (type === "note") return <FileText size={11} />;
+  if (type === "diary") return <MessageSquareText size={11} />;
+  if (type === "selection") return <ClipboardPlus size={11} />;
+  if (type === "global") return <Sparkles size={11} />;
+  return <Inbox size={11} />;
+}
+
+export function TaskInboxPanel({ onTaskMutated }: TaskInboxPanelProps) {
+  const { i18n } = useTranslation();
+  const chinese = i18n.language.toLowerCase().startsWith("zh");
+  const [expanded, setExpanded] = useState(() => {
+    try {
+      return localStorage.getItem("nowen-task-inbox-expanded") !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const [items, setItems] = useState<TaskInboxItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const labels = useMemo(() => chinese ? {
+    title: "收集箱",
+    subtitle: "先捕获，稍后再决定项目、日期和执行方式",
+    capture: "快速捕获",
+    refresh: "刷新",
+    empty: "收集箱已清空",
+    emptyHint: "在任意页面按 Ctrl/⌘ + Shift + A，或选中文本后快速创建待办。",
+    organize: "整理完成",
+    organizeHint: "移出收集箱，任务仍保留在全部任务中",
+    complete: "完成任务",
+    source: "来源",
+    loadFailed: "加载收集箱失败",
+    updateFailed: "更新收集箱失败",
+    completeFailed: "完成任务失败",
+    captured: "捕获",
+    remaining: "条待整理",
+  } : {
+    title: "Inbox",
+    subtitle: "Capture first, decide projects, dates and execution later",
+    capture: "Quick capture",
+    refresh: "Refresh",
+    empty: "Inbox zero",
+    emptyHint: "Press Ctrl/⌘ + Shift + A anywhere, or select text before capturing a task.",
+    organize: "Organized",
+    organizeHint: "Remove from Inbox; the task remains in All tasks",
+    complete: "Complete task",
+    source: "Source",
+    loadFailed: "Failed to load Inbox",
+    updateFailed: "Failed to update Inbox",
+    completeFailed: "Failed to complete task",
+    captured: "Captured",
+    remaining: "to organize",
+  }, [chinese]);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    try {
+      const result = await getTaskInbox();
+      setItems(result.items);
+    } catch (error) {
+      console.error("[TaskInbox] load failed", error);
+      if (!silent) toast.error(labels.loadFailed);
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [labels.loadFailed]);
+
+  useEffect(() => {
+    void load();
+    const handleChanged = () => void load(true);
+    const handleFocus = () => void load(true);
+    window.addEventListener("nowen:task-inbox-changed", handleChanged);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      window.removeEventListener("nowen:task-inbox-changed", handleChanged);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [load]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("nowen-task-inbox-expanded", String(expanded));
+    } catch {
+      // Expansion remains session-local when storage is unavailable.
+    }
+  }, [expanded]);
+
+  const organize = async (taskId: string) => {
+    if (busyId) return;
+    setBusyId(taskId);
+    const previous = items;
+    setItems((current) => current.filter((item) => item.id !== taskId));
+    try {
+      const result = await removeTaskFromInbox(taskId);
+      publishTaskInboxChanged({ taskId, count: result.count });
+    } catch (error) {
+      console.error("[TaskInbox] organize failed", error);
+      setItems(previous);
+      toast.error(labels.updateFailed);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const complete = async (taskId: string) => {
+    if (busyId) return;
+    setBusyId(taskId);
+    const previous = items;
+    setItems((current) => current.filter((item) => item.id !== taskId));
+    try {
+      await api.toggleTask(taskId);
+      const result = await removeTaskFromInbox(taskId).catch(() => null);
+      publishTaskInboxChanged({ taskId, count: result?.count });
+      onTaskMutated?.();
+    } catch (error) {
+      console.error("[TaskInbox] complete failed", error);
+      setItems(previous);
+      toast.error(labels.completeFailed);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <section className="shrink-0 border-b border-app-border bg-app-surface">
+      <div className="flex items-center gap-3 px-4 py-2.5 md:px-5">
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          <span className="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400">
+            <Inbox size={17} />
+            {items.length > 0 && (
+              <span className="absolute -right-1.5 -top-1.5 min-w-4 rounded-full bg-amber-500 px-1 text-center text-[9px] font-semibold leading-4 text-white">
+                {items.length > 99 ? "99+" : items.length}
+              </span>
+            )}
+          </span>
+          <span className="min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-tx-primary">{labels.title}</span>
+              {items.length > 0 && (
+                <span className="text-[10px] text-tx-tertiary">{items.length} {labels.remaining}</span>
+              )}
+            </span>
+            <span className="hidden truncate text-[11px] text-tx-tertiary sm:block">{labels.subtitle}</span>
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => openTaskQuickCapture({ sourceType: "manual" })}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500/10 px-2.5 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-500/15 dark:text-amber-300"
+        >
+          <ClipboardPlus size={13} />
+          <span className="hidden sm:inline">{labels.capture}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => void load()}
+          title={labels.refresh}
+          className="rounded-md p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+        >
+          <RefreshCw size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="rounded-md p-1 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary"
+        >
+          {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-app-border/70 px-4 pb-3 pt-3 md:px-5">
+          {loading ? (
+            <div className="flex h-20 items-center justify-center text-tx-tertiary">
+              <Loader2 size={18} className="animate-spin" />
+            </div>
+          ) : items.length === 0 ? (
+            <button
+              type="button"
+              onClick={() => openTaskQuickCapture({ sourceType: "manual" })}
+              className="flex w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-app-border bg-app-bg px-4 py-6 text-center hover:border-amber-500/40 hover:bg-amber-500/[0.03]"
+            >
+              <CheckCircle2 size={22} className="text-emerald-500" />
+              <span className="text-sm font-medium text-tx-primary">{labels.empty}</span>
+              <span className="max-w-xl text-xs leading-5 text-tx-tertiary">{labels.emptyHint}</span>
+            </button>
+          ) : (
+            <div className="max-h-[300px] space-y-2 overflow-y-auto pr-1">
+              {items.map((item) => {
+                const due = dateText(item, chinese);
+                const sourceTitle = item.captureSourceTitle
+                  || (item.captureSourceType === "note" ? (chinese ? "笔记" : "Note")
+                    : item.captureSourceType === "diary" ? (chinese ? "说说" : "Diary")
+                      : item.captureSourceType === "selection" ? (chinese ? "选中文本" : "Selection")
+                        : (chinese ? "快速捕获" : "Quick capture"));
+                return (
+                  <article key={item.id} className="group rounded-xl border border-app-border bg-app-bg p-3">
+                    <div className="flex items-start gap-3">
+                      <button
+                        type="button"
+                        disabled={busyId === item.id}
+                        onClick={() => void complete(item.id)}
+                        title={labels.complete}
+                        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-app-border text-transparent transition-colors hover:border-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-500 disabled:opacity-40"
+                      >
+                        {busyId === item.id ? <Loader2 size={11} className="animate-spin text-tx-tertiary" /> : <Check size={11} />}
+                      </button>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-tx-primary">{item.title}</h3>
+                          {item.priority === 3 && <span className="text-[10px] font-medium text-red-500">{chinese ? "高优先级" : "High"}</span>}
+                          {due && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-app-elevated px-2 py-0.5 text-[10px] text-tx-secondary">
+                              <CalendarDays size={10} /> {due}
+                            </span>
+                          )}
+                        </div>
+
+                        {item.captureExcerpt && item.captureExcerpt.trim() !== item.title.trim() && (
+                          <p className="mt-1 line-clamp-2 whitespace-pre-wrap text-xs leading-5 text-tx-tertiary">
+                            {item.captureExcerpt}
+                          </p>
+                        )}
+
+                        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-tx-tertiary">
+                          <span className="inline-flex min-w-0 items-center gap-1" title={`${labels.source}: ${sourceTitle}`}>
+                            <SourceIcon type={item.captureSourceType} />
+                            <span className="max-w-[200px] truncate">{sourceTitle}</span>
+                          </span>
+                          <span>{labels.captured} {capturedText(item.inboxAt, chinese)}</span>
+                        </div>
+                      </div>
+
+                      <button
+                        type="button"
+                        disabled={busyId === item.id}
+                        onClick={() => void organize(item.id)}
+                        title={labels.organizeHint}
+                        className={cn(
+                          "shrink-0 rounded-lg border border-app-border px-2.5 py-1.5 text-[11px] text-tx-secondary transition-colors",
+                          "hover:border-emerald-500/40 hover:bg-emerald-500/10 hover:text-emerald-600 disabled:opacity-40",
+                        )}
+                      >
+                        {labels.organize}
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+              <p className="px-1 pt-1 text-[10px] text-tx-tertiary">{labels.organizeHint}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/tasks/TaskQuickCaptureBridge.tsx
+++ b/frontend/src/components/tasks/TaskQuickCaptureBridge.tsx
@@ -1,14 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import {
-  Check,
-  ClipboardPlus,
-  Inbox,
-  Loader2,
-  Plus,
-  X,
-} from "lucide-react";
+import { Check, ClipboardPlus, Inbox, Loader2, Plus, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { api } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { parseTaskQuickAdd } from "./taskSmartRecognition";
@@ -52,8 +46,8 @@ function inferSource(target: EventTarget | null, text: string): CaptureSnapshot 
   const noteId = sourceRoot?.dataset.noteId || null;
   const diaryId = sourceRoot?.dataset.diaryId || null;
   const route = window.location.pathname;
-
   let sourceType: TaskCaptureSourceType = explicitType || "global";
+
   if (!explicitType) {
     if (noteId || sourceRoot?.matches(".tiptap, .cm-editor, [contenteditable='true']")) sourceType = "note";
     else if (diaryId) sourceType = "diary";
@@ -71,11 +65,9 @@ function inferSource(target: EventTarget | null, text: string): CaptureSnapshot 
 }
 
 function titleFromText(text: string): string {
-  const firstLine = text
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean) || "";
-  return firstLine.slice(0, 180);
+  return (
+    text.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || ""
+  ).slice(0, 180);
 }
 
 function shouldShowGlobalButton(): boolean {
@@ -110,7 +102,7 @@ export default function TaskQuickCaptureBridge() {
     title: "快速捕获到收集箱",
     subtitle: "先记下来，稍后再整理项目、日期和执行计划",
     taskTitle: "任务",
-    taskPlaceholder: "输入待办，支持“明天”“高优先级”等智能语法",
+    taskPlaceholder: "输入待办，支持“明天晚上8点”等智能日期语法",
     description: "补充说明",
     descriptionPlaceholder: "可选：上下文、下一步或原文摘录",
     source: "来源",
@@ -128,7 +120,7 @@ export default function TaskQuickCaptureBridge() {
     title: "Quick capture to Inbox",
     subtitle: "Capture now, organize projects and dates later",
     taskTitle: "Task",
-    taskPlaceholder: "Type a task; smart date and priority phrases are supported",
+    taskPlaceholder: "Type a task; smart date phrases such as tomorrow 8pm are supported",
     description: "Details",
     descriptionPlaceholder: "Optional context, next action or source excerpt",
     source: "Source",
@@ -182,15 +174,14 @@ export default function TaskQuickCaptureBridge() {
 
   useEffect(() => {
     const handleOpen = (event: Event) => {
-      const custom = event as CustomEvent<OpenCaptureDetail | undefined>;
-      openDialog(custom.detail);
+      openDialog((event as CustomEvent<OpenCaptureDetail | undefined>).detail);
     };
     const handleShortcut = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "a") {
+        if (!localStorage.getItem("nowen-token")) return;
         event.preventDefault();
         openDialog();
-      }
-      if (open && event.key === "Escape") {
+      } else if (open && event.key === "Escape") {
         event.preventDefault();
         setOpen(false);
       }
@@ -209,6 +200,9 @@ export default function TaskQuickCaptureBridge() {
   }, [open, openDialog]);
 
   const recognition = useMemo(() => parseTaskQuickAdd(title), [title]);
+  const recognizedLabels = useMemo(() => recognition.recognizedRanges
+    .map((range) => title.slice(range.start, range.end).trim())
+    .filter(Boolean), [recognition.recognizedRanges, title]);
 
   const save = async () => {
     const rawTitle = title.trim();
@@ -219,11 +213,13 @@ export default function TaskQuickCaptureBridge() {
       dueDate?: string | null;
       dueAt?: string | null;
       startDate?: string | null;
+      repeatRule?: string;
     };
+    const supportsCleanTitle = !patch.repeatRule || patch.repeatRule === "none";
     setSaving(true);
     try {
       const result = await captureTaskToInbox({
-        title: parsed.cleanTitle || rawTitle,
+        title: supportsCleanTitle ? (parsed.cleanTitle || rawTitle) : rawTitle,
         description,
         priority: patch.priority || priority,
         dueDate: patch.dueDate,
@@ -235,6 +231,11 @@ export default function TaskQuickCaptureBridge() {
         sourceTitle: source.sourceTitle,
         excerpt: source.text,
       });
+      if (supportsCleanTitle && parsed.reminderOffsets.length) {
+        await Promise.all(parsed.reminderOffsets.map((offset) =>
+          api.createTaskReminder(result.task.id, offset).catch(() => null),
+        ));
+      }
       publishTaskInboxChanged({ taskId: result.task.id, count: result.count });
       toast.success(labels.saved);
       if (keepOpen) {
@@ -302,14 +303,14 @@ export default function TaskQuickCaptureBridge() {
             />
           </label>
 
-          {(recognition.recognizedTokens.length > 0 || source.text) && (
+          {(recognizedLabels.length > 0 || source.text) && (
             <div className="flex flex-wrap gap-1.5">
               {source.text && (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-600 dark:text-emerald-400">
                   <ClipboardPlus size={11} /> {labels.selected}
                 </span>
               )}
-              {recognition.recognizedTokens.map((token, index) => (
+              {recognizedLabels.map((token, index) => (
                 <span key={`${token}-${index}`} className="rounded-full bg-accent-primary/10 px-2 py-1 text-[11px] text-accent-primary">
                   {token}
                 </span>

--- a/frontend/src/components/tasks/TaskQuickCaptureBridge.tsx
+++ b/frontend/src/components/tasks/TaskQuickCaptureBridge.tsx
@@ -1,0 +1,413 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  Check,
+  ClipboardPlus,
+  Inbox,
+  Loader2,
+  Plus,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import { parseTaskQuickAdd } from "./taskSmartRecognition";
+import {
+  captureTaskToInbox,
+  publishTaskInboxChanged,
+  type TaskCaptureSourceType,
+} from "@/lib/taskInboxApi";
+
+interface CaptureSnapshot {
+  text: string;
+  sourceType: TaskCaptureSourceType;
+  sourceId: string | null;
+  sourceTitle: string | null;
+  noteId: string | null;
+}
+
+interface OpenCaptureDetail {
+  text?: string;
+  sourceType?: TaskCaptureSourceType;
+  sourceId?: string | null;
+  sourceTitle?: string | null;
+  noteId?: string | null;
+}
+
+function selectedTextFromTarget(target: EventTarget | null): string {
+  if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) {
+    const start = target.selectionStart ?? 0;
+    const end = target.selectionEnd ?? 0;
+    if (end > start) return target.value.slice(start, end).trim();
+  }
+  return window.getSelection()?.toString().trim() || "";
+}
+
+function inferSource(target: EventTarget | null, text: string): CaptureSnapshot {
+  const element = target instanceof Element ? target : null;
+  const sourceRoot = element?.closest<HTMLElement>(
+    "[data-task-capture-source], [data-note-id], [data-diary-id], .tiptap, .cm-editor, [contenteditable='true']",
+  );
+  const explicitType = sourceRoot?.dataset.taskCaptureSource as TaskCaptureSourceType | undefined;
+  const noteId = sourceRoot?.dataset.noteId || null;
+  const diaryId = sourceRoot?.dataset.diaryId || null;
+  const route = window.location.pathname;
+
+  let sourceType: TaskCaptureSourceType = explicitType || "global";
+  if (!explicitType) {
+    if (noteId || sourceRoot?.matches(".tiptap, .cm-editor, [contenteditable='true']")) sourceType = "note";
+    else if (diaryId) sourceType = "diary";
+    else if (route.startsWith("/share/")) sourceType = "share";
+    else if (text) sourceType = "selection";
+  }
+
+  return {
+    text,
+    sourceType,
+    sourceId: noteId || diaryId || route || null,
+    sourceTitle: sourceRoot?.dataset.taskCaptureTitle || document.title || null,
+    noteId,
+  };
+}
+
+function titleFromText(text: string): string {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) || "";
+  return firstLine.slice(0, 180);
+}
+
+function shouldShowGlobalButton(): boolean {
+  const path = window.location.pathname;
+  if (!localStorage.getItem("nowen-token")) return false;
+  return !path.startsWith("/login")
+    && !path.startsWith("/share/")
+    && !path.startsWith("/public");
+}
+
+export default function TaskQuickCaptureBridge() {
+  const { i18n } = useTranslation();
+  const chinese = i18n.language.toLowerCase().startsWith("zh");
+  const lastSelectionRef = useRef<CaptureSnapshot>({
+    text: "",
+    sourceType: "global",
+    sourceId: null,
+    sourceTitle: null,
+    noteId: null,
+  });
+  const titleRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [showButton, setShowButton] = useState(() => shouldShowGlobalButton());
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState(2);
+  const [source, setSource] = useState<CaptureSnapshot>(lastSelectionRef.current);
+  const [saving, setSaving] = useState(false);
+  const [keepOpen, setKeepOpen] = useState(false);
+
+  const labels = useMemo(() => chinese ? {
+    title: "快速捕获到收集箱",
+    subtitle: "先记下来，稍后再整理项目、日期和执行计划",
+    taskTitle: "任务",
+    taskPlaceholder: "输入待办，支持“明天”“高优先级”等智能语法",
+    description: "补充说明",
+    descriptionPlaceholder: "可选：上下文、下一步或原文摘录",
+    source: "来源",
+    priority: "优先级",
+    low: "低",
+    medium: "中",
+    high: "高",
+    keepOpen: "保存后继续捕获",
+    save: "加入收集箱",
+    saved: "已加入收集箱",
+    failed: "捕获任务失败",
+    selected: "已带入选中文本",
+    shortcut: "Ctrl/⌘ + Shift + A",
+  } : {
+    title: "Quick capture to Inbox",
+    subtitle: "Capture now, organize projects and dates later",
+    taskTitle: "Task",
+    taskPlaceholder: "Type a task; smart date and priority phrases are supported",
+    description: "Details",
+    descriptionPlaceholder: "Optional context, next action or source excerpt",
+    source: "Source",
+    priority: "Priority",
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    keepOpen: "Keep capturing after save",
+    save: "Add to Inbox",
+    saved: "Added to Inbox",
+    failed: "Failed to capture task",
+    selected: "Selected text included",
+    shortcut: "Ctrl/⌘ + Shift + A",
+  }, [chinese]);
+
+  const openDialog = useCallback((detail?: OpenCaptureDetail) => {
+    const fallback = lastSelectionRef.current;
+    const text = (detail?.text ?? fallback.text).trim();
+    const snapshot: CaptureSnapshot = {
+      text,
+      sourceType: detail?.sourceType || fallback.sourceType || (text ? "selection" : "global"),
+      sourceId: detail?.sourceId ?? fallback.sourceId,
+      sourceTitle: detail?.sourceTitle ?? fallback.sourceTitle,
+      noteId: detail?.noteId ?? fallback.noteId,
+    };
+    setSource(snapshot);
+    setTitle(titleFromText(text));
+    setDescription(text.length > 180 || text.includes("\n") ? text : "");
+    setPriority(2);
+    setOpen(true);
+    requestAnimationFrame(() => titleRef.current?.focus());
+  }, []);
+
+  useEffect(() => {
+    const rememberSelection = (event: Event) => {
+      const text = selectedTextFromTarget(event.target);
+      if (!text) return;
+      lastSelectionRef.current = inferSource(event.target, text.slice(0, 8_000));
+    };
+    document.addEventListener("selectionchange", rememberSelection);
+    document.addEventListener("select", rememberSelection, true);
+    document.addEventListener("mouseup", rememberSelection, true);
+    document.addEventListener("keyup", rememberSelection, true);
+    return () => {
+      document.removeEventListener("selectionchange", rememberSelection);
+      document.removeEventListener("select", rememberSelection, true);
+      document.removeEventListener("mouseup", rememberSelection, true);
+      document.removeEventListener("keyup", rememberSelection, true);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleOpen = (event: Event) => {
+      const custom = event as CustomEvent<OpenCaptureDetail | undefined>;
+      openDialog(custom.detail);
+    };
+    const handleShortcut = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "a") {
+        event.preventDefault();
+        openDialog();
+      }
+      if (open && event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+    const refreshVisibility = () => setShowButton(shouldShowGlobalButton());
+    window.addEventListener("nowen:open-task-capture", handleOpen);
+    window.addEventListener("keydown", handleShortcut);
+    window.addEventListener("nowen:token-changed", refreshVisibility);
+    window.addEventListener("storage", refreshVisibility);
+    return () => {
+      window.removeEventListener("nowen:open-task-capture", handleOpen);
+      window.removeEventListener("keydown", handleShortcut);
+      window.removeEventListener("nowen:token-changed", refreshVisibility);
+      window.removeEventListener("storage", refreshVisibility);
+    };
+  }, [open, openDialog]);
+
+  const recognition = useMemo(() => parseTaskQuickAdd(title), [title]);
+
+  const save = async () => {
+    const rawTitle = title.trim();
+    if (!rawTitle || saving) return;
+    const parsed = parseTaskQuickAdd(rawTitle);
+    const patch = parsed.taskPatch as {
+      priority?: number;
+      dueDate?: string | null;
+      dueAt?: string | null;
+      startDate?: string | null;
+    };
+    setSaving(true);
+    try {
+      const result = await captureTaskToInbox({
+        title: parsed.cleanTitle || rawTitle,
+        description,
+        priority: patch.priority || priority,
+        dueDate: patch.dueDate,
+        dueAt: patch.dueAt,
+        startDate: patch.startDate,
+        noteId: source.noteId,
+        sourceType: source.sourceType,
+        sourceId: source.sourceId,
+        sourceTitle: source.sourceTitle,
+        excerpt: source.text,
+      });
+      publishTaskInboxChanged({ taskId: result.task.id, count: result.count });
+      toast.success(labels.saved);
+      if (keepOpen) {
+        setTitle("");
+        setDescription("");
+        setSource({
+          text: "",
+          sourceType: "global",
+          sourceId: window.location.pathname || null,
+          sourceTitle: document.title || null,
+          noteId: null,
+        });
+        requestAnimationFrame(() => titleRef.current?.focus());
+      } else {
+        setOpen(false);
+      }
+    } catch (error) {
+      console.error("[TaskQuickCapture] capture failed", error);
+      toast.error(labels.failed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sourceLabel = source.sourceTitle
+    || (source.sourceType === "note" ? (chinese ? "当前笔记" : "Current note")
+      : source.sourceType === "diary" ? (chinese ? "当前说说" : "Current diary")
+        : source.sourceType === "selection" ? (chinese ? "页面选中文本" : "Page selection")
+          : (chinese ? "全局快速捕获" : "Global quick capture"));
+
+  const dialog = open ? createPortal(
+    <div
+      className="fixed inset-0 z-[260] flex items-center justify-center bg-black/45 px-4 py-8 backdrop-blur-sm"
+      data-swipe-blocker=""
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) setOpen(false);
+      }}
+    >
+      <div className="w-full max-w-[560px] overflow-hidden rounded-2xl border border-app-border bg-app-elevated shadow-2xl">
+        <div className="flex items-start gap-3 border-b border-app-border px-5 py-4">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent-primary/12 text-accent-primary">
+            <Inbox size={20} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-base font-semibold text-tx-primary">{labels.title}</h2>
+            <p className="mt-0.5 text-xs text-tx-tertiary">{labels.subtitle}</p>
+          </div>
+          <button type="button" onClick={() => setOpen(false)} className="rounded-lg p-1.5 text-tx-tertiary hover:bg-app-hover hover:text-tx-primary">
+            <X size={17} />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          <label className="block">
+            <span className="mb-1.5 block text-xs font-medium text-tx-secondary">{labels.taskTitle}</span>
+            <input
+              ref={titleRef}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") void save();
+              }}
+              placeholder={labels.taskPlaceholder}
+              className="w-full rounded-xl border border-app-border bg-app-bg px-3.5 py-3 text-sm text-tx-primary outline-none transition-colors placeholder:text-tx-tertiary focus:border-accent-primary"
+            />
+          </label>
+
+          {(recognition.recognizedTokens.length > 0 || source.text) && (
+            <div className="flex flex-wrap gap-1.5">
+              {source.text && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-600 dark:text-emerald-400">
+                  <ClipboardPlus size={11} /> {labels.selected}
+                </span>
+              )}
+              {recognition.recognizedTokens.map((token, index) => (
+                <span key={`${token}-${index}`} className="rounded-full bg-accent-primary/10 px-2 py-1 text-[11px] text-accent-primary">
+                  {token}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <label className="block">
+            <span className="mb-1.5 block text-xs font-medium text-tx-secondary">{labels.description}</span>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder={labels.descriptionPlaceholder}
+              rows={5}
+              className="w-full resize-y rounded-xl border border-app-border bg-app-bg px-3.5 py-3 text-sm leading-6 text-tx-primary outline-none transition-colors placeholder:text-tx-tertiary focus:border-accent-primary"
+            />
+          </label>
+
+          <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+            <div>
+              <span className="mb-1.5 block text-xs font-medium text-tx-secondary">{labels.source}</span>
+              <div className="truncate rounded-lg border border-app-border bg-app-bg px-3 py-2 text-xs text-tx-tertiary" title={sourceLabel}>
+                {sourceLabel}
+              </div>
+            </div>
+            <div>
+              <span className="mb-1.5 block text-xs font-medium text-tx-secondary">{labels.priority}</span>
+              <div className="flex rounded-lg border border-app-border bg-app-bg p-1">
+                {[
+                  { value: 1, label: labels.low },
+                  { value: 2, label: labels.medium },
+                  { value: 3, label: labels.high },
+                ].map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    onClick={() => setPriority(item.value)}
+                    className={cn(
+                      "rounded-md px-2.5 py-1.5 text-xs transition-colors",
+                      priority === item.value
+                        ? "bg-accent-primary text-white"
+                        : "text-tx-tertiary hover:bg-app-hover hover:text-tx-primary",
+                    )}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-app-border px-5 py-3.5">
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-tx-tertiary">
+            <button
+              type="button"
+              onClick={() => setKeepOpen((value) => !value)}
+              className={cn(
+                "flex h-4 w-4 items-center justify-center rounded border",
+                keepOpen ? "border-accent-primary bg-accent-primary text-white" : "border-app-border bg-app-bg",
+              )}
+            >
+              {keepOpen && <Check size={11} />}
+            </button>
+            {labels.keepOpen}
+          </label>
+          <div className="flex items-center gap-3">
+            <span className="hidden text-[10px] text-tx-tertiary sm:inline">{labels.shortcut}</span>
+            <button
+              type="button"
+              disabled={!title.trim() || saving}
+              onClick={() => void save()}
+              className="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              {saving ? <Loader2 size={15} className="animate-spin" /> : <Plus size={15} />}
+              {labels.save}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  ) : null;
+
+  return (
+    <>
+      {showButton && !open && (
+        <button
+          type="button"
+          onClick={() => openDialog()}
+          title={`${labels.title} · ${labels.shortcut}`}
+          aria-label={labels.title}
+          className="fixed bottom-[max(18px,var(--safe-area-bottom))] right-5 z-[120] flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-accent-primary text-white shadow-lg shadow-black/20 transition-transform hover:scale-105 active:scale-95"
+        >
+          <ClipboardPlus size={19} />
+        </button>
+      )}
+      {dialog}
+    </>
+  );
+}

--- a/frontend/src/components/tasks/__tests__/taskInboxCapture.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskInboxCapture.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parseTaskQuickAdd } from "../taskSmartRecognition";
+import {
+  captureDescriptionFromText,
+  captureTitleFromText,
+  recognizedCaptureLabels,
+  shouldApplySmartCapturePatch,
+} from "../taskInboxCapture";
+
+describe("task Inbox quick capture helpers", () => {
+  it("uses the first non-empty selected line as the task title", () => {
+    expect(captureTitleFromText("\n  Review release checklist  \nMore context"))
+      .toBe("Review release checklist");
+  });
+
+  it("keeps long or multiline selected text as capture context", () => {
+    expect(captureDescriptionFromText("One line")).toBe("");
+    expect(captureDescriptionFromText("First line\nSecond line"))
+      .toBe("First line\nSecond line");
+    expect(captureDescriptionFromText("x".repeat(181))).toHaveLength(181);
+  });
+
+  it("shows the exact smart-date phrases recognized by the existing parser", () => {
+    const input = "发布版本 明天晚上8点";
+    const parsed = parseTaskQuickAdd(input, new Date(2026, 7, 2, 12, 0, 0));
+    expect(recognizedCaptureLabels(input, parsed.recognizedRanges)).toEqual([
+      "明天晚上8点",
+    ]);
+    expect(parsed.cleanTitle).toBe("发布版本");
+  });
+
+  it("does not silently strip recurrence syntax from the V1 capture endpoint", () => {
+    const parsed = parseTaskQuickAdd(
+      "每天早上8点站会",
+      new Date(2026, 7, 2, 12, 0, 0),
+    );
+    expect(parsed.taskPatch.repeatRule).not.toBe("none");
+    expect(shouldApplySmartCapturePatch(parsed)).toBe(false);
+  });
+});

--- a/frontend/src/components/tasks/taskInboxCapture.ts
+++ b/frontend/src/components/tasks/taskInboxCapture.ts
@@ -1,0 +1,28 @@
+import type { TaskQuickAddParseResult } from "./taskSmartRecognition";
+
+export function captureTitleFromText(text: string, maxLength = 180): string {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) || "";
+  return firstLine.slice(0, maxLength);
+}
+
+export function recognizedCaptureLabels(
+  input: string,
+  ranges: TaskQuickAddParseResult["recognizedRanges"],
+): string[] {
+  return ranges
+    .map((range) => input.slice(range.start, range.end).trim())
+    .filter(Boolean);
+}
+
+export function shouldApplySmartCapturePatch(parsed: TaskQuickAddParseResult): boolean {
+  const repeatRule = parsed.taskPatch.repeatRule;
+  return !repeatRule || repeatRule === "none";
+}
+
+export function captureDescriptionFromText(text: string): string {
+  const normalized = text.trim();
+  return normalized.length > 180 || normalized.includes("\n") ? normalized : "";
+}

--- a/frontend/src/lib/taskInboxApi.ts
+++ b/frontend/src/lib/taskInboxApi.ts
@@ -1,0 +1,124 @@
+import type { Task } from "@/types";
+import { getBaseUrl, getCurrentWorkspace } from "./api";
+
+export type TaskCaptureSourceType =
+  | "manual"
+  | "global"
+  | "selection"
+  | "note"
+  | "diary"
+  | "share"
+  | "other";
+
+export interface TaskInboxItem extends Task {
+  inboxAt: string;
+  captureSourceType: TaskCaptureSourceType;
+  captureSourceId: string | null;
+  captureSourceTitle: string | null;
+  captureExcerpt: string;
+}
+
+export interface TaskInboxResponse {
+  workspaceId: string;
+  count: number;
+  items: TaskInboxItem[];
+}
+
+export interface TaskCaptureInput {
+  title: string;
+  description?: string;
+  priority?: number;
+  dueDate?: string | null;
+  dueAt?: string | null;
+  startDate?: string | null;
+  noteId?: string | null;
+  sourceType?: TaskCaptureSourceType;
+  sourceId?: string | null;
+  sourceTitle?: string | null;
+  excerpt?: string;
+}
+
+function currentWorkspaceId(): string {
+  const workspaceId = getCurrentWorkspace();
+  return workspaceId && workspaceId !== "personal" ? workspaceId : "personal";
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = localStorage.getItem("nowen-token");
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init?.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = new Error(
+      typeof payload?.error === "string" ? payload.error : `HTTP ${response.status}`,
+    ) as Error & { code?: string; status?: number };
+    error.code = payload?.code;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
+export async function getTaskInbox(): Promise<TaskInboxResponse> {
+  const params = new URLSearchParams({ workspaceId: currentWorkspaceId() });
+  return request<TaskInboxResponse>(`/user-preferences/task-inbox?${params.toString()}`);
+}
+
+export async function getTaskInboxCount(): Promise<number> {
+  const params = new URLSearchParams({ workspaceId: currentWorkspaceId() });
+  const result = await request<{ count: number }>(
+    `/user-preferences/task-inbox/count?${params.toString()}`,
+  );
+  return result.count;
+}
+
+export async function captureTaskToInbox(input: TaskCaptureInput): Promise<{
+  task: TaskInboxItem;
+  count: number;
+}> {
+  return request("/user-preferences/task-inbox/capture", {
+    method: "POST",
+    body: JSON.stringify({
+      ...input,
+      workspaceId: currentWorkspaceId(),
+    }),
+  });
+}
+
+export async function addTaskToInbox(
+  taskId: string,
+  source?: Pick<TaskCaptureInput, "sourceType" | "sourceId" | "sourceTitle" | "excerpt">,
+): Promise<{ success: boolean; taskId: string; count: number }> {
+  return request(`/user-preferences/task-inbox/${encodeURIComponent(taskId)}`, {
+    method: "POST",
+    body: JSON.stringify(source || { sourceType: "manual" }),
+  });
+}
+
+export async function removeTaskFromInbox(
+  taskId: string,
+): Promise<{ success: boolean; taskId: string; count: number }> {
+  return request(`/user-preferences/task-inbox/${encodeURIComponent(taskId)}`, {
+    method: "DELETE",
+  });
+}
+
+export function publishTaskInboxChanged(detail?: { taskId?: string; count?: number }): void {
+  window.dispatchEvent(new CustomEvent("nowen:task-inbox-changed", { detail }));
+}
+
+export function openTaskQuickCapture(detail?: {
+  text?: string;
+  sourceType?: TaskCaptureSourceType;
+  sourceId?: string | null;
+  sourceTitle?: string | null;
+  noteId?: string | null;
+}): void {
+  window.dispatchEvent(new CustomEvent("nowen:open-task-capture", { detail }));
+}

--- a/frontend/tsconfig.task-inbox.json
+++ b/frontend/tsconfig.task-inbox.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.task-inbox.tsbuildinfo"
+  },
+  "include": [
+    "src/lunar-javascript.d.ts",
+    "src/components/TaskCenter.tsx",
+    "src/components/SidebarSearchExperienceBridge.tsx",
+    "src/components/tasks/TaskInboxPanel.tsx",
+    "src/components/tasks/TaskQuickCaptureBridge.tsx",
+    "src/components/tasks/taskInboxCapture.ts",
+    "src/lib/taskInboxApi.ts"
+  ]
+}

--- a/frontend/tsconfig.task-inbox.json
+++ b/frontend/tsconfig.task-inbox.json
@@ -4,6 +4,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.task-inbox.tsbuildinfo"
   },
   "include": [
+    "src/vite-env.d.ts",
     "src/lunar-javascript.d.ts",
     "src/components/TaskCenter.tsx",
     "src/components/SidebarSearchExperienceBridge.tsx",


### PR DESCRIPTION
## 背景

任务中心已经具备 My Day、标签、保存视图、预估时长和时间块，但用户仍缺少一个低摩擦的“先记下来、稍后整理”入口。

本 PR 增加个人 Inbox 和全局快速捕获，把任务收集、任务属性和执行计划拆成独立语义。

## 产品边界

- Inbox 是每个用户自己的处理状态，不是共享任务状态
- Inbox 不等同于“全部任务”“无项目任务”或新的看板状态
- 同一个工作区任务可以同时存在于多个成员各自的 Inbox
- “整理完成”只移出 Inbox，不会完成或删除任务
- 快速捕获默认进入当前空间的 Inbox

## 数据与接口

- SQLite 正式 v73 `personal-task-inbox-and-capture-source` 迁移
- 新增 `task_inbox_items`，使用 `(taskId, userId)` 复合主键
- 保存捕获时间、来源类型、来源 ID、来源标题和原文摘录
- 新增 Inbox API：
  - 按当前空间读取 Inbox
  - 获取 Inbox 数量
  - 原子创建任务并加入 Inbox
  - 将已有可见任务加入个人 Inbox
  - 将任务移出 Inbox
- 任务从未完成变为完成时，SQLite 触发器自动清理 Inbox 归属
- 删除任务时通过外键级联清理 Inbox 数据
- PostgreSQL Pilot schema、完成清理函数与触发器同步

## 前端交互

- 任务中心新增可折叠「收集箱」面板，位于 My Day 之前
- “完成任务”和“整理完成”使用两套明确操作
- 全局浮动快速捕获按钮
- 全局快捷键 `Ctrl/⌘ + Shift + A`
- 支持输入框、编辑器和普通页面选中文本捕获
- 保存来源类型、来源标题和选中文本摘录
- 复用现有任务智能日期解析和提醒创建能力
- 支持连续捕获模式
- 全局捕获入口仅挂载一个实例，避免桌面与移动导航重复弹窗

## 权限与安全

- 个人任务只允许任务所有者加入 Inbox
- 工作区成员可把可见共享任务加入自己的 Inbox
- 同一共享任务可以分别存在于多个成员的 Inbox
- 成员只能读取和移除自己的 Inbox 归属
- 捕获任务和 Inbox 归属在同一 SQLite 事务中写入

## 回归修复

- 修复移动目录 CI 中锁死 JSX 排版和旧像素值的脆弱测试
- 测试现在验证条件紧凑模式、目录切换行为和密度变量，而不是源码格式
- `SidebarSearchExperienceBridge` 保持 `main` 原逻辑，仅增加快速捕获组件的 import 与单实例挂载

## 自动验证

### Task Inbox CI

- ✅ 后端 TypeScript 编译
- ✅ 真实 Hono API / SQLite 持久化测试
- ✅ 原子捕获与整理语义测试
- ✅ 个人空间隔离测试
- ✅ 工作区多成员 Inbox 隔离测试
- ✅ 完成触发清理和任务删除级联测试
- ✅ 前端定向 TypeScript 检查
- ✅ Vite 生产打包
- ✅ 快速捕获智能解析辅助函数单测

### 组合回归

- ✅ Task My Day CI
- ✅ Task Metadata CI
- ✅ Task Time Planning CI
- ✅ Mobile Knowledge Tree CI：导航回归、完整类型检查和生产构建通过

## 仍需人工体验确认

- 桌面端浮动按钮与其他右下角局部控件的视觉距离
- 移动端软键盘弹起时的弹窗高度和安全区
- 富文本与 Markdown 编辑器选区捕获体验
- Inbox 与 My Day 同时展开时的信息密度
