### PR TITLE
fix(share): normalize all shared comment timestamps

### DIFF
--- a/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
@@ -6,6 +6,7 @@ import { normalizeShareCommentTimestamp } from "@/lib/shareCommentTime";
 import type { ShareComment } from "@/types";
 
 const COMMENT_DISPLAY_STATE_KEY = "__nowenSharedCommentDisplayRuntime__" as const;
+const COMMENT_DISPLAY_RUNTIME_VERSION = 2;
 
 type GetSharedComments = typeof api.getSharedComments;
 type AddSharedComment = typeof api.addSharedComment;
@@ -64,7 +65,7 @@ export function normalizeSharedCommentDisplayName(comment: ShareComment): ShareC
 
 function installCommentDisplayBridge(): void {
   const state = getCommentDisplayRuntimeState();
-  if (state.version >= 1) return;
+  if (state.version >= COMMENT_DISPLAY_RUNTIME_VERSION) return;
 
   state.nativeGetSharedComments = state.nativeGetSharedComments || api.getSharedComments.bind(api);
   state.nativeAddSharedComment = state.nativeAddSharedComment || api.addSharedComment.bind(api);
@@ -82,7 +83,7 @@ function installCommentDisplayBridge(): void {
     return normalizeSharedCommentDisplayName(comment);
   };
 
-  state.version = 1;
+  state.version = COMMENT_DISPLAY_RUNTIME_VERSION;
 }
 
 installCommentDisplayBridge();

--- a/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
+++ b/frontend/src/components/SharedNoteCommentDisplayRuntime.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import SharedNoteCommentIdentityRuntime from "./SharedNoteCommentIdentityRuntime";
 import { api } from "@/lib/api";
+import { normalizeShareCommentTimestamp } from "@/lib/shareCommentTime";
 import type { ShareComment } from "@/types";
 
 const COMMENT_DISPLAY_STATE_KEY = "__nowenSharedCommentDisplayRuntime__" as const;
