### PR TITLE
fix: calendar ICS export and task all-day toggle

### DIFF
--- a/backend/src/routes/task-calendar.ts
+++ b/backend/src/routes/task-calendar.ts
@@ -53,11 +53,18 @@ function addDaysToIcsDate(value: string, days: number): string {
 }
 
 function toIcsDate(dateStr: string): { value: string; isDateTime: boolean } {
-  const normalized = dateStr.trim().replace(" ", "T").replace(/Z$/, "");
+  // Normalize spaces→T, strip trailing Z, strip milliseconds
+  const normalized = dateStr.trim().replace(" ", "T").replace(/Z$/i, "").replace(/\.\d+$/, "");
   const dateTime = normalized.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/);
   if (dateTime) {
     const [, year, month, day, hour, minute, second = "00"] = dateTime;
     return { value: `${year}${month}${day}T${hour}${minute}${second}`, isDateTime: true };
+  }
+  // Pure date (no time component at all)
+  const dateOnly = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return { value: `${year}${month}${day}`, isDateTime: false };
   }
   return { value: normalized.replace(/-/g, ""), isDateTime: false };
 }
@@ -72,26 +79,33 @@ function buildVEvent(task: any, feed: any, reminders: any[]): string {
     lines.push(icsFold(`DESCRIPTION:${icsEscape(task.description)}`));
   }
 
-  const start = task.startDate ? toIcsDate(task.startDate) : null;
-  const endSource = task.dueAt || task.dueDate;
-  const end = endSource ? toIcsDate(endSource) : null;
+  // startDate 优先，回退到 dueAt / dueDate，确保开始时间不丢失
+  const startRaw = task.startDate || task.dueAt || task.dueDate;
+  const start = startRaw ? toIcsDate(startRaw) : null;
+  // dueAt 优先（含时间），回退到 dueDate（纯日期）
+  const endRaw = task.dueAt || task.dueDate;
+  const end = endRaw ? toIcsDate(endRaw) : null;
 
   if (start?.isDateTime) {
     lines.push(icsFold(`DTSTART:${start.value}`));
-    if (end?.isDateTime) {
+    if (end?.isDateTime && end.value !== start.value) {
+      // 有明确的结束时间且不同于开始时间
       lines.push(icsFold(`DTEND:${end.value}`));
-    } else if (end) {
-      lines.push(icsFold(`DTEND:${addDaysToIcsDate(end.value, 1)}T000000`));
+    } else if (end && !end.isDateTime) {
+      // 开始有具体时间，结束是纯日期 → 全天事件
+      lines.push(icsFold(`DTEND;VALUE=DATE:${addDaysToIcsDate(end.value, 1)}`));
     }
+    // 结束时间等于开始时间或无结束 → 省略 DTEND (RFC 5545 允许)
   } else if (start && end?.isDateTime) {
-    lines.push(icsFold(`DTSTART:${start.value}T000000`));
+    // 全天开始 + 具体结束时间
+    lines.push(icsFold(`DTSTART;VALUE=DATE:${start.value}`));
     lines.push(icsFold(`DTEND:${end.value}`));
   } else if (start) {
+    // 纯日期（全天事件）
     lines.push(icsFold(`DTSTART;VALUE=DATE:${start.value}`));
     lines.push(icsFold(`DTEND;VALUE=DATE:${addDaysToIcsDate(end?.value || start.value, 1)}`));
   } else if (end?.isDateTime) {
-    // A task with only a due time is an instant event. Do not invent a
-    // one-minute duration: RFC 5545 allows VEVENT without DTEND.
+    // 仅截止时间 → 即时事件
     lines.push(icsFold(`DTSTART:${end.value}`));
   } else if (end) {
     lines.push(icsFold(`DTSTART;VALUE=DATE:${end.value}`));

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -184,8 +184,11 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
   const [priority, setPriority] = useState<TaskPriority>(task.priority);
   const [dueDate, setDueDate] = useState(getDateValue(task.dueDate || task.dueAt));
   const [dueAt, setDueAt] = useState(getDueTimeValue(task.dueAt || task.dueDate));
+  const hasStartTime = !!(task.startDate && task.startDate.includes("T"));
+  const hasEndTime = !!(task.dueAt || (task.dueDate && task.dueDate.includes("T")));
   const [startDate, setStartDate] = useState(getDateValue(task.startDate));
   const [startAt, setStartAt] = useState(getDueTimeValue(task.startDate));
+  const [allDay, setAllDay] = useState(!(hasStartTime || hasEndTime));
   const [repeatRule, setRepeatRule] = useState<"none" | "daily" | "weekly" | "monthly" | "yearly" | "custom">(task.repeatRule || "none");
   const [repeatInterval, setRepeatInterval] = useState(task.repeatInterval || 1);
   const [repeatEndDate, setRepeatEndDate] = useState(task.repeatEndDate || "");
@@ -229,6 +232,9 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
     setDueAt(getDueTimeValue(task.dueAt || task.dueDate));
     setStartDate(getDateValue(task.startDate));
     setStartAt(getDueTimeValue(task.startDate));
+    const hasStartTimeNew = !!(task.startDate && task.startDate.includes("T"));
+    const hasEndTimeNew = !!(task.dueAt || (task.dueDate && task.dueDate.includes("T")));
+    setAllDay(!(hasStartTimeNew || hasEndTimeNew));
     setRepeatRule(task.repeatRule || "none");
     setRepeatInterval(task.repeatInterval || 1);
     setRepeatEndDate(task.repeatEndDate || "");
@@ -274,8 +280,8 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
       title: title.trim() || task.title,
       priority,
       dueDate: dueDate || null,
-      dueAt: buildDueAtFromDateAndTime(dueDate, dueAt),
-      startDate: buildStartDateFromDateAndTime(startDate, startAt),
+      dueAt: allDay ? null : buildDueAtFromDateAndTime(dueDate, dueAt),
+      startDate: allDay ? (startDate || null) : buildStartDateFromDateAndTime(startDate, startAt),
     });
   };
 
