### PR TITLE
chore(sync): merge latest markdown clipboard fix into pg-migration-unified

### DIFF
--- a/frontend/src/components/MarkdownEditorImpl.tsx
+++ b/frontend/src/components/MarkdownEditorImpl.tsx
@@ -119,6 +119,7 @@ import { findTextAction, type TextAction } from "@/lib/textActions";
 import { cn } from "@/lib/utils";
 import { normalizeToMarkdown, markdownToPlainText } from "@/lib/contentFormat";
 import { internalMarkdownMarkerExtensions } from "@/lib/markdownInternalMarkers";
+import { sanitizeMarkdownClipboardText } from "@/lib/markdownUserContent";
 import { shouldEmitTitleUpdate, shouldSkipTitleChange, shouldSyncTitleValue } from "@/lib/titleIme";
 import { scrollMarkdownPreviewToPosition } from "@/lib/markdownPreviewOutline";
 import {
@@ -594,7 +595,9 @@ export default forwardRef<NoteEditorHandle, MarkdownEditorProps>(function Markdo
     if (!view) return;
     const sel = view.state.selection.main;
     if (sel.empty) return;
-    const ok = await copyText(view.state.doc.sliceString(sel.from, sel.to));
+    const ok = await copyText(sanitizeMarkdownClipboardText(
+      view.state.doc.sliceString(sel.from, sel.to),
+    ));
     if (ok) toast.success(tr('tiptap.copySelectionText'));
     else toast.info(tr('tiptap.copySelectionFail'));
     queueMicrotask(() => view.focus());

--- a/frontend/src/lib/__tests__/markdownUserContent.test.ts
+++ b/frontend/src/lib/__tests__/markdownUserContent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   findInternalMarkdownMarkerRanges,
   projectMarkdownForUser,
+  sanitizeMarkdownClipboardText,
 } from "../markdownUserContent";
 
 const HEADING_ID = "blk_11111111-1111-4111-8111-111111111111";
@@ -66,5 +67,31 @@ describe("projectMarkdownForUser", () => {
       { kind: "inline", blockId: HEADING_ID },
       { kind: "line", blockId: CODE_ID },
     ]);
+  });
+});
+
+describe("sanitizeMarkdownClipboardText", () => {
+  it("removes generated block IDs even after they move into the middle of a line", () => {
+    expect(sanitizeMarkdownClipboardText(
+      `前半段 ^${PARAGRAPH_ID} 后半段`,
+    )).toBe("前半段 后半段");
+  });
+
+  it("removes copied line-end and standalone generated markers", () => {
+    expect(sanitizeMarkdownClipboardText([
+      `标题 ^${HEADING_ID}`,
+      `^${PARAGRAPH_ID}`,
+      "正文",
+    ].join("\n"))).toBe("标题\n\n正文");
+  });
+
+  it("preserves marker-like text in fenced code and ordinary user text", () => {
+    const source = [
+      "```text",
+      `literal ^${CODE_ID}`,
+      "```",
+      "普通示例 ^blk_example_text",
+    ].join("\n");
+    expect(sanitizeMarkdownClipboardText(source)).toBe(source);
   });
 });

--- a/frontend/src/lib/markdownInternalMarkers.ts
+++ b/frontend/src/lib/markdownInternalMarkers.ts
@@ -3,6 +3,7 @@ import { Decoration, EditorView, type DecorationSet } from "@codemirror/view";
 import {
   findInternalMarkdownMarkerRanges,
   projectMarkdownForUser,
+  sanitizeMarkdownClipboardText,
 } from "@/lib/markdownUserContent";
 
 function buildMarkerDecorations(markdown: string): DecorationSet {
@@ -47,8 +48,17 @@ const cleanClipboard = EditorView.domEventHandlers({
     const selected = view.state.selection.ranges
       .map((range) => view.state.doc.sliceString(range.from, range.to))
       .join("\n");
-    event.clipboardData.setData("text/plain", projectMarkdownForUser(selected));
+    event.clipboardData.setData("text/plain", sanitizeMarkdownClipboardText(projectMarkdownForUser(selected)));
     event.preventDefault();
+    return true;
+  },
+  paste(event, view) {
+    if (!event.clipboardData) return false;
+    const pasted = event.clipboardData.getData("text/plain");
+    const sanitized = sanitizeMarkdownClipboardText(pasted);
+    if (sanitized === pasted) return false;
+    event.preventDefault();
+    view.dispatch(view.state.replaceSelection(sanitized));
     return true;
   },
 });

--- a/frontend/src/lib/markdownUserContent.ts
+++ b/frontend/src/lib/markdownUserContent.ts
@@ -12,6 +12,10 @@ export interface InternalMarkdownMarkerRange {
 const GENERATED_BLOCK_ID = String.raw`blk_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8,12}`;
 const INLINE_MARKER_RE = new RegExp(String.raw`[ \t]*\^(${GENERATED_BLOCK_ID})[ \t]*$`, "i");
 const LINE_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${GENERATED_BLOCK_ID})[ \t]*$`, "i");
+const PASTED_MARKER_RE = new RegExp(
+  String.raw`(^|[ \t]+)\^(${GENERATED_BLOCK_ID})($|[ \t]+)`,
+  "ig",
+);
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 
 /**
@@ -81,4 +85,39 @@ export function projectMarkdownForUser(markdown: string): string {
     output = output.slice(0, range.from) + output.slice(range.to);
   }
   return output;
+}
+
+/**
+ * Remove reserved block identity from pasted text, including markers that were
+ * moved into the middle of a line by a previous paste. Fenced code is preserved
+ * verbatim so documentation and code samples can still contain marker-like text.
+ */
+export function sanitizeMarkdownClipboardText(markdown: string): string {
+  if (!markdown || !markdown.includes("^blk_")) return markdown;
+  const lines = markdown.split("\n");
+  let fenceChar = "";
+  let fenceLength = 0;
+
+  return lines.map((line) => {
+    if (fenceChar) {
+      const closeRe = new RegExp(`^[ \\t]{0,3}${fenceChar}{${fenceLength},}[ \\t]*$`);
+      if (closeRe.test(line)) {
+        fenceChar = "";
+        fenceLength = 0;
+      }
+      return line;
+    }
+
+    const opener = line.match(FENCE_OPEN_RE);
+    if (opener) {
+      fenceChar = opener[1][0];
+      fenceLength = opener[1].length;
+      return line;
+    }
+
+    PASTED_MARKER_RE.lastIndex = 0;
+    return line.replace(PASTED_MARKER_RE, (_match, left: string, _blockId: string, right: string) =>
+      left && right ? " " : "",
+    );
+  }).join("\n");
 }


### PR DESCRIPTION
同步 main@0f86d9dd45117c10d1d4a90bb84f6a3a7adb9e6b 到 pg-migration-unified。内容为 Markdown 复制/粘贴时过滤内部 block ID。本 PR 仅用于生成正式 merge commit；PostgreSQL 迁移主 PR 仍为 #299。