### PR TITLE
fix: 永久清理 Markdown 内部块 ID 泄漏

### DIFF
--- a/backend/src/lib/markdownUserContent.ts
+++ b/backend/src/lib/markdownUserContent.ts
@@ -7,25 +7,51 @@ export interface MarkdownNoteForProjection {
   [key: string]: unknown;
 }
 
-const INLINE_MARKER_RE = /[ \t]+\^(blk_[A-Za-z0-9_-]{6,})[ \t]*$/;
-const LINE_MARKER_RE = /^[ \t]*\^(blk_[A-Za-z0-9_-]{6,})[ \t]*$/;
+const CURRENT_BLOCK_ID = String.raw`blk_[A-Za-z0-9_-]{6,}`;
+const STRICT_GENERATED_BLOCK_ID = String.raw`blk_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8,12}`;
+// v1.4.5 及更早版本、部分导入器曾写入无下划线的 32 位十六进制块 ID。
+// 该格式足够严格，可以在没有 note_blocks_index 记录时安全识别为内部元数据。
+const LEGACY_COMPACT_BLOCK_ID = String.raw`blk[0-9a-f]{32}`;
+const MARKER_BLOCK_ID = String.raw`(?:${CURRENT_BLOCK_ID}|${LEGACY_COMPACT_BLOCK_ID})`;
+const STRICT_INTERNAL_BLOCK_ID = String.raw`(?:${STRICT_GENERATED_BLOCK_ID}|${LEGACY_COMPACT_BLOCK_ID})`;
+
+const INLINE_MARKER_RE = new RegExp(String.raw`[ \t]+\^(${MARKER_BLOCK_ID})[ \t]*$`, "i");
+const LINE_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${MARKER_BLOCK_ID})[ \t]*$`, "i");
+const ATTACHED_STRICT_MARKER_RE = new RegExp(String.raw`\^(${STRICT_INTERNAL_BLOCK_ID})[ \t]*$`, "i");
+const LEGACY_PREFIX_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${LEGACY_COMPACT_BLOCK_ID})[ \t]+`, "i");
+const LEGACY_COMPACT_BLOCK_ID_RE = new RegExp(String.raw`^${LEGACY_COMPACT_BLOCK_ID}$`, "i");
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
+
+function isLegacyCompactBlockId(blockId: string): boolean {
+  return LEGACY_COMPACT_BLOCK_ID_RE.test(blockId);
+}
+
+function shouldRemoveBlockId(
+  blockId: string,
+  knownBlockIds?: ReadonlySet<string>,
+): boolean {
+  // 旧版紧凑 ID 不再属于当前块身份体系，始终作为历史内部元数据清理。
+  if (isLegacyCompactBlockId(blockId)) return true;
+  return !knownBlockIds || knownBlockIds.has(blockId);
+}
 
 /**
  * Remove reserved block markers from a user-facing Markdown projection.
- * When knownBlockIds is supplied, only markers owned by the note index are removed.
+ *
+ * Current-format markers are removed only when they belong to the note index
+ * (unless no index set is supplied). Strict legacy compact IDs are always
+ * removed because old clients/importers persisted them as hidden metadata.
+ * Fenced code remains byte-for-byte unchanged.
  */
 export function projectMarkdownForUser(
   markdown: string,
   knownBlockIds?: ReadonlySet<string>,
 ): string {
-  if (!markdown || !markdown.includes("^blk_")) return markdown;
+  if (!markdown || !markdown.includes("^blk")) return markdown;
   const removals: Array<{ from: number; to: number }> = [];
   let offset = 0;
   let fenceChar = "";
   let fenceLength = 0;
-
-  const owned = (blockId: string) => !knownBlockIds || knownBlockIds.has(blockId);
 
   while (offset <= markdown.length) {
     const newline = markdown.indexOf("\n", offset);
@@ -46,12 +72,32 @@ export function projectMarkdownForUser(
         fenceLength = opener[1].length;
       } else {
         const standalone = line.match(LINE_MARKER_RE);
-        if (standalone && owned(standalone[1])) {
+        if (standalone && shouldRemoveBlockId(standalone[1], knownBlockIds)) {
           removals.push({ from: offset, to: lineEndWithNewline });
         } else {
           const inline = line.match(INLINE_MARKER_RE);
-          if (inline && inline.index != null && owned(inline[1])) {
+          if (
+            inline
+            && inline.index != null
+            && shouldRemoveBlockId(inline[1], knownBlockIds)
+          ) {
             removals.push({ from: offset + inline.index, to: lineEnd });
+          } else {
+            // 严格系统 ID 即使前导空格被历史编辑器误删，也不能暴露给用户。
+            const attached = line.match(ATTACHED_STRICT_MARKER_RE);
+            if (
+              attached
+              && attached.index != null
+              && shouldRemoveBlockId(attached[1], knownBlockIds)
+            ) {
+              removals.push({ from: offset + attached.index, to: lineEnd });
+            } else {
+              // 少量历史导入文件把紧凑块 ID 放在行首，后面紧跟正文。
+              const prefix = line.match(LEGACY_PREFIX_MARKER_RE);
+              if (prefix) {
+                removals.push({ from: offset, to: offset + prefix[0].length });
+              }
+            }
           }
         }
       }
@@ -68,6 +114,15 @@ export function projectMarkdownForUser(
   return output;
 }
 
+/**
+ * Remove only obsolete compact block markers before Markdown is re-indexed.
+ * Current-format block identity is preserved and will continue to be managed by
+ * note_blocks_index.
+ */
+export function stripLegacyInternalMarkdownMarkers(markdown: string): string {
+  return projectMarkdownForUser(markdown, new Set<string>());
+}
+
 export function projectMarkdownNoteForUser<T extends MarkdownNoteForProjection>(
   db: Database.Database,
   note: T,
@@ -77,10 +132,12 @@ export function projectMarkdownNoteForUser<T extends MarkdownNoteForProjection>(
     const rows = db.prepare(
       "SELECT blockId FROM note_blocks_index WHERE noteId = ?",
     ).all(note.id) as Array<{ blockId: string }>;
-    if (rows.length === 0) return note;
     const known = new Set(rows.map((row) => row.blockId));
-    return { ...note, content: projectMarkdownForUser(note.content, known) };
+    const content = projectMarkdownForUser(note.content, known);
+    return content === note.content ? note : { ...note, content };
   } catch {
-    return note;
+    // 老库在块索引表建立前也要隐藏严格的历史紧凑标记。
+    const content = stripLegacyInternalMarkdownMarkers(note.content);
+    return content === note.content ? note : { ...note, content };
   }
 }

--- a/backend/src/lib/noteBlocks.ts
+++ b/backend/src/lib/noteBlocks.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { v4 as uuid } from "uuid";
 import type Database from "better-sqlite3";
+import { stripLegacyInternalMarkdownMarkers } from "./markdownUserContent";
 
 export const SUPPORTED_NOTE_BLOCK_TYPES = [
   "heading",
@@ -175,8 +176,11 @@ function cleanMarkdownText(type: NoteBlockType, value: string): string {
 }
 
 function normalizeGeneratedMarkdownMarkers(content: string): string {
-  if (!content.includes("^blk_")) return content;
-  const lines = lineOffsets(content);
+  // 旧版无下划线块 ID 不属于当前身份体系：先从正文中物理清除，随后
+  // assignCandidateIds/applyMarkdownIds 会为真实内容生成标准 blk_<uuid> 标记。
+  const legacySanitized = stripLegacyInternalMarkdownMarkers(content);
+  if (!legacySanitized.includes("^blk_")) return legacySanitized;
+  const lines = lineOffsets(legacySanitized);
   const edits: Array<{ from: number; to: number; insert: string }> = [];
   let fenceChar = "";
   let fenceLength = 0;
@@ -223,7 +227,7 @@ function normalizeGeneratedMarkdownMarkers(content: string): string {
     }
   }
 
-  let normalized = content;
+  let normalized = legacySanitized;
   for (const edit of edits.sort((a, b) => b.from - a.from)) {
     normalized = normalized.slice(0, edit.from) + edit.insert + normalized.slice(edit.to);
   }

--- a/backend/src/lib/searchIndex.ts
+++ b/backend/src/lib/searchIndex.ts
@@ -1,8 +1,13 @@
 import type Database from "better-sqlite3";
-import { plainTextFromNoteContent } from "./noteBlocks";
+import { plainTextFromNoteContent, syncNoteBlocks } from "./noteBlocks";
+import { stripLegacyInternalMarkdownMarkers } from "./markdownUserContent";
 import { normalizeSearchText } from "./searchQuery";
 
 const SEARCH_REBUILT_AT_KEY = "search_index_last_rebuilt_at";
+const SEARCH_CONTENT_EXTRACTOR_VERSION_KEY = "search_content_extractor_version";
+// Bump when user-visible text extraction semantics change. Startup will then
+// normalize affected Markdown, repair contentText and rebuild both search indexes once.
+const SEARCH_CONTENT_EXTRACTOR_VERSION = "2";
 const normalizedSearchFunctionDatabases = new WeakSet<object>();
 
 type SearchSourceRow = {
@@ -136,6 +141,28 @@ export function repairSearchContentText(db: Database.Database): SearchContentRep
   };
 }
 
+/**
+ * Upgrade obsolete compact Markdown block IDs into the current block-index model.
+ * Only notes whose visible projection actually changes are touched. syncNoteBlocks
+ * intentionally preserves note updatedAt/version while rebuilding block rows and
+ * contentText, so links/search stop leaking the historical metadata permanently.
+ */
+export function repairLegacyMarkdownBlockMetadata(db: Database.Database): number {
+  const rows = db.prepare(`
+    SELECT id, COALESCE(content, '') AS content
+    FROM notes
+    WHERE contentFormat = 'markdown' AND content LIKE '%^blk%'
+  `).all() as Array<{ id: string; content: string }>;
+
+  let repairedCount = 0;
+  for (const row of rows) {
+    if (stripLegacyInternalMarkdownMarkers(row.content) === row.content) continue;
+    syncNoteBlocks(db, row.id, row.content, "markdown");
+    repairedCount += 1;
+  }
+  return repairedCount;
+}
+
 function createNormalizedSearchFts(db: Database.Database): void {
   if (!normalizedSearchFunctionDatabases.has(db as object)) {
     db.function(
@@ -212,9 +239,48 @@ export function rebuildNormalizedSearchFts(db: Database.Database): void {
   `).run();
 }
 
+function readSystemSetting(db: Database.Database, key: string): string | null {
+  const row = db.prepare("SELECT value FROM system_settings WHERE key = ?")
+    .get(key) as { value?: string } | undefined;
+  return row?.value ?? null;
+}
+
+function writeSystemSetting(db: Database.Database, key: string, value: string): void {
+  db.prepare(`
+    INSERT INTO system_settings (key, value, updatedAt)
+    VALUES (?, ?, datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      value = excluded.value,
+      updatedAt = datetime('now')
+  `).run(key, value);
+}
+
+/**
+ * Repair persisted user-visible text whenever extraction semantics are upgraded.
+ * The version marker is written last, making an interrupted startup safely retryable.
+ */
+function ensureSearchContentExtractorVersion(db: Database.Database): boolean {
+  if (readSystemSetting(db, SEARCH_CONTENT_EXTRACTOR_VERSION_KEY) === SEARCH_CONTENT_EXTRACTOR_VERSION) {
+    return false;
+  }
+
+  const markdownRepaired = repairLegacyMarkdownBlockMetadata(db);
+  const textRepair = repairSearchContentText(db);
+  db.prepare("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')").run();
+  rebuildNormalizedSearchFts(db);
+  markSearchIndexRebuilt(db);
+  writeSystemSetting(db, SEARCH_CONTENT_EXTRACTOR_VERSION_KEY, SEARCH_CONTENT_EXTRACTOR_VERSION);
+  console.log(
+    `[search] extractor v${SEARCH_CONTENT_EXTRACTOR_VERSION}: `
+      + `${markdownRepaired} markdown notes normalized, ${textRepair.repairedCount} text rows repaired`,
+  );
+  return true;
+}
+
 /** Ensure the normalized candidate index and its triggers exist after startup. */
 export function ensureNormalizedSearchFts(db: Database.Database): void {
   createNormalizedSearchFts(db);
+  if (ensureSearchContentExtractorVersion(db)) return;
   const noteCount = Number((db.prepare("SELECT COUNT(*) AS count FROM notes").get() as { count?: number })?.count) || 0;
   const indexCount = Number((db.prepare("SELECT COUNT(*) AS count FROM notes_search_fts").get() as { count?: number })?.count) || 0;
   if (noteCount !== indexCount) rebuildNormalizedSearchFts(db);

--- a/backend/tests/markdown-user-content.test.ts
+++ b/backend/tests/markdown-user-content.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { projectMarkdownForUser } from "../src/lib/markdownUserContent";
+import {
+  projectMarkdownForUser,
+  stripLegacyInternalMarkdownMarkers,
+} from "../src/lib/markdownUserContent";
+
+const LEGACY_BLOCK_ID = "blk4e38ed87e6734393a537ba817a91e00f";
 
 test("projects only indexed Markdown block markers", () => {
   const source = [
@@ -22,6 +27,40 @@ test("projects only indexed Markdown block markers", () => {
     "```",
     "^blk_heading1",
     "```",
+    "尾声",
+  ].join("\n"));
+});
+
+test("projects legacy compact block metadata without exposing or deleting code samples", () => {
+  const source = [
+    `正文 ^${LEGACY_BLOCK_ID}`,
+    `^${LEGACY_BLOCK_ID}`,
+    `^${LEGACY_BLOCK_ID} 前置说明`,
+    "```text",
+    `^${LEGACY_BLOCK_ID}`,
+    "```",
+    "普通示例 ^blk_example_text",
+  ].join("\n");
+
+  assert.equal(projectMarkdownForUser(source, new Set()), [
+    "正文",
+    "前置说明",
+    "```text",
+    `^${LEGACY_BLOCK_ID}`,
+    "```",
+    "普通示例 ^blk_example_text",
+  ].join("\n"));
+});
+
+test("legacy normalization preserves current block identity", () => {
+  const source = [
+    "正文 ^blk_current001",
+    `^${LEGACY_BLOCK_ID}`,
+    "尾声",
+  ].join("\n");
+
+  assert.equal(stripLegacyInternalMarkdownMarkers(source), [
+    "正文 ^blk_current001",
     "尾声",
   ].join("\n"));
 });

--- a/backend/tests/search-index.test.ts
+++ b/backend/tests/search-index.test.ts
@@ -6,8 +6,11 @@ import {
   getSearchIndexRebuiltAt,
   inspectSearchContentText,
   markSearchIndexRebuilt,
+  repairLegacyMarkdownBlockMetadata,
   repairSearchContentText,
 } from "../src/lib/searchIndex";
+
+const LEGACY_BLOCK_ID = "blk4e38ed87e6734393a537ba817a91e00f";
 
 test("extractSearchableText handles Markdown, Tiptap JSON and HTML on the server", () => {
   assert.match(
@@ -32,6 +35,18 @@ test("extractSearchableText handles Markdown, Tiptap JSON and HTML on the server
     extractSearchableText("<style>.x{}</style><h1>HTML 标题</h1><p>HTML 正文</p>", "html"),
     "HTML 标题 HTML 正文",
   );
+});
+
+test("extractSearchableText strips legacy compact block metadata", () => {
+  const extracted = extractSearchableText([
+    "# 活性碳酸钙",
+    `^${LEGACY_BLOCK_ID}`,
+    "前置说明",
+  ].join("\n"), "markdown");
+
+  assert.match(extracted, /活性碳酸钙/);
+  assert.match(extracted, /前置说明/);
+  assert.doesNotMatch(extracted, /blk4e38/);
 });
 
 test("extractSearchableText does not duplicate nested table and list text", () => {
@@ -62,6 +77,44 @@ test("extractSearchableText does not duplicate nested table and list text", () =
     extractSearchableText(tiptap, "tiptap-json"),
     "租赁合同\n\n合同期限",
   );
+});
+
+test("repairLegacyMarkdownBlockMetadata upgrades historical Markdown and block index", () => {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE notes (
+      id TEXT PRIMARY KEY,
+      content TEXT,
+      contentText TEXT,
+      contentFormat TEXT
+    );
+  `);
+  db.prepare(
+    "INSERT INTO notes (id, content, contentText, contentFormat) VALUES (?, ?, ?, ?)",
+  ).run(
+    "legacy",
+    ["# 标题", `^${LEGACY_BLOCK_ID}`, "前置说明"].join("\n"),
+    `标题 ${LEGACY_BLOCK_ID} 前置说明`,
+    "markdown",
+  );
+
+  assert.equal(repairLegacyMarkdownBlockMetadata(db), 1);
+  assert.equal(repairLegacyMarkdownBlockMetadata(db), 0);
+
+  const row = db.prepare("SELECT content, contentText FROM notes WHERE id = 'legacy'").get() as {
+    content: string;
+    contentText: string;
+  };
+  assert.doesNotMatch(row.content, /blk4e38/);
+  assert.match(row.content, /\^blk_[0-9a-f-]+/i);
+  assert.doesNotMatch(row.contentText, /blk4e38/);
+  assert.match(row.contentText, /前置说明/);
+
+  const blocks = db.prepare(
+    "SELECT plainText FROM note_blocks_index WHERE noteId = 'legacy' ORDER BY blockOrder",
+  ).all() as Array<{ plainText: string }>;
+  assert.equal(blocks.some((block) => block.plainText.includes("blk4e38")), false);
+  db.close();
 });
 
 test("repairSearchContentText fixes empty and stale historical rows without touching valid rows", () => {

--- a/frontend/src/lib/__tests__/markdownUserContent.test.ts
+++ b/frontend/src/lib/__tests__/markdownUserContent.test.ts
@@ -8,6 +8,7 @@ import {
 const HEADING_ID = "blk_11111111-1111-4111-8111-111111111111";
 const PARAGRAPH_ID = "blk_22222222-2222-4222-8222-222222222222";
 const CODE_ID = "blk_33333333-3333-4333-8333-333333333333";
+const LEGACY_ID = "blk4e38ed87e6734393a537ba817a91e00f";
 
 describe("projectMarkdownForUser", () => {
   it("removes generated inline and post-fence markers while preserving code contents", () => {
@@ -33,6 +34,21 @@ describe("projectMarkdownForUser", () => {
       "const value = '^blk_inside';",
       "```",
       "",
+      "尾声",
+    ].join("\n"));
+  });
+
+  it("removes legacy compact markers from imported Markdown", () => {
+    const source = [
+      `正文 ^${LEGACY_ID}`,
+      `^${LEGACY_ID}`,
+      `^${LEGACY_ID} 前置说明`,
+      "尾声",
+    ].join("\n");
+
+    expect(projectMarkdownForUser(source)).toBe([
+      "正文",
+      "前置说明",
       "尾声",
     ].join("\n"));
   });
@@ -68,6 +84,15 @@ describe("projectMarkdownForUser", () => {
       { kind: "line", blockId: CODE_ID },
     ]);
   });
+
+  it("preserves legacy-looking text inside fenced code", () => {
+    const source = [
+      "```text",
+      `^${LEGACY_ID}`,
+      "```",
+    ].join("\n");
+    expect(projectMarkdownForUser(source)).toBe(source);
+  });
 });
 
 describe("sanitizeMarkdownClipboardText", () => {
@@ -85,10 +110,18 @@ describe("sanitizeMarkdownClipboardText", () => {
     ].join("\n"))).toBe("标题\n\n正文");
   });
 
