### PR TITLE
chore(sync): merge latest main into pg-migration-unified

### DIFF
--- a/backend/src/routes/task-calendar.ts
+++ b/backend/src/routes/task-calendar.ts
@@ -44,33 +44,6 @@ function pad2(value: number): string {
   return String(value).padStart(2, "0");
 }
 
-function formatLocalDateTime(date: Date): string {
-  return [
-    date.getFullYear(),
-    pad2(date.getMonth() + 1),
-    pad2(date.getDate()),
-    "T",
-    pad2(date.getHours()),
-    pad2(date.getMinutes()),
-    pad2(date.getSeconds()),
-  ].join("");
-}
-
-function addMinutesToIcsDateTime(value: string, minutes: number): string {
-  const match = value.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})$/);
-  if (!match) return value;
-  const [, year, month, day, hour, minute, second] = match;
-  const date = new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute) + minutes,
-    Number(second),
-  );
-  return formatLocalDateTime(date);
-}
-
 function addDaysToIcsDate(value: string, days: number): string {
   const match = value.match(/^(\d{4})(\d{2})(\d{2})$/);
   if (!match) return value;
@@ -99,13 +72,30 @@ function buildVEvent(task: any, feed: any, reminders: any[]): string {
     lines.push(icsFold(`DESCRIPTION:${icsEscape(task.description)}`));
   }
 
-  const dt = toIcsDate(task.dueAt || task.dueDate);
-  if (dt.isDateTime) {
-    lines.push(icsFold(`DTSTART:${dt.value}`));
-    lines.push(icsFold(`DTEND:${addMinutesToIcsDateTime(dt.value, 1)}`));
-  } else {
-    lines.push(icsFold(`DTSTART;VALUE=DATE:${dt.value}`));
-    lines.push(icsFold(`DTEND;VALUE=DATE:${addDaysToIcsDate(dt.value, 1)}`));
+  const start = task.startDate ? toIcsDate(task.startDate) : null;
+  const endSource = task.dueAt || task.dueDate;
+  const end = endSource ? toIcsDate(endSource) : null;
+
+  if (start?.isDateTime) {
+    lines.push(icsFold(`DTSTART:${start.value}`));
+    if (end?.isDateTime) {
+      lines.push(icsFold(`DTEND:${end.value}`));
+    } else if (end) {
+      lines.push(icsFold(`DTEND:${addDaysToIcsDate(end.value, 1)}T000000`));
+    }
+  } else if (start && end?.isDateTime) {
+    lines.push(icsFold(`DTSTART:${start.value}T000000`));
+    lines.push(icsFold(`DTEND:${end.value}`));
+  } else if (start) {
+    lines.push(icsFold(`DTSTART;VALUE=DATE:${start.value}`));
+    lines.push(icsFold(`DTEND;VALUE=DATE:${addDaysToIcsDate(end?.value || start.value, 1)}`));
+  } else if (end?.isDateTime) {
+    // A task with only a due time is an instant event. Do not invent a
+    // one-minute duration: RFC 5545 allows VEVENT without DTEND.
+    lines.push(icsFold(`DTSTART:${end.value}`));
+  } else if (end) {
+    lines.push(icsFold(`DTSTART;VALUE=DATE:${end.value}`));
+    lines.push(icsFold(`DTEND;VALUE=DATE:${addDaysToIcsDate(end.value, 1)}`));
   }
 
   if (task.updatedAt) {
@@ -257,10 +247,10 @@ taskCalendar.get("/feed/:token", (c) => {
 
   // Query tasks
   let sql = `
-    SELECT t.id, t.title, t.description, t.dueDate, t.dueAt, t.updatedAt, t.isCompleted
+    SELECT t.id, t.title, t.description, t.startDate, t.dueDate, t.dueAt, t.updatedAt, t.isCompleted
     FROM tasks t
     WHERE t.userId = ?
-      AND (t.dueAt IS NOT NULL OR t.dueDate IS NOT NULL)
+      AND (t.startDate IS NOT NULL OR t.dueAt IS NOT NULL OR t.dueDate IS NOT NULL)
   `;
   const params: any[] = [feed.userId];
 
@@ -271,7 +261,7 @@ taskCalendar.get("/feed/:token", (c) => {
     sql += " AND t.workspaceId = ?";
     params.push(feed.workspaceId);
   }
-  sql += " ORDER BY COALESCE(t.dueAt, t.dueDate) ASC";
+  sql += " ORDER BY COALESCE(t.startDate, t.dueAt, t.dueDate) ASC";
 
   const tasks = db.prepare(sql).all(...params) as any[];
 
@@ -409,15 +399,15 @@ export function buildIcsForToken(token: string): { body: string; feedId: string 
   } catch { /* ignore */ }
 
   let sql = `
-    SELECT t.id, t.title, t.description, t.dueDate, t.dueAt, t.updatedAt, t.isCompleted
+    SELECT t.id, t.title, t.description, t.startDate, t.dueDate, t.dueAt, t.updatedAt, t.isCompleted
     FROM tasks t
     WHERE t.userId = ?
-      AND (t.dueAt IS NOT NULL OR t.dueDate IS NOT NULL)
+      AND (t.startDate IS NOT NULL OR t.dueAt IS NOT NULL OR t.dueDate IS NOT NULL)
   `;
   const params: any[] = [feed.userId];
   if (!feed.includeCompleted) sql += " AND t.isCompleted = 0";
   if (feed.workspaceId) { sql += " AND t.workspaceId = ?"; params.push(feed.workspaceId); }
-  sql += " ORDER BY COALESCE(t.dueAt, t.dueDate) ASC";
+  sql += " ORDER BY COALESCE(t.startDate, t.dueAt, t.dueDate) ASC";
 
   const tasks = db.prepare(sql).all(...params) as any[];
 

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -33,6 +33,27 @@ function collectDescendantIds(db: any, rootIds: string[]): string[] {
   return [...result];
 }
 
+function isInvalidTaskDateRange(
+  startDate: string | null,
+  dueDate: string | null,
+  dueAt: string | null,
+): boolean {
+  if (!startDate) return false;
+  const end = dueAt || dueDate;
+  if (!end) return false;
+
+  const normalizedStart = startDate.trim().replace(" ", "T");
+  const normalizedEnd = end.trim().replace(" ", "T");
+  const startDay = normalizedStart.slice(0, 10);
+  const endDay = normalizedEnd.slice(0, 10);
+  if (startDay !== endDay) return startDay > endDay;
+
+  // A date-only dueDate means the end of that day. Compare exact times only
+  // when both boundaries include a time component.
+  if (!normalizedStart.includes("T") || !normalizedEnd.includes("T")) return false;
+  return normalizedStart > normalizedEnd;
+}
+
 const tasks = new Hono();
 
 // ---------------------------------------------------------------------------
@@ -317,7 +338,7 @@ tasks.post("/", requireWorkspaceFeature("tasks"), async (c) => {
     return c.json({ error: "Repeating task requires dueDate or dueAt", code: "REPEAT_REQUIRES_DATE" }, 400);
   }
 
-  if (startDate && dueDate && startDate > dueDate) {
+  if (isInvalidTaskDateRange(startDate, dueDate, dueAt)) {
     return c.json({ error: "startDate cannot be after dueDate", code: "INVALID_DATE_RANGE" }, 400);
   }
 
@@ -454,7 +475,7 @@ tasks.put("/:id", (c) => {
       return c.json({ error: "Repeating task requires dueDate or dueAt", code: "REPEAT_REQUIRES_DATE" }, 400);
     }
 
-    if (startDate && dueDate && startDate > dueDate) {
+    if (isInvalidTaskDateRange(startDate, dueDate, dueAt)) {
       return c.json({ error: "startDate cannot be after dueDate", code: "INVALID_DATE_RANGE" }, 400);
     }
 

--- a/backend/tests/task-calendar.test.ts
+++ b/backend/tests/task-calendar.test.ts
@@ -53,7 +53,7 @@ function createTestDb() {
       id TEXT PRIMARY KEY, userId TEXT NOT NULL, workspaceId TEXT,
       title TEXT NOT NULL, description TEXT, isCompleted INTEGER DEFAULT 0,
       status TEXT DEFAULT 'todo', priority INTEGER DEFAULT 2,
-      dueDate TEXT, dueAt TEXT,
+      startDate TEXT, dueDate TEXT, dueAt TEXT,
       noteId TEXT, parentId TEXT, sortOrder INTEGER DEFAULT 0,
       createdAt TEXT DEFAULT (datetime('now')), updatedAt TEXT DEFAULT (datetime('now')),
       FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
@@ -269,26 +269,38 @@ test("真实 ICS 输出使用兼容的 DATE-TIME、DTEND，并且公开订阅与
   `).run("feed-real", "u-real", "real-token");
 
   const insertRealTask = db.prepare(`
-    INSERT INTO tasks (id, userId, title, description, dueDate, dueAt, updatedAt, isCompleted)
-    VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+    INSERT INTO tasks (id, userId, title, description, startDate, dueDate, dueAt, updatedAt, isCompleted)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
   `);
-  insertRealTask.run("t-minute", "u-real", "分钟时间", "", null, "2026-07-02T13:29", "2026-07-02 13:29:00");
-  insertRealTask.run("t-seconds", "u-real", "秒级时间", "", null, "2026-07-02T13:29:00", "2026-07-02 13:29:00");
-  insertRealTask.run("t-space", "u-real", "空格时间", "", null, "2026-07-02 13:29", "2026-07-02 13:29:00");
-  insertRealTask.run("t-date", "u-real", "全天任务", "", "2026-11-02", null, "2026-11-02 00:00:00");
+  insertRealTask.run("t-minute", "u-real", "分钟时间", "", "2026-07-02T12:29", null, "2026-07-02T13:29", "2026-07-02 13:29:00");
+  insertRealTask.run("t-seconds", "u-real", "秒级时间", "", null, null, "2026-07-02T13:29:00", "2026-07-02 13:29:00");
+  insertRealTask.run("t-space", "u-real", "空格时间", "", null, null, "2026-07-02 13:29", "2026-07-02 13:29:00");
+  insertRealTask.run("t-date", "u-real", "全天任务", "", "2026-11-01", "2026-11-02", null, "2026-11-02 00:00:00");
+  insertRealTask.run("t-start-only", "u-real", "仅开始时间", "", "2026-07-03T09:00", null, null, "2026-07-03 09:00:00");
+  insertRealTask.run("t-due-date-range", "u-real", "dueDate 时间段", "", "2026-07-04T14:00", "2026-07-04T15:00", null, "2026-07-04 15:00:00");
 
   const result = buildIcsForToken("real-token");
   assert.ok(result);
   assert.equal(result.feedId, "feed-real");
 
   const body = result.body;
+  assert.ok(body.includes("DTSTART:20260702T122900"));
   assert.ok(body.includes("DTSTART:20260702T132900"));
-  assert.ok(body.includes("DTEND:20260702T133000"));
+  assert.ok(body.includes("DTEND:20260702T132900"));
+  assert.ok(!body.includes("DTEND:20260702T133000"));
   assert.ok(!body.includes("DTSTART:202607021329"));
   assert.ok(!body.includes("DUE:"));
 
-  assert.ok(body.includes("DTSTART;VALUE=DATE:20261102"));
+  assert.ok(body.includes("DTSTART;VALUE=DATE:20261101"));
   assert.ok(body.includes("DTEND;VALUE=DATE:20261103"));
+  const startOnlyEvent = body.split("BEGIN:VEVENT").find((event) => event.includes("UID:task-t-start-only@nowen-note"));
+  assert.ok(startOnlyEvent);
+  assert.ok(startOnlyEvent.includes("DTSTART:20260703T090000"));
+  assert.ok(!startOnlyEvent.includes("DTEND:"));
+  const dueDateRangeEvent = body.split("BEGIN:VEVENT").find((event) => event.includes("UID:task-t-due-date-range@nowen-note"));
+  assert.ok(dueDateRangeEvent);
+  assert.ok(dueDateRangeEvent.includes("DTSTART:20260704T140000"));
+  assert.ok(dueDateRangeEvent.includes("DTEND:20260704T150000"));
 
   const publicResponse = await taskCalendar.request("/feed/real-token.ics");
   assert.equal(publicResponse.status, 200);

--- a/frontend/src/components/EditorPane.tsx
+++ b/frontend/src/components/EditorPane.tsx
@@ -3381,9 +3381,8 @@ const moveToTrash = useCallback(async () => {
           {/* 原生 Markdown 笔记：contentFormat === "markdown" 时始终用 MarkdownEditor */}
           {activeNote.contentFormat === "markdown" ? (
             <MarkdownEditor
-              // Y.Doc arrives after the first render. Remount once it is available so the
-              // CodeMirror instance is actually created with yCollab; otherwise the editor
-              // stops REST-saving but has no CRDT persistence extension attached.
+              // useYDoc only exposes the document after y:sync. Remount at that point so
+              // CodeMirror gains yCollab without disabling normal saves while unsynced.
               key={collabYDoc ? `md-native-y-${activeNote.id}` : `md-native-${activeNote.id}`}
               ref={editorHandleRef}
               note={activeNote}

--- a/frontend/src/components/EditorPane.tsx
+++ b/frontend/src/components/EditorPane.tsx
@@ -1788,18 +1788,47 @@ export default function EditorPane({
 
   // �ֶ�����ͬ�������±��浱ǰ�༭������
   const handleManualSync = useCallback(async () => {
-    if (!activeNote || syncStatus === "saving") return;
+    const currentNote = activeNoteRef.current;
+    if (!currentNote || syncStatus === "saving") return;
+
+    // Manual sync must submit what is visible in the editor. In CRDT mode the live
+    // Markdown resides in CodeMirror/Y.Doc and activeNote.content can still be the
+    // previous server acknowledgement, which used to overwrite the second edit.
+    const snapshot = editorHandleRef.current?.getSnapshot?.();
+    editorHandleRef.current?.discardPending?.();
+    const title = snapshot?.title ?? currentNote.title;
+    const content = snapshot?.content ?? currentNote.content;
+    const contentText = snapshot?.contentText ?? currentNote.contentText;
+
     actions.setSyncStatus("saving");
     try {
-      const updated = await api.updateNote(activeNote.id, {
-        title: activeNote.title,
-        content: activeNote.content,
-        contentText: activeNote.contentText,
-        contentFormat: activeNote.contentFormat,
-        version: activeNote.version,
-      } as any);
+      // GET flushes an active server-side Y.Doc first and gives this explicit save the
+      // current optimistic-lock version. If the Y update already arrived, avoid a
+      // redundant PUT/version bump; otherwise persist the editor snapshot and align Y.Doc.
+      const persisted = await api.getNote(currentNote.id);
+      const alreadyPersisted = persisted.title === title
+        && persisted.content === content
+        && persisted.contentText === contentText
+        && persisted.contentFormat === currentNote.contentFormat;
+      const updated = alreadyPersisted
+        ? persisted
+        : await api.updateNoteConfirmed(currentNote.id, {
+          title,
+          content,
+          contentText,
+          contentFormat: currentNote.contentFormat,
+          version: persisted.version,
+          syncToYjs: true,
+        } as any);
+      activeNoteRef.current = updated;
       actions.setActiveNote(updated);
-      actions.updateNoteInList({ id: updated.id, title: updated.title, contentText: updated.contentText, updatedAt: updated.updatedAt });
+      actions.updateNoteInList({
+        id: updated.id,
+        title: updated.title,
+        contentText: updated.contentText,
+        updatedAt: updated.updatedAt,
+        version: updated.version,
+      });
       actions.updateNoteTab({
         id: updated.id,
         title: updated.title,
@@ -1812,10 +1841,11 @@ export default function EditorPane({
       actions.setLastSynced(new Date().toISOString());
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => actions.setSyncStatus("idle"), 2000);
-    } catch {
+    } catch (error) {
+      console.warn("[EditorPane] manual sync failed:", error);
       actions.setSyncStatus("error");
     }
-  }, [activeNote, syncStatus, actions]);
+  }, [syncStatus, actions]);
 
   const toggleFavorite = useCallback(async () => {
     if (!activeNote || activeNote.isTrashed) return;

--- a/frontend/src/components/__tests__/EditorPaneNativeMarkdownCollab.test.ts
+++ b/frontend/src/components/__tests__/EditorPaneNativeMarkdownCollab.test.ts
@@ -6,9 +6,18 @@ const editorPaneSource = readFileSync(
   path.resolve(__dirname, "../EditorPane.tsx"),
   "utf8",
 );
+const useYDocSource = readFileSync(
+  path.resolve(__dirname, "../../hooks/useYDoc.ts"),
+  "utf8",
+);
 
 describe("EditorPane native Markdown collaboration", () => {
-  it("remounts the editor when the CRDT document becomes available", () => {
+  it("keeps normal saves active until the CRDT document has synced", () => {
+    expect(useYDocSource).toContain(
+      "setState({ doc: null, provider, status: provider.getStatus(), synced: false });",
+    );
+    expect(useYDocSource).toContain("{ ...prev, doc, synced: true }");
+
     const start = editorPaneSource.indexOf('activeNote.contentFormat === "markdown"');
     const end = editorPaneSource.indexOf(") : htmlPreviewMode", start);
 
@@ -17,5 +26,6 @@ describe("EditorPane native Markdown collaboration", () => {
     expect(editorPaneSource.slice(start, end)).toContain(
       "key={collabYDoc ? `md-native-y-${activeNote.id}` : `md-native-${activeNote.id}`}",
     );
+    expect(editorPaneSource.slice(start, end)).toContain("yDoc={collabYDoc}");
   });
 });

--- a/frontend/src/components/__tests__/EditorPaneSaveSafety.test.ts
+++ b/frontend/src/components/__tests__/EditorPaneSaveSafety.test.ts
@@ -75,14 +75,20 @@ describe("EditorPane save safety", () => {
     expect(saveFailureFallback).toContain("contentFormat: currentNote.contentFormat");
   });
 
-  it("includes contentFormat when manually syncing active note content", () => {
+  it("manually syncs the live editor snapshot with the latest server version", () => {
     const manualSync = sourceBetween(
       editorPaneSource,
       "const handleManualSync = useCallback(async () => {",
       "const toggleFavorite = useCallback",
     );
 
-    expect(manualSync).toContain("contentFormat: activeNote.contentFormat");
+    expect(manualSync).toContain("editorHandleRef.current?.getSnapshot?.()");
+    expect(manualSync).toContain("editorHandleRef.current?.discardPending?.()");
+    expect(manualSync).toContain("const persisted = await api.getNote(currentNote.id)");
+    expect(manualSync).toContain("api.updateNoteConfirmed(currentNote.id");
+    expect(manualSync).toContain("contentFormat: currentNote.contentFormat");
+    expect(manualSync).toContain("version: persisted.version");
+    expect(manualSync).toContain("syncToYjs: true");
   });
 
   it("does not replay normalized content with a newer version after a 409", () => {

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -20,7 +20,14 @@ import { isTaskBlockedByDependency, getDependencyScheduleWarnings } from "./task
 import type { TaskTreeNode } from "./taskProgress";
 import { calculateTaskProgress } from "./taskProgress";
 import { insertTaskTitleSnippet, parseTaskTitle, TitleView } from "./taskTitleTokens";
-import { buildDueAtFromDateAndTime, buildDueDatePatch, getDueTimeValue } from "./taskDateUtils";
+import {
+  buildDueAtFromDateAndTime,
+  buildDueDatePatch,
+  buildStartDateFromDateAndTime,
+  getDateValue,
+  getDueTimeValue,
+  isTaskDateRangeInvalid,
+} from "./taskDateUtils";
 import { buildCustomReminderOffset, sortRemindersByOffset } from "./taskReminderUtils";
 import {
   buildCustomRepeatRule,
@@ -175,9 +182,10 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
   const [description, setDescription] = useState(task.description ?? "");
   const [descriptionMode, setDescriptionMode] = useState<"edit" | "preview">("edit");
   const [priority, setPriority] = useState<TaskPriority>(task.priority);
-  const [dueDate, setDueDate] = useState(task.dueDate || "");
-  const [dueAt, setDueAt] = useState(getDueTimeValue(task.dueAt));
-  const [startDate, setStartDate] = useState(task.startDate || "");
+  const [dueDate, setDueDate] = useState(getDateValue(task.dueDate || task.dueAt));
+  const [dueAt, setDueAt] = useState(getDueTimeValue(task.dueAt || task.dueDate));
+  const [startDate, setStartDate] = useState(getDateValue(task.startDate));
+  const [startAt, setStartAt] = useState(getDueTimeValue(task.startDate));
   const [repeatRule, setRepeatRule] = useState<"none" | "daily" | "weekly" | "monthly" | "yearly" | "custom">(task.repeatRule || "none");
   const [repeatInterval, setRepeatInterval] = useState(task.repeatInterval || 1);
   const [repeatEndDate, setRepeatEndDate] = useState(task.repeatEndDate || "");
@@ -217,9 +225,10 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
     setTitle(task.title);
     setDescription(task.description ?? "");
     setPriority(task.priority);
-    setDueDate(task.dueDate || "");
-    setDueAt(getDueTimeValue(task.dueAt));
-    setStartDate(task.startDate || "");
+    setDueDate(getDateValue(task.dueDate || task.dueAt));
+    setDueAt(getDueTimeValue(task.dueAt || task.dueDate));
+    setStartDate(getDateValue(task.startDate));
+    setStartAt(getDueTimeValue(task.startDate));
     setRepeatRule(task.repeatRule || "none");
     setRepeatInterval(task.repeatInterval || 1);
     setRepeatEndDate(task.repeatEndDate || "");
@@ -266,7 +275,7 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
       priority,
       dueDate: dueDate || null,
       dueAt: buildDueAtFromDateAndTime(dueDate, dueAt),
-      startDate: startDate || null,
+      startDate: buildStartDateFromDateAndTime(startDate, startAt),
     });
   };
 
@@ -528,15 +537,39 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
             value={startDate}
             onChange={(e) => {
               const newVal = e.target.value;
+              const nextStart = buildStartDateFromDateAndTime(newVal, startAt);
               setStartDate(newVal);
-              if (newVal && dueDate && newVal > dueDate) {
+              if (!newVal) setStartAt("");
+              if (isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
                 setDateError(t("tasks.gantt.invalidDateRange"));
                 return;
               }
               setDateError(null);
-              onUpdate(task.id, { startDate: newVal || null });
+              onUpdate(task.id, { startDate: nextStart });
             }}
             className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors"
+          />
+        </div>
+
+        {/* Start At (time) */}
+        <div>
+          <label className="text-xs text-tx-tertiary uppercase tracking-wider mb-1.5 block">{t("tasks.startAt")}</label>
+          <input
+            type="time"
+            value={startAt}
+            disabled={!startDate}
+            onChange={(e) => {
+              const nextTime = e.target.value;
+              const nextStart = buildStartDateFromDateAndTime(startDate, nextTime);
+              setStartAt(nextTime);
+              if (isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
+                setDateError(t("tasks.gantt.invalidDateRange"));
+                return;
+              }
+              setDateError(null);
+              onUpdate(task.id, { startDate: nextStart });
+            }}
+            className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           />
         </div>
 
@@ -586,8 +619,14 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
             disabled={!dueDate}
             onChange={(e) => {
               const nextTime = e.target.value;
+              const nextDueAt = buildDueAtFromDateAndTime(dueDate, nextTime);
               setDueAt(nextTime);
-              onUpdate(task.id, { dueAt: buildDueAtFromDateAndTime(dueDate, nextTime) });
+              if (isTaskDateRangeInvalid(buildStartDateFromDateAndTime(startDate, startAt), dueDate, nextDueAt)) {
+                setDateError(t("tasks.gantt.invalidDateRange"));
+                return;
+              }
+              setDateError(null);
+              onUpdate(task.id, { dueAt: nextDueAt });
             }}
             className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           />

--- a/frontend/src/components/tasks/__tests__/taskDueTimeUtils.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskDueTimeUtils.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildDueAtFromDateAndTime,
   buildDueDatePatch,
+  buildStartDateFromDateAndTime,
   compareTasksByDueTime,
+  getDateValue,
   getDueTimeValue,
+  isTaskDateRangeInvalid,
 } from "../taskDateUtils";
 import type { Task } from "@/types";
 
@@ -45,6 +48,19 @@ describe("due time helpers", () => {
     expect(buildDueAtFromDateAndTime("2026-06-17", "17:00")).toBe("2026-06-17T17:00");
     expect(buildDueAtFromDateAndTime("", "17:00")).toBeNull();
     expect(buildDueAtFromDateAndTime("2026-06-17", "")).toBeNull();
+  });
+
+  it("splits and rebuilds a start date with an optional time", () => {
+    expect(getDateValue("2026-06-17T09:15")).toBe("2026-06-17");
+    expect(getDueTimeValue("2026-06-17 09:15:00")).toBe("09:15");
+    expect(buildStartDateFromDateAndTime("2026-06-17", "09:15")).toBe("2026-06-17T09:15");
+    expect(buildStartDateFromDateAndTime("2026-06-17", "")).toBe("2026-06-17");
+  });
+
+  it("validates exact start and due times on the same day", () => {
+    expect(isTaskDateRangeInvalid("2026-06-17T18:01", "2026-06-17", "2026-06-17T18:00")).toBe(true);
+    expect(isTaskDateRangeInvalid("2026-06-17T17:00", "2026-06-17", "2026-06-17T18:00")).toBe(false);
+    expect(isTaskDateRangeInvalid("2026-06-17T17:00", "2026-06-17", null)).toBe(false);
   });
 
   it("clearing dueDate also clears dueAt and disables repeat", () => {

--- a/frontend/src/components/tasks/__tests__/taskGanttUtils.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskGanttUtils.test.ts
@@ -89,6 +89,12 @@ describe("getTaskStartDate", () => {
     expect(getTaskStartDate(task)).toBe("2026-06-10");
   });
 
+  it("uses the date part when startDate contains a time", () => {
+    const task = { ...baseTask, startDate: "2026-06-10T09:15", dueDate: "2026-06-15" };
+    expect(getTaskStartDate(task)).toBe("2026-06-10");
+    expect(moveTaskDateRange(task, "2026-06-20")?.startDate).toBe("2026-06-20T09:15");
+  });
+
   it("returns null when no dates", () => {
     expect(getTaskStartDate(baseTask)).toBeNull();
   });

--- a/frontend/src/components/tasks/__tests__/taskMyDay.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskMyDay.test.ts
@@ -47,12 +47,13 @@ describe("taskMyDay", () => {
       task({ id: "overdue", dueDate: "2026-08-01", priority: 1 }),
       task({ id: "today", dueDate: "2026-08-02", priority: 3 }),
       task({ id: "starting", startDate: "2026-08-02" }),
+      task({ id: "starting-with-time", startDate: "2026-08-02T09:30" }),
       task({ id: "future", dueDate: "2026-08-03" }),
       task({ id: "done", dueDate: "2026-08-01", isCompleted: 1, status: "done" }),
     ];
 
     expect(getMyDaySuggestions(tasks, "2026-08-02", ["planned"]).map((item) => item.id))
-      .toEqual(["overdue", "today", "starting"]);
+      .toEqual(["overdue", "today", "starting", "starting-with-time"]);
   });
 
   it("orders focus tasks first and completed tasks last within each group", () => {

--- a/frontend/src/components/tasks/taskDateUtils.ts
+++ b/frontend/src/components/tasks/taskDateUtils.ts
@@ -2,8 +2,36 @@ import type { Task } from "@/types";
 
 export function getDueTimeValue(dueAt: string | null | undefined): string {
   if (!dueAt) return "";
-  const timePart = dueAt.split("T")[1] || "";
+  const timePart = dueAt.replace(" ", "T").split("T")[1] || "";
   return timePart.slice(0, 5);
+}
+
+export function getDateValue(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.replace(" ", "T").split("T")[0];
+}
+
+export function buildStartDateFromDateAndTime(dateValue: string | null | undefined, timeValue: string): string | null {
+  if (!dateValue) return null;
+  return timeValue ? `${dateValue}T${timeValue.slice(0, 5)}` : dateValue;
+}
+
+export function isTaskDateRangeInvalid(
+  startDate: string | null | undefined,
+  dueDate: string | null | undefined,
+  dueAt: string | null | undefined,
+): boolean {
+  if (!startDate) return false;
+  const end = dueAt || dueDate;
+  if (!end) return false;
+
+  const normalizedStart = startDate.replace(" ", "T");
+  const normalizedEnd = end.replace(" ", "T");
+  const startDay = normalizedStart.slice(0, 10);
+  const endDay = normalizedEnd.slice(0, 10);
+  if (startDay !== endDay) return startDay > endDay;
+  if (!normalizedStart.includes("T") || !normalizedEnd.includes("T")) return false;
+  return normalizedStart > normalizedEnd;
 }
 
 export function buildDueAtFromDateAndTime(dueDate: string | null | undefined, timeValue: string): string | null {

--- a/frontend/src/components/tasks/taskDependencyUtils.ts
+++ b/frontend/src/components/tasks/taskDependencyUtils.ts
@@ -152,7 +152,7 @@ export function getDependencyScheduleWarnings(
   const suggestedStart = addDays(latestBlockerDue, 1);
 
   // Check if current task dates need adjustment
-  const currentStart = task.startDate || null;
+  const currentStart = task.startDate?.slice(0, 10) || null;
   const currentDue = task.dueDate || null;
   const now = new Date();
   const todayStr = format(now);

--- a/frontend/src/components/tasks/taskGanttUtils.ts
+++ b/frontend/src/components/tasks/taskGanttUtils.ts
@@ -1,11 +1,17 @@
 import type { Task } from "../../types";
+import { getDateValue, getDueTimeValue } from "./taskDateUtils";
+
+function preserveStartTime(dateValue: string, originalStartDate: string | null | undefined): string {
+  const timeValue = getDueTimeValue(originalStartDate);
+  return timeValue ? `${dateValue}T${timeValue}` : dateValue;
+}
 
 export function getTaskStartDate(task: Task): string | null {
-  return task.startDate || task.dueDate || null;
+  return getDateValue(task.startDate || task.dueDate) || null;
 }
 
 export function getTaskEndDate(task: Task): string | null {
-  return task.dueDate || task.startDate || null;
+  return getDateValue(task.dueDate || task.startDate) || null;
 }
 
 export function getTaskDurationDays(task: Task): number {
@@ -30,7 +36,7 @@ export function moveTaskDateRange(task: Task, targetStartDate: string): { startD
   const nm = String(newEndDate.getMonth() + 1).padStart(2, '0');
   const nd = String(newEndDate.getDate()).padStart(2, '0');
   const newEnd = ny + '-' + nm + '-' + nd;
-  return { startDate: targetStartDate, dueDate: newEnd };
+  return { startDate: preserveStartTime(targetStartDate, task.startDate), dueDate: newEnd };
 }
 
 export function isTaskScheduled(task: Task): boolean {
@@ -59,11 +65,11 @@ export function resizeTaskDateRange(
   if (side === "start") {
     const effectiveEnd = end || targetDate;
     if (targetDate > effectiveEnd) return null;
-    return { startDate: targetDate, dueDate: effectiveEnd };
+    return { startDate: preserveStartTime(targetDate, task.startDate), dueDate: effectiveEnd };
   } else {
     const effectiveStart = start || targetDate;
     if (effectiveStart > targetDate) return null;
-    return { startDate: effectiveStart, dueDate: targetDate };
+    return { startDate: preserveStartTime(effectiveStart, task.startDate), dueDate: targetDate };
   }
 }
 

--- a/frontend/src/components/tasks/taskMyDay.ts
+++ b/frontend/src/components/tasks/taskMyDay.ts
@@ -27,7 +27,7 @@ export function isTaskOverdue(task: Task, today: string): boolean {
 }
 
 export function isTaskStartingToday(task: Task, today: string): boolean {
-  return !task.isCompleted && task.startDate === today;
+  return !task.isCompleted && task.startDate?.slice(0, 10) === today;
 }
 
 export function normalizeMyDayPlan(

--- a/frontend/src/hooks/useYDoc.ts
+++ b/frontend/src/hooks/useYDoc.ts
@@ -70,7 +70,10 @@ export function useYDoc({ noteId, user, enabled }: UseYDocOptions): UseYDocResul
     const provider = new NowenYjsProvider(noteId, user, doc);
     currentRef.current = { doc, provider };
 
-    setState({ doc, provider, status: provider.getStatus(), synced: false });
+    // The provider and its local doc exist before the server replies. Do not expose
+    // that doc to editors yet: binding it would disable their normal persistence path
+    // even when the WebSocket never completes the initial sync.
+    setState({ doc: null, provider, status: provider.getStatus(), synced: false });
 
     // 关键：provider 构造函数里已经同步发出了 y:join。如果 y:sync 在下面这行
     // `provider.on("synced", ...)` 之前就已经到达并 emit，我们就永远收不到。
@@ -80,7 +83,7 @@ export function useYDoc({ noteId, user, enabled }: UseYDocOptions): UseYDocResul
     if (currentStatus === "synced") {
       console.debug(`[useYDoc] provider already synced on subscribe time for ${noteId}, backfilling`);
       setState((prev) =>
-        prev.provider === provider ? { ...prev, synced: true, status: "synced" } : prev,
+        prev.provider === provider ? { ...prev, doc, synced: true, status: "synced" } : prev,
       );
     }
 
@@ -92,7 +95,7 @@ export function useYDoc({ noteId, user, enabled }: UseYDocOptions): UseYDocResul
     const offSynced = provider.on("synced", () => {
       console.debug(`[useYDoc] received 'synced' for ${noteId}`);
       setState((prev) =>
-        prev.provider === provider ? { ...prev, synced: true } : prev,
+        prev.provider === provider ? { ...prev, doc, synced: true } : prev,
       );
     });
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1383,6 +1383,8 @@
     },
     "descriptionMarkdownHint": "Markdown supported",
     "priority": "Priority",
+    "startDate": "Start Date",
+    "startAt": "Start Time",
     "dueDate": "Due Date",
     "dueAt": "Due Time",
     "createdAt": "Created",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1510,6 +1510,7 @@
     "calendarEmpty": "这天没有任务",
     "timelineView": "时间线",
     "startDate": "开始日期",
+    "startAt": "开始时间",
     "gantt": {
       "title": "时间线",
       "today": "今天",
@@ -1519,7 +1520,7 @@
       "month": "月",
       "unscheduled": "未排期任务",
       "noScheduledTasks": "暂无排期任务",
-      "invalidDateRange": "开始日期不能晚于截止日期",
+      "invalidDateRange": "开始时间不能晚于截止时间",
       "scheduleToday": "设为今天"
     },
     "repeat": {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -413,6 +413,7 @@ export interface Task {
   dueDate: string | null;
   /** Phase 2: 精确到分钟的截止时间，ISO 8601 格式（如 2026-06-12T18:00）。兼容旧 dueDate */
   dueAt: string | null;
+  /** 开始日期或精确到分钟的开始时间（YYYY-MM-DD 或 YYYY-MM-DDTHH:mm） */
   startDate?: string | null;
   noteId: string | null;
   parentId: string | null;


### PR DESCRIPTION
该同步 PR 已由正式语义 merge commit `81d400c0b72b1faa9ec4e914ba4d554f427b84d2` 取代。唯一冲突 `backend/src/routes/task-calendar.ts` 已在 `pg-migration-unified` 中保留 Adapter/Repository 异步边界，同时吸收 main 的 startDate、真实 DTEND 和 Markdown 协同修复。分支当前已追平 main，本 PR 关闭。