@@ -34,15 +35,28 @@ function getCommentDisplayRuntimeState(): CommentDisplayRuntimeState {
  * returns anonymous visitor identity through `displayName` / `guestName`. Project the public
  * identity into the legacy field at the runtime boundary so both existing and newly-added
  * comments render the nickname without changing the management-side comment contract.
+ *
+ * The same boundary also canonicalizes SQLite's timezone-less UTC `createdAt` value to an
+ * explicit ISO timestamp, so all existing SharedNoteView date rendering uses the viewer's
+ * local timezone correctly.
  */
 export function normalizeSharedCommentDisplayName(comment: ShareComment): ShareComment {
-  const displayName = [comment.displayName, comment.guestName, comment.username]
+  const normalizedComment = normalizeShareCommentTimestamp(comment);
+  const displayName = [
+    normalizedComment.displayName,
+    normalizedComment.guestName,
+    normalizedComment.username,
+  ]
     .find((value) => typeof value === "string" && value.trim())
     ?.trim() || "匿名";
 
-  if (comment.username === displayName && comment.displayName === displayName) return comment;
+  if (
+    normalizedComment.username === displayName &&
+    normalizedComment.displayName === displayName
+  ) return normalizedComment;
+
   return {
-    ...comment,
+    ...normalizedComment,
     username: displayName,
     displayName,
   };

--- a/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
+++ b/frontend/src/components/__tests__/SharedNoteCommentDisplayRuntime.test.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeShareCommentTimestamp } from "@/lib/shareCommentTime";
 import type { ShareComment } from "@/types";
 
 const mocks = vi.hoisted(() => ({
@@ -51,12 +52,13 @@ describe("SharedNoteCommentDisplayRuntime", () => {
     mocks.addSharedComment.mockReset();
   });
 
-  it("projects displayName into username for existing public comments", async () => {
+  it("projects displayName into username and normalizes existing SQLite UTC timestamps", async () => {
     mocks.getSharedComments.mockResolvedValue([
       {
         ...BASE_COMMENT,
         guestName: "访客甲",
         displayName: "访客甲",
+        createdAt: "2026-08-04 05:00:00",
       },
     ]);
 
@@ -64,13 +66,15 @@ describe("SharedNoteCommentDisplayRuntime", () => {
 
     expect(comments[0].username).toBe("访客甲");
     expect(comments[0].displayName).toBe("访客甲");
+    expect(comments[0].createdAt).toBe("2026-08-04T05:00:00.000Z");
   });
 
-  it("projects the nickname immediately after an anonymous comment is added", async () => {
+  it("projects the nickname and timestamp immediately after an anonymous comment is added", async () => {
     mocks.addSharedComment.mockResolvedValue({
       ...BASE_COMMENT,
       guestName: "访客乙",
       displayName: "访客乙",
+      createdAt: "2026-08-04 05:00:00",
     });
 
     const comment = await api.addSharedComment(
@@ -80,6 +84,7 @@ describe("SharedNoteCommentDisplayRuntime", () => {
 
     expect(comment.username).toBe("访客乙");
     expect(comment.displayName).toBe("访客乙");
+    expect(comment.createdAt).toBe("2026-08-04T05:00:00.000Z");
   });
 
   it("falls back from displayName to guestName and finally 匿名", () => {
@@ -88,6 +93,16 @@ describe("SharedNoteCommentDisplayRuntime", () => {
       guestName: " 小王 ",
     }).username).toBe("小王");
     expect(normalizeSharedCommentDisplayName(BASE_COMMENT).username).toBe("匿名");
+  });
+
+  it("preserves invalid timestamps instead of replacing them with the current time", () => {
+    const comment = {
+      ...BASE_COMMENT,
+      createdAt: "invalid-time",
+    };
+
+    expect(normalizeShareCommentTimestamp(comment)).toBe(comment);
+    expect(normalizeShareCommentTimestamp(comment).createdAt).toBe("invalid-time");
   });
 
   it("keeps the identity runtime mounted", () => {

--- a/frontend/src/lib/notebookPublicationApi.ts
+++ b/frontend/src/lib/notebookPublicationApi.ts
@@ -1,4 +1,5 @@
 import { getServerUrl } from "@/lib/api";
+import { normalizeShareCommentTimestamp } from "@/lib/shareCommentTime";
 
 export type NotebookPublicationAccessMode = "public" | "link" | "code" | "password";
 export type NotebookPublicationPermission = "read" | "comment" | "write";
@@ -193,12 +194,13 @@ export const notebookPublicationApi = {
     );
   },
 
-  getManagedComments(notebookId: string) {
-    return request<ManagedPublicationComment[]>(
+  async getManagedComments(notebookId: string) {
+    const comments = await request<ManagedPublicationComment[]>(
       `/notebooks/${encodeURIComponent(notebookId)}/publication/comments`,
       {},
       { authenticated: true },
     );
+    return comments.map(normalizeShareCommentTimestamp);
   },
 
   moderateComment(notebookId: string, commentId: string, input: { isResolved?: boolean; isHidden?: boolean }) {
@@ -281,20 +283,22 @@ export const notebookPublicationApi = {
     return { ...note, contentFormat: normalizeContentFormat(note.contentFormat) };
   },
 
-  getComments(token: string, noteId: string, accessToken?: string) {
-    return request<PublicComment[]>(
+  async getComments(token: string, noteId: string, accessToken?: string) {
+    const comments = await request<PublicComment[]>(
       `/shared/notebook-public/${encodeURIComponent(token)}/notes/${encodeURIComponent(noteId)}/comments`,
       {},
       { accessToken },
     );
+    return comments.map(normalizeShareCommentTimestamp);
   },
 
-  addComment(token: string, noteId: string, input: { nickname: string; content: string; _hp?: string }, accessToken?: string) {
-    return request<PublicComment>(
+  async addComment(token: string, noteId: string, input: { nickname: string; content: string; _hp?: string }, accessToken?: string) {
+    const comment = await request<PublicComment>(
       `/shared/notebook-public/${encodeURIComponent(token)}/notes/${encodeURIComponent(noteId)}/comments`,
       { method: "POST", body: JSON.stringify(input) },
       { accessToken },
     );
+    return normalizeShareCommentTimestamp(comment);
   },
 
   joinPublication(token: string, accessToken?: string) {

--- a/frontend/src/lib/shareCommentTime.ts
+++ b/frontend/src/lib/shareCommentTime.ts
@@ -1,0 +1,20 @@
+import { parseServerTime } from "@/lib/dateTime";
+
+/**
+ * Normalize backend comment timestamps to an explicit UTC ISO string.
+ *
+ * SQLite stores `datetime('now')` as a timezone-less UTC value. Keeping the
+ * normalization at the API/runtime boundary means every consumer can safely
+ * use the native Date constructor without re-implementing SQLite semantics.
+ * Invalid timestamps are preserved instead of being replaced with the current
+ * time, so corrupted historical data is never presented as a new comment.
+ */
+export function normalizeShareCommentTimestamp<T extends { createdAt: string }>(comment: T): T {
+  const parsed = parseServerTime(comment.createdAt);
+  if (!parsed) return comment;
+
+  const createdAt = parsed.toISOString();
+  return createdAt === comment.createdAt
+    ? comment
+    : { ...comment, createdAt };
+}


### PR DESCRIPTION
## 问题

SQLite 使用 `datetime('now')` 保存 UTC 时间，但返回值没有 `Z` 时区标识。共享笔记、公开笔记本和公开评论管理页面直接使用 `new Date(createdAt)`，浏览器会把时间误认为本地时间，UTC+8 环境下会相差 8 小时。

## 修复

- 在共享评论数据边界统一把 SQLite 朴素 UTC 时间转换为明确的 ISO UTC 字符串；
- 覆盖单篇共享笔记已有评论与新增评论；
- 覆盖公开笔记本评论列表、新增评论和管理端评论列表；
- 不在组件中重复处理时区，现有展示代码继续使用原生 `Date`；
- 非法历史时间保持原值，不回退到当前时间，避免伪造评论创建时间。

## 回归

- 增加 SQLite UTC 时间规范化测试；
- 覆盖已存在评论与新增评论；
- 保留匿名访客昵称桥接行为；
- 前端 TypeScript 由 Shared Comment CI 验证。

## 与 #648 的关系

#648 正确识别了根因，但只修改两个访客侧组件，遗漏公开评论管理入口，并在解析失败时回退到当前时间。本 PR 改为在 API/runtime 边界统一修复全部评论入口。

Refs #648