### PR TITLE
fix(openapi): correct task priority description (1=low, 1≠high)

### DIFF
--- a/backend/src/services/openapi.ts
+++ b/backend/src/services/openapi.ts
@@ -73,7 +73,7 @@ export function generateOpenAPISpec(): Record<string, any> {
             id: { type: "string", format: "uuid" },
             title: { type: "string" },
             isCompleted: { type: "integer", enum: [0, 1] },
-            priority: { type: "integer", description: "1=高 2=中 3=低" },
+            priority: { type: "integer", description: "1=低 2=中 3=高" },
             dueDate: { type: "string", nullable: true },
             noteId: { type: "string", nullable: true },
             createdAt: { type: "string", format: "date-time" },


### PR DESCRIPTION
The OpenAPI schema description for the `priority` field was inverted, stating "1=高 2=中 3=低" when the actual system behavior is the opposite: 1=低 (low), 2=中 (medium), 3=高 (high).

This matches the canonical definition in the frontend TaskPriority type, the AI subtask prompt, the PRIORITY_CONFIG color mapping (red=high/3), and the backend ORDER BY priority DESC sort order.