### PR TITLE
perf(clipper): avoid persistent injection on local development pages

### DIFF
--- a/packages/nowen-clipper/public/manifest.json
+++ b/packages/nowen-clipper/public/manifest.json
@@ -57,7 +57,7 @@
     "clip-selection": {
       "suggested_key": {
         "default": "Alt+Shift+A",
-        "mac": "Alt+Shift+S"
+        "mac": "Alt+Shift+A"
       },
       "description": "剪藏选中内容"
     }

--- a/packages/nowen-clipper/public/manifest.json
+++ b/packages/nowen-clipper/public/manifest.json
@@ -32,6 +32,14 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "exclude_matches": [
+        "http://localhost/*",
+        "https://localhost/*",
+        "http://127.0.0.1/*",
+        "https://127.0.0.1/*",
+        "http://[::1]/*",
+        "https://[::1]/*"
+      ],
       "js": ["content.js"],
       "run_at": "document_idle",
       "all_frames": false
@@ -49,7 +57,7 @@
     "clip-selection": {
       "suggested_key": {
         "default": "Alt+Shift+A",
-        "mac": "Alt+Shift+A"
+        "mac": "Alt+Shift+S"
       },
       "description": "剪藏选中内容"
     }

--- a/packages/nowen-clipper/tests/manifest-local-exclusion.test.ts
+++ b/packages/nowen-clipper/tests/manifest-local-exclusion.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const manifestUrl = new URL("../public/manifest.json", import.meta.url);
+
+const LOCAL_DEVELOPMENT_ORIGINS = [
+  "http://localhost/*",
+  "https://localhost/*",
+  "http://127.0.0.1/*",
+  "https://127.0.0.1/*",
+  "http://[::1]/*",
+  "https://[::1]/*",
+];
+
+test("persistent content script excludes local development origins", async () => {
+  const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
+  const contentScript = manifest.content_scripts?.[0];
+
+  assert.ok(contentScript, "manifest should declare a content script");
+  assert.deepEqual(contentScript.matches, ["<all_urls>"]);
+
+  for (const origin of LOCAL_DEVELOPMENT_ORIGINS) {
+    assert.ok(
+      contentScript.exclude_matches?.includes(origin),
+      `expected content_scripts.exclude_matches to include ${origin}`,
+    );
+  }
+});
+
+test("explicit clipping permissions remain available", async () => {
+  const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
+
+  assert.ok(manifest.permissions.includes("activeTab"));
+  assert.ok(manifest.permissions.includes("scripting"));
+  assert.deepEqual(manifest.host_permissions, ["<all_urls>"]);
+});


### PR DESCRIPTION
## 背景

NOWEN 本地开发页 `http://localhost:39100` 会被已安装的 Nowen Clipper content script 常驻注入。页面本身的布局测量热点已经收口后，Chrome DevTools 仍会显示无来源的 Forced reflow 警告，并能看到旧版 `nowen-clipper content v0.4.0` 注册日志，导致应用性能问题与扩展注入难以区分。

## 改动

- 保留 `<all_urls>` host permissions，确保用户主动点击剪藏时仍可按需注入。
- 为声明式 `content_scripts` 增加本地开发排除：
  - `localhost`
  - `127.0.0.1`
  - `[::1]`
  - HTTP 与 HTTPS
- Firefox 清单由 Chrome manifest 自动派生，因此同步获得相同排除规则。
- 增加 manifest 回归测试，锁定本地域名排除与 `activeTab` / `scripting` 能力。

## 结果

- 打开 NOWEN、nowen-note 等本地开发页面时，Clipper 不再常驻加载 content script。
- 普通网页剪藏不受影响。
- 用户主动在本地页面执行剪藏时，后台仍可通过 `activeTab + scripting` 按需注入。

## 升级注意

已安装的 v0.4.0 扩展必须重新构建并在 `chrome://extensions` 中点击“重新加载”，旧标签页也需要刷新，新的排除规则才会生效。