### PR TITLE
fix(migrations): 修复 1.2.4 升级后的容器重启循环

### DIFF
--- a/backend/src/db/tagScopeUniquenessMigration.ts
+++ b/backend/src/db/tagScopeUniquenessMigration.ts
@@ -1,6 +1,43 @@
 import type Database from "better-sqlite3";
 import type { Migration } from "./migrations.impl.js";
 
+type ForeignKeyViolation = {
+  table: string;
+  rowid: number;
+  parent: string;
+  fkid: number;
+};
+
+/**
+ * 1.2.x 的部分数据库可能残留已经找不到 users 父记录的登录会话。
+ * 会话本身属于可丢弃的认证缓存，不包含用户内容；v59 是历史上首次执行全库
+ * foreign_key_check 的迁移，因此这些既有脏记录会让无关的标签迁移反复失败。
+ */
+function repairLegacyOrphanedUserSessions(db: Database.Database): void {
+  const table = db.prepare(`
+    SELECT 1
+    FROM sqlite_master
+    WHERE type = 'table' AND name = 'user_sessions'
+  `).get();
+  if (!table) return;
+
+  const columns = db.prepare("PRAGMA table_info(user_sessions)").all() as Array<{ name: string }>;
+  if (!columns.some((column) => column.name === "userId")) return;
+
+  const result = db.prepare(`
+    DELETE FROM user_sessions
+    WHERE NOT EXISTS (
+      SELECT 1 FROM users WHERE users.id = user_sessions.userId
+    )
+  `).run();
+
+  if (result.changes > 0) {
+    console.warn(
+      `[migrations:v59] removed ${result.changes} orphaned legacy user session(s)`,
+    );
+  }
+}
+
 /**
  * v59: 标签名称从“账号全局唯一”调整为真正的空间唯一。
  *
@@ -15,6 +52,8 @@ export const tagScopeUniquenessMigration: Migration = {
   version: 59,
   name: "tag-scope-unique-names",
   up: (db: Database.Database) => {
+    repairLegacyOrphanedUserSessions(db);
+
     db.exec(`
       CREATE TABLE tags_v59 (
         id TEXT PRIMARY KEY,
@@ -103,9 +142,16 @@ export const tagScopeUniquenessMigration: Migration = {
         WHERE workspaceId IS NOT NULL;
     `);
 
-    const fkErrors = db.prepare("PRAGMA foreign_key_check").all();
-    if (fkErrors.length > 0) {
-      throw new Error(`tag scope migration foreign key check failed: ${JSON.stringify(fkErrors)}`);
+    // 这里只验证本迁移重建的表。旧库其他表已有的外键问题不能被误报成 v59 失败，
+    // 否则 Docker restart policy 会把一次可恢复的数据兼容问题放大成无限重启。
+    const fkErrors = db.prepare("PRAGMA foreign_key_check").all() as ForeignKeyViolation[];
+    const migrationFkErrors = fkErrors.filter(
+      (error) => error.table === "tags" || error.table === "note_tags",
+    );
+    if (migrationFkErrors.length > 0) {
+      throw new Error(
+        `tag scope migration foreign key check failed: ${JSON.stringify(migrationFkErrors)}`,
+      );
     }
   },
 };

--- a/backend/tests/tag-scope-uniqueness-migration.test.ts
+++ b/backend/tests/tag-scope-uniqueness-migration.test.ts
@@ -3,6 +3,13 @@ import test from "node:test";
 import Database from "better-sqlite3";
 import { tagScopeUniquenessMigration } from "../src/db/tagScopeUniquenessMigration";
 
+type ForeignKeyViolation = {
+  table: string;
+  rowid: number;
+  parent: string;
+  fkid: number;
+};
+
 function createLegacyDb(): Database.Database {
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
@@ -29,6 +36,11 @@ function createLegacyDb(): Database.Database {
       PRIMARY KEY (noteId, tagId),
       FOREIGN KEY (noteId) REFERENCES notes(id) ON DELETE CASCADE,
       FOREIGN KEY (tagId) REFERENCES tags(id) ON DELETE CASCADE
+    );
+    CREATE TABLE user_sessions (
+      id TEXT PRIMARY KEY,
+      userId TEXT NOT NULL,
+      FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
     );
   `);
   db.prepare("INSERT INTO users (id) VALUES (?), (?)").run("u1", "u2");
@@ -111,6 +123,53 @@ test("v59 enforces personal and workspace scoped names", () => {
       .run("personal-other", "u2", null, "React");
 
     assert.equal((db.prepare("SELECT COUNT(*) AS count FROM tags").get() as { count: number }).count, 4);
+  } finally {
+    db.close();
+  }
+});
+
+test("v59 repairs orphaned user sessions left by a 1.2.x database", () => {
+  const db = createLegacyDb();
+  try {
+    db.pragma("foreign_keys = OFF");
+    db.prepare("INSERT INTO user_sessions (id, userId) VALUES (?, ?)")
+      .run("legacy-session", "deleted-user");
+    db.pragma("foreign_keys = ON");
+
+    const before = db.prepare("PRAGMA foreign_key_check").all() as ForeignKeyViolation[];
+    assert.equal(before.filter((error) => error.table === "user_sessions").length, 1);
+
+    assert.doesNotThrow(() => tagScopeUniquenessMigration.up(db));
+    assert.equal(
+      (db.prepare("SELECT COUNT(*) AS count FROM user_sessions").get() as { count: number }).count,
+      0,
+    );
+    assert.deepEqual(db.prepare("PRAGMA foreign_key_check").all(), []);
+  } finally {
+    db.close();
+  }
+});
+
+test("v59 does not report unrelated legacy foreign key errors as tag migration failures", () => {
+  const db = createLegacyDb();
+  try {
+    db.exec(`
+      CREATE TABLE legacy_refs (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+      );
+    `);
+    db.pragma("foreign_keys = OFF");
+    db.prepare("INSERT INTO legacy_refs (id, userId) VALUES (?, ?)")
+      .run("legacy-ref", "deleted-user");
+    db.pragma("foreign_keys = ON");
+
+    assert.doesNotThrow(() => tagScopeUniquenessMigration.up(db));
+
+    const remaining = db.prepare("PRAGMA foreign_key_check").all() as ForeignKeyViolation[];
+    assert.equal(remaining.length, 1);
+    assert.equal(remaining[0].table, "legacy_refs");
   } finally {
     db.close();
   }


### PR DESCRIPTION
## 问题

用户从 1.2.4 升级到 1.4.4 后，v59 `tag-scope-unique-names` 迁移执行了全库外键检查。旧数据库中引用已删除用户的 `user_sessions` 孤儿记录被错误归因到标签迁移，进程退出后触发 Docker restart policy，形成无限重启。

## 修复

- v59 执行前检测并删除引用不存在用户的旧登录会话
  - 登录会话属于可丢弃认证缓存，不包含用户笔记或业务数据
  - 兼容不存在 `user_sessions` 或旧表缺少 `userId` 列的数据库
- v59 迁移完成后只验收本次重建的 `tags` 与 `note_tags` 外键
- 保留标签迁移自身错误的阻断能力，不把无关历史表错误归因到 v59

## 回归测试

- 覆盖 1.2.x 数据库残留孤儿 `user_sessions` 的升级场景
- 验证孤儿会话被清理且 v59 成功完成
- 验证其他无关表的历史外键错误不会导致标签迁移失败
- 保留原有重复标签合并和作用域唯一性测试

Closes #625