@@ -537,10 +543,10 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
             value={startDate}
             onChange={(e) => {
               const newVal = e.target.value;
-              const nextStart = buildStartDateFromDateAndTime(newVal, startAt);
+              const nextStart = allDay ? newVal : buildStartDateFromDateAndTime(newVal, startAt);
               setStartDate(newVal);
               if (!newVal) setStartAt("");
-              if (isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
+              if (!allDay && isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
                 setDateError(t("tasks.gantt.invalidDateRange"));
                 return;
               }
@@ -548,28 +554,6 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
               onUpdate(task.id, { startDate: nextStart });
             }}
             className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors"
-          />
-        </div>
-
-        {/* Start At (time) */}
-        <div>
-          <label className="text-xs text-tx-tertiary uppercase tracking-wider mb-1.5 block">{t("tasks.startAt")}</label>
-          <input
-            type="time"
-            value={startAt}
-            disabled={!startDate}
-            onChange={(e) => {
-              const nextTime = e.target.value;
-              const nextStart = buildStartDateFromDateAndTime(startDate, nextTime);
-              setStartAt(nextTime);
-              if (isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
-                setDateError(t("tasks.gantt.invalidDateRange"));
-                return;
-              }
-              setDateError(null);
-              onUpdate(task.id, { startDate: nextStart });
-            }}
-            className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           />
         </div>
 
@@ -606,31 +590,99 @@ export const TaskDetailPanel = React.forwardRef<HTMLDivElement, {
           />
         </div>
 
+        {/* All Day Toggle */}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              const next = !allDay;
+              setAllDay(next);
+              if (next) {
+                // 开启全天 → 清除时间
+                setStartAt("");
+                setDueAt("");
+                onUpdate(task.id, {
+                  startDate: startDate || null,
+                  dueAt: null,
+                });
+              }
+            }}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+              allDay ? "bg-accent-primary" : "bg-app-border"
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform",
+                allDay ? "translate-x-4" : "translate-x-0"
+              )}
+            />
+          </button>
+          <label className="text-xs text-tx-secondary cursor-pointer select-none" onClick={() => {
+            const next = !allDay;
+            setAllDay(next);
+            if (next) {
+              setStartAt("");
+              setDueAt("");
+              onUpdate(task.id, { startDate: startDate || null, dueAt: null });
+            }
+          }}>
+            {t("tasks.allDay")}
+          </label>
+        </div>
+
         {dateError && (
           <p className="text-xs text-red-500 -mt-1 mb-1">{dateError}</p>
         )}
 