+  it("removes legacy compact markers from pasted imports", () => {
+    expect(sanitizeMarkdownClipboardText([
+      `标题 ^${LEGACY_ID}`,
+      `^${LEGACY_ID} 前置说明`,
+    ].join("\n"))).toBe("标题\n前置说明");
+  });
+
   it("preserves marker-like text in fenced code and ordinary user text", () => {
     const source = [
       "```text",
       `literal ^${CODE_ID}`,
+      `^${LEGACY_ID}`,
       "```",
       "普通示例 ^blk_example_text",
     ].join("\n");

--- a/frontend/src/lib/markdownUserContent.ts
+++ b/frontend/src/lib/markdownUserContent.ts
@@ -10,10 +10,14 @@ export interface InternalMarkdownMarkerRange {
 // 系统生成的块 ID 偶尔会在隐藏标记边界被误删尾部字符；仍按内部标记处理，
 // 但保留严格的 UUID 结构，避免隐藏用户主动输入的 ^blk_example_text。
 const GENERATED_BLOCK_ID = String.raw`blk_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8,12}`;
-const INLINE_MARKER_RE = new RegExp(String.raw`[ \t]*\^(${GENERATED_BLOCK_ID})[ \t]*$`, "i");
-const LINE_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${GENERATED_BLOCK_ID})[ \t]*$`, "i");
+// v1.4.5 及更早版本、部分 Markdown 导入器使用过无下划线的 32 位块 ID。
+const LEGACY_COMPACT_BLOCK_ID = String.raw`blk[0-9a-f]{32}`;
+const INTERNAL_BLOCK_ID = String.raw`(?:${GENERATED_BLOCK_ID}|${LEGACY_COMPACT_BLOCK_ID})`;
+const INLINE_MARKER_RE = new RegExp(String.raw`[ \t]*\^(${INTERNAL_BLOCK_ID})[ \t]*$`, "i");
+const LINE_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${INTERNAL_BLOCK_ID})[ \t]*$`, "i");
+const LEGACY_PREFIX_MARKER_RE = new RegExp(String.raw`^[ \t]*\^(${LEGACY_COMPACT_BLOCK_ID})[ \t]+`, "i");
 const PASTED_MARKER_RE = new RegExp(
-  String.raw`(^|[ \t]+)\^(${GENERATED_BLOCK_ID})($|[ \t]+)`,
+  String.raw`(^|[ \t]+)\^(${INTERNAL_BLOCK_ID})($|[ \t]+)`,
   "ig",
 );
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
@@ -23,7 +27,7 @@ const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
  * The returned offsets refer to the original internal Markdown string.
  */
 export function findInternalMarkdownMarkerRanges(markdown: string): InternalMarkdownMarkerRange[] {
-  if (!markdown || !markdown.includes("^blk_")) return [];
+  if (!markdown || !markdown.includes("^blk")) return [];
   const ranges: InternalMarkdownMarkerRange[] = [];
   let offset = 0;
   let fenceChar = "";
@@ -64,6 +68,16 @@ export function findInternalMarkdownMarkerRanges(markdown: string): InternalMark
               kind: "inline",
               blockId: inline[1],
             });
