### PR TITLE
fix(journal): compact daily record paragraph spacing

### DIFF
--- a/frontend/src/lib/__tests__/dailyRecords.test.ts
+++ b/frontend/src/lib/__tests__/dailyRecords.test.ts
@@ -60,7 +60,13 @@ describe("daily journal preview", () => {
     expect(extractJournalPreview(content)).toBe("今日复盘\n修复了日期导航。");
   });
 
+  it("compacts repeated paragraph gaps from contentText", () => {
+    expect(extractJournalPreview("", "第一段\n\n\n第二段\n \n第三段")).toBe(
+      "第一段\n第二段\n第三段",
+    );
+  });
+
   it("normalizes markdown and truncates long content", () => {
-    expect(extractJournalPreview("# 标题\n\n**正文**", "", 5)).toBe("标题\n\n正…");
+    expect(extractJournalPreview("# 标题\n\n**正文**", "", 4)).toBe("标题\n正…");
   });
 });

--- a/frontend/src/lib/dailyRecords.ts
+++ b/frontend/src/lib/dailyRecords.ts
@@ -96,9 +96,13 @@ export function extractJournalPreview(content: string, contentText = "", maxLeng
     }
   }
 
+  // The journal card is a compact read-only overview rather than the editor canvas.
+  // Preserve real line breaks, but collapse empty paragraph separators produced by
+  // Tiptap contentText or Markdown so each paragraph does not consume a blank row.
   const normalized = text
-    .replace(/\r\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]*\n+/g, "\n")
     .trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, maxLength).trimEnd()}…`;


### PR DESCRIPTION
## 用户反馈

每日记录阅读页中的正文段落间距过大。编辑器中连续段落本身较紧凑，但阅读页预览会保留 `contentText` 或 Markdown 中的双换行，因此每个段落之间额外出现一整行空白。

## 根因

`extractJournalPreview` 只把 3 个以上连续换行压缩为 2 个换行，仍然保留常见的段落分隔 `\n\n`。阅读页使用 `whitespace-pre-wrap` 渲染后，双换行会占用完整空白行。

## 修复

- 仅在每日记录只读预览中压缩连续空行；
- 保留单个换行，列表、逐行记录和手动换行仍然保持结构；
- 不修改 Tiptap/Markdown 编辑器正文样式，不影响其他笔记页面；
- 增加 `contentText` 连续空行的回归测试，并同步更新 Markdown 截断测试。

## 预期效果

用户截图中每段约一整行的额外空白将被移除，正文按正常行高连续展示，信息密度明显提高，同时不会挤成一整段。