-        {/* Due At (time) */}
-        <div>
-          <label className="text-xs text-tx-tertiary uppercase tracking-wider mb-1.5 block">{t("tasks.dueAt")}</label>
-          <input
-            type="time"
-            value={dueAt}
-            disabled={!dueDate}
-            onChange={(e) => {
-              const nextTime = e.target.value;
-              const nextDueAt = buildDueAtFromDateAndTime(dueDate, nextTime);
-              setDueAt(nextTime);
-              if (isTaskDateRangeInvalid(buildStartDateFromDateAndTime(startDate, startAt), dueDate, nextDueAt)) {
-                setDateError(t("tasks.gantt.invalidDateRange"));
-                return;
-              }
-              setDateError(null);
-              onUpdate(task.id, { dueAt: nextDueAt });
-            }}
-            className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          />
-        </div>
+        {/* Start At (time) — hidden in all-day mode */}
+        {!allDay && (
+          <div>
+            <label className="text-xs text-tx-tertiary uppercase tracking-wider mb-1.5 block">{t("tasks.startAt")}</label>
+            <input
+              type="time"
+              value={startAt}
+              disabled={!startDate}
+              onChange={(e) => {
+                const nextTime = e.target.value;
+                const nextStart = buildStartDateFromDateAndTime(startDate, nextTime);
+                setStartAt(nextTime);
+                if (isTaskDateRangeInvalid(nextStart, dueDate, buildDueAtFromDateAndTime(dueDate, dueAt))) {
+                  setDateError(t("tasks.gantt.invalidDateRange"));
+                  return;
+                }
+                setDateError(null);
+                onUpdate(task.id, { startDate: nextStart });
+              }}
+              className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+          </div>
+        )}
+
+        {/* Due At (time) — hidden in all-day mode */}
+        {!allDay && (
+          <div>
+            <label className="text-xs text-tx-tertiary uppercase tracking-wider mb-1.5 block">{t("tasks.dueAt")}</label>
+            <input
+              type="time"
+              value={dueAt}
+              disabled={!dueDate}
+              onChange={(e) => {
+                const nextTime = e.target.value;
+                const nextDueAt = buildDueAtFromDateAndTime(dueDate, nextTime);
+                setDueAt(nextTime);
+                if (isTaskDateRangeInvalid(buildStartDateFromDateAndTime(startDate, startAt), dueDate, nextDueAt)) {
+                  setDateError(t("tasks.gantt.invalidDateRange"));
+                  return;
+                }
+                setDateError(null);
+                onUpdate(task.id, { dueAt: nextDueAt });
+              }}
+              className="w-full px-3 py-2 rounded-md bg-app-bg border border-app-border text-sm text-tx-primary focus:outline-none focus:border-accent-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+          </div>
+        )}
 
         {/* Created At */}
         <div className="text-xs text-tx-tertiary">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1385,6 +1385,7 @@
     "priority": "Priority",
     "startDate": "Start Date",
     "startAt": "Start Time",
+    "allDay": "All Day",
     "dueDate": "Due Date",
     "dueAt": "Due Time",
     "createdAt": "Created",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1511,6 +1511,7 @@
     "timelineView": "时间线",
     "startDate": "开始日期",
     "startAt": "开始时间",
+    "allDay": "全天",
     "gantt": {
       "title": "时间线",
       "today": "今天",


### PR DESCRIPTION
## 修复内容

### 1. 日历 ICS 导出 4 个 bug (backend/src/routes/task-calendar.ts)
- **开始时间丢失**：buildVEvent startDate 改为 startDate → dueAt → dueDate 三级回退
- **DTEND 错误**：DTEND 仅在实际结束时间 ≠ 开始时间时输出，不再生成虚假的 +1min
- **毫秒/时区解析**：toIcsDate 支持 `.000Z` 后缀的毫秒格式
- **纯日期非全天**：纯日期任务正确使用 VALUE=DATE 标记为全天事件

### 2. 任务全天开关 (frontend)
- TaskDetailPanel 添加全天 toggle，开启后隐藏时间输入、保存时清除时间字段
- 中英文 i18n 支持

### 验证
- 现有测试全部通过
- TypeScript 编译无错误