+          } else {
+            const legacyPrefix = line.match(LEGACY_PREFIX_MARKER_RE);
+            if (legacyPrefix) {
+              ranges.push({
+                from: offset,
+                to: offset + legacyPrefix[0].length,
+                kind: "inline",
+                blockId: legacyPrefix[1],
+              });
+            }
           }
         }
       }
@@ -93,7 +107,7 @@ export function projectMarkdownForUser(markdown: string): string {
  * verbatim so documentation and code samples can still contain marker-like text.
  */
 export function sanitizeMarkdownClipboardText(markdown: string): string {
-  if (!markdown || !markdown.includes("^blk_")) return markdown;
+  if (!markdown || !markdown.includes("^blk")) return markdown;
   const lines = markdown.split("\n");
   let fenceChar = "";
   let fenceLength = 0;


### PR DESCRIPTION
## 问题

v1.4.5 的部分 Markdown 导入数据包含旧版无下划线紧凑块 ID，例如：

```text
^blk4e38ed87e6734393a537ba817a91e00f
```

这些内部元数据会进入 `contentText`、搜索索引、块索引和移动端列表摘要，造成飞牛客户端 / Docker Web 显示一串字符。此前只兼容当前 `^blk_<uuid>` 格式，因此问题会被不同导入入口反复触发。

## 修复

- 服务端用户可见 Markdown 投影统一兼容旧版 32 位紧凑块 ID
- 代码围栏内的同类文本保持原样，避免误删文档示例
- Markdown 块索引前先物理清理旧元数据，再生成当前标准 `blk_<uuid>`
- 引入文本提取器版本号；升级后自动执行一次：
  - 历史 Markdown 内容规范化
  - `contentText` 重建
  - 传统 FTS 与 trigram FTS 重建
  - 块索引重建
- Windows / Web / Android 共用的前端投影与剪贴板清理同步兼容
- 不修改笔记 `updatedAt` 和 `version`

## 回归覆盖

- 行尾旧块 ID
- 独立行旧块 ID
- 行首旧块 ID + 正文
- 代码块内旧块 ID 保留
- 普通用户输入 `^blk_example_text` 保留
- 历史数据修复幂等
- `contentText`、块索引和搜索内容不再包含旧块 ID

## 验收

1. 使用含 `^blk<32 hex>` 的 Markdown 导入笔记
2. Docker Web / 飞牛客户端列表不再显示块 ID
3. 搜索结果不再命中块 ID
4. 打开正文不显示块 ID
5. 重启服务后历史数据自动修复且不会重复执行