### PR TITLE
feat(pg): add resumable SQLite copy executor

### DIFF
--- a/.github/workflows/pg-sqlite-data-migration.yml
+++ b/.github/workflows/pg-sqlite-data-migration.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     paths:
       - "backend/src/db/migration/sqliteMigrationSource.ts"
+      - "backend/src/db/migration/sqliteMigrationReader.ts"
       - "backend/src/db/postgres/migrations/0023_sqlite_postgres_migration_runs.sql"
       - "backend/src/repositories/sqlitePostgresMigrationRepository.ts"
+      - "backend/src/services/sqlite-postgres-copy-runtime.ts"
       - "backend/src/services/sqlite-postgres-migration-runtime.ts"
       - "backend/scripts/migrate-sqlite-to-postgres.ts"
       - "backend/tests/sqlite-postgres-migration-runtime-pg.test.ts"
@@ -17,8 +19,10 @@ on:
     branches: [pg-migration-unified]
     paths:
       - "backend/src/db/migration/sqliteMigrationSource.ts"
+      - "backend/src/db/migration/sqliteMigrationReader.ts"
       - "backend/src/db/postgres/migrations/0023_sqlite_postgres_migration_runs.sql"
       - "backend/src/repositories/sqlitePostgresMigrationRepository.ts"
+      - "backend/src/services/sqlite-postgres-copy-runtime.ts"
       - "backend/src/services/sqlite-postgres-migration-runtime.ts"
       - "backend/scripts/migrate-sqlite-to-postgres.ts"
       - "backend/tests/sqlite-postgres-migration-runtime-pg.test.ts"
@@ -32,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  foundation:
+  executor:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:
@@ -66,7 +70,7 @@ jobs:
           npm run build:tsc -- --noEmit
           npm run audit:sqlite-boundaries
           npm run audit:pg-schema-parity
-      - name: Migration foundation regressions
+      - name: Migration executor regressions
         working-directory: backend
         run: >-
           node --import tsx --test --test-concurrency=1

--- a/backend/docs/sqlite-to-postgres-migration.md
+++ b/backend/docs/sqlite-to-postgres-migration.md
@@ -1,6 +1,6 @@
 # SQLite → PostgreSQL data migration
 
-This document describes the first durable execution slice for issue #251.
+This document describes the durable preflight, copy and verification slices for issue #251.
 
 ## Current scope
 
@@ -12,20 +12,29 @@ Implemented:
 - full-backup comparison by schema version, schema hash and per-table row counts;
 - PostgreSQL target schema and emptiness inspection;
 - dependency-ordered migration plan;
-- durable migration run, table checkpoint and batch checkpoint schema;
+- durable migration run, table checkpoint and batch checkpoint state;
 - idempotent apply-plan creation;
 - table-level leases with expired-lease takeover;
-- machine-readable dry-run CLI report.
+- primary-key cursor batch reads from a verified frozen backup;
+- transactional PostgreSQL upsert + batch checkpoint + table cursor commits;
+- INTEGER 0/1 → BOOLEAN conversion;
+- SQLite time text → TIMESTAMPTZ conversion;
+- BLOB → BYTEA conversion;
+- JSON/JSONB validation and conversion;
+- BIGINT-safe transfer without JavaScript precision loss;
+- nullable self-referencing foreign-key repair after row insertion;
+- identity/sequence repair;
+- per-batch content checksum and per-table row/checksum verification;
+- independent machine-readable `--verify` mode;
+- restart/resume and idempotent replay.
 
 Not enabled yet:
 
-- copying business rows;
-- type conversion and sequence repair;
-- independent verification;
-- rollback execution;
+- apply into a non-empty target database;
+- run-owned row tracking and rollback execution;
 - production read/write switching.
 
-The CLI deliberately exposes only `--dry-run` until the copy worker is complete.
+FTS and vector tables remain excluded and are rebuilt in #252.
 
 ## Dry run
 
@@ -42,34 +51,82 @@ npm run migrate:sqlite-to-postgres -- \
 
 The command is read-only for both the SQLite source and PostgreSQL business data. It exits with code `2` when safety blockers remain.
 
-A non-empty target is rejected by default. The explicit override is:
+A non-empty target is rejected by default. `--allow-non-empty-target` only allows risk inspection and plan creation; the current apply executor still refuses to write into a target that was non-empty during preflight.
+
+## Apply
+
+Use one stable idempotency key for the complete migration attempt:
 
 ```bash
---allow-non-empty-target
+cd backend
+DATABASE_URL='postgres://...' \
+npm run migrate:sqlite-to-postgres -- \
+  --apply \
+  --source /path/to/nowen-note.db \
+  --backup /path/to/nowen-note.backup.db \
+  --idempotency-key migration-2026-08-05
 ```
 
-Using the override only changes preflight planning. It does not enable data copying.
+Optional batch size:
+
+```bash
+--batch-size 500
+```
+
+Valid range is `1..2000`; the default is `200`.
+
+The live source is used only for preflight. All copied rows are read from the verified backup, which acts as the frozen execution snapshot. Each batch commits the following in one PostgreSQL transaction:
+
+1. idempotent row upserts;
+2. completed batch checkpoint;
+3. primary-key cursor and copied-row progress;
+4. run-level copied-row progress.
+
+A process crash before commit leaves no target rows or checkpoint for that batch. A crash after commit resumes from the persisted cursor and does not duplicate rows.
+
+Exit codes:
+
+- `0`: all planned tables copied and verified;
+- `1`: command/runtime failure;
+- `2`: dry-run blockers;
+- `3`: apply stopped before terminal completion;
+- `4`: independent verification mismatch.
+
+## Independent verification
+
+```bash
+cd backend
+DATABASE_URL='postgres://...' \
+npm run migrate:sqlite-to-postgres -- \
+  --verify \
+  --backup /path/to/nowen-note.backup.db \
+  --idempotency-key migration-2026-08-05
+```
+
+Verification re-reads the frozen SQLite backup and the PostgreSQL target in the same primary-key order. It compares every batch row count and canonical content checksum, covering BOOLEAN, timestamps, JSON, binary values and BIGINT values.
 
 ## Safety model
 
-- The source SQLite connection is opened with `readonly`, `fileMustExist` and `query_only`.
+- SQLite is opened with `readonly`, `fileMustExist` and `query_only`.
+- The verified backup is the only apply/verify row source.
 - Paths in reports are reduced to file names.
 - Row contents, credentials, tokens and document bodies are never logged.
 - FTS, vector and SQLite internal tables are excluded and deferred to #252.
-- A verified full backup is mandatory before an apply plan can be persisted.
+- Every copied business table must have a stable primary key.
+- Cross-table foreign-key cycles remain a preflight blocker; nullable self-references are handled in a recoverable second pass.
 - Durable checkpoints are stored only in PostgreSQL.
 - Table claims use lease tokens and `FOR UPDATE SKIP LOCKED`.
-- An expired lease can be safely reclaimed after process restart.
-- Reusing an idempotency key with a different plan is rejected.
+- Expired leases can be reclaimed after process restart.
+- Reusing an idempotency key with a different source, plan or batch size is rejected.
+- The source and backup files are never modified.
 
-## Next execution slice
+## Remaining #251 slice
 
-The next slice will consume table checkpoints and implement:
+The next slice will add:
 
-1. consistent SQLite snapshot acquisition;
-2. batched primary-key cursor reads;
-3. PostgreSQL transactional upserts;
-4. BOOLEAN/TIMESTAMPTZ/BYTEA/JSON conversion;
-5. batch checkpoint persistence;
-6. table and run verification;
-7. rollback of rows owned by a migration run.
+1. run-owned primary-key tracking;
+2. safe rollback in reverse dependency order;
+3. non-empty target conflict policy and restoration records;
+4. final migration report persistence;
+5. larger generated datasets and failure-injection coverage;
+6. cutover readiness signal after successful verify and rollback drill.

--- a/backend/scripts/migrate-sqlite-to-postgres.ts
+++ b/backend/scripts/migrate-sqlite-to-postgres.ts
@@ -6,27 +6,35 @@ import { PostgresAdapter } from "../src/db/postgresAdapter";
 import { createSqlitePostgresMigrationRuntime } from "../src/services/sqlite-postgres-migration-runtime";
 
 type CliOptions = {
-  mode: "dry-run";
-  sourcePath: string;
+  mode: "dry-run" | "apply" | "verify";
+  sourcePath?: string;
   backupPath?: string;
+  idempotencyKey?: string;
   allowNonEmptyTarget: boolean;
+  batchSize?: number;
 };
 
 function usage(): string {
   return [
-    "SQLite → PostgreSQL migration preflight",
+    "SQLite → PostgreSQL migration tool",
     "",
     "Usage:",
     "  npm run migrate:sqlite-to-postgres -- --dry-run --source <nowen-note.db> --backup <backup.db>",
+    "  npm run migrate:sqlite-to-postgres -- --apply --source <nowen-note.db> --backup <backup.db> --idempotency-key <key>",
+    "  npm run migrate:sqlite-to-postgres -- --verify --backup <backup.db> --idempotency-key <key>",
     "",
     "Options:",
     "  --dry-run                  Run read-only preflight; never writes target data",
-    "  --source <path>            Source SQLite file (defaults to DB_PATH)",
-    "  --backup <path>            Full SQLite backup used for safety verification",
-    "  --allow-non-empty-target   Explicitly allow planning against a non-empty target",
+    "  --apply                    Copy and verify all planned business tables",
+    "  --verify                   Independently re-read the frozen backup and verify PostgreSQL",
+    "  --source <path>            Live SQLite source used only for preflight (defaults to DB_PATH)",
+    "  --backup <path>            Verified frozen SQLite backup used as the execution source",
+    "  --idempotency-key <key>    Stable 8–128 character migration key for apply/verify",
+    "  --batch-size <1..2000>     Rows per transactional upsert/checkpoint batch (default 200)",
+    "  --allow-non-empty-target   Allow planning against non-empty PostgreSQL; apply remains blocked",
     "  --help                     Show this help",
     "",
-    "The apply/verify/rollback workers are intentionally not enabled in this slice.",
+    "Rollback remains disabled until run-owned row tracking is implemented.",
   ].join("\n");
 }
 
@@ -35,23 +43,48 @@ function valueAfter(args: string[], name: string): string | undefined {
   return index >= 0 ? args[index + 1] : undefined;
 }
 
