### PR TITLE
ci(pg): diagnose latest main merge

### DIFF
--- a/.github/workflows/pg-main-sync-command.yml
+++ b/.github/workflows/pg-main-sync-command.yml
@@ -36,3 +36,5 @@ jobs:
           if [ "${merge_status}" -ne 0 ]; then
             exit 1
           fi
+
+# one-shot trigger: 2026-08-04


### PR DESCRIPTION
一次性触发 PostgreSQL 统一迁移分支的 main 合并冲突诊断。仅执行诊断，不合入此 PR。