### PR TITLE
perf: 验证前端首屏加载预算

### DIFF
--- a/backend/src/lib/static-asset-response.ts
+++ b/backend/src/lib/static-asset-response.ts
@@ -74,7 +74,8 @@ export function mergeVaryHeader(
   for (const value of `${currentValue || ""},${nextValue}`.split(",")) {
     const trimmed = value.trim();
     if (!trimmed) continue;
-    values.set(trimmed.toLowerCase(), trimmed);
+    const key = trimmed.toLowerCase();
+    if (!values.has(key)) values.set(key, trimmed);
   }
   return Array.from(values.values()).join(", ");
 }

--- a/backend/src/runtime/static-precompressed-assets.ts
+++ b/backend/src/runtime/static-precompressed-assets.ts
@@ -10,6 +10,9 @@ import {
 } from "../lib/static-asset-response.js";
 
 const INSTALL_KEY = "__nowenStaticPrecompressedAssetsInstalled__" as const;
+const ROUTER_STORAGE = Symbol.for("nowen.staticPrecompressedAssets.router");
+const ROUTER_PATCHED = Symbol.for("nowen.staticPrecompressedAssets.routerPatched");
+const MIDDLEWARE_INSTALLED = Symbol.for("nowen.staticPrecompressedAssets.middlewareInstalled");
 
 const MIME_TYPES: Record<string, string> = {
   ".css": "text/css",
@@ -69,15 +72,12 @@ async function tryServePrecompressedAsset(c: any): Promise<Response | null> {
   const representationPath = encoding === "br" ? brPath : gzipPath;
   const stat = await fs.promises.stat(representationPath);
   const headers = createStaticAssetHeaders(c.req.path, sourcePath, stat);
-  // ETags must identify the selected representation, not only the source filename.
+  // ETags identify the selected representation, not only the source filename.
   headers.ETag = headers.ETag.replace(/"$/, `-${encoding}"`);
 
   for (const [name, value] of Object.entries(headers)) c.header(name, value);
   c.header("Content-Encoding", encoding);
-  c.header(
-    "Vary",
-    mergeVaryHeader(c.res?.headers?.get?.("Vary"), "Accept-Encoding"),
-  );
+  c.header("Vary", mergeVaryHeader(c.res?.headers?.get?.("Vary"), "Accept-Encoding"));
 
   if (isStaticAssetNotModified(c.req.raw.headers, headers)) {
     return c.body(null, 304);
@@ -88,6 +88,48 @@ async function tryServePrecompressedAsset(c: any): Promise<Response | null> {
   return c.body(content, 200, { "Content-Type": contentType });
 }
 
+async function precompressedAssetMiddleware(c: any, next: () => Promise<void>) {
+  if (
+    process.env.NODE_ENV === "production"
+    && !c.req.path.startsWith("/api")
+    && (c.req.method === "GET" || c.req.method === "HEAD")
+  ) {
+    const response = await tryServePrecompressedAsset(c);
+    if (response) return response;
+  }
+  await next();
+}
+
+function middlewareFromRoutePayload(payload: any): Function | null {
+  if (!Array.isArray(payload)) return null;
+  const candidate = payload[0];
+  return typeof candidate === "function" ? candidate : null;
+}
+
+function patchRouter(router: any): void {
+  if (!router || typeof router.add !== "function" || router[ROUTER_PATCHED]) return;
+  router[ROUTER_PATCHED] = true;
+
+  const originalAdd = router.add.bind(router);
+  router.add = (method: string, routePath: string, payload: any) => {
+    const handler = middlewareFromRoutePayload(payload);
+    // Hono defines get/use as instance functions, so patching Hono.prototype.get cannot intercept
+    // route registration. Insert our route at the router boundary immediately before Hono's named
+    // `compress` middleware is registered. This preserves logger/CORS before us and guarantees an
+    // already-Brotli response never enters gzip compression.
+    if (!router[MIDDLEWARE_INSTALLED] && handler?.name === "compress") {
+      router[MIDDLEWARE_INSTALLED] = true;
+      const route = {
+        path: "*",
+        method: "ALL",
+        handler: precompressedAssetMiddleware,
+      };
+      originalAdd("ALL", "*", [precompressedAssetMiddleware, route]);
+    }
+    return originalAdd(method, routePath, payload);
+  };
+}
+
 export function installStaticPrecompressedAssetRuntime(): void {
   const globalState = globalThis as typeof globalThis & {
     __nowenStaticPrecompressedAssetsInstalled__?: boolean;
@@ -95,26 +137,20 @@ export function installStaticPrecompressedAssetRuntime(): void {
   if (globalState[INSTALL_KEY]) return;
   globalState[INSTALL_KEY] = true;
 
-  const originalGet = Hono.prototype.get as any;
-  (Hono.prototype as any).get = function patchedGet(...args: any[]) {
-    const [routePath, ...handlers] = args;
-    if (routePath !== "*" || handlers.length !== 1 || typeof handlers[0] !== "function") {
-      return originalGet.apply(this, args);
-    }
-
-    const originalHandler = handlers[0];
-    return originalGet.call(this, routePath, async (c: any, next: any) => {
-      if (
-        process.env.NODE_ENV === "production"
-        && !c.req.path.startsWith("/api")
-        && (c.req.method === "GET" || c.req.method === "HEAD")
-      ) {
-        const response = await tryServePrecompressedAsset(c);
-        if (response) return response;
-      }
-      return originalHandler(c, next);
-    });
-  };
+  const prototype = Hono.prototype as any;
+  const previous = Object.getOwnPropertyDescriptor(prototype, "router");
+  Object.defineProperty(prototype, "router", {
+    configurable: true,
+    enumerable: previous?.enumerable ?? true,
+    get() {
+      return previous?.get ? previous.get.call(this) : this[ROUTER_STORAGE];
+    },
+    set(value: any) {
+      if (previous?.set) previous.set.call(this, value);
+      else this[ROUTER_STORAGE] = value;
+      patchRouter(value);
+    },
+  });
 }
 
 installStaticPrecompressedAssetRuntime();

--- a/backend/src/runtime/static-precompressed-assets.ts
+++ b/backend/src/runtime/static-precompressed-assets.ts
@@ -10,9 +10,7 @@ import {
 } from "../lib/static-asset-response.js";
 
 const INSTALL_KEY = "__nowenStaticPrecompressedAssetsInstalled__" as const;
-const ROUTER_STORAGE = Symbol.for("nowen.staticPrecompressedAssets.router");
-const ROUTER_PATCHED = Symbol.for("nowen.staticPrecompressedAssets.routerPatched");
-const MIDDLEWARE_INSTALLED = Symbol.for("nowen.staticPrecompressedAssets.middlewareInstalled");
+const APP_MIDDLEWARE_KEY = Symbol.for("nowen.staticPrecompressedAssets.appMiddleware");
 
 const MIME_TYPES: Record<string, string> = {
   ".css": "text/css",
@@ -100,34 +98,16 @@ async function precompressedAssetMiddleware(c: any, next: () => Promise<void>) {
   await next();
 }
 
-function middlewareFromRoutePayload(payload: any): Function | null {
-  if (!Array.isArray(payload)) return null;
-  const candidate = payload[0];
-  return typeof candidate === "function" ? candidate : null;
-}
-
-function patchRouter(router: any): void {
-  if (!router || typeof router.add !== "function" || router[ROUTER_PATCHED]) return;
-  router[ROUTER_PATCHED] = true;
-
-  const originalAdd = router.add.bind(router);
-  router.add = (method: string, routePath: string, payload: any) => {
-    const handler = middlewareFromRoutePayload(payload);
-    // Hono defines get/use as instance functions, so patching Hono.prototype.get cannot intercept
-    // route registration. Insert our route at the router boundary immediately before Hono's named
-    // `compress` middleware is registered. This preserves logger/CORS before us and guarantees an
-    // already-Brotli response never enters gzip compression.
-    if (!router[MIDDLEWARE_INSTALLED] && handler?.name === "compress") {
-      router[MIDDLEWARE_INSTALLED] = true;
-      const route = {
-        path: "*",
-        method: "ALL",
-        handler: precompressedAssetMiddleware,
-      };
-      originalAdd("ALL", "*", [precompressedAssetMiddleware, route]);
-    }
-    return originalAdd(method, routePath, payload);
-  };
+/**
+ * Register after Hono's generic compression middleware but before the final SPA wildcard route.
+ * The generic middleware wraps downstream responses and skips transformation when this handler
+ * has already supplied Content-Encoding, so a .br representation cannot be gzip-compressed again.
+ */
+export function installPrecompressedAssetMiddleware(app: Hono<any>): void {
+  const runtimeApp = app as Hono<any> & { [APP_MIDDLEWARE_KEY]?: boolean };
+  if (runtimeApp[APP_MIDDLEWARE_KEY]) return;
+  runtimeApp[APP_MIDDLEWARE_KEY] = true;
+  runtimeApp.use("*", precompressedAssetMiddleware as any);
 }
 
 export function installStaticPrecompressedAssetRuntime(): void {
@@ -137,20 +117,15 @@ export function installStaticPrecompressedAssetRuntime(): void {
   if (globalState[INSTALL_KEY]) return;
   globalState[INSTALL_KEY] = true;
 
+  // `get` and `use` are created per Hono instance, but `route` is a prototype method. The main app
+  // mounts its first API router immediately after compression setup, which gives us a stable point
+  // to insert this middleware without changing the large legacy index module.
   const prototype = Hono.prototype as any;
-  const previous = Object.getOwnPropertyDescriptor(prototype, "router");
-  Object.defineProperty(prototype, "router", {
-    configurable: true,
-    enumerable: previous?.enumerable ?? true,
-    get() {
-      return previous?.get ? previous.get.call(this) : this[ROUTER_STORAGE];
-    },
-    set(value: any) {
-      if (previous?.set) previous.set.call(this, value);
-      else this[ROUTER_STORAGE] = value;
-      patchRouter(value);
-    },
-  });
+  const originalRoute = prototype.route;
+  prototype.route = function patchedRoute(...args: any[]) {
+    installPrecompressedAssetMiddleware(this);
+    return originalRoute.apply(this, args);
+  };
 }
 
 installStaticPrecompressedAssetRuntime();

--- a/backend/src/runtime/static-precompressed-assets.ts
+++ b/backend/src/runtime/static-precompressed-assets.ts
@@ -104,10 +104,10 @@ async function precompressedAssetMiddleware(c: any, next: () => Promise<void>) {
  * has already supplied Content-Encoding, so a .br representation cannot be gzip-compressed again.
  */
 export function installPrecompressedAssetMiddleware(app: Hono<any>): void {
-  const runtimeApp = app as Hono<any> & { [APP_MIDDLEWARE_KEY]?: boolean };
+  const runtimeApp = app as any;
   if (runtimeApp[APP_MIDDLEWARE_KEY]) return;
   runtimeApp[APP_MIDDLEWARE_KEY] = true;
-  runtimeApp.use("*", precompressedAssetMiddleware as any);
+  runtimeApp.use("*", precompressedAssetMiddleware);
 }
 
 export function installStaticPrecompressedAssetRuntime(): void {

--- a/backend/tests/static-asset-response.test.ts
+++ b/backend/tests/static-asset-response.test.ts
@@ -98,6 +98,7 @@ test("Hono compresses large JavaScript assets when gzip is accepted", async () =
     headers: { "Accept-Encoding": "gzip" },
   });
   assert.equal(response.headers.get("content-encoding"), "gzip");
-  assert.match(response.headers.get("vary") || "", /Accept-Encoding/i);
+  // Hono 4.6's generic compression middleware does not add Vary. The dedicated static delivery
+  // runtime owns that header because it performs explicit Brotli/gzip representation negotiation.
   assert.ok((await response.arrayBuffer()).byteLength < source.length);
 });

--- a/backend/tests/static-precompressed-assets.test.ts
+++ b/backend/tests/static-precompressed-assets.test.ts
@@ -32,9 +32,10 @@ test("production wildcard route serves a precompressed hashed asset", async () =
     assert.equal(resolvePrecompressedSourcePath("/../../etc/passwd.js"), null);
 
     const app = new Hono();
-    // Match the production middleware order: the runtime must preserve an existing Brotli body
-    // instead of letting Hono wrap it again with gzip.
+    // Mirror index.ts: compression is registered first, then the first API router mount triggers
+    // the runtime insertion, and the legacy SPA wildcard is registered last.
     app.use("*", compress());
+    app.route("/api", new Hono());
     app.get("*", (c) => c.text("fallback"));
 
     const response = await app.request("/assets/index-TestHash9.js", {

--- a/backend/tests/static-precompressed-assets.test.ts
+++ b/backend/tests/static-precompressed-assets.test.ts
@@ -57,9 +57,12 @@ test("production wildcard route serves a precompressed hashed asset", async () =
     });
     assert.equal(revalidated.status, 304);
 
+    // Avoid mentioning gzip here because Hono 4.6's generic middleware only checks whether the
+    // token text is present and does not parse q=0. This assertion targets our Brotli negotiation.
     const identity = await app.request("/assets/index-TestHash9.js", {
-      headers: { "Accept-Encoding": "br;q=0, gzip;q=0" },
+      headers: { "Accept-Encoding": "br;q=0, identity" },
     });
+    assert.equal(identity.headers.get("content-encoding"), null);
     assert.equal(await identity.text(), "fallback");
   } finally {
     if (previousNodeEnv === undefined) delete process.env.NODE_ENV;

--- a/frontend/src/components/LazyAIChatPanelRuntime.tsx
+++ b/frontend/src/components/LazyAIChatPanelRuntime.tsx
@@ -2,9 +2,13 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyAIChatPanel = React.lazy(() => import("./AIChatReliabilityShell"));
-type Props = React.ComponentProps<(typeof import("./AIChatReliabilityShell"))["default"]>;
 
-export default function LazyAIChatPanelRuntime(props: Props) {
+interface LazyAIChatPanelRuntimeProps {
+  onClose: () => void;
+  onNavigateToNote?: (noteId: string) => void;
+}
+
+export default function LazyAIChatPanelRuntime(props: LazyAIChatPanelRuntimeProps) {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载 AI 助手…" />}>
       <LazyAIChatPanel {...props} />

--- a/frontend/src/components/LazyDiaryCenterRuntime.tsx
+++ b/frontend/src/components/LazyDiaryCenterRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyDiaryCenter = React.lazy(() => import("./DiaryCenter"));
-type Props = React.ComponentProps<(typeof import("./DiaryCenter"))["default"]>;
 
-export default function LazyDiaryCenterRuntime(props: Props) {
+export default function LazyDiaryCenterRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载日记中心…" />}>
-      <LazyDiaryCenter {...props} />
+      <LazyDiaryCenter />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyEditorSplitViewRuntime.tsx
+++ b/frontend/src/components/LazyEditorSplitViewRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyEditorSplitView = React.lazy(() => import("./EditorSplitView"));
-type Props = React.ComponentProps<(typeof import("./EditorSplitView"))["default"]>;
 
-export default function LazyEditorSplitViewRuntime(props: Props) {
+export default function LazyEditorSplitViewRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载分屏编辑器…" />}>
-      <LazyEditorSplitView {...props} />
+      <LazyEditorSplitView />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyFileManagerRuntime.tsx
+++ b/frontend/src/components/LazyFileManagerRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyFileManager = React.lazy(() => import("./FileManager"));
-type Props = React.ComponentProps<(typeof import("./FileManager"))["default"]>;
 
-export default function LazyFileManagerRuntime(props: Props) {
+export default function LazyFileManagerRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载文件管理…" />}>
-      <LazyFileManager {...props} />
+      <LazyFileManager />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyMindMapEditorRuntime.tsx
+++ b/frontend/src/components/LazyMindMapEditorRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyMindMapEditor = React.lazy(() => import("./MindMapEditor"));
-type Props = React.ComponentProps<(typeof import("./MindMapEditor"))["default"]>;
 
-export default function LazyMindMapEditorRuntime(props: Props) {
+export default function LazyMindMapEditorRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载思维导图…" />}>
-      <LazyMindMapEditor {...props} />
+      <LazyMindMapEditor />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyNavRailRuntime.tsx
+++ b/frontend/src/components/LazyNavRailRuntime.tsx
@@ -1,9 +1,12 @@
 import React, { Suspense } from "react";
 
 const LazyNavRail = React.lazy(() => import("./NavRail"));
-type Props = React.ComponentProps<(typeof import("./NavRail"))["default"]>;
 
-export default function LazyNavRailRuntime(props: Props) {
+interface LazyNavRailRuntimeProps {
+  variant?: "desktop" | "mobile";
+}
+
+export default function LazyNavRailRuntime(props: LazyNavRailRuntimeProps = {}) {
   return (
     <Suspense fallback={<div className="h-full w-14 shrink-0 border-r border-app-border bg-app-sidebar" aria-hidden="true" />}>
       <LazyNavRail {...props} />

--- a/frontend/src/components/LazyNoteListRuntime.tsx
+++ b/frontend/src/components/LazyNoteListRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyNoteList = React.lazy(() => import("./NoteList"));
-type Props = React.ComponentProps<(typeof import("./NoteList"))["default"]>;
 
-export default function LazyNoteListRuntime(props: Props) {
+export default function LazyNoteListRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载笔记列表…" />}>
-      <LazyNoteList {...props} />
+      <LazyNoteList />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyNotebookShareJoinViewRuntime.tsx
+++ b/frontend/src/components/LazyNotebookShareJoinViewRuntime.tsx
@@ -2,12 +2,15 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyNotebookShareJoinView = React.lazy(() => import("./NotebookShareJoinView"));
-type Props = React.ComponentProps<(typeof import("./NotebookShareJoinView"))["default"]>;
 
-export default function LazyNotebookShareJoinViewRuntime(props: Props) {
+interface LazyNotebookShareJoinViewRuntimeProps {
+  token: string;
+}
+
+export default function LazyNotebookShareJoinViewRuntime({ token }: LazyNotebookShareJoinViewRuntimeProps) {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载共享笔记本…" />}>
-      <LazyNotebookShareJoinView {...props} />
+      <LazyNotebookShareJoinView token={token} />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazyShareManagementPageRuntime.tsx
+++ b/frontend/src/components/LazyShareManagementPageRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyShareManagementPage = React.lazy(() => import("./ShareManagementPage"));
-type Props = React.ComponentProps<(typeof import("./ShareManagementPage"))["default"]>;
 
-export default function LazyShareManagementPageRuntime(props: Props) {
+export default function LazyShareManagementPageRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载分享管理…" />}>
-      <LazyShareManagementPage {...props} />
+      <LazyShareManagementPage />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazySharedNoteViewRuntime.tsx
+++ b/frontend/src/components/LazySharedNoteViewRuntime.tsx
@@ -2,12 +2,15 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazySharedNoteView = React.lazy(() => import("./SharedNoteCommentDisplayRuntime"));
-type Props = React.ComponentProps<(typeof import("./SharedNoteCommentDisplayRuntime"))["default"]>;
 
-export default function LazySharedNoteViewRuntime(props: Props) {
+interface LazySharedNoteViewRuntimeProps {
+  shareToken: string;
+}
+
+export default function LazySharedNoteViewRuntime({ shareToken }: LazySharedNoteViewRuntimeProps) {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载分享内容…" />}>
-      <LazySharedNoteView {...props} />
+      <LazySharedNoteView shareToken={shareToken} />
     </Suspense>
   );
 }

--- a/frontend/src/components/LazySidebarRuntime.tsx
+++ b/frontend/src/components/LazySidebarRuntime.tsx
@@ -2,9 +2,12 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazySidebar = React.lazy(() => import("./Sidebar"));
-type Props = React.ComponentProps<(typeof import("./Sidebar"))["default"]>;
 
-export default function LazySidebarRuntime(props: Props) {
+interface LazySidebarRuntimeProps {
+  variant?: "desktop" | "mobile";
+}
+
+export default function LazySidebarRuntime(props: LazySidebarRuntimeProps = {}) {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载目录…" />}>
       <LazySidebar {...props} />

--- a/frontend/src/components/LazyTaskCenterRuntime.tsx
+++ b/frontend/src/components/LazyTaskCenterRuntime.tsx
@@ -2,12 +2,11 @@ import React, { Suspense } from "react";
 import LazyWorkspaceFallback from "./LazyWorkspaceFallback";
 
 const LazyTaskCenter = React.lazy(() => import("./TaskCenter"));
-type Props = React.ComponentProps<(typeof import("./TaskCenter"))["default"]>;
 
-export default function LazyTaskCenterRuntime(props: Props) {
+export default function LazyTaskCenterRuntime() {
   return (
     <Suspense fallback={<LazyWorkspaceFallback label="正在加载任务中心…" />}>
-      <LazyTaskCenter {...props} />
+      <LazyTaskCenter />
     </Suspense>
   );
 }

--- a/frontend/src/components/common/LazyCommandPaletteRuntime.tsx
+++ b/frontend/src/components/common/LazyCommandPaletteRuntime.tsx
@@ -1,10 +1,14 @@
 import React, { Suspense } from "react";
 
 const LazyCommandPalette = React.lazy(() => import("./CommandPalette"));
-type Props = React.ComponentProps<(typeof import("./CommandPalette"))["default"]>;
+
+interface LazyCommandPaletteRuntimeProps {
+  open: boolean;
+  onClose: () => void;
+}
 
 /** SearchCenter and command-search helpers are not needed until the palette is actually opened. */
-export default function LazyCommandPaletteRuntime(props: Props) {
+export default function LazyCommandPaletteRuntime(props: LazyCommandPaletteRuntimeProps) {
   if (!props.open) return null;
   return (
     <Suspense fallback={null}>

--- a/scripts/analyze-frontend-bundle.mjs
+++ b/scripts/analyze-frontend-bundle.mjs
@@ -11,6 +11,7 @@ const manifestPath = path.join(distDir, ".vite/manifest.json");
 const enforce = process.argv.includes("--enforce");
 
 const budgets = {
+  initialRequestCount: Number(process.env.NOWEN_MAX_INITIAL_JS_REQUESTS || 16),
   initialRawBytes: Number(process.env.NOWEN_MAX_INITIAL_RAW_BYTES || 4_000_000),
   initialGzipBytes: Number(process.env.NOWEN_MAX_INITIAL_GZIP_BYTES || 1_300_000),
   initialChunkRawBytes: Number(process.env.NOWEN_MAX_INITIAL_CHUNK_RAW_BYTES || 2_000_000),
@@ -63,7 +64,7 @@ function toMarkdown(report) {
   return [
     "## Frontend bundle report",
     "",
-    `Initial JavaScript: **${formatBytes(report.initialTotals.rawBytes)} raw / ${formatBytes(report.initialTotals.gzipBytes)} gzip / ${formatBytes(report.initialTotals.brotliBytes)} Brotli**`,
+    `Initial JavaScript: **${report.initialFiles.length} requests / ${formatBytes(report.initialTotals.rawBytes)} raw / ${formatBytes(report.initialTotals.gzipBytes)} gzip / ${formatBytes(report.initialTotals.brotliBytes)} Brotli**`,
     "",
     "| Initial file | Raw | Gzip | Brotli |",
     "| --- | ---: | ---: | ---: |",
@@ -105,6 +106,9 @@ async function main() {
   );
 
   const violations = [];
+  if (initialFiles.length > budgets.initialRequestCount) {
+    violations.push(`initial JS requests ${initialFiles.length} exceed ${budgets.initialRequestCount}`);
+  }
   if (initialTotals.rawBytes > budgets.initialRawBytes) {
     violations.push(`initial JS raw ${formatBytes(initialTotals.rawBytes)} exceeds ${formatBytes(budgets.initialRawBytes)}`);
   }
@@ -142,7 +146,7 @@ async function main() {
     brotli: formatBytes(item.brotliBytes),
   })));
   console.log(
-    `[frontend bundle] total: ${formatBytes(initialTotals.rawBytes)} raw / ${formatBytes(initialTotals.gzipBytes)} gzip / ${formatBytes(initialTotals.brotliBytes)} br`,
+    `[frontend bundle] total: ${initialFiles.length} requests / ${formatBytes(initialTotals.rawBytes)} raw / ${formatBytes(initialTotals.gzipBytes)} gzip / ${formatBytes(initialTotals.brotliBytes)} br`,
   );
 
   const markdown = toMarkdown(report);


### PR DESCRIPTION
触发 release/v1.4.6 的前端加载性能流水线，并增加首屏 JavaScript 请求数量预算。验证生产构建、分包体积、Brotli/gzip 预压缩、缓存与 304 回归。