+function parseBatchSize(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 2_000) {
+    throw new Error("--batch-size must be an integer between 1 and 2000.");
+  }
+  return parsed;
+}
+
 function parseArgs(args: string[]): CliOptions {
   if (args.includes("--help")) {
     console.log(usage());
     process.exit(0);
   }
-  if (!args.includes("--dry-run")) {
-    throw new Error("Only --dry-run is enabled. Apply/verify/rollback are not available yet.");
+  const selected = ["--dry-run", "--apply", "--verify"].filter((mode) => args.includes(mode));
+  if (selected.length !== 1) {
+    throw new Error("Select exactly one mode: --dry-run, --apply, or --verify.");
   }
+  const mode = selected[0] === "--apply"
+    ? "apply"
+    : selected[0] === "--verify"
+      ? "verify"
+      : "dry-run";
   const sourcePath = valueAfter(args, "--source") || process.env.DB_PATH;
-  if (!sourcePath) {
+  const backupPath = valueAfter(args, "--backup");
+  const idempotencyKey = valueAfter(args, "--idempotency-key");
+  if ((mode === "dry-run" || mode === "apply") && !sourcePath) {
     throw new Error("SQLite source path is required via --source or DB_PATH.");
   }
+  if (!backupPath) {
+    throw new Error("A frozen SQLite backup is required via --backup.");
+  }
+  if ((mode === "apply" || mode === "verify") && !idempotencyKey) {
+    throw new Error("--idempotency-key is required for apply and verify.");
+  }
   return {
-    mode: "dry-run",
+    mode,
     sourcePath,
-    backupPath: valueAfter(args, "--backup"),
+    backupPath,
+    idempotencyKey,
     allowNonEmptyTarget: args.includes("--allow-non-empty-target"),
+    batchSize: parseBatchSize(valueAfter(args, "--batch-size")),
   };
 }
 
@@ -65,20 +98,42 @@ async function main(): Promise<void> {
   const pool = new Pool({
     connectionString: databaseUrl,
     max: 2,
-    application_name: "nowen-note-sqlite-pg-migration-preflight",
+    application_name: "nowen-note-sqlite-pg-migration",
   });
   try {
     await pool.query("SELECT 1");
     const runtime = createSqlitePostgresMigrationRuntime(
       new PostgresAdapter(pool),
     );
-    const report = await runtime.dryRun({
-      sourcePath: options.sourcePath,
-      backupPath: options.backupPath,
-      allowNonEmptyTarget: options.allowNonEmptyTarget,
+    if (options.mode === "dry-run") {
+      const report = await runtime.dryRun({
+        sourcePath: options.sourcePath!,
+        backupPath: options.backupPath,
+        allowNonEmptyTarget: options.allowNonEmptyTarget,
+        batchSize: options.batchSize,
+      });
+      console.log(JSON.stringify(report, null, 2));
+      if (!report.canApply) process.exitCode = 2;
+      return;
+    }
+    if (options.mode === "apply") {
+      const result = await runtime.apply({
+        idempotencyKey: options.idempotencyKey!,
+        sourcePath: options.sourcePath!,
+        backupPath: options.backupPath!,
+        allowNonEmptyTarget: options.allowNonEmptyTarget,
+        batchSize: options.batchSize,
+      });
+      console.log(JSON.stringify(result, null, 2));
+      if (result.snapshot.run.status !== "completed") process.exitCode = 3;
+      return;
+    }
+    const report = await runtime.verify({
+      idempotencyKey: options.idempotencyKey!,
+      backupPath: options.backupPath!,
     });
     console.log(JSON.stringify(report, null, 2));
-    if (!report.canApply) process.exitCode = 2;
+    if (!report.ok) process.exitCode = 4;
   } finally {
     await pool.end();
   }
@@ -88,7 +143,7 @@ main().catch((error) => {
   const message = error instanceof Error ? error.message : String(error);
   console.error(JSON.stringify({
     ok: false,
-    code: "SQLITE_PG_MIGRATION_PREFLIGHT_FAILED",
+    code: "SQLITE_PG_MIGRATION_COMMAND_FAILED",
     error: message,
   }));
   process.exitCode = 1;

--- a/backend/src/db/migration/sqliteMigrationReader.ts
+++ b/backend/src/db/migration/sqliteMigrationReader.ts
@@ -1,0 +1,123 @@
+import { existsSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+import Database from "better-sqlite3";
+
+export type SqliteMigrationCursor = Record<string, string | number | boolean | null>;
+
+export type SqliteMigrationBatch = {
+  rows: Array<Record<string, unknown>>;
+  cursorStart: SqliteMigrationCursor | null;
+  cursorEnd: SqliteMigrationCursor | null;
+};
+
+function quoteIdentifier(value: string): string {
+  const name = String(value || "");
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error("[pg-data-migration] unsafe SQLite identifier");
+  }
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function jsonSafeCursorValue(value: unknown): string | number | boolean | null {
+  if (value == null) return null;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function buildCursor(
+  row: Record<string, unknown>,
+  primaryKeyColumns: string[],
+): SqliteMigrationCursor {
+  return Object.fromEntries(
+    primaryKeyColumns.map((column) => [column, jsonSafeCursorValue(row[column])]),
+  );
+}
+
+export function openSqliteMigrationReader(inputPath: string) {
+  const absolutePath = resolve(String(inputPath || "").trim());
+  if (!inputPath || !existsSync(absolutePath)) {
+    throw new Error(
+      `[pg-data-migration] frozen SQLite snapshot does not exist: ${basename(absolutePath || "unknown.db")}`,
+    );
+  }
+
+  const db = new Database(absolutePath, {
+    readonly: true,
+    fileMustExist: true,
+  });
+  db.pragma("query_only = ON");
+  db.defaultSafeIntegers(true);
+
+  return {
+    readBatch(input: {
+      tableName: string;
+      columns: string[];
+      primaryKeyColumns: string[];
+      lastCursor?: SqliteMigrationCursor | null;
+      limit: number;
+    }): SqliteMigrationBatch {
+      const columns = Array.from(new Set(input.columns.map((column) => String(column || "").trim())))
+        .filter(Boolean);
+      const primaryKeyColumns = Array.from(new Set(
+        input.primaryKeyColumns.map((column) => String(column || "").trim()),
+      )).filter(Boolean);
+      if (columns.length === 0) {
+        throw new Error("[pg-data-migration] source table has no readable columns");
+      }
+      if (primaryKeyColumns.length === 0) {
+        throw new Error("[pg-data-migration] source table has no stable primary key cursor");
+      }
+      for (const primaryKey of primaryKeyColumns) {
+        if (!columns.includes(primaryKey)) {
+          throw new Error("[pg-data-migration] primary key column is missing from source projection");
+        }
+      }
+
+      const tableSql = quoteIdentifier(input.tableName);
+      const columnSql = columns.map(quoteIdentifier).join(", ");
+      const orderSql = primaryKeyColumns.map(quoteIdentifier).join(", ");
+      const limit = Math.max(1, Math.min(2_000, Math.trunc(input.limit || 200)));
+      const params: unknown[] = [];
+      let whereSql = "";
+
+      if (input.lastCursor) {
+        const cursorValues = primaryKeyColumns.map((column) => {
+          if (!(column in input.lastCursor!)) {
+            throw new Error("[pg-data-migration] persisted cursor is incomplete");
+          }
+          return input.lastCursor![column];
+        });
+        const cursorColumns = primaryKeyColumns.map(quoteIdentifier).join(", ");
+        const placeholders = primaryKeyColumns.map(() => "?").join(", ");
+        whereSql = ` WHERE (${cursorColumns}) > (${placeholders})`;
+        params.push(...cursorValues);
+      }
+      params.push(limit);
+
+      const rows = db.prepare(
+        `SELECT ${columnSql}
+           FROM ${tableSql}${whereSql}
+          ORDER BY ${orderSql}
+          LIMIT ?`,
+      ).all(...params) as Array<Record<string, unknown>>;
+      const cursorStart = rows.length > 0
+        ? buildCursor(rows[0], primaryKeyColumns)
+        : null;
+      const cursorEnd = rows.length > 0
+        ? buildCursor(rows[rows.length - 1], primaryKeyColumns)
+        : null;
+      return { rows, cursorStart, cursorEnd };
+    },
+
+    close(): void {
+      db.close();
+    },
+  };
+}
+
+export type SqliteMigrationReader = ReturnType<typeof openSqliteMigrationReader>;

--- a/backend/src/repositories/sqlitePostgresMigrationRepository.ts
+++ b/backend/src/repositories/sqlitePostgresMigrationRepository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { DatabaseAdapter } from "../db/adapters/types";
+import type { DatabaseAdapter, DbStatement } from "../db/adapters/types";
 import { getDatabaseAdapter } from "../db/runtime";
 
 export type SqlitePostgresMigrationTableStatus =
@@ -77,6 +77,24 @@ export type SqlitePostgresMigrationTableCheckpoint = {
   completedAt: string | null;
   createdAt: string;
   updatedAt: string;
+};
+
+export type SqlitePostgresMigrationBatchCheckpoint = {
+  id: string;
+  runId: string;
+  tableName: string;
+  batchSequence: number;
+  status: "planned" | "writing" | "completed" | "failed";
+  cursorStart: Record<string, unknown> | null;
+  cursorEnd: Record<string, unknown> | null;
+  rowCount: number;
+  checksum: string | null;
+  attempts: number;
+  leaseExpiresAt: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
 };
 
 export type SqlitePostgresMigrationSnapshot = {
@@ -170,6 +188,19 @@ function normalizeTable(row: Row): SqlitePostgresMigrationTableCheckpoint {
   } as SqlitePostgresMigrationTableCheckpoint;
 }
 
+function normalizeBatch(row: Row): SqlitePostgresMigrationBatchCheckpoint {
+  return {
+    ...row,
+    batchSequence: numberValue(row.batchSequence),
+    rowCount: numberValue(row.rowCount),
+    attempts: numberValue(row.attempts),
+    leaseExpiresAt: optionalTimestamp(row.leaseExpiresAt),
+    createdAt: timestamp(row.createdAt),
+    updatedAt: timestamp(row.updatedAt),
+    completedAt: optionalTimestamp(row.completedAt),
+  } as SqlitePostgresMigrationBatchCheckpoint;
+}
+
 export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapter) {
   const db = adapter ?? getDatabaseAdapter();
 
@@ -210,6 +241,27 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
     progress.complete = tables.length > 0
       && tables.every((table) => table.status === "verified" || table.status === "skipped");
     return { run: normalizeRun(runRow), tables, progress };
+  }
+
+  async function refreshRunProgress(runId: string): Promise<void> {
+    await db.execute(
+      `UPDATE sqlite_postgres_migration_runs run
+          SET "completedTables" = summary.completed_tables,
+              "copiedRows" = summary.copied_rows,
+              "verifiedRows" = summary.verified_rows,
+              "updatedAt" = CURRENT_TIMESTAMP
+         FROM (
+           SELECT "runId",
+                  COUNT(*) FILTER (WHERE status IN ('verified', 'skipped'))::int AS completed_tables,
+                  COALESCE(SUM("copiedRows"), 0)::bigint AS copied_rows,
+                  COALESCE(SUM("verifiedRows"), 0)::bigint AS verified_rows
+             FROM sqlite_postgres_migration_table_checkpoints
+            WHERE "runId" = ?
+            GROUP BY "runId"
+         ) summary
+        WHERE run.id = summary."runId"`,
+      [runId],
+    );
   }
 
   return {
@@ -310,8 +362,8 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
              FROM sqlite_postgres_migration_table_checkpoints checkpoint
              JOIN sqlite_postgres_migration_runs run ON run.id = checkpoint."runId"
             WHERE checkpoint."runId" = ?
-              AND run.status IN ('planned', 'copying', 'failed')
-              AND checkpoint.status IN ('planned', 'copying', 'failed')
+              AND run.status IN ('planned', 'copying', 'verifying', 'failed')
+              AND checkpoint.status IN ('planned', 'copying', 'verifying', 'failed')
               AND checkpoint.attempts < ?
               AND checkpoint."availableAt" <= CURRENT_TIMESTAMP
               AND (
@@ -323,7 +375,7 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
                   FROM sqlite_postgres_migration_table_checkpoints dependency
                  WHERE dependency."runId" = checkpoint."runId"
                    AND dependency."dependencyOrder" < checkpoint."dependencyOrder"
-                   AND dependency.status NOT IN ('copied', 'verified', 'skipped')
+                   AND dependency.status NOT IN ('verified', 'skipped')
               )
             ORDER BY checkpoint."dependencyOrder", checkpoint."tableName"
             FOR UPDATE OF checkpoint SKIP LOCKED
@@ -335,6 +387,7 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
                 "leaseToken" = ?,
                 "leaseExpiresAt" = CURRENT_TIMESTAMP + (? * INTERVAL '1 second'),
                 "startedAt" = COALESCE("startedAt", CURRENT_TIMESTAMP),
+                "lastError" = NULL,
                 "updatedAt" = CURRENT_TIMESTAMP
            FROM candidate
           WHERE checkpoint."runId" = candidate."runId"
@@ -350,10 +403,10 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
       if (!row) return null;
       await db.execute(
         `UPDATE sqlite_postgres_migration_runs
-            SET status = 'copying', "currentTable" = ?,
+            SET status = 'copying', "currentTable" = ?, "lastError" = NULL,
                 "startedAt" = COALESCE("startedAt", CURRENT_TIMESTAMP),
                 "updatedAt" = CURRENT_TIMESTAMP
-          WHERE id = ? AND status IN ('planned', 'copying', 'failed')`,
+          WHERE id = ? AND status IN ('planned', 'copying', 'verifying', 'failed')`,
         [row.tableName, row.runId],
       );
       return {
@@ -365,6 +418,197 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
         lastCursor: row.lastCursor ?? null,
         leaseToken,
       };
+    },
+
+    async getCompletedBatches(input: {
+      runId: string;
+      tableName: string;
+    }): Promise<SqlitePostgresMigrationBatchCheckpoint[]> {
+      return (await db.queryMany<Row>(
+        `SELECT *
+           FROM sqlite_postgres_migration_batch_checkpoints
+          WHERE "runId" = ? AND "tableName" = ? AND status = 'completed'
+          ORDER BY "batchSequence"`,
+        [input.runId, input.tableName],
+      )).map(normalizeBatch);
+    },
+
+    async commitBatch(input: {
+      runId: string;
+      tableName: string;
+      leaseToken: string;
+      batchSequence: number;
+      cursorStart: Record<string, unknown> | null;
+      cursorEnd: Record<string, unknown> | null;
+      rowCount: number;
+      checksum: string;
+      copiedRows: number;
+      lastCursor: Record<string, unknown>;
+      leaseSeconds?: number;
+      statements: DbStatement[];
+    }): Promise<void> {
+      const statements: DbStatement[] = [
+        ...input.statements,
+        {
+          sql: `INSERT INTO sqlite_postgres_migration_batch_checkpoints (
+                  id, "runId", "tableName", "batchSequence", status,
+                  "cursorStart", "cursorEnd", "rowCount", checksum,
+                  attempts, "completedAt", "updatedAt"
+                ) VALUES (?, ?, ?, ?, 'completed', ?::jsonb, ?::jsonb, ?, ?, 1,
+                          CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                ON CONFLICT ("runId", "tableName", "batchSequence") DO UPDATE
+                  SET status = 'completed',
+                      "cursorStart" = EXCLUDED."cursorStart",
+                      "cursorEnd" = EXCLUDED."cursorEnd",
+                      "rowCount" = EXCLUDED."rowCount",
+                      checksum = EXCLUDED.checksum,
+                      attempts = sqlite_postgres_migration_batch_checkpoints.attempts + 1,
+                      "lastError" = NULL,
+                      "completedAt" = CURRENT_TIMESTAMP,
+                      "updatedAt" = CURRENT_TIMESTAMP`,
+          params: [
+            randomUUID(), input.runId, input.tableName,
+            Math.max(0, Math.trunc(input.batchSequence)),
+            JSON.stringify(input.cursorStart), JSON.stringify(input.cursorEnd),
+            Math.max(0, Math.trunc(input.rowCount)),
+            normalizeHash(input.checksum, "batch checksum"),
+          ],
+        },
+        {
+          sql: `UPDATE sqlite_postgres_migration_table_checkpoints
+                   SET status = 'copying', "copiedRows" = ?, "lastCursor" = ?::jsonb,
+                       "leaseExpiresAt" = CURRENT_TIMESTAMP + (? * INTERVAL '1 second'),
+                       "lastError" = NULL, "updatedAt" = CURRENT_TIMESTAMP
+                 WHERE "runId" = ? AND "tableName" = ? AND "leaseToken" = ?`,
+          params: [
+            Math.max(0, Math.trunc(input.copiedRows)),
+            JSON.stringify(input.lastCursor),
+            Math.max(30, Math.trunc(input.leaseSeconds ?? 300)),
+            input.runId, input.tableName, input.leaseToken,
+          ],
+          requireChanges: 1,
+        },
+        {
+          sql: `UPDATE sqlite_postgres_migration_runs run
+                   SET "copiedRows" = summary.copied_rows,
+                       "currentTable" = ?, "updatedAt" = CURRENT_TIMESTAMP
+                  FROM (
+                    SELECT "runId", COALESCE(SUM("copiedRows"), 0)::bigint AS copied_rows
+                      FROM sqlite_postgres_migration_table_checkpoints
+                     WHERE "runId" = ?
+                     GROUP BY "runId"
+                  ) summary
+                 WHERE run.id = summary."runId"`,
+          params: [input.tableName, input.runId],
+        },
+      ];
+      await db.executeStatements(statements);
+    },
+
+    async markTableVerifying(input: {
+      runId: string;
+      tableName: string;
+      leaseToken: string;
+      sourceChecksum: string;
+      leaseSeconds?: number;
+    }): Promise<void> {
+      const result = await db.execute(
+        `UPDATE sqlite_postgres_migration_table_checkpoints
+            SET status = 'verifying', "sourceChecksum" = ?,
+                "leaseExpiresAt" = CURRENT_TIMESTAMP + (? * INTERVAL '1 second'),
+                "lastError" = NULL, "updatedAt" = CURRENT_TIMESTAMP
+          WHERE "runId" = ? AND "tableName" = ? AND "leaseToken" = ?`,
+        [
+          normalizeHash(input.sourceChecksum, "source checksum"),
+          Math.max(30, Math.trunc(input.leaseSeconds ?? 300)),
+          input.runId, input.tableName, input.leaseToken,
+        ],
+      );
+      if (result.changes !== 1) {
+        throw new SqlitePostgresMigrationError(
+          "SQLITE_PG_MIGRATION_TABLE_LEASE_LOST",
+          "数据迁移表租约已失效",
+          409,
+        );
+      }
+      await db.execute(
+        `UPDATE sqlite_postgres_migration_runs
+            SET status = 'verifying', "currentTable" = ?, "updatedAt" = CURRENT_TIMESTAMP
+          WHERE id = ?`,
+        [input.tableName, input.runId],
+      );
+    },
+
+    async markTableVerified(input: {
+      runId: string;
+      tableName: string;
+      leaseToken: string;
+      verifiedRows: number;
+      targetChecksum: string;
+    }): Promise<void> {
+      const result = await db.execute(
+        `UPDATE sqlite_postgres_migration_table_checkpoints
+            SET status = 'verified', "verifiedRows" = ?, "targetChecksum" = ?,
+                "leaseToken" = NULL, "leaseExpiresAt" = NULL,
+                "lastError" = NULL, "completedAt" = CURRENT_TIMESTAMP,
+                "updatedAt" = CURRENT_TIMESTAMP
+          WHERE "runId" = ? AND "tableName" = ? AND "leaseToken" = ?`,
+        [
+          Math.max(0, Math.trunc(input.verifiedRows)),
+          normalizeHash(input.targetChecksum, "target checksum"),
+          input.runId, input.tableName, input.leaseToken,
+        ],
+      );
+      if (result.changes !== 1) {
+        throw new SqlitePostgresMigrationError(
+          "SQLITE_PG_MIGRATION_TABLE_LEASE_LOST",
+          "数据迁移表租约已失效",
+          409,
+        );
+      }
+      await refreshRunProgress(input.runId);
+      const remaining = await db.queryOne<{ count: number | string }>(
+        `SELECT COUNT(*)::bigint AS count
+           FROM sqlite_postgres_migration_table_checkpoints
+          WHERE "runId" = ? AND status NOT IN ('verified', 'skipped')`,
+        [input.runId],
+      );
+      const complete = numberValue(remaining?.count) === 0;
+      await db.execute(
+        `UPDATE sqlite_postgres_migration_runs
+            SET status = ?, "currentTable" = NULL, "lastError" = NULL,
+                "completedAt" = CASE WHEN ? THEN CURRENT_TIMESTAMP ELSE NULL END,
+                "updatedAt" = CURRENT_TIMESTAMP
+          WHERE id = ?`,
+        [complete ? "completed" : "copying", complete, input.runId],
+      );
+    },
+
+    async releaseTableLease(input: {
+      runId: string;
+      tableName: string;
+      leaseToken: string;
+    }): Promise<void> {
+      const result = await db.execute(
+        `UPDATE sqlite_postgres_migration_table_checkpoints
+            SET status = 'copying', "leaseToken" = NULL, "leaseExpiresAt" = NULL,
+                "availableAt" = CURRENT_TIMESTAMP, "updatedAt" = CURRENT_TIMESTAMP
+          WHERE "runId" = ? AND "tableName" = ? AND "leaseToken" = ?`,
+        [input.runId, input.tableName, input.leaseToken],
+      );
+      if (result.changes !== 1) {
+        throw new SqlitePostgresMigrationError(
+          "SQLITE_PG_MIGRATION_TABLE_LEASE_LOST",
+          "数据迁移表租约已失效",
+          409,
+        );
+      }
+      await db.execute(
+        `UPDATE sqlite_postgres_migration_runs
+            SET "currentTable" = NULL, "updatedAt" = CURRENT_TIMESTAMP
+          WHERE id = ?`,
+        [input.runId],
+      );
     },
 
     async markTableCopied(input: {
@@ -396,24 +640,7 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
           409,
         );
       }
-      await db.execute(
-        `UPDATE sqlite_postgres_migration_runs run
-            SET "completedTables" = summary.completed_tables,
-                "copiedRows" = summary.copied_rows,
-                "currentTable" = NULL,
-                "updatedAt" = CURRENT_TIMESTAMP
-           FROM (
-             SELECT "runId",
-                    COUNT(*) FILTER (WHERE status IN ('copied', 'verified', 'skipped'))::int
-                      AS completed_tables,
-                    COALESCE(SUM("copiedRows"), 0)::bigint AS copied_rows
-               FROM sqlite_postgres_migration_table_checkpoints
-              WHERE "runId" = ?
-              GROUP BY "runId"
-           ) summary
-          WHERE run.id = summary."runId"`,
-        [input.runId],
-      );
+      await refreshRunProgress(input.runId);
     },
 
     async markTableFailed(input: {
@@ -449,6 +676,16 @@ export function createSqlitePostgresMigrationRepository(adapter?: DatabaseAdapte
                 "currentTable" = NULL, "updatedAt" = CURRENT_TIMESTAMP
           WHERE id = ?`,
         [message, input.runId],
+      );
+    },
+
+    async markRunFailed(input: { runId: string; error: string }): Promise<void> {
+      await db.execute(
+        `UPDATE sqlite_postgres_migration_runs
+            SET status = 'failed', "lastError" = ?, attempts = attempts + 1,
+                "currentTable" = NULL, "updatedAt" = CURRENT_TIMESTAMP
+          WHERE id = ? AND status <> 'completed'`,
+        [String(input.error || "unknown migration error").slice(0, 2_000), input.runId],
       );
     },
   };

--- a/backend/src/services/sqlite-postgres-copy-runtime.ts
+++ b/backend/src/services/sqlite-postgres-copy-runtime.ts
@@ -1,0 +1,957 @@
+import { createHash } from "node:crypto";
+
+import type { DatabaseAdapter, DbStatement } from "../db/adapters/types";
+import {
+  inspectSqliteMigrationSource,
+  type SqliteMigrationSourceSnapshot,
+  type SqliteMigrationTable,
+} from "../db/migration/sqliteMigrationSource";
+import {
+  openSqliteMigrationReader,
+  type SqliteMigrationCursor,
+  type SqliteMigrationReader,
+} from "../db/migration/sqliteMigrationReader";
+import {
+  createSqlitePostgresMigrationRepository,
+  SqlitePostgresMigrationError,
+  type SqlitePostgresMigrationBatchCheckpoint,
+  type SqlitePostgresMigrationSnapshot,
+  type SqlitePostgresMigrationTableClaim,
+} from "../repositories/sqlitePostgresMigrationRepository";
+
+const DEFAULT_BATCH_SIZE = 200;
+const DEFAULT_LEASE_SECONDS = 600;
+const DEFAULT_MAX_ATTEMPTS = 10;
+
+type Repository = ReturnType<typeof createSqlitePostgresMigrationRepository>;
+
+type TargetColumn = {
+  name: string;
+  dataType: string;
+  udtName: string;
+  nullable: boolean;
+  columnDefault: string | null;
+  identity: boolean;
+};
+
+type TargetForeignKey = {
+  columnName: string;
+  foreignTableName: string;
+  nullable: boolean;
+};
+
+type TargetTableShape = {
+  columns: TargetColumn[];
+  foreignKeys: TargetForeignKey[];
+};
+
+type CanonicalBatch = {
+  batchSequence: number;
+  rowCount: number;
+  checksum: string;
+};
+
+export type SqlitePostgresCopyVerificationTable = {
+  tableName: string;
+  sourceRows: number;
+  targetRows: number;
+  sourceChecksum: string;
+  targetChecksum: string;
+  matched: boolean;
+};
+
+export type SqlitePostgresCopyVerificationReport = {
+  generatedAt: string;
+  ok: boolean;
+  runId: string;
+  tables: SqlitePostgresCopyVerificationTable[];
+  failures: Array<{
+    tableName: string;
+    code: string;
+    message: string;
+  }>;
+};
+
+export type SqlitePostgresCopyRuntimeOptions = {
+  repository?: Repository;
+  inspectSource?: typeof inspectSqliteMigrationSource;
+  openReader?: typeof openSqliteMigrationReader;
+  batchSize?: number;
+  leaseSeconds?: number;
+  maxAttempts?: number;
+};
+
+function quoteIdentifier(value: string): string {
+  const name = String(value || "");
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_IDENTIFIER_INVALID",
+      "迁移表或列名不安全",
+      500,
+    );
+  }
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function stableJson(value: unknown): string {
+  if (value == null) return "null";
+  if (typeof value === "bigint") return JSON.stringify(value.toString());
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Buffer.isBuffer(value)) {
+    return `{"$bytea":${JSON.stringify(value.toString("hex"))}}`;
+  }
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`).join(",")}}`;
+  }
+  const encoded = JSON.stringify(value);
+  return encoded === undefined ? "null" : encoded;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeTimestamp(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  let text = String(value || "").trim();
+  if (!text) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_TIMESTAMP_INVALID",
+      "SQLite 时间字段包含空值但目标列要求时间类型",
+      409,
+    );
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(text)) text = `${text}T00:00:00Z`;
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(text)) {
+    text = `${text.replace(" ", "T")}Z`;
+  }
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_TIMESTAMP_INVALID",
+      "SQLite 时间字段无法转换为 PostgreSQL TIMESTAMPTZ",
+      409,
+    );
+  }
+  return parsed.toISOString();
+}
+
+function normalizeBoolean(value: unknown): boolean {
+  if (value === true || value === 1 || value === 1n || value === "1") return true;
+  if (value === false || value === 0 || value === 0n || value === "0") return false;
+  const text = String(value).trim().toLowerCase();
+  if (text === "true") return true;
+  if (text === "false") return false;
+  throw new SqlitePostgresMigrationError(
+    "SQLITE_PG_MIGRATION_BOOLEAN_INVALID",
+    "SQLite BOOLEAN 字段不是 0/1 或 true/false",
+    409,
+  );
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_JSON_INVALID",
+      "SQLite JSON 字段包含无效 JSON",
+      409,
+    );
+  }
+}
+
+function convertValue(column: TargetColumn, value: unknown): unknown {
+  if (value == null) return null;
+  const dataType = column.dataType.toLowerCase();
+  const udtName = column.udtName.toLowerCase();
+
+  if (dataType === "boolean") return normalizeBoolean(value);
+  if (dataType.includes("timestamp") || dataType === "date") return normalizeTimestamp(value);
+  if (dataType === "bytea" || udtName === "bytea") {
+    if (Buffer.isBuffer(value)) return value;
+    if (value instanceof Uint8Array) return Buffer.from(value);
+    return Buffer.from(String(value), "utf8");
+  }
+  if (dataType === "json" || dataType === "jsonb" || udtName === "json" || udtName === "jsonb") {
+    return parseJson(value);
+  }
+  if (dataType === "bigint" || udtName === "int8") {
+    return typeof value === "bigint" ? value.toString() : String(value);
+  }
+  if (dataType === "integer" || dataType === "smallint" || udtName === "int4" || udtName === "int2") {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed)) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_INTEGER_INVALID",
+        "SQLite 整数字段无法转换为 PostgreSQL INTEGER",
+        409,
+      );
+    }
+    return parsed;
+  }
+  if (dataType === "numeric" || dataType === "decimal") return String(value);
+  if (dataType === "real" || dataType === "double precision") {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_NUMBER_INVALID",
+        "SQLite 数值字段无法转换为 PostgreSQL 浮点类型",
+        409,
+      );
+    }
+    return parsed;
+  }
+  if (dataType === "array") {
+    const parsed = typeof value === "string" ? parseJson(value) : value;
+    if (!Array.isArray(parsed)) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_ARRAY_INVALID",
+        "SQLite 字段无法转换为 PostgreSQL ARRAY",
+        409,
+      );
+    }
+    return parsed;
+  }
+  if (typeof value === "bigint") return value.toString();
+  return value;
+}
+
+function canonicalValue(column: TargetColumn, value: unknown): unknown {
+  const converted = convertValue(column, value);
+  if (converted == null) return null;
+  const dataType = column.dataType.toLowerCase();
+  const udtName = column.udtName.toLowerCase();
+  if (dataType.includes("timestamp") || dataType === "date") return normalizeTimestamp(converted);
+  if (dataType === "bytea" || udtName === "bytea") {
+    return Buffer.isBuffer(converted)
+      ? { $bytea: converted.toString("hex") }
+      : { $bytea: Buffer.from(converted as Uint8Array).toString("hex") };
+  }
+  if (dataType === "json" || dataType === "jsonb" || udtName === "json" || udtName === "jsonb") {
+    return parseJson(converted);
+  }
+  if (dataType === "bigint" || dataType === "numeric" || dataType === "decimal"
+    || udtName === "int8") {
+    return String(converted);
+  }
+  return converted;
+}
+
+function checksumRows(rows: Array<Record<string, unknown>>, columns: TargetColumn[]): string {
+  const payload = rows.map((row) => stableJson(Object.fromEntries(
+    columns.map((column) => [column.name, canonicalValue(column, row[column.name])]),
+  ))).join("\n");
+  return sha256(payload);
+}
+
+function checksumBatches(batches: CanonicalBatch[]): string {
+  return sha256(
+    batches
+      .sort((left, right) => left.batchSequence - right.batchSequence)
+      .map((batch) => `${batch.batchSequence}:${batch.rowCount}:${batch.checksum}`)
+      .join("\n"),
+  );
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof SqlitePostgresMigrationError) {
+    return `${error.code}: ${error.message}`;
+  }
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+function jsonCursor(row: Record<string, unknown>, columns: string[]): SqliteMigrationCursor {
+  return Object.fromEntries(columns.map((column) => {
+    const value = row[column];
+    if (value == null || typeof value === "string" || typeof value === "number"
+      || typeof value === "boolean") {
+      return [column, value ?? null];
+    }
+    if (typeof value === "bigint") return [column, value.toString()];
+    if (value instanceof Date) return [column, value.toISOString()];
+    return [column, String(value)];
+  }));
+}
+
+function sourceSnapshotFromRun(snapshot: SqlitePostgresMigrationSnapshot): SqliteMigrationSourceSnapshot {
+  return snapshot.run.sourceSnapshot as unknown as SqliteMigrationSourceSnapshot;
+}
+
+function assertFrozenSnapshotMatches(
+  expected: SqliteMigrationSourceSnapshot,
+  actual: SqliteMigrationSourceSnapshot,
+): void {
+  const expectedRows = new Map(expected.tables.map((table) => [table.name, table.rowCount]));
+  const matches = actual.integrityOk
+    && actual.foreignKeyViolationCount === 0
+    && actual.schemaHash === expected.schemaHash
+    && actual.sourceSchemaVersion === expected.sourceSchemaVersion
+    && actual.tables.length === expected.tables.length
+    && actual.tables.every((table) => expectedRows.get(table.name) === table.rowCount);
+  if (!matches) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_FROZEN_SNAPSHOT_MISMATCH",
+      "执行时提供的 SQLite 冻结备份与已持久化迁移计划不一致",
+      409,
+    );
+  }
+  if (actual.walPresent && actual.walSize > 0) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_FROZEN_SNAPSHOT_HAS_WAL",
+      "执行源仍存在非空 WAL，不是可安全恢复的冻结快照",
+      409,
+      { walSize: actual.walSize },
+    );
+  }
+}
+
+async function inspectTargetTable(
+  adapter: DatabaseAdapter,
+  tableName: string,
+): Promise<TargetTableShape> {
+  const columns = await adapter.queryMany<{
+    name: string;
+    dataType: string;
+    udtName: string;
+    isNullable: string;
+    columnDefault: string | null;
+    isIdentity: string;
+  }>(
+    `SELECT column_name AS name,
+            data_type AS "dataType",
+            udt_name AS "udtName",
+            is_nullable AS "isNullable",
+            column_default AS "columnDefault",
+            is_identity AS "isIdentity"
+       FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = ?
+      ORDER BY ordinal_position`,
+    [tableName],
+  );
+  if (columns.length === 0) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_TARGET_TABLE_MISSING",
+      "目标 PostgreSQL 表不存在",
+      409,
+      { tableName },
+    );
+  }
+  const normalizedColumns: TargetColumn[] = columns.map((column) => ({
+    name: column.name,
+    dataType: column.dataType,
+    udtName: column.udtName,
+    nullable: column.isNullable === "YES",
+    columnDefault: column.columnDefault,
+    identity: column.isIdentity === "YES",
+  }));
+  const nullableByName = new Map(normalizedColumns.map((column) => [column.name, column.nullable]));
+  const foreignKeys = await adapter.queryMany<{
+    columnName: string;
+    foreignTableName: string;
+  }>(
+    `SELECT kcu.column_name AS "columnName",
+            ccu.table_name AS "foreignTableName"
+       FROM information_schema.table_constraints tc
+       JOIN information_schema.key_column_usage kcu
+         ON tc.constraint_name = kcu.constraint_name
+        AND tc.constraint_schema = kcu.constraint_schema
+       JOIN information_schema.constraint_column_usage ccu
+         ON ccu.constraint_name = tc.constraint_name
+        AND ccu.constraint_schema = tc.constraint_schema
+      WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+        AND tc.table_name = ?
+      ORDER BY kcu.ordinal_position`,
+    [tableName],
+  );
+  return {
+    columns: normalizedColumns,
+    foreignKeys: foreignKeys.map((foreignKey) => ({
+      ...foreignKey,
+      nullable: nullableByName.get(foreignKey.columnName) === true,
+    })),
+  };
+}
+
+function resolveColumns(
+  sourceTable: SqliteMigrationTable,
+  target: TargetTableShape,
+): TargetColumn[] {
+  const sourceNames = new Set(sourceTable.columns.map((column) => column.name));
+  const targetByName = new Map(target.columns.map((column) => [column.name, column]));
+  const missingTargetColumns = [...sourceNames].filter((name) => !targetByName.has(name));
+  if (missingTargetColumns.length > 0) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_TARGET_COLUMNS_MISSING",
+      "目标 PostgreSQL 缺少 SQLite 源列",
+      409,
+      { tableName: sourceTable.name, columns: missingTargetColumns },
+    );
+  }
+  const requiredTargetColumns = target.columns.filter((column) => (
+    !sourceNames.has(column.name)
+    && !column.nullable
+    && column.columnDefault == null
+    && !column.identity
+  ));
+  if (requiredTargetColumns.length > 0) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_SOURCE_COLUMNS_MISSING",
+      "SQLite 源表缺少目标 PostgreSQL 必填列",
+      409,
+      {
+        tableName: sourceTable.name,
+        columns: requiredTargetColumns.map((column) => column.name),
+      },
+    );
+  }
+  return sourceTable.columns.map((column) => targetByName.get(column.name)!);
+}
+
+function buildUpsertStatement(input: {
+  tableName: string;
+  columns: TargetColumn[];
+  primaryKeyColumns: string[];
+  row: Record<string, unknown>;
+  deferredSelfColumns: Set<string>;
+}): DbStatement {
+  const columnNames = input.columns.map((column) => column.name);
+  const values = input.columns.map((column) => (
+    input.deferredSelfColumns.has(column.name)
+      ? null
+      : convertValue(column, input.row[column.name])
+  ));
+  const identityOverride = input.columns.some((column) => column.identity)
+    ? " OVERRIDING SYSTEM VALUE"
+    : "";
+  const updates = columnNames
+    .filter((column) => !input.primaryKeyColumns.includes(column))
+    .map((column) => `${quoteIdentifier(column)} = EXCLUDED.${quoteIdentifier(column)}`);
+  const conflictSql = updates.length > 0
+    ? `DO UPDATE SET ${updates.join(", ")}`
+    : "DO NOTHING";
+  return {
+    sql: `INSERT INTO ${quoteIdentifier(input.tableName)}
+            (${columnNames.map(quoteIdentifier).join(", ")})${identityOverride}
+          VALUES (${columnNames.map(() => "?").join(", ")})
+          ON CONFLICT (${input.primaryKeyColumns.map(quoteIdentifier).join(", ")})
+          ${conflictSql}`,
+    params: values,
+  };
+}
+
+async function repairSelfReferences(input: {
+  adapter: DatabaseAdapter;
+  reader: SqliteMigrationReader;
+  tableName: string;
+  primaryKeyColumns: string[];
+  deferredColumns: TargetColumn[];
+  batchSize: number;
+}): Promise<void> {
+  if (input.deferredColumns.length === 0) return;
+  const projection = Array.from(new Set([
+    ...input.primaryKeyColumns,
+    ...input.deferredColumns.map((column) => column.name),
+  ]));
+  let cursor: SqliteMigrationCursor | null = null;
+  while (true) {
+    const batch = input.reader.readBatch({
+      tableName: input.tableName,
+      columns: projection,
+      primaryKeyColumns: input.primaryKeyColumns,
+      lastCursor: cursor,
+      limit: input.batchSize,
+    });
+    if (batch.rows.length === 0) return;
+    const statements: DbStatement[] = batch.rows.map((row) => ({
+      sql: `UPDATE ${quoteIdentifier(input.tableName)}
+               SET ${input.deferredColumns
+                 .map((column) => `${quoteIdentifier(column.name)} = ?`)
+                 .join(", ")}
+             WHERE ${input.primaryKeyColumns
+               .map((column) => `${quoteIdentifier(column)} = ?`)
+               .join(" AND ")}`,
+      params: [
+        ...input.deferredColumns.map((column) => convertValue(column, row[column.name])),
+        ...input.primaryKeyColumns.map((column) => row[column]),
+      ],
+      requireChanges: 1,
+    }));
+    await input.adapter.executeStatements(statements);
+    cursor = batch.cursorEnd;
+  }
+}
+
+async function repairIdentitySequences(
+  adapter: DatabaseAdapter,
+  tableName: string,
+  columns: TargetColumn[],
+): Promise<void> {
+  for (const column of columns.filter((entry) => entry.identity)) {
+    const sequence = await adapter.queryOne<{ sequenceName: string | null }>(
+      `SELECT pg_get_serial_sequence(?, ?) AS "sequenceName"`,
+      [`public.${tableName}`, column.name],
+    );
+    if (!sequence?.sequenceName) continue;
+    await adapter.queryOne(
+      `SELECT setval(
+          ?::regclass,
+          COALESCE(MAX(${quoteIdentifier(column.name)})::bigint, 1),
+          COUNT(*) > 0
+        )
+         FROM ${quoteIdentifier(tableName)}`,
+      [sequence.sequenceName],
+    );
+  }
+}
+
+async function readTargetBatch(input: {
+  adapter: DatabaseAdapter;
+  tableName: string;
+  columns: TargetColumn[];
+  primaryKeyColumns: string[];
+  lastCursor: SqliteMigrationCursor | null;
+  limit: number;
+}): Promise<Array<Record<string, unknown>>> {
+  const params: unknown[] = [];
+  let whereSql = "";
+  if (input.lastCursor) {
+    const cursorValues = input.primaryKeyColumns.map((column) => input.lastCursor![column]);
+    whereSql = ` WHERE (${input.primaryKeyColumns.map(quoteIdentifier).join(", ")})
+                       > (${input.primaryKeyColumns.map(() => "?").join(", ")})`;
+    params.push(...cursorValues);
+  }
+  params.push(input.limit);
+  return input.adapter.queryMany<Record<string, unknown>>(
+    `SELECT ${input.columns.map((column) => quoteIdentifier(column.name)).join(", ")}
+       FROM ${quoteIdentifier(input.tableName)}${whereSql}
+      ORDER BY ${input.primaryKeyColumns.map(quoteIdentifier).join(", ")}
+      LIMIT ?`,
+    params,
+  );
+}
+
+async function verifyTargetBatches(input: {
+  adapter: DatabaseAdapter;
+  tableName: string;
+  columns: TargetColumn[];
+  primaryKeyColumns: string[];
+  sourceBatches: CanonicalBatch[];
+  batchSize: number;
+}): Promise<{ rowCount: number; checksum: string }> {
+  const targetBatches: CanonicalBatch[] = [];
+  let cursor: SqliteMigrationCursor | null = null;
+  let sequence = 0;
+  let rowCount = 0;
+  while (true) {
+    const rows = await readTargetBatch({ ...input, lastCursor: cursor, limit: input.batchSize });
+    if (rows.length === 0) break;
+    const checksum = checksumRows(rows, input.columns);
+    targetBatches.push({ batchSequence: sequence, rowCount: rows.length, checksum });
+    rowCount += rows.length;
+    cursor = jsonCursor(rows[rows.length - 1], input.primaryKeyColumns);
+    sequence += 1;
+  }
+
+  if (targetBatches.length !== input.sourceBatches.length) {
+    throw new SqlitePostgresMigrationError(
+      "SQLITE_PG_MIGRATION_BATCH_COUNT_MISMATCH",
+      "PostgreSQL 目标表批次数与 SQLite 源表不一致",
+      409,
+      { tableName: input.tableName },
+    );
+  }
+  for (let index = 0; index < input.sourceBatches.length; index += 1) {
+    const source = input.sourceBatches[index];
+    const target = targetBatches[index];
+    if (source.rowCount !== target.rowCount || source.checksum !== target.checksum) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_BATCH_CHECKSUM_MISMATCH",
+        "PostgreSQL 目标批次与 SQLite 源批次内容不一致",
+        409,
+        { tableName: input.tableName, batchSequence: source.batchSequence },
+      );
+    }
+  }
+  return { rowCount, checksum: checksumBatches(targetBatches) };
+}
+
+function canonicalBatchesFromCheckpoints(
+  batches: SqlitePostgresMigrationBatchCheckpoint[],
+): CanonicalBatch[] {
+  return batches.map((batch) => {
+    if (!batch.checksum) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_BATCH_CHECKSUM_MISSING",
+        "已完成迁移批次缺少 checksum",
+        500,
+        { tableName: batch.tableName, batchSequence: batch.batchSequence },
+      );
+    }
+    return {
+      batchSequence: batch.batchSequence,
+      rowCount: batch.rowCount,
+      checksum: batch.checksum,
+    };
+  });
+}
+
+export function createSqlitePostgresCopyRuntime(
+  adapter: DatabaseAdapter,
+  options: SqlitePostgresCopyRuntimeOptions = {},
+) {
+  const repository = options.repository || createSqlitePostgresMigrationRepository(adapter);
+  const inspectSource = options.inspectSource || inspectSqliteMigrationSource;
+  const openReader = options.openReader || openSqliteMigrationReader;
+  const configuredBatchSize = Math.max(1, Math.min(2_000, Math.trunc(
+    options.batchSize ?? DEFAULT_BATCH_SIZE,
+  )));
+  const leaseSeconds = Math.max(30, Math.trunc(options.leaseSeconds ?? DEFAULT_LEASE_SECONDS));
+  const maxAttempts = Math.max(1, Math.trunc(options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS));
+
+  function batchSizeFor(snapshot: SqlitePostgresMigrationSnapshot): number {
+    const execution = (snapshot.run.plan as { execution?: { batchSize?: number } }).execution;
+    return Math.max(1, Math.min(2_000, Math.trunc(
+      execution?.batchSize ?? configuredBatchSize,
+    )));
+  }
+
+  async function processClaim(input: {
+    claim: SqlitePostgresMigrationTableClaim;
+    source: SqliteMigrationSourceSnapshot;
+    reader: SqliteMigrationReader;
+    batchSize: number;
+    remainingBatches: { value: number | null };
+  }): Promise<"verified" | "bounded"> {
+    const sourceTable = input.source.tables.find((table) => table.name === input.claim.tableName);
+    if (!sourceTable) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_SOURCE_TABLE_MISSING",
+        "冻结 SQLite 快照缺少计划中的表",
+        409,
+        { tableName: input.claim.tableName },
+      );
+    }
+    if (sourceTable.primaryKeyColumns.length === 0) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_PRIMARY_KEY_REQUIRED",
+        "实际复制阶段要求每个业务表具备稳定主键",
+        409,
+        { tableName: sourceTable.name },
+      );
+    }
+
+    const target = await inspectTargetTable(adapter, sourceTable.name);
+    const columns = resolveColumns(sourceTable, target);
+    const targetByName = new Map(columns.map((column) => [column.name, column]));
+    const deferredSelfColumns = target.foreignKeys
+      .filter((foreignKey) => foreignKey.foreignTableName === sourceTable.name)
+      .map((foreignKey) => {
+        if (!foreignKey.nullable) {
+          throw new SqlitePostgresMigrationError(
+            "SQLITE_PG_MIGRATION_SELF_REFERENCE_NOT_NULL",
+            "检测到不可置空的自引用外键，当前安全执行器无法分阶段恢复",
+            409,
+            { tableName: sourceTable.name, column: foreignKey.columnName },
+          );
+        }
+        return targetByName.get(foreignKey.columnName);
+      })
+      .filter((column): column is TargetColumn => Boolean(column));
+    const deferredNames = new Set(deferredSelfColumns.map((column) => column.name));
+
+    let cursor = input.claim.lastCursor as SqliteMigrationCursor | null;
+    let copiedRows = input.claim.copiedRows;
+    while (true) {
+      const batch = input.reader.readBatch({
+        tableName: sourceTable.name,
+        columns: sourceTable.columns.map((column) => column.name),
+        primaryKeyColumns: sourceTable.primaryKeyColumns,
+        lastCursor: cursor,
+        limit: input.batchSize,
+      });
+      if (batch.rows.length === 0) break;
+      const completed = await repository.getCompletedBatches({
+        runId: input.claim.runId,
+        tableName: sourceTable.name,
+      });
+      const batchSequence = completed.length;
+      const canonicalRows = batch.rows.map((row) => Object.fromEntries(
+        columns.map((column) => [column.name, convertValue(column, row[column.name])]),
+      ));
+      const checksum = checksumRows(canonicalRows, columns);
+      const statements = batch.rows.map((row) => buildUpsertStatement({
+        tableName: sourceTable.name,
+        columns,
+        primaryKeyColumns: sourceTable.primaryKeyColumns,
+        row,
+        deferredSelfColumns: deferredNames,
+      }));
+      copiedRows += batch.rows.length;
+      await repository.commitBatch({
+        runId: input.claim.runId,
+        tableName: sourceTable.name,
+        leaseToken: input.claim.leaseToken,
+        batchSequence,
+        cursorStart: batch.cursorStart,
+        cursorEnd: batch.cursorEnd,
+        rowCount: batch.rows.length,
+        checksum,
+        copiedRows,
+        lastCursor: batch.cursorEnd!,
+        leaseSeconds,
+        statements,
+      });
+      cursor = batch.cursorEnd;
+      if (input.remainingBatches.value != null) {
+        input.remainingBatches.value -= 1;
+        if (input.remainingBatches.value <= 0) {
+          await repository.releaseTableLease({
+            runId: input.claim.runId,
+            tableName: sourceTable.name,
+            leaseToken: input.claim.leaseToken,
+          });
+          return "bounded";
+        }
+      }
+    }
+
+    if (copiedRows !== sourceTable.rowCount) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_SOURCE_ROW_COUNT_DRIFT",
+        "SQLite 冻结快照实际读取行数与预检计划不一致",
+        409,
+        { tableName: sourceTable.name, expected: sourceTable.rowCount, actual: copiedRows },
+      );
+    }
+    const completedBatches = canonicalBatchesFromCheckpoints(
+      await repository.getCompletedBatches({
+        runId: input.claim.runId,
+        tableName: sourceTable.name,
+      }),
+    );
+    const sourceChecksum = checksumBatches(completedBatches);
+    await repository.markTableVerifying({
+      runId: input.claim.runId,
+      tableName: sourceTable.name,
+      leaseToken: input.claim.leaseToken,
+      sourceChecksum,
+      leaseSeconds,
+    });
+    await repairSelfReferences({
+      adapter,
+      reader: input.reader,
+      tableName: sourceTable.name,
+      primaryKeyColumns: sourceTable.primaryKeyColumns,
+      deferredColumns: deferredSelfColumns,
+      batchSize: input.batchSize,
+    });
+    await repairIdentitySequences(adapter, sourceTable.name, columns);
+    const verified = await verifyTargetBatches({
+      adapter,
+      tableName: sourceTable.name,
+      columns,
+      primaryKeyColumns: sourceTable.primaryKeyColumns,
+      sourceBatches: completedBatches,
+      batchSize: input.batchSize,
+    });
+    if (verified.rowCount !== sourceTable.rowCount || verified.checksum !== sourceChecksum) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_TABLE_VERIFY_FAILED",
+        "PostgreSQL 目标表整体验证失败",
+        409,
+        { tableName: sourceTable.name },
+      );
+    }
+    await repository.markTableVerified({
+      runId: input.claim.runId,
+      tableName: sourceTable.name,
+      leaseToken: input.claim.leaseToken,
+      verifiedRows: verified.rowCount,
+      targetChecksum: verified.checksum,
+    });
+    return "verified";
+  }
+
+  async function apply(input: {
+    runId: string;
+    snapshotPath: string;
+    maxBatches?: number | null;
+  }): Promise<SqlitePostgresMigrationSnapshot> {
+    let snapshot = await repository.getSnapshotByRunId(input.runId);
+    if (snapshot.run.status === "completed") return snapshot;
+    if (!snapshot.run.targetWasEmpty) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_NON_EMPTY_APPLY_NOT_ENABLED",
+        "当前复制执行切片仅允许写入预检时为空的 PostgreSQL 目标库",
+        409,
+      );
+    }
+    const expectedSource = sourceSnapshotFromRun(snapshot);
+    const frozenSource = inspectSource(input.snapshotPath);
+    assertFrozenSnapshotMatches(expectedSource, frozenSource);
+    const reader = openReader(input.snapshotPath);
+    const remainingBatches = {
+      value: input.maxBatches == null
+        ? null
+        : Math.max(1, Math.trunc(input.maxBatches)),
+    };
+    const batchSize = batchSizeFor(snapshot);
+
+    try {
+      while (true) {
+        const claim = await repository.claimNextTable({
+          runId: snapshot.run.id,
+          maxAttempts,
+          leaseSeconds,
+        });
+        if (!claim) break;
+        try {
+          const result = await processClaim({
+            claim,
+            source: frozenSource,
+            reader,
+            batchSize,
+            remainingBatches,
+          });
+          if (result === "bounded") return repository.getSnapshotByRunId(snapshot.run.id);
+        } catch (error) {
+          await repository.markTableFailed({
+            runId: claim.runId,
+            tableName: claim.tableName,
+            leaseToken: claim.leaseToken,
+            error: errorMessage(error),
+            retryDelaySeconds: 0,
+          }).catch((leaseError) => {
+            if (!(leaseError instanceof SqlitePostgresMigrationError)
+              || leaseError.code !== "SQLITE_PG_MIGRATION_TABLE_LEASE_LOST") {
+              throw leaseError;
+            }
+          });
+          throw error;
+        }
+        snapshot = await repository.getSnapshotByRunId(snapshot.run.id);
+      }
+      return repository.getSnapshotByRunId(snapshot.run.id);
+    } finally {
+      reader.close();
+    }
+  }
+
+  async function recomputeSourceBatches(input: {
+    reader: SqliteMigrationReader;
+    sourceTable: SqliteMigrationTable;
+    columns: TargetColumn[];
+    batchSize: number;
+  }): Promise<CanonicalBatch[]> {
+    const batches: CanonicalBatch[] = [];
+    let cursor: SqliteMigrationCursor | null = null;
+    let sequence = 0;
+    while (true) {
+      const batch = input.reader.readBatch({
+        tableName: input.sourceTable.name,
+        columns: input.sourceTable.columns.map((column) => column.name),
+        primaryKeyColumns: input.sourceTable.primaryKeyColumns,
+        lastCursor: cursor,
+        limit: input.batchSize,
+      });
+      if (batch.rows.length === 0) return batches;
+      const canonicalRows = batch.rows.map((row) => Object.fromEntries(
+        input.columns.map((column) => [column.name, convertValue(column, row[column.name])]),
+      ));
+      batches.push({
+        batchSequence: sequence,
+        rowCount: batch.rows.length,
+        checksum: checksumRows(canonicalRows, input.columns),
+      });
+      cursor = batch.cursorEnd;
+      sequence += 1;
+    }
+  }
+
+  async function verify(input: {
+    runId: string;
+    snapshotPath: string;
+  }): Promise<SqlitePostgresCopyVerificationReport> {
+    const snapshot = await repository.getSnapshotByRunId(input.runId);
+    const expectedSource = sourceSnapshotFromRun(snapshot);
+    const frozenSource = inspectSource(input.snapshotPath);
+    assertFrozenSnapshotMatches(expectedSource, frozenSource);
+    const reader = openReader(input.snapshotPath);
+    const batchSize = batchSizeFor(snapshot);
+    const tables: SqlitePostgresCopyVerificationTable[] = [];
+    const failures: SqlitePostgresCopyVerificationReport["failures"] = [];
+    try {
+      for (const sourceTable of frozenSource.tables) {
+        try {
+          if (sourceTable.primaryKeyColumns.length === 0) {
+            throw new SqlitePostgresMigrationError(
+              "SQLITE_PG_MIGRATION_PRIMARY_KEY_REQUIRED",
+              "独立校验要求业务表具备稳定主键",
+              409,
+              { tableName: sourceTable.name },
+            );
+          }
+          const target = await inspectTargetTable(adapter, sourceTable.name);
+          const columns = resolveColumns(sourceTable, target);
+          const sourceBatches = await recomputeSourceBatches({
+            reader,
+            sourceTable,
+            columns,
+            batchSize,
+          });
+          const sourceChecksum = checksumBatches(sourceBatches);
+          const targetResult = await verifyTargetBatches({
+            adapter,
+            tableName: sourceTable.name,
+            columns,
+            primaryKeyColumns: sourceTable.primaryKeyColumns,
+            sourceBatches,
+            batchSize,
+          });
+          const matched = targetResult.rowCount === sourceTable.rowCount
+            && targetResult.checksum === sourceChecksum;
+          tables.push({
+            tableName: sourceTable.name,
+            sourceRows: sourceTable.rowCount,
+            targetRows: targetResult.rowCount,
+            sourceChecksum,
+            targetChecksum: targetResult.checksum,
+            matched,
+          });
+          if (!matched) {
+            failures.push({
+              tableName: sourceTable.name,
+              code: "SQLITE_PG_MIGRATION_TABLE_VERIFY_FAILED",
+              message: "目标表行数或 checksum 不一致",
+            });
+          }
+        } catch (error) {
+          failures.push({
+            tableName: sourceTable.name,
+            code: error instanceof SqlitePostgresMigrationError
+              ? error.code
+              : "SQLITE_PG_MIGRATION_VERIFY_FAILED",
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } finally {
+      reader.close();
+    }
+    return {
+      generatedAt: new Date().toISOString(),
+      ok: failures.length === 0,
+      runId: snapshot.run.id,
+      tables,
+      failures,
+    };
+  }
+
+  return { apply, verify };
+}

--- a/backend/src/services/sqlite-postgres-migration-runtime.ts
+++ b/backend/src/services/sqlite-postgres-migration-runtime.ts
@@ -12,6 +12,10 @@ import {
   type SqlitePostgresMigrationSnapshot,
   type SqlitePostgresMigrationTablePlan,
 } from "../repositories/sqlitePostgresMigrationRepository";
+import {
+  createSqlitePostgresCopyRuntime,
+  type SqlitePostgresCopyVerificationReport,
+} from "./sqlite-postgres-copy-runtime";
 
 export type SqlitePostgresMigrationRisk = {
   code: string;
@@ -53,6 +57,11 @@ export type SqlitePostgresMigrationDryRunReport = {
     totalRows: number;
     deferredTables: string[];
     unsupportedTables: string[];
+    execution: {
+      batchSize: number;
+      source: "verified-backup";
+      writes: "transactional-upsert-checkpoint";
+    };
   };
   blockers: SqlitePostgresMigrationRisk[];
   warnings: SqlitePostgresMigrationRisk[];
@@ -60,6 +69,7 @@ export type SqlitePostgresMigrationDryRunReport = {
 
 export type SqlitePostgresMigrationRuntimeOptions = {
   repository?: ReturnType<typeof createSqlitePostgresMigrationRepository>;
+  copy?: ReturnType<typeof createSqlitePostgresCopyRuntime>;
   inspectSource?: typeof inspectSqliteMigrationSource;
 };
 
@@ -70,6 +80,8 @@ const TARGET_METADATA_TABLES = new Set([
   "sqlite_postgres_migration_table_checkpoints",
   "sqlite_postgres_migration_batch_checkpoints",
 ]);
+
+const DEFAULT_BATCH_SIZE = 200;
 
 function quoteIdentifier(value: string): string {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
@@ -99,6 +111,10 @@ function sha256(value: unknown): string {
   return createHash("sha256").update(stableJson(value)).digest("hex");
 }
 
+function normalizeBatchSize(value: number | undefined): number {
+  return Math.max(1, Math.min(2_000, Math.trunc(value ?? DEFAULT_BATCH_SIZE)));
+}
+
 function backupMatches(
   source: SqliteMigrationSourceSnapshot,
   backup: SqliteMigrationSourceSnapshot,
@@ -115,12 +131,19 @@ function backupMatches(
 function orderTables(tables: SqliteMigrationTable[]): {
   ordered: SqliteMigrationTable[];
   cyclic: string[];
+  selfReferential: string[];
 } {
   const byName = new Map(tables.map((table) => [table.name, table]));
+  const selfReferential = tables
+    .filter((table) => table.dependencies.includes(table.name))
+    .map((table) => table.name)
+    .sort();
   const dependencies = new Map(
     tables.map((table) => [
       table.name,
-      new Set(table.dependencies.filter((dependency) => byName.has(dependency))),
+      new Set(table.dependencies.filter(
+        (dependency) => dependency !== table.name && byName.has(dependency),
+      )),
     ]),
   );
   const remaining = new Set(byName.keys());
@@ -140,7 +163,7 @@ function orderTables(tables: SqliteMigrationTable[]): {
 
   const cyclic = [...remaining].sort();
   for (const name of cyclic) ordered.push(byName.get(name)!);
-  return { ordered, cyclic };
+  return { ordered, cyclic, selfReferential };
 }
 
 async function inspectPostgresTarget(
@@ -194,17 +217,20 @@ export function createSqlitePostgresMigrationRuntime(
   const repository = options.repository
     || createSqlitePostgresMigrationRepository(adapter);
   const inspectSource = options.inspectSource || inspectSqliteMigrationSource;
+  const copy = options.copy || createSqlitePostgresCopyRuntime(adapter, { repository });
 
   async function dryRun(input: {
     sourcePath: string;
     backupPath?: string | null;
     allowNonEmptyTarget?: boolean;
+    batchSize?: number;
   }): Promise<SqlitePostgresMigrationDryRunReport> {
     const source = inspectSource(input.sourcePath);
     const backup = input.backupPath ? inspectSource(input.backupPath) : null;
     const target = await inspectPostgresTarget(adapter);
     const blockers: SqlitePostgresMigrationRisk[] = [];
     const warnings: SqlitePostgresMigrationRisk[] = [];
+    const batchSize = normalizeBatchSize(input.batchSize);
 
     if (!source.integrityOk) {
       blockers.push({
@@ -257,14 +283,14 @@ export function createSqlitePostgresMigrationRuntime(
     if (source.walPresent && source.walSize > 0) {
       warnings.push({
         code: "SQLITE_WAL_PRESENT",
-        message: "源数据库存在非空 WAL；正式执行前应先生成一致性快照",
+        message: "源数据库存在非空 WAL；正式执行将只读取已验证的冻结备份",
         details: { walSize: source.walSize },
       });
     }
     if (input.allowNonEmptyTarget && !target.targetWasEmpty) {
       warnings.push({
         code: "POSTGRES_NON_EMPTY_OVERRIDE",
-        message: "已显式允许非空目标库；后续写入必须使用幂等 upsert 与冲突报告",
+        message: "已显式允许非空目标库进行规划；当前 apply 执行器仍只开放空目标库写入",
         details: { totalBusinessRows: target.totalBusinessRows },
       });
     }
@@ -290,12 +316,31 @@ export function createSqlitePostgresMigrationRuntime(
     }
 
     const migratable = source.tables.filter((table) => targetNames.has(table.name));
-    const { ordered, cyclic } = orderTables(migratable);
+    const withoutPrimaryKey = migratable
+      .filter((table) => table.primaryKeyColumns.length === 0)
+      .map((table) => table.name)
+      .sort();
+    if (withoutPrimaryKey.length > 0) {
+      blockers.push({
+        code: "SQLITE_PRIMARY_KEY_REQUIRED",
+        message: "实际复制要求每个业务表具备稳定主键游标",
+        details: { tables: withoutPrimaryKey },
+      });
+    }
+
+    const { ordered, cyclic, selfReferential } = orderTables(migratable);
     if (cyclic.length > 0) {
-      warnings.push({
-        code: "SQLITE_FOREIGN_KEY_CYCLE",
-        message: "检测到循环外键；执行器需在延迟约束事务中处理这些表",
+      blockers.push({
+        code: "SQLITE_FOREIGN_KEY_CYCLE_UNSUPPORTED",
+        message: "检测到跨表循环外键，当前安全执行器不会绕过 PostgreSQL 约束",
         details: { tables: cyclic },
+      });
+    }
+    if (selfReferential.length > 0) {
+      warnings.push({
+        code: "SQLITE_SELF_REFERENTIAL_TABLES",
+        message: "自引用外键将在行复制后以幂等修复批次恢复",
+        details: { tables: selfReferential },
       });
     }
     const tablePlan = ordered.map((table, dependencyOrder) => ({
@@ -322,69 +367,132 @@ export function createSqlitePostgresMigrationRuntime(
         totalRows: tablePlan.reduce((sum, table) => sum + table.totalRows, 0),
         deferredTables: source.excludedTables,
         unsupportedTables,
+        execution: {
+          batchSize,
+          source: "verified-backup",
+          writes: "transactional-upsert-checkpoint",
+        },
       },
       blockers,
       warnings,
     };
   }
 
+  async function prepareApply(input: {
+    idempotencyKey: string;
+    sourcePath: string;
+    backupPath: string;
+    allowNonEmptyTarget?: boolean;
+    batchSize?: number;
+  }): Promise<{
+    report: SqlitePostgresMigrationDryRunReport;
+    snapshot: SqlitePostgresMigrationSnapshot;
+    reused: boolean;
+  }> {
+    const report = await dryRun(input);
+    if (!report.canApply) {
+      throw new SqlitePostgresMigrationError(
+        "SQLITE_PG_MIGRATION_PREFLIGHT_BLOCKED",
+        "SQLite → PostgreSQL 迁移预检未通过",
+        409,
+        {
+          blockers: report.blockers.map((blocker) => blocker.code),
+        },
+      );
+    }
+
+    const requestHash = sha256({
+      sourceFingerprint: report.source.sourceFingerprint,
+      backupFingerprint: report.backup.snapshot?.sourceFingerprint ?? null,
+      targetLatestMigration: report.target.latestMigration,
+      targetWasEmpty: report.target.targetWasEmpty,
+      allowNonEmptyTarget: Boolean(input.allowNonEmptyTarget),
+      tables: report.plan.tables,
+      execution: report.plan.execution,
+    });
+    const created = await repository.createPlannedRun({
+      idempotencyKey: input.idempotencyKey,
+      requestHash,
+      sourceFingerprint: report.source.sourceFingerprint,
+      sourcePathHint: report.source.sourcePathHint,
+      sourceSchemaVersion: report.source.sourceSchemaVersion,
+      sourceFileSize: report.source.fileSize,
+      sourceModifiedAt: report.source.modifiedAt,
+      sourceSnapshot: report.source as unknown as Record<string, unknown>,
+      plan: report.plan as unknown as Record<string, unknown>,
+      targetWasEmpty: report.target.targetWasEmpty,
+      allowNonEmptyTarget: Boolean(input.allowNonEmptyTarget),
+      tables: report.plan.tables,
+    });
+
+    return {
+      report,
+      snapshot: created.snapshot,
+      reused: created.reused,
+    };
+  }
+
   return {
     dryRun,
+    prepareApply,
 
-    async prepareApply(input: {
+    async apply(input: {
       idempotencyKey: string;
       sourcePath: string;
       backupPath: string;
       allowNonEmptyTarget?: boolean;
+      batchSize?: number;
+      maxBatches?: number | null;
     }): Promise<{
-      report: SqlitePostgresMigrationDryRunReport;
+      report: SqlitePostgresMigrationDryRunReport | null;
       snapshot: SqlitePostgresMigrationSnapshot;
       reused: boolean;
     }> {
-      const report = await dryRun(input);
-      if (!report.canApply) {
-        throw new SqlitePostgresMigrationError(
-          "SQLITE_PG_MIGRATION_PREFLIGHT_BLOCKED",
-          "SQLite → PostgreSQL 迁移预检未通过",
-          409,
-          {
-            blockers: report.blockers.map((blocker) => blocker.code),
-          },
-        );
+      let prepared: Awaited<ReturnType<typeof prepareApply>> | null = null;
+      let existing: SqlitePostgresMigrationSnapshot | null = null;
+      try {
+        existing = await repository.getSnapshotByIdempotencyKey(input.idempotencyKey);
+      } catch (error) {
+        if (!(error instanceof SqlitePostgresMigrationError)
+          || error.code !== "SQLITE_PG_MIGRATION_RUN_NOT_FOUND") {
+          throw error;
+        }
       }
-
-      const requestHash = sha256({
-        sourceFingerprint: report.source.sourceFingerprint,
-        backupFingerprint: report.backup.snapshot?.sourceFingerprint ?? null,
-        targetLatestMigration: report.target.latestMigration,
-        targetWasEmpty: report.target.targetWasEmpty,
-        allowNonEmptyTarget: Boolean(input.allowNonEmptyTarget),
-        tables: report.plan.tables,
+      if (!existing) {
+        prepared = await prepareApply(input);
+        existing = prepared.snapshot;
+      }
+      const snapshot = await copy.apply({
+        runId: existing.run.id,
+        snapshotPath: input.backupPath,
+        maxBatches: input.maxBatches,
       });
-      const created = await repository.createPlannedRun({
-        idempotencyKey: input.idempotencyKey,
-        requestHash,
-        sourceFingerprint: report.source.sourceFingerprint,
-        sourcePathHint: report.source.sourcePathHint,
-        sourceSchemaVersion: report.source.sourceSchemaVersion,
-        sourceFileSize: report.source.fileSize,
-        sourceModifiedAt: report.source.modifiedAt,
-        sourceSnapshot: report.source as unknown as Record<string, unknown>,
-        plan: report.plan as unknown as Record<string, unknown>,
-        targetWasEmpty: report.target.targetWasEmpty,
-        allowNonEmptyTarget: Boolean(input.allowNonEmptyTarget),
-        tables: report.plan.tables,
-      });
-
       return {
-        report,
-        snapshot: created.snapshot,
-        reused: created.reused,
+        report: prepared?.report ?? null,
+        snapshot,
+        reused: prepared?.reused ?? true,
       };
+    },
+
+    async verify(input: {
+      idempotencyKey: string;
+      backupPath: string;
+    }): Promise<SqlitePostgresCopyVerificationReport> {
+      const snapshot = await repository.getSnapshotByIdempotencyKey(input.idempotencyKey);
+      return copy.verify({
+        runId: snapshot.run.id,
+        snapshotPath: input.backupPath,
+      });
     },
 
     getStatus(runId: string): Promise<SqlitePostgresMigrationSnapshot> {
       return repository.getSnapshotByRunId(runId);
+    },
+
+    getStatusByIdempotencyKey(
+      idempotencyKey: string,
+    ): Promise<SqlitePostgresMigrationSnapshot> {
+      return repository.getSnapshotByIdempotencyKey(idempotencyKey);
     },
   };
 }

--- a/backend/tests/sqlite-postgres-migration-runtime-pg.test.ts
+++ b/backend/tests/sqlite-postgres-migration-runtime-pg.test.ts
@@ -42,6 +42,35 @@ async function truncateBusinessTables(pool: import("pg").Pool): Promise<void> {
   );
 }
 
+async function resetMigrationMetadata(pool: import("pg").Pool): Promise<void> {
+  await pool.query("DELETE FROM sqlite_postgres_migration_batch_checkpoints");
+  await pool.query("DELETE FROM sqlite_postgres_migration_table_checkpoints");
+  await pool.query("DELETE FROM sqlite_postgres_migration_runs");
+}
+
+async function createTargetFixtures(pool: import("pg").Pool): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS migration_type_fixture (
+      id TEXT PRIMARY KEY,
+      enabled BOOLEAN NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL,
+      payload JSONB NOT NULL,
+      bytes BYTEA NOT NULL,
+      counter BIGINT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS migration_tree_fixture (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT REFERENCES migration_tree_fixture(id),
+      label TEXT NOT NULL
+    );
+  `);
+}
+
+async function dropTargetFixtures(pool: import("pg").Pool): Promise<void> {
+  await pool.query("DROP TABLE IF EXISTS migration_tree_fixture CASCADE");
+  await pool.query("DROP TABLE IF EXISTS migration_type_fixture CASCADE");
+}
+
 function createSource(path: string, extraUser = false): void {
   const db = new Database(path);
   try {
@@ -66,6 +95,22 @@ function createSource(path: string, extraUser = false): void {
         ownerId TEXT NOT NULL,
         FOREIGN KEY (ownerId) REFERENCES users(id)
       );
+
+      CREATE TABLE migration_type_fixture (
+        id TEXT PRIMARY KEY,
+        enabled INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        bytes BLOB NOT NULL,
+        counter INTEGER NOT NULL
+      );
+
+      CREATE TABLE migration_tree_fixture (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT,
+        label TEXT NOT NULL,
+        FOREIGN KEY (parent_id) REFERENCES migration_tree_fixture(id)
+      );
     `);
     const insertUser = db.prepare(
       `INSERT INTO users (id, username, passwordHash, tokenVersion)
@@ -77,6 +122,35 @@ function createSource(path: string, extraUser = false): void {
       `INSERT INTO workspaces (id, name, ownerId)
        VALUES ('migration-workspace-1', 'Migration workspace', 'migration-user-1')`,
     ).run();
+    const insertType = db.prepare(
+      `INSERT INTO migration_type_fixture
+         (id, enabled, created_at, payload, bytes, counter)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    insertType.run(
+      "type-1",
+      1,
+      "2026-08-05 08:00:00",
+      JSON.stringify({ nested: { ok: true }, list: [1, 2, 3] }),
+      Buffer.from([0, 1, 2, 255]),
+      9_007_199_254_740_000n,
+    );
+    insertType.run(
+      "type-2",
+      0,
+      "2026-08-05T09:30:00Z",
+      JSON.stringify({ message: "migration" }),
+      Buffer.from("nowen"),
+      42,
+    );
+    db.prepare(
+      `INSERT INTO migration_tree_fixture (id, parent_id, label)
+       VALUES ('z-parent', NULL, 'Parent')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO migration_tree_fixture (id, parent_id, label)
+       VALUES ('a-child', 'z-parent', 'Child')`,
+    ).run();
   } finally {
     db.close();
   }
@@ -87,16 +161,15 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
 }, async () => {
   const pool = await getPgPool();
   assert.ok(pool);
-  const directory = mkdtempSync(join(tmpdir(), "nowen-pg-data-"));
+  const directory = mkdtempSync(join(tmpdir(), "nowen-pg-data-foundation-"));
   const sourcePath = join(directory, "source.db");
   const backupPath = join(directory, "backup.db");
 
   try {
     await initPgSchema(pool);
+    await createTargetFixtures(pool);
     await truncateBusinessTables(pool);
-    await pool.query("DELETE FROM sqlite_postgres_migration_batch_checkpoints");
-    await pool.query("DELETE FROM sqlite_postgres_migration_table_checkpoints");
-    await pool.query("DELETE FROM sqlite_postgres_migration_runs");
+    await resetMigrationMetadata(pool);
 
     createSource(sourcePath);
     cpSync(sourcePath, backupPath);
@@ -112,6 +185,7 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
     const report = await runtime.dryRun({
       sourcePath,
       backupPath,
+      batchSize: 1,
     });
     const afterDryRun = await pool.query<{ count: string }>(
       "SELECT COUNT(*)::text AS count FROM sqlite_postgres_migration_runs",
@@ -124,13 +198,14 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
     assert.equal(report.source.foreignKeyViolationCount, 0);
     assert.equal(report.source.sourcePathHint, "source.db");
     assert.equal(report.source.sourceSchemaVersion, 78);
+    assert.equal(report.plan.execution.batchSize, 1);
     assert.deepEqual(
       report.plan.tables.map((table) => table.tableName),
-      ["users", "workspaces"],
+      ["migration_tree_fixture", "migration_type_fixture", "users", "workspaces"],
     );
-    assert.deepEqual(
-      report.plan.tables.map((table) => table.primaryKeyColumns),
-      [["id"], ["id"]],
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "SQLITE_SELF_REFERENTIAL_TABLES"),
+      true,
     );
     assert.equal(beforeDryRun.rows[0].count, afterDryRun.rows[0].count);
     assert.equal(statSync(sourcePath).mtimeMs, sourceMtimeBefore);
@@ -139,27 +214,18 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
       idempotencyKey: "sqlite-pg-foundation-001",
       sourcePath,
       backupPath,
+      batchSize: 1,
     });
     assert.equal(prepared.reused, false);
     assert.equal(prepared.snapshot.run.status, "planned");
-    assert.equal(prepared.snapshot.run.totalTables, 2);
-    assert.equal(prepared.snapshot.run.totalRows, 2);
-    assert.deepEqual(
-      prepared.snapshot.tables.map((table) => [
-        table.tableName,
-        table.dependencyOrder,
-        table.status,
-      ]),
-      [
-        ["users", 0, "planned"],
-        ["workspaces", 1, "planned"],
-      ],
-    );
+    assert.equal(prepared.snapshot.run.totalTables, 4);
+    assert.equal(prepared.snapshot.run.totalRows, 6);
 
     const replay = await runtime.prepareApply({
       idempotencyKey: "sqlite-pg-foundation-001",
       sourcePath,
       backupPath,
+      batchSize: 1,
     });
     assert.equal(replay.reused, true);
     assert.equal(replay.snapshot.run.id, prepared.snapshot.run.id);
@@ -169,7 +235,7 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
       leaseSeconds: 30,
     });
     assert.ok(firstClaim);
-    assert.equal(firstClaim.tableName, "users");
+    assert.equal(firstClaim.tableName, "migration_tree_fixture");
 
     const concurrentClaim = await repository.claimNextTable({
       runId: prepared.snapshot.run.id,
@@ -180,7 +246,7 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
     await pool.query(
       `UPDATE sqlite_postgres_migration_table_checkpoints
           SET "leaseExpiresAt" = CURRENT_TIMESTAMP - INTERVAL '1 second'
-        WHERE "runId" = $1 AND "tableName" = 'users'`,
+        WHERE "runId" = $1 AND "tableName" = 'migration_tree_fixture'`,
       [prepared.snapshot.run.id],
     );
     const recoveredClaim = await repository.claimNextTable({
@@ -188,7 +254,7 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
       leaseSeconds: 30,
     });
     assert.ok(recoveredClaim);
-    assert.equal(recoveredClaim.tableName, "users");
+    assert.equal(recoveredClaim.tableName, "migration_tree_fixture");
     assert.notEqual(recoveredClaim.leaseToken, firstClaim.leaseToken);
 
     await repository.markTableCopied({
@@ -196,24 +262,15 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
       tableName: recoveredClaim.tableName,
       leaseToken: recoveredClaim.leaseToken,
       copiedRows: recoveredClaim.totalRows,
-      lastCursor: { id: "migration-user-1" },
+      lastCursor: { id: "z-parent" },
       sourceChecksum: "a".repeat(64),
     });
-    const secondClaim = await repository.claimNextTable({
-      runId: prepared.snapshot.run.id,
-      leaseSeconds: 30,
-    });
-    assert.ok(secondClaim);
-    assert.equal(secondClaim.tableName, "workspaces");
 
     await pool.query(
       `INSERT INTO users (id, username, "passwordHash", "tokenVersion")
        VALUES ('pg-existing-user', 'pg-existing-user', 'hash', 0)`,
     );
-    const blocked = await runtime.dryRun({
-      sourcePath,
-      backupPath,
-    });
+    const blocked = await runtime.dryRun({ sourcePath, backupPath });
     assert.equal(blocked.canApply, false);
     assert(
       blocked.blockers.some((entry) => entry.code === "POSTGRES_TARGET_NOT_EMPTY"),
@@ -239,6 +296,7 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
         idempotencyKey: "sqlite-pg-foundation-001",
         sourcePath,
         backupPath,
+        batchSize: 1,
       }),
       (error: unknown) => {
         assert.equal(
@@ -250,6 +308,145 @@ test("SQLite to PostgreSQL preflight and durable checkpoints are safe and resuma
     );
   } finally {
     rmSync(directory, { recursive: true, force: true });
+    await truncateBusinessTables(pool).catch(() => undefined);
+    await resetMigrationMetadata(pool).catch(() => undefined);
+    await dropTargetFixtures(pool).catch(() => undefined);
+    await closePgPool(pool);
+  }
+});
+
+test("SQLite to PostgreSQL apply is transactional, resumable, idempotent and independently verifiable", {
+  skip: !hasPg,
+}, async () => {
+  const pool = await getPgPool();
+  assert.ok(pool);
+  const directory = mkdtempSync(join(tmpdir(), "nowen-pg-data-copy-"));
+  const sourcePath = join(directory, "source.db");
+  const backupPath = join(directory, "backup.db");
+
+  try {
+    await initPgSchema(pool);
+    await createTargetFixtures(pool);
+    await truncateBusinessTables(pool);
+    await resetMigrationMetadata(pool);
+    createSource(sourcePath);
+    cpSync(sourcePath, backupPath);
+    const sourceMtimeBefore = statSync(sourcePath).mtimeMs;
+    const backupMtimeBefore = statSync(backupPath).mtimeMs;
+
+    const adapter = new PostgresAdapter(pool);
+    const runtime = createSqlitePostgresMigrationRuntime(adapter);
+    const first = await runtime.apply({
+      idempotencyKey: "sqlite-pg-copy-resume-001",
+      sourcePath,
+      backupPath,
+      batchSize: 1,
+      maxBatches: 1,
+    });
+    assert.notEqual(first.snapshot.run.status, "completed");
+    assert.equal(first.snapshot.run.copiedRows, 1);
+    const firstBatchCount = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+         FROM sqlite_postgres_migration_batch_checkpoints
+        WHERE "runId" = $1`,
+      [first.snapshot.run.id],
+    );
+    assert.equal(firstBatchCount.rows[0].count, "1");
+
+    const resumed = await runtime.apply({
+      idempotencyKey: "sqlite-pg-copy-resume-001",
+      sourcePath,
+      backupPath,
+      batchSize: 1,
+    });
+    assert.equal(resumed.reused, true);
+    assert.equal(resumed.snapshot.run.status, "completed");
+    assert.equal(resumed.snapshot.run.copiedRows, 6);
+    assert.equal(resumed.snapshot.run.verifiedRows, 6);
+    assert.equal(resumed.snapshot.progress.complete, true);
+    assert(resumed.snapshot.tables.every((table) => table.status === "verified"));
+    assert(resumed.snapshot.tables.every((table) => table.sourceChecksum === table.targetChecksum));
+
+    const typeRows = await pool.query<{
+      id: string;
+      enabled: boolean;
+      created_at: Date;
+      payload: unknown;
+      bytes: Buffer;
+      counter: string;
+    }>(
+      `SELECT id, enabled, created_at, payload, bytes, counter::text
+         FROM migration_type_fixture
+        ORDER BY id`,
+    );
+    assert.equal(typeRows.rows.length, 2);
+    assert.equal(typeRows.rows[0].enabled, true);
+    assert.equal(typeRows.rows[0].created_at.toISOString(), "2026-08-05T08:00:00.000Z");
+    assert.deepEqual(typeRows.rows[0].payload, { nested: { ok: true }, list: [1, 2, 3] });
+    assert.deepEqual(typeRows.rows[0].bytes, Buffer.from([0, 1, 2, 255]));
+    assert.equal(typeRows.rows[0].counter, "9007199254740000");
+    assert.equal(typeRows.rows[1].enabled, false);
+
+    const treeRows = await pool.query<{ id: string; parent_id: string | null }>(
+      `SELECT id, parent_id FROM migration_tree_fixture ORDER BY id`,
+    );
+    assert.deepEqual(treeRows.rows, [
+      { id: "a-child", parent_id: "z-parent" },
+      { id: "z-parent", parent_id: null },
+    ]);
+
+    const users = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM users WHERE id LIKE 'migration-user-%'`,
+    );
+    const workspaces = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM workspaces WHERE id = 'migration-workspace-1'`,
+    );
+    assert.equal(users.rows[0].count, "1");
+    assert.equal(workspaces.rows[0].count, "1");
+
+    const replay = await runtime.apply({
+      idempotencyKey: "sqlite-pg-copy-resume-001",
+      sourcePath,
+      backupPath,
+      batchSize: 1,
+    });
+    assert.equal(replay.snapshot.run.status, "completed");
+    const replayRows = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM migration_type_fixture`,
+    );
+    assert.equal(replayRows.rows[0].count, "2");
+
+    const verified = await runtime.verify({
+      idempotencyKey: "sqlite-pg-copy-resume-001",
+      backupPath,
+    });
+    assert.equal(verified.ok, true, JSON.stringify(verified.failures));
+    assert.equal(verified.tables.length, 4);
+
+    await pool.query(
+      `UPDATE migration_type_fixture
+          SET payload = '{"tampered":true}'::jsonb
+        WHERE id = 'type-1'`,
+    );
+    const tampered = await runtime.verify({
+      idempotencyKey: "sqlite-pg-copy-resume-001",
+      backupPath,
+    });
+    assert.equal(tampered.ok, false);
+    assert(
+      tampered.failures.some((failure) => (
+        failure.tableName === "migration_type_fixture"
+        && failure.code === "SQLITE_PG_MIGRATION_BATCH_CHECKSUM_MISMATCH"
+      )),
+    );
+
+    assert.equal(statSync(sourcePath).mtimeMs, sourceMtimeBefore);
+    assert.equal(statSync(backupPath).mtimeMs, backupMtimeBefore);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+    await truncateBusinessTables(pool).catch(() => undefined);
+    await resetMigrationMetadata(pool).catch(() => undefined);
+    await dropTargetFixtures(pool).catch(() => undefined);
     await closePgPool(pool);
   }
 });


### PR DESCRIPTION
## Scope

Second independently testable #251 slice on top of `pg-migration-unified`.

### Added

- frozen SQLite backup batch reader
- primary-key cursor pagination
- transactional row upsert + batch checkpoint + table cursor commit
- restart/resume and idempotent replay
- BOOLEAN / TIMESTAMPTZ / JSONB / BYTEA / BIGINT conversion
- nullable self-reference second-pass repair
- identity sequence repair
- per-batch canonical content checksums
- per-table copy verification
- independent `--verify` mode
- `--apply` CLI for empty PostgreSQL targets

### Safety boundaries

- apply reads rows only from the verified frozen backup
- live SQLite source remains preflight-only and read-only
- current apply still refuses non-empty PostgreSQL targets
- cross-table FK cycles remain blocked
- rollback remains disabled until run-owned row tracking exists

### Tests

Real PostgreSQL coverage includes type conversion, child-before-parent self-reference ordering, bounded interruption/resume, replay idempotency, independent verify and tamper detection.