### PR TITLE
fix(share): use parseServerTime for shared comment timestamps

### DIFF
--- a/frontend/src/components/PublicNotebookView.tsx
+++ b/frontend/src/components/PublicNotebookView.tsx
@@ -21,6 +21,7 @@ import TiptapEditor from "@/components/TiptapEditor";
 import type { Note } from "@/types";
 import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
+import { parseServerTime } from "@/lib/dateTime";
 import { navigateToAppPath } from "@/lib/appPathNavigation";
 import {
   notebookPublicationApi,
@@ -457,7 +458,7 @@ function PublicNotebookReader({ token }: { token: string }) {
                     <div className="mt-4 space-y-3">
                       {comments.map((comment) => (
                         <div key={comment.id} className="rounded-xl border border-app-border bg-app-surface p-3">
-                          <div className="flex items-center justify-between gap-3 text-xs"><span className="font-medium">{comment.nickname}</span><span className="text-tx-tertiary">{new Date(comment.createdAt).toLocaleString("zh-CN")}</span></div>
+                          <div className="flex items-center justify-between gap-3 text-xs"><span className="font-medium">{comment.nickname}</span><span className="text-tx-tertiary">{(parseServerTime(comment.createdAt) ?? new Date()).toLocaleString("zh-CN")}</span></div>
                           <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-tx-secondary">{comment.content}</p>
                         </div>
                       ))}

--- a/frontend/src/components/SharedNoteView.tsx
+++ b/frontend/src/components/SharedNoteView.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { api, resolveAttachmentUrl } from "@/lib/api";
 import { ShareInfo, SharedNoteContent, ShareComment, Note } from "@/types";
 import { cn } from "@/lib/utils";
+import { parseServerTime } from "@/lib/dateTime";
 import { toast } from "@/lib/toast";
 import { common, createLowlight } from "lowlight";
 import ReactMarkdown from "react-markdown";
@@ -1411,7 +1412,7 @@ export default function SharedNoteView({ shareToken }: SharedNoteViewProps) {
                       </div>
                       <span className="text-[11px] font-medium text-zinc-700 dark:text-zinc-300">{comment.username || "匿名"}</span>
                       <span className="text-[10px] text-zinc-400">
-                        {new Date(comment.createdAt).toLocaleDateString("zh-CN", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                        {(parseServerTime(comment.createdAt) ?? new Date()).toLocaleDateString("zh-CN", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
                       </span>
                     </div>
                     <p className="text-xs text-zinc-600 dark:text-zinc-300 leading-relaxed whitespace-pre-wrap">{comment.content}</p>


### PR DESCRIPTION
问题 ：共享笔记的评论时间显示与本地时区相差 8 小时（在中国时区下测试）。

根因 ：SQLite 的 createdAt 字段使用 datetime('now') 存储 UTC 时间，但缺少时区标识（ Z 后缀）。前端 SharedNoteView 和 PublicNotebookView 直接用 new Date() 解析，被 JavaScript 当作本地时间处理。

修复 ：改用已有的 parseServerTime() 工具函数，该函数会自动为 SQLite 的朴素时间字符串补 Z 后缀，确保按 UTC 正确解析。