### PR TITLE
fix(sync): 修复单端误冲突、重复副本与保存状态异常

### DIFF
--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -27,12 +27,14 @@ on:
       - "frontend/src/lib/yjsDurability.ts"
       - "frontend/src/lib/draftStorage.ts"
       - "frontend/src/lib/editorLifecycleSafety.ts"
+      - "frontend/src/lib/noteSyncSafety.ts"
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
+      - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -61,12 +63,14 @@ on:
       - "frontend/src/lib/yjsDurability.ts"
       - "frontend/src/lib/draftStorage.ts"
       - "frontend/src/lib/editorLifecycleSafety.ts"
+      - "frontend/src/lib/noteSyncSafety.ts"
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
+      - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -117,6 +121,7 @@ jobs:
           src/components/__tests__/EditorPaneNativeMarkdownCollab.test.ts
           src/lib/__tests__/draftStorage.conflict.test.ts
           src/lib/__tests__/editorLifecycleSafety.test.ts
+          src/lib/__tests__/noteSyncSafety.integration.test.ts
           src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
           src/lib/__tests__/conflictResolution.test.ts
       - name: Frontend typecheck

--- a/frontend/src/lib/__tests__/conflictResolution.test.ts
+++ b/frontend/src/lib/__tests__/conflictResolution.test.ts
@@ -8,18 +8,20 @@ const apiMock = vi.hoisted(() => ({
   createNoteConfirmed: vi.fn(),
 }));
 const discardResolvedQueueItems = vi.hoisted(() => vi.fn());
+const getQueue = vi.hoisted(() => vi.fn());
 const clearDraft = vi.hoisted(() => vi.fn());
 const loadDraft = vi.hoisted(() => vi.fn());
 const clearOfflineNoteSnapshot = vi.hoisted(() => vi.fn());
 const clearNoteSyncConflict = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
-vi.mock("@/lib/offlineQueue", () => ({ discardResolvedQueueItems }));
+vi.mock("@/lib/offlineQueue", () => ({ discardResolvedQueueItems, getQueue }));
 vi.mock("@/lib/draftStorage", () => ({ clearDraft, loadDraft }));
 vi.mock("@/lib/offlineRead", () => ({ clearOfflineNoteSnapshot }));
 vi.mock("@/lib/noteSyncSafety", () => ({ clearNoteSyncConflict }));
 
 import {
+  discardConflictStateForDeletedCopy,
   getConflictCopyId,
   resolveNoteConflict,
   resolveQueuedNoteConflicts,
@@ -87,8 +89,11 @@ describe("resolveNoteConflict", () => {
     vi.clearAllMocks();
     localStorage.clear();
     loadDraft.mockReturnValue(null);
+    getQueue.mockReturnValue([]);
     discardResolvedQueueItems.mockReturnValue({ discarded: true, remainingForNote: false });
     apiMock.getNote.mockResolvedValue(remoteNote());
+    apiMock.updateNoteConfirmed.mockReset();
+    apiMock.createNoteConfirmed.mockReset();
   });
 
   it("distinguishes debounced editor input from the conflict payload already copied", () => {
@@ -264,7 +269,13 @@ describe("resolveNoteConflict", () => {
       status: 409,
       code: "NOTE_ID_CONFLICT",
     });
-    const existingCopy = remoteNote({ id: copyId, title: "已存在的冲突副本", version: 1 });
+    const existingCopy = remoteNote({
+      id: copyId,
+      title: "已存在的冲突副本",
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 1,
+    });
     apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
     apiMock.getNote
       .mockResolvedValueOnce(remoteNote())
@@ -273,8 +284,40 @@ describe("resolveNoteConflict", () => {
     const result = await resolveNoteConflict(item, "use-server");
 
     expect(apiMock.getNote).toHaveBeenNthCalledWith(2, copyId);
+    expect(apiMock.updateNoteConfirmed).not.toHaveBeenCalled();
     expect(result.conflictCopy).toBe(existingCopy);
     expect(discardResolvedQueueItems).toHaveBeenCalledWith(item);
+  });
+
+  it("updates the same deterministic copy when later local input arrives", async () => {
+    const item = conflictItem();
+    const copyId = getConflictCopyId(item.id);
+    const conflictError = Object.assign(new Error("duplicate"), {
+      status: 409,
+      code: "NOTE_ID_CONFLICT",
+    });
+    const existingCopy = remoteNote({ id: copyId, title: "已存在的冲突副本", version: 1 });
+    const refreshedCopy = remoteNote({
+      id: copyId,
+      title: "已存在的冲突副本",
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 2,
+    });
+    apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
+    apiMock.getNote
+      .mockResolvedValueOnce(remoteNote())
+      .mockResolvedValueOnce(existingCopy);
+    apiMock.updateNoteConfirmed.mockResolvedValue(refreshedCopy);
+
+    const result = await resolveNoteConflict(item, "use-server");
+
+    expect(apiMock.updateNoteConfirmed).toHaveBeenCalledWith(copyId, expect.objectContaining({
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 1,
+    }));
+    expect(result.conflictCopy).toBe(refreshedCopy);
   });
 
   it("keeps a newer local payload after recovering a copy whose response was lost", async () => {
@@ -286,7 +329,12 @@ describe("resolveNoteConflict", () => {
     apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
     apiMock.getNote
       .mockResolvedValueOnce(remoteNote())
-      .mockResolvedValueOnce(remoteNote({ id: getConflictCopyId(item.id), version: 1 }));
+      .mockResolvedValueOnce(remoteNote({
+        id: getConflictCopyId(item.id),
+        content: "本地正文",
+        contentText: "本地正文",
+        version: 1,
+      }));
     discardResolvedQueueItems.mockReturnValue({ discarded: false, remainingForNote: true });
 
     await expect(resolveNoteConflict(item, "use-server")).rejects.toThrow("本地内容已更新");
@@ -326,5 +374,15 @@ describe("resolveNoteConflict", () => {
     expect(discardResolvedQueueItems).not.toHaveBeenCalled();
     expect(clearDraft).not.toHaveBeenCalled();
     expect(clearNoteSyncConflict).not.toHaveBeenCalled();
+  });
+
+  it("clears the source conflict generation when its generated copy is deleted", () => {
+    const item = conflictItem();
+    getQueue.mockReturnValue([item]);
+
+    expect(discardConflictStateForDeletedCopy(getConflictCopyId(item.id))).toBe("note-1");
+    expect(discardResolvedQueueItems).toHaveBeenCalledWith(item);
+    expect(clearDraft).toHaveBeenCalledWith("note-1");
+    expect(clearNoteSyncConflict).toHaveBeenCalledWith("note-1");
   });
 });

--- a/frontend/src/lib/__tests__/conflictResolution.test.ts
+++ b/frontend/src/lib/__tests__/conflictResolution.test.ts
@@ -385,4 +385,21 @@ describe("resolveNoteConflict", () => {
     expect(clearDraft).toHaveBeenCalledWith("note-1");
     expect(clearNoteSyncConflict).toHaveBeenCalledWith("note-1");
   });
+
+  it("reasserts the queued UI state while a pending conflict remains durable", () => {
+    vi.useFakeTimers();
+    const item = conflictItem();
+    getQueue.mockReturnValue([item]);
+    const queuedEvents = vi.fn();
+    window.addEventListener("nowen:offline-queued", queuedEvents);
+
+    window.dispatchEvent(new CustomEvent("nowen:note-sync-pending", {
+      detail: { noteId: "note-1", queued: true },
+    }));
+    vi.runAllTimers();
+
+    expect(queuedEvents).toHaveBeenCalledTimes(2);
+    window.removeEventListener("nowen:offline-queued", queuedEvents);
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/lib/__tests__/draftStorage.conflict.test.ts
+++ b/frontend/src/lib/__tests__/draftStorage.conflict.test.ts
@@ -74,6 +74,26 @@ describe("draft conflict preservation", () => {
     )).toBe(true);
   });
 
+  it("never lets generic save-success cleanup delete an unresolved conflicted draft", () => {
+    saveDraft({
+      noteId: "note-conflicted-clear",
+      editorMode: "md",
+      title: "Local title",
+      content: "local unresolved body",
+      contentText: "local unresolved body",
+      baseVersion: 3,
+      savedAt: Date.now(),
+      conflicted: true,
+      serverVersion: 9,
+    });
+
+    expect(clearDraft("note-conflicted-clear")).toBe(false);
+    expect(loadDraft("note-conflicted-clear")).toEqual(expect.objectContaining({
+      content: "local unresolved body",
+      conflicted: true,
+    }));
+  });
+
   it("offers a divergent local body even when the server clock is ahead", () => {
     const draft = {
       noteId: "note-clock-skew",

--- a/frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
+++ b/frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
@@ -131,6 +131,19 @@ describe("LatestOnlyVersionedSaveQueue", () => {
       .rejects.toMatchObject({ code: "SAVE_NOT_CONFIRMED", saveBaseVersion: 4 });
   });
 
+  it("accepts a locally preserved pending conflict without pretending it is an ACK", async () => {
+    const queue = new LatestOnlyVersionedSaveQueue<string, { version: number; __syncPending?: boolean }>(
+      async (_noteId, _payload, version) => ({ version, __syncPending: true }),
+    );
+
+    await expect(queue.enqueue({ key: "n1", baseVersion: 4, payload: "draft" }))
+      .resolves.toMatchObject({
+        baseVersion: 4,
+        result: { version: 4, __syncPending: true },
+      });
+    expect(queue.getConfirmedVersion("n1")).toBe(4);
+  });
+
   it("accepts a newer base after a real conflict is resolved", async () => {
     let fail = true;
     const calls: number[] = [];

--- a/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
+++ b/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 });
 
 describe("installed note sync safety", () => {
-  it("does not report an optimistic offline response as server-confirmed", async () => {
+  it("returns a complete local-pending note instead of reporting an optimistic response as saved", async () => {
     const transportUpdate = vi.fn().mockResolvedValue(note(4, "local body"));
     (api as any).getNote = vi.fn().mockResolvedValue(note(4));
     (api as any).updateNote = transportUpdate;
@@ -68,9 +68,13 @@ describe("installed note sync safety", () => {
       content: "local body",
       contentText: "local body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      code: "OFFLINE_WRITE_QUEUED",
-      queued: true,
+    } as any)).resolves.toMatchObject({
+      id: "note-1",
+      userId: "user-1",
+      notebookId: "notebook-1",
+      version: 4,
+      content: "local body",
+      __syncPending: true,
     });
     window.removeEventListener(NOTE_SYNC_PENDING_EVENT, pending);
 
@@ -79,7 +83,7 @@ describe("installed note sync safety", () => {
     expect(localStorage.getItem("nowen-draft-note-1")).toContain("local body");
   });
 
-  it("fetches the server revision and blocks PUT when an offline detail is stale", async () => {
+  it("preserves a stale offline edit as one pending conflict without issuing PUT", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(9, "new server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -93,18 +97,20 @@ describe("installed note sync safety", () => {
       content: "old cached body",
       contentText: "old cached body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      status: 409,
-      code: "VERSION_CONFLICT",
-      currentVersion: 9,
+    } as any)).resolves.toMatchObject({
+      id: "note-1",
+      version: 9,
+      content: "old cached body",
+      __syncPending: true,
     });
 
     expect(transportGet).toHaveBeenCalledTimes(1);
     expect(transportUpdate).not.toHaveBeenCalled();
     expect(localStorage.getItem("nowen-note-sync-conflicts:v1")).toContain("new server body");
+    expect(getQueue()).toHaveLength(1);
   });
 
-  it("pauses later writes after one conflict and only refreshes the preserved local payload", async () => {
+  it("pauses later writes after one conflict and refreshes the same queue generation", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(9, "new server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -112,18 +118,17 @@ describe("installed note sync safety", () => {
     markOfflineNoteSnapshot(note(4, "old cached body"));
     installNoteSyncSafety();
 
-    const conflictEvents = vi.fn();
-    window.addEventListener("offlineQueue:conflict", conflictEvents);
     await expect(api.updateNote("note-1", {
       version: 4,
       title: "Title",
       content: "first local body",
       contentText: "first local body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({ code: "VERSION_CONFLICT" });
+    } as any)).resolves.toMatchObject({ __syncPending: true });
+    const firstQueueId = getQueue()[0]?.id;
 
     await expect(api.updateNote("note-1", {
-      version: 4,
+      version: 9,
       title: "Title",
       content: "latest local body",
       contentText: "latest local body",
@@ -132,14 +137,14 @@ describe("installed note sync safety", () => {
       id: "note-1",
       version: 9,
       content: "latest local body",
+      __syncPending: true,
     });
-    window.removeEventListener("offlineQueue:conflict", conflictEvents);
 
     expect(transportGet).toHaveBeenCalledTimes(1);
     expect(transportUpdate).not.toHaveBeenCalled();
-    expect(conflictEvents).not.toHaveBeenCalled();
     expect(getQueue()).toEqual([
       expect.objectContaining({
+        id: firstQueueId,
         noteId: "note-1",
         conflict: true,
         localPayload: expect.objectContaining({ content: "latest local body" }),
@@ -147,7 +152,7 @@ describe("installed note sync safety", () => {
     ]);
   });
 
-  it("blocks same-version writes when the cached base body differs from the server", async () => {
+  it("preserves same-version body mismatches as a pending conflict", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(4, "important server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -161,14 +166,14 @@ describe("installed note sync safety", () => {
       content: "",
       contentText: "",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      status: 409,
-      code: "VERSION_CONFLICT",
-      currentVersion: 4,
-      baseContentMismatch: true,
+    } as any)).resolves.toMatchObject({
+      version: 4,
+      content: "",
+      __syncPending: true,
     });
 
     expect(transportUpdate).not.toHaveBeenCalled();
+    expect(getQueue()).toHaveLength(1);
   });
 
   it("allows a cached detail only after a fresh GET confirms revision and base body", async () => {
@@ -208,5 +213,62 @@ describe("installed note sync safety", () => {
     } as any)).resolves.toMatchObject({ version: 5, content: "" });
 
     expect(transportUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("automatically rebases a version-only conflict and retries the latest snapshot once", async () => {
+    const conflict = Object.assign(new Error("conflict"), {
+      status: 409,
+      code: "VERSION_CONFLICT",
+      currentVersion: 5,
+    });
+    const transportGet = vi.fn()
+      .mockResolvedValueOnce(note(4, "server body"))
+      .mockResolvedValueOnce(note(5, "server body"));
+    const transportUpdate = vi.fn()
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce(note(6, "local body"));
+    (api as any).getNote = transportGet;
+    (api as any).updateNote = transportUpdate;
+    installNoteSyncSafety();
+
+    await api.getNote("note-1");
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "local body",
+      contentText: "local body",
+      contentFormat: "markdown",
+    } as any)).resolves.toMatchObject({ version: 6, content: "local body" });
+
+    expect(transportUpdate).toHaveBeenNthCalledWith(2, "note-1", expect.objectContaining({ version: 5 }));
+    expect(getQueue()).toHaveLength(0);
+  });
+
+  it("treats a fetched matching body as a lost acknowledgement instead of a conflict", async () => {
+    const conflict = Object.assign(new Error("conflict"), {
+      status: 409,
+      code: "VERSION_CONFLICT",
+      currentVersion: 5,
+    });
+    const transportGet = vi.fn()
+      .mockResolvedValueOnce(note(4, "server body"))
+      .mockResolvedValueOnce(note(5, "local body"));
+    const transportUpdate = vi.fn().mockRejectedValueOnce(conflict);
+    (api as any).getNote = transportGet;
+    (api as any).updateNote = transportUpdate;
+    installNoteSyncSafety();
+
+    await api.getNote("note-1");
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "local body",
+      contentText: "local body",
+      contentFormat: "markdown",
+    } as any)).resolves.toMatchObject({ version: 5, content: "local body" });
+
+    expect(transportUpdate).toHaveBeenCalledTimes(1);
+    expect(getQueue()).toHaveLength(0);
+    expect(localStorage.getItem("nowen-note-sync-conflicts:v1")).toBeNull();
   });
 });

--- a/frontend/src/lib/conflictResolution.ts
+++ b/frontend/src/lib/conflictResolution.ts
@@ -11,6 +11,10 @@ import { clearNoteSyncConflict } from "@/lib/noteSyncSafety";
 
 export type ConflictResolutionChoice = "keep-local" | "use-server";
 export const NOTE_CONFLICT_AUTO_RESOLVED_EVENT = "nowen:note-conflict-auto-resolved";
+const DELETE_GUARD_INSTALL_KEY = "__NOWEN_CONFLICT_COPY_DELETE_GUARD_V1__" as const;
+const PENDING_STATUS_BRIDGE_INSTALL_KEY = "__NOWEN_PENDING_SYNC_STATUS_BRIDGE_V1__" as const;
+const NOTE_SYNC_PENDING_EVENT_NAME = "nowen:note-sync-pending";
+const OFFLINE_QUEUED_EVENT_NAME = "nowen:offline-queued";
 
 export interface NoteConflictAutoResolvedDetail {
   note: Note;
@@ -57,6 +61,11 @@ type ConflictPayload = {
 type DraftStorageCompatibility = {
   clearDraft: (noteId: string) => unknown;
   forceClearDraft?: (noteId: string) => void;
+};
+
+type ConflictBridgeWindow = Window & typeof globalThis & {
+  [DELETE_GUARD_INSTALL_KEY]?: () => void;
+  [PENDING_STATUS_BRIDGE_INSTALL_KEY]?: () => void;
 };
 
 function payloadFromQueue(item: OfflineQueueItem): Partial<ConflictPayload> {
@@ -157,6 +166,63 @@ export function discardConflictStateForDeletedCopy(copyId: string): string | nul
   );
   if (!item) return null;
   return clearResolvedConflict(item) ? item.noteId : null;
+}
+
+/**
+ * Conflict copies are ordinary notes in the tree, so the regular trash action is the only reliable
+ * place to learn that the user intentionally discarded one. Install an outer API guard after App
+ * lazy-load: a confirmed trash write clears the source conflict generation and prevents sync from
+ * recreating the same deterministic copy.
+ */
+export function installConflictCopyDeletionGuard(): void {
+  if (typeof window === "undefined" || typeof (api as any).updateNote !== "function") return;
+  const guardedWindow = window as ConflictBridgeWindow;
+  if (guardedWindow[DELETE_GUARD_INSTALL_KEY]) return;
+
+  const originalUpdateNote = api.updateNote.bind(api);
+  (api as any).updateNote = async (noteId: string, data: Partial<Note>): Promise<Note> => {
+    const updated = await originalUpdateNote(noteId, data);
+    if ((data as Partial<Note>).isTrashed === 1) {
+      discardConflictStateForDeletedCopy(noteId);
+    }
+    return updated;
+  };
+
+  guardedWindow[DELETE_GUARD_INSTALL_KEY] = () => {
+    (api as any).updateNote = originalUpdateNote;
+    delete guardedWindow[DELETE_GUARD_INSTALL_KEY];
+  };
+}
+
+/**
+ * EditorPane historically reports every resolved update Promise as "saved" and resets it to idle
+ * two seconds later. Pending conflict/offline responses are deliberately resolved so autosave does
+ * not enter its failure/requeue loop, therefore reassert the existing global "queued" UI event
+ * after both transitions while the note still has a durable queue item.
+ */
+export function installPendingSyncStatusBridge(): void {
+  if (typeof window === "undefined") return;
+  const guardedWindow = window as ConflictBridgeWindow;
+  if (guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY]) return;
+
+  const publishQueuedIfPending = (noteId: string) => {
+    if (!getQueue().some((item) => item.noteId === noteId)) return;
+    window.dispatchEvent(new CustomEvent(OFFLINE_QUEUED_EVENT_NAME, {
+      detail: { noteId, pending: true },
+    }));
+  };
+  const onPending = (event: Event) => {
+    const noteId = (event as CustomEvent<{ noteId?: string }>).detail?.noteId;
+    if (!noteId) return;
+    window.setTimeout(() => publishQueuedIfPending(noteId), 0);
+    window.setTimeout(() => publishQueuedIfPending(noteId), 2200);
+  };
+
+  window.addEventListener(NOTE_SYNC_PENDING_EVENT_NAME, onPending);
+  guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY] = () => {
+    window.removeEventListener(NOTE_SYNC_PENDING_EVENT_NAME, onPending);
+    delete guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY];
+  };
 }
 
 async function keepLocalVersion(
@@ -300,3 +366,6 @@ export async function resolveQueuedNoteConflicts(
     failures,
   };
 }
+
+installConflictCopyDeletionGuard();
+installPendingSyncStatusBridge();

--- a/frontend/src/lib/conflictResolution.ts
+++ b/frontend/src/lib/conflictResolution.ts
@@ -2,6 +2,7 @@ import type { Note } from "@/types";
 import { api } from "@/lib/api";
 import {
   discardResolvedQueueItems,
+  getQueue,
   type OfflineQueueItem,
 } from "@/lib/offlineQueue";
 import * as draftStorage from "@/lib/draftStorage";
@@ -91,6 +92,12 @@ function sameContent(local: ConflictPayload, remote: Note): boolean {
     && (local.contentFormat || remote.contentFormat) === remote.contentFormat;
 }
 
+function sameConflictCopyContent(copy: Note, local: ConflictPayload, remote: Note): boolean {
+  return copy.content === local.content
+    && copy.contentText === local.contentText
+    && copy.contentFormat === (local.contentFormat || remote.contentFormat);
+}
+
 function formatConflictCopyTitle(title: string, now = new Date()): string {
   const pad = (value: number) => String(value).padStart(2, "0");
   const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
@@ -138,6 +145,20 @@ function clearResolvedConflict(item: OfflineQueueItem): boolean {
   return true;
 }
 
+/**
+ * When a user deletes a generated conflict copy, discard the source conflict generation too.
+ * Otherwise the next sync pass recreates the same copy and makes deletion appear broken.
+ */
+export function discardConflictStateForDeletedCopy(copyId: string): string | null {
+  const item = getQueue().find(
+    (queued) => queued.type === "updateNote"
+      && (queued.conflict || queued.errorCode === "VERSION_CONFLICT")
+      && getConflictCopyId(queued.id) === copyId,
+  );
+  if (!item) return null;
+  return clearResolvedConflict(item) ? item.noteId : null;
+}
+
 async function keepLocalVersion(
   item: OfflineQueueItem,
   remote: Note,
@@ -157,6 +178,24 @@ async function keepLocalVersion(
     throw new Error("处理期间本地内容已更新，等待下一次后台同步。");
   }
   return { note: updated, resolvedLocal: local };
+}
+
+async function updateExistingConflictCopy(
+  existing: Note,
+  remote: Note,
+  local: ConflictPayload,
+): Promise<Note> {
+  if (sameConflictCopyContent(existing, local, remote)) return existing;
+  const updated = await api.updateNoteConfirmed(existing.id, {
+    content: local.content,
+    contentText: local.contentText,
+    contentFormat: local.contentFormat || remote.contentFormat,
+    version: existing.version,
+  });
+  if (typeof updated.version !== "number" || updated.version <= existing.version) {
+    throw new Error("冲突副本尚未得到服务器确认，请稍后重试。");
+  }
+  return updated;
 }
 
 async function createOrLoadConflictCopy(
@@ -179,8 +218,10 @@ async function createOrLoadConflictCopy(
     const details = error as { status?: number; code?: string };
     if (details.status !== 409 || details.code !== "NOTE_ID_CONFLICT") throw error;
     // The previous request may have committed successfully while its response was lost. Because
-    // the id is deterministic for this conflict, loading it is safe and makes retry idempotent.
-    return api.getNote(copyId);
+    // the id is deterministic for this conflict, load and refresh that same copy with the latest
+    // local snapshot instead of creating a second timestamped document.
+    const existing = await api.getNote(copyId);
+    return updateExistingConflictCopy(existing, remote, local);
   }
 }
 

--- a/frontend/src/lib/draftStorage.ts
+++ b/frontend/src/lib/draftStorage.ts
@@ -168,6 +168,7 @@ export function loadDraft(noteId: string): NoteDraft | null {
 /**
  * Clear a draft after save success without allowing an older response to delete newer local text.
  *
+ * - Conflicted draft: explicit conflict resolution is the only allowed cleanup path.
  * - No ACK marker: preserve historical/manual cleanup behavior and delete immediately.
  * - ACK body differs from current draft: refuse cleanup; the draft is newer than the response.
  * - ACK body matches: delay deletion and re-check savedAt/body after the editor debounce window.
@@ -178,6 +179,8 @@ export function clearDraft(noteId: string): boolean {
     removeDraftNow(noteId);
     return true;
   }
+
+  if (draft.conflicted) return false;
 
   const acknowledgement = acknowledgements.get(noteId);
   if (!acknowledgement) {

--- a/frontend/src/lib/latestOnlyVersionedSaveQueue.ts
+++ b/frontend/src/lib/latestOnlyVersionedSaveQueue.ts
@@ -1,5 +1,10 @@
 export interface VersionedSaveResult {
   version: number;
+  /**
+   * The original note was not committed, but the latest local snapshot was durably
+   * preserved in the conflict queue. This is a pending state rather than a transport error.
+   */
+  __syncPending?: boolean;
 }
 
 export interface VersionedSaveEnvelope<TPayload, TResult extends VersionedSaveResult> {
@@ -119,7 +124,8 @@ export class LatestOnlyVersionedSaveQueue<TPayload, TResult extends VersionedSav
         return;
       }
 
-      if (!Number.isFinite(result.version) || result.version <= baseVersion) {
+      const locallyPreserved = result.__syncPending === true;
+      if (!Number.isFinite(result.version) || (!locallyPreserved && result.version <= baseVersion)) {
         const error = new Error("Server did not confirm a newer version") as Error & {
           code?: string;
           saveBaseVersion?: number;
@@ -135,7 +141,9 @@ export class LatestOnlyVersionedSaveQueue<TPayload, TResult extends VersionedSav
         return;
       }
 
-      state.confirmedVersion = result.version;
+      // Pending-conflict responses carry the latest known server revision without
+      // acknowledging the local body. Keep the queue rebased while draft cleanup stays off.
+      state.confirmedVersion = Math.max(state.confirmedVersion, result.version);
       const pending = this.readPending(state);
       if (pending) {
         pending.waiters.unshift(...batch.waiters);

--- a/frontend/src/lib/noteSyncSafety.ts
+++ b/frontend/src/lib/noteSyncSafety.ts
@@ -8,12 +8,7 @@ import {
   isOfflineNoteSnapshot,
   markOfflineNoteSnapshot,
 } from "@/lib/offlineRead";
-import {
-  enqueue,
-  getQueue,
-  removeItem,
-  updateItem,
-} from "@/lib/offlineQueue";
+import { dequeue, enqueue, getQueue, updateItem } from "@/lib/offlineQueue";
 import { saveDraft } from "@/lib/draftStorage";
 
 const INSTALL_KEY = "__NOWEN_NOTE_SYNC_SAFETY_V1__" as const;
@@ -40,17 +35,12 @@ export interface NoteSyncConflictRecord {
   reason: "STALE_OFFLINE_BASE" | "VERSION_CONFLICT" | "REMOTE_BASE_UNVERIFIED";
 }
 
-type GuardedWindow = Window & typeof globalThis & {
-  [INSTALL_KEY]?: () => void;
-};
-
+type GuardedWindow = Window & typeof globalThis & { [INSTALL_KEY]?: () => void };
 type NoteMutation = Partial<Note> & Record<string, unknown>;
 type PendingNote = Note & { __syncPending: true };
 
 export function isVersionedNoteMutation(data: NoteMutation): boolean {
-  return ["title", "content", "contentText", "contentFormat"].some(
-    (field) => data[field] !== undefined,
-  );
+  return ["title", "content", "contentText", "contentFormat"].some((field) => data[field] !== undefined);
 }
 
 export function isServerConfirmedNoteWrite(baseVersion: number, responseVersion: unknown): boolean {
@@ -59,17 +49,17 @@ export function isServerConfirmedNoteWrite(baseVersion: number, responseVersion:
 
 function isCompleteNote(value: unknown, noteId?: string): value is Note {
   const note = value as Partial<Note> | null;
-  return !!note &&
-    typeof note.id === "string" && note.id.length > 0 &&
-    (!noteId || note.id === noteId) &&
-    typeof note.userId === "string" && note.userId.length > 0 &&
-    typeof note.notebookId === "string" && note.notebookId.length > 0 &&
-    typeof note.title === "string" &&
-    typeof note.content === "string" &&
-    typeof note.contentText === "string" &&
-    typeof note.version === "number" && Number.isFinite(note.version) &&
-    typeof note.createdAt === "string" && note.createdAt.length > 0 &&
-    typeof note.updatedAt === "string" && note.updatedAt.length > 0;
+  return !!note
+    && typeof note.id === "string" && note.id.length > 0
+    && (!noteId || note.id === noteId)
+    && typeof note.userId === "string" && note.userId.length > 0
+    && typeof note.notebookId === "string" && note.notebookId.length > 0
+    && typeof note.title === "string"
+    && typeof note.content === "string"
+    && typeof note.contentText === "string"
+    && typeof note.version === "number" && Number.isFinite(note.version)
+    && typeof note.createdAt === "string" && note.createdAt.length > 0
+    && typeof note.updatedAt === "string" && note.updatedAt.length > 0;
 }
 
 function rememberConfirmedNote(note: unknown, noteId?: string): note is Note {
@@ -79,10 +69,10 @@ function rememberConfirmedNote(note: unknown, noteId?: string): note is Note {
 }
 
 function noteBodiesEqual(left: Partial<Note>, right: Partial<Note>): boolean {
-  return left.title === right.title &&
-    left.content === right.content &&
-    left.contentText === right.contentText &&
-    left.contentFormat === right.contentFormat;
+  return left.title === right.title
+    && left.content === right.content
+    && left.contentText === right.contentText
+    && left.contentFormat === right.contentFormat;
 }
 
 function mutationMatchesNote(note: Partial<Note>, data: NoteMutation): boolean {
@@ -90,7 +80,7 @@ function mutationMatchesNote(note: Partial<Note>, data: NoteMutation): boolean {
   return fields.every((field) => data[field] === undefined || note[field] === data[field]);
 }
 
-function pendingNote(server: Note, data: NoteMutation): PendingNote {
+function makePendingNote(server: Note, data: NoteMutation): PendingNote {
   return {
     ...server,
     ...(typeof data.title === "string" ? { title: data.title } : {}),
@@ -145,14 +135,10 @@ export function clearNoteSyncConflict(noteId: string): void {
     if (next.length === 0) localStorage.removeItem(CONFLICT_STORAGE_KEY);
     else localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(next));
   } catch {
-    /* keep queue/draft as the durable fallback */
+    // Queue and draft remain the durable fallback.
   }
 }
 
-/**
- * Persist one current record per note. Returning false means the exact same conflict was
- * already known, allowing callers to suppress duplicate toasts without losing the payload.
- */
 export function recordNoteSyncConflict(record: NoteSyncConflictRecord): boolean {
   const previous = getNoteSyncConflict(record.noteId);
   const changed = !previous || conflictSignature(previous) !== conflictSignature(record);
@@ -161,7 +147,7 @@ export function recordNoteSyncConflict(record: NoteSyncConflictRecord): boolean 
     records.unshift(record);
     localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(records.slice(0, MAX_CONFLICTS)));
   } catch {
-    // The complete local edit remains in draftStorage and offlineQueue even if metadata hits quota.
+    // Queue and draft still contain the complete local edit.
   }
   return changed;
 }
@@ -225,15 +211,9 @@ function isConflictQueueItem(item: { conflict?: boolean; errorCode?: string }): 
   return item.conflict === true || item.errorCode === "VERSION_CONFLICT";
 }
 
-function upsertConflictQueueItem(
-  noteId: string,
-  data: NoteMutation,
-  serverVersion?: number,
-): void {
+function upsertConflictQueueItem(noteId: string, data: NoteMutation, serverVersion?: number): void {
   const body = { ...data } as Record<string, unknown>;
-  const candidates = getQueue().filter(
-    (item) => item.noteId === noteId && item.type === "updateNote",
-  );
+  const candidates = getQueue().filter((item) => item.noteId === noteId && item.type === "updateNote");
   const existing = candidates.find(isConflictQueueItem) || candidates[0];
   const patch = {
     body,
@@ -250,11 +230,10 @@ function upsertConflictQueueItem(
   } as const;
 
   if (existing) {
-    // Preserve the original queue id. conflictResolution derives one deterministic copy id
-    // from it, so later edits update the same conflict generation instead of creating copies.
+    // Keep the queue id stable so all later edits target the same deterministic copy.
     updateItem(existing.id, patch);
     for (const duplicate of candidates) {
-      if (duplicate.id !== existing.id) removeItem(duplicate.id);
+      if (duplicate.id !== existing.id) dequeue(duplicate.id);
     }
     return;
   }
@@ -272,22 +251,18 @@ function clearResolvedConflictArtifacts(noteId: string): void {
   clearNoteSyncConflict(noteId);
   for (const item of getQueue()) {
     if (item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item)) {
-      removeItem(item.id);
+      dequeue(item.id);
     }
   }
 }
 
 export function hasPendingNoteSyncConflict(noteId: string): boolean {
-  if (getNoteSyncConflict(noteId)) return true;
-  return getQueue().some(
+  return !!getNoteSyncConflict(noteId) || getQueue().some(
     (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
   );
 }
 
-export async function runWithNoteConflictResolution<T>(
-  noteId: string,
-  task: () => Promise<T>,
-): Promise<T> {
+export async function runWithNoteConflictResolution<T>(noteId: string, task: () => Promise<T>): Promise<T> {
   resolvingNoteIds.add(noteId);
   try {
     return await task();
@@ -310,7 +285,6 @@ function preserveConflict(
   return record;
 }
 
-/** 把编辑器尚未提交的最新快照直接存为冲突，不向服务器发起写请求。 */
 export function preserveNoteSyncConflictSnapshot(
   noteId: string,
   data: NoteMutation,
@@ -330,12 +304,16 @@ function restorePendingDraft(
   noteId: string,
   data: NoteMutation,
   baseVersion: number,
+  conflict: boolean,
   serverVersion?: number,
 ): void {
-  // EditorPane clears drafts after every resolved update. Restore the unresolved snapshot after
-  // that bookkeeping finishes, while deliberately avoiding another network request.
   window.setTimeout(() => {
-    persistLocalDraft(noteId, data, baseVersion, { serverVersion });
+    persistLocalDraft(
+      noteId,
+      data,
+      baseVersion,
+      conflict ? { serverVersion } : undefined,
+    );
   }, 0);
 }
 
@@ -364,26 +342,16 @@ export function installNoteSyncSafety(): void {
     server: Note,
     conflict: boolean,
   ): PendingNote {
-    persistLocalDraft(
-      noteId,
-      data,
-      baseVersion,
-      conflict ? { serverVersion: server.version } : undefined,
-    );
-    restorePendingDraft(noteId, data, baseVersion, conflict ? server.version : undefined);
+    persistLocalDraft(noteId, data, baseVersion, conflict ? { serverVersion: server.version } : undefined);
+    restorePendingDraft(noteId, data, baseVersion, conflict, server.version);
     dispatchPending(noteId, baseVersion, { conflict, serverVersion: server.version });
-    return pendingNote(server, data);
+    return makePendingNote(server, data);
   }
 
-  async function retryOnFreshVersion(
-    noteId: string,
-    data: NoteMutation,
-    fresh: Note,
-  ): Promise<Note | null> {
+  async function retryOnFreshVersion(noteId: string, data: NoteMutation, fresh: Note): Promise<Note | null> {
     try {
-      const rebased = { ...data, version: fresh.version } as Partial<Note>;
-      const updated = await originalUpdateNote(noteId, rebased);
-      if (!isServerConfirmedNoteWrite(fresh.version, updated?.version) || !isCompleteNote(updated, noteId)) {
+      const updated = await originalUpdateNote(noteId, { ...data, version: fresh.version } as Partial<Note>);
+      if (!isCompleteNote(updated, noteId) || !isServerConfirmedNoteWrite(fresh.version, updated.version)) {
         return null;
       }
       clearOfflineNoteSnapshot(noteId);
@@ -420,7 +388,7 @@ export function installNoteSyncSafety(): void {
         server = await fetchCurrentServerNote(noteId);
         if (server) confirmedNotes.set(noteId, server);
       }
-      const record = preserveConflict(
+      preserveConflict(
         noteId,
         data,
         baseVersion,
@@ -428,10 +396,7 @@ export function installNoteSyncSafety(): void {
         getNoteSyncConflict(noteId)?.reason || "VERSION_CONFLICT",
       );
       if (!server) {
-        throw syncError(
-          "REMOTE_BASE_UNVERIFIED",
-          "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
-        );
+        throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
       }
       return completePendingResponse(noteId, data, baseVersion, server, true);
     }
@@ -444,13 +409,8 @@ export function installNoteSyncSafety(): void {
       const fresh = await fetchCurrentServerNote(noteId);
       if (!fresh) {
         preserveConflict(noteId, data, baseVersion, previousConfirmed, "REMOTE_BASE_UNVERIFIED");
-        if (previousConfirmed) {
-          return completePendingResponse(noteId, data, baseVersion, previousConfirmed, true);
-        }
-        throw syncError(
-          "REMOTE_BASE_UNVERIFIED",
-          "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
-        );
+        if (previousConfirmed) return completePendingResponse(noteId, data, baseVersion, previousConfirmed, true);
+        throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
       }
 
       if (isCurrentlyOffline()) {
@@ -460,25 +420,19 @@ export function installNoteSyncSafety(): void {
 
       clearOfflineNoteSnapshot(noteId);
       const baseContentMismatch = !!(
-        offlineBase?.contentFingerprint &&
-        fingerprintNoteContent(fresh.content) !== offlineBase.contentFingerprint
+        offlineBase?.contentFingerprint
+        && fingerprintNoteContent(fresh.content) !== offlineBase.contentFingerprint
       );
       if (fresh.version !== baseVersion || baseContentMismatch) {
-        // A timeout can happen after the server committed the exact body. Treat the fetched
-        // note as the missing acknowledgement rather than manufacturing a conflict copy.
         if (mutationMatchesNote(fresh, data)) {
           clearResolvedConflictArtifacts(noteId);
           rememberConfirmedNote(fresh, noteId);
           return fresh;
         }
-
-        // A version-only advance with an unchanged body is not a real editing conflict. Rebase
-        // the latest local snapshot once onto the server revision and continue silently.
         if (previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
           const retried = await retryOnFreshVersion(noteId, data, fresh);
           if (retried) return retried;
         }
-
         preserveConflict(noteId, data, baseVersion, fresh, "STALE_OFFLINE_BASE");
         confirmedNotes.set(noteId, fresh);
         return completePendingResponse(noteId, data, baseVersion, fresh, true);
@@ -488,23 +442,13 @@ export function installNoteSyncSafety(): void {
     const previousConfirmed = confirmedNotes.get(noteId) || null;
     try {
       const updated = await originalUpdateNote(noteId, data as Partial<Note>);
-
       if (versioned && !isServerConfirmedNoteWrite(baseVersion, updated?.version)) {
         persistLocalDraft(noteId, data, baseVersion);
-        markOfflineNoteSnapshot({
-          id: noteId,
-          version: baseVersion,
-          updatedAt: updated?.updatedAt,
-        });
+        markOfflineNoteSnapshot({ id: noteId, version: baseVersion, updatedAt: updated?.updatedAt });
         const server = previousConfirmed || (isCompleteNote(updated, noteId) ? updated : null);
-        if (server) {
-          return completePendingResponse(noteId, data, baseVersion, server, false);
-        }
+        if (server) return completePendingResponse(noteId, data, baseVersion, server, false);
         dispatchPending(noteId, baseVersion, { responseIncomplete: true });
-        const error = syncError(
-          "OFFLINE_WRITE_QUEUED",
-          "修改已保存在本地并等待上传，尚未得到服务端确认。",
-        ) as any;
+        const error = syncError("OFFLINE_WRITE_QUEUED", "修改已保存在本地并等待上传，尚未得到服务端确认。") as any;
         error.queued = true;
         throw error;
       }
@@ -518,42 +462,30 @@ export function installNoteSyncSafety(): void {
 
       const fresh = await fetchCurrentServerNote(noteId);
       if (fresh && mutationMatchesNote(fresh, data)) {
-        // Lost ACK: the server already contains the exact local mutation.
         clearOfflineNoteSnapshot(noteId);
         clearResolvedConflictArtifacts(noteId);
         rememberConfirmedNote(fresh, noteId);
         return fresh;
       }
-
       if (fresh && previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
         const retried = await retryOnFreshVersion(noteId, data, fresh);
         if (retried) return retried;
       }
 
-      const currentVersion = typeof error.currentVersion === "number"
-        ? error.currentVersion
-        : undefined;
+      const currentVersion = typeof error.currentVersion === "number" ? error.currentVersion : undefined;
       const fallbackServer = previousConfirmed
-        ? ({
-            ...previousConfirmed,
-            version: currentVersion ?? previousConfirmed.version,
-          } as Note)
+        ? ({ ...previousConfirmed, version: currentVersion ?? previousConfirmed.version } as Note)
         : null;
       const server = fresh || fallbackServer;
       const record = preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
       if (typeof error.currentVersion !== "number" && typeof record.serverVersion === "number") {
         error.currentVersion = record.serverVersion;
       }
-
       if (server) {
         if (fresh) confirmedNotes.set(noteId, fresh);
         return completePendingResponse(noteId, data, baseVersion, server, true);
       }
-
-      throw syncError(
-        "REMOTE_BASE_UNVERIFIED",
-        "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
-      );
+      throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
     }
   };
 

--- a/frontend/src/lib/noteSyncSafety.ts
+++ b/frontend/src/lib/noteSyncSafety.ts
@@ -11,7 +11,8 @@ import {
 import {
   enqueue,
   getQueue,
-  replaceItem,
+  removeItem,
+  updateItem,
 } from "@/lib/offlineQueue";
 import { saveDraft } from "@/lib/draftStorage";
 
@@ -20,6 +21,7 @@ const CONFLICT_STORAGE_KEY = "nowen-note-sync-conflicts:v1";
 const MAX_CONFLICTS = 20;
 const MAX_SNAPSHOT_CHARS = 500_000;
 const resolvingNoteIds = new Set<string>();
+const confirmedNotes = new Map<string, Note>();
 
 export const NOTE_SYNC_PENDING_EVENT = "nowen:note-sync-pending";
 
@@ -43,6 +45,7 @@ type GuardedWindow = Window & typeof globalThis & {
 };
 
 type NoteMutation = Partial<Note> & Record<string, unknown>;
+type PendingNote = Note & { __syncPending: true };
 
 export function isVersionedNoteMutation(data: NoteMutation): boolean {
   return ["title", "content", "contentText", "contentFormat"].some(
@@ -52,6 +55,51 @@ export function isVersionedNoteMutation(data: NoteMutation): boolean {
 
 export function isServerConfirmedNoteWrite(baseVersion: number, responseVersion: unknown): boolean {
   return typeof responseVersion === "number" && Number.isFinite(responseVersion) && responseVersion > baseVersion;
+}
+
+function isCompleteNote(value: unknown, noteId?: string): value is Note {
+  const note = value as Partial<Note> | null;
+  return !!note &&
+    typeof note.id === "string" && note.id.length > 0 &&
+    (!noteId || note.id === noteId) &&
+    typeof note.userId === "string" && note.userId.length > 0 &&
+    typeof note.notebookId === "string" && note.notebookId.length > 0 &&
+    typeof note.title === "string" &&
+    typeof note.content === "string" &&
+    typeof note.contentText === "string" &&
+    typeof note.version === "number" && Number.isFinite(note.version) &&
+    typeof note.createdAt === "string" && note.createdAt.length > 0 &&
+    typeof note.updatedAt === "string" && note.updatedAt.length > 0;
+}
+
+function rememberConfirmedNote(note: unknown, noteId?: string): note is Note {
+  if (!isCompleteNote(note, noteId)) return false;
+  confirmedNotes.set(note.id, note);
+  return true;
+}
+
+function noteBodiesEqual(left: Partial<Note>, right: Partial<Note>): boolean {
+  return left.title === right.title &&
+    left.content === right.content &&
+    left.contentText === right.contentText &&
+    left.contentFormat === right.contentFormat;
+}
+
+function mutationMatchesNote(note: Partial<Note>, data: NoteMutation): boolean {
+  const fields = ["title", "content", "contentText", "contentFormat"] as const;
+  return fields.every((field) => data[field] === undefined || note[field] === data[field]);
+}
+
+function pendingNote(server: Note, data: NoteMutation): PendingNote {
+  return {
+    ...server,
+    ...(typeof data.title === "string" ? { title: data.title } : {}),
+    ...(typeof data.content === "string" ? { content: data.content } : {}),
+    ...(typeof data.contentText === "string" ? { contentText: data.contentText } : {}),
+    ...(data.contentFormat !== undefined ? { contentFormat: data.contentFormat } : {}),
+    version: server.version,
+    __syncPending: true,
+  } as PendingNote;
 }
 
 function trimSnapshot(value: unknown): string | undefined {
@@ -183,9 +231,10 @@ function upsertConflictQueueItem(
   serverVersion?: number,
 ): void {
   const body = { ...data } as Record<string, unknown>;
-  const existing = getQueue().find(
+  const candidates = getQueue().filter(
     (item) => item.noteId === noteId && item.type === "updateNote",
   );
+  const existing = candidates.find(isConflictQueueItem) || candidates[0];
   const patch = {
     body,
     localPayload: body,
@@ -201,7 +250,12 @@ function upsertConflictQueueItem(
   } as const;
 
   if (existing) {
-    replaceItem(existing.id, patch);
+    // Preserve the original queue id. conflictResolution derives one deterministic copy id
+    // from it, so later edits update the same conflict generation instead of creating copies.
+    updateItem(existing.id, patch);
+    for (const duplicate of candidates) {
+      if (duplicate.id !== existing.id) removeItem(duplicate.id);
+    }
     return;
   }
 
@@ -212,6 +266,15 @@ function upsertConflictQueueItem(
     method: "PUT",
     ...patch,
   });
+}
+
+function clearResolvedConflictArtifacts(noteId: string): void {
+  clearNoteSyncConflict(noteId);
+  for (const item of getQueue()) {
+    if (item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item)) {
+      removeItem(item.id);
+    }
+  }
 }
 
 export function hasPendingNoteSyncConflict(noteId: string): boolean {
@@ -257,35 +320,23 @@ export function preserveNoteSyncConflictSnapshot(
   preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
 }
 
-function pausedConflictResponse(
+function dispatchPending(noteId: string, baseVersion: number, detail?: Record<string, unknown>): void {
+  window.dispatchEvent(new CustomEvent(NOTE_SYNC_PENDING_EVENT, {
+    detail: { noteId, baseVersion, queued: true, ...detail },
+  }));
+}
+
+function restorePendingDraft(
   noteId: string,
   data: NoteMutation,
   baseVersion: number,
-): Note {
-  const record = getNoteSyncConflict(noteId);
-  const queued = getQueue().find(
-    (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
-  );
-  const serverVersion = record?.serverVersion ?? queued?.serverVersion ?? baseVersion;
-  const updatedAt = record?.serverUpdatedAt || new Date().toISOString();
-
-  persistLocalDraft(noteId, data, baseVersion, { serverVersion });
-  upsertConflictQueueItem(noteId, data, serverVersion);
-  // EditorPane clears drafts after every resolved update. Restore the conflicted draft after that
-  // success bookkeeping finishes, while deliberately avoiding another network request.
+  serverVersion?: number,
+): void {
+  // EditorPane clears drafts after every resolved update. Restore the unresolved snapshot after
+  // that bookkeeping finishes, while deliberately avoiding another network request.
   window.setTimeout(() => {
     persistLocalDraft(noteId, data, baseVersion, { serverVersion });
   }, 0);
-
-  return {
-    id: noteId,
-    title: typeof data.title === "string" ? data.title : record?.localTitle || "",
-    content: typeof data.content === "string" ? data.content : record?.localContent || "",
-    contentText: typeof data.contentText === "string" ? data.contentText : record?.localContentText || "",
-    contentFormat: (data.contentFormat || "markdown") as Note["contentFormat"],
-    version: serverVersion,
-    updatedAt,
-  } as Note;
 }
 
 export function installNoteSyncSafety(): void {
@@ -296,9 +347,58 @@ export function installNoteSyncSafety(): void {
   const originalGetNote = api.getNote.bind(api);
   const originalUpdateNote = api.updateNote.bind(api);
 
+  async function fetchCurrentServerNote(noteId: string): Promise<Note | null> {
+    try {
+      const note = await originalGetNote(noteId);
+      if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
+      return isCompleteNote(note, noteId) ? note : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function completePendingResponse(
+    noteId: string,
+    data: NoteMutation,
+    baseVersion: number,
+    server: Note,
+    conflict: boolean,
+  ): PendingNote {
+    persistLocalDraft(
+      noteId,
+      data,
+      baseVersion,
+      conflict ? { serverVersion: server.version } : undefined,
+    );
+    restorePendingDraft(noteId, data, baseVersion, conflict ? server.version : undefined);
+    dispatchPending(noteId, baseVersion, { conflict, serverVersion: server.version });
+    return pendingNote(server, data);
+  }
+
+  async function retryOnFreshVersion(
+    noteId: string,
+    data: NoteMutation,
+    fresh: Note,
+  ): Promise<Note | null> {
+    try {
+      const rebased = { ...data, version: fresh.version } as Partial<Note>;
+      const updated = await originalUpdateNote(noteId, rebased);
+      if (!isServerConfirmedNoteWrite(fresh.version, updated?.version) || !isCompleteNote(updated, noteId)) {
+        return null;
+      }
+      clearOfflineNoteSnapshot(noteId);
+      clearResolvedConflictArtifacts(noteId);
+      rememberConfirmedNote(updated, noteId);
+      return updated;
+    } catch {
+      return null;
+    }
+  }
+
   (api as any).getNote = async (noteId: string): Promise<Note> => {
     const note = await originalGetNote(noteId);
     if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
+    rememberConfirmedNote(note, noteId);
     return note;
   };
 
@@ -315,18 +415,38 @@ export function installNoteSyncSafety(): void {
     }
 
     if (versioned && !resolvingNoteIds.has(noteId) && hasPendingNoteSyncConflict(noteId)) {
-      return pausedConflictResponse(noteId, data, baseVersion);
+      let server = confirmedNotes.get(noteId) || null;
+      if (!server) {
+        server = await fetchCurrentServerNote(noteId);
+        if (server) confirmedNotes.set(noteId, server);
+      }
+      const record = preserveConflict(
+        noteId,
+        data,
+        baseVersion,
+        server,
+        getNoteSyncConflict(noteId)?.reason || "VERSION_CONFLICT",
+      );
+      if (!server) {
+        throw syncError(
+          "REMOTE_BASE_UNVERIFIED",
+          "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
+        );
+      }
+      return completePendingResponse(noteId, data, baseVersion, server, true);
     }
 
     if (versioned) persistLocalDraft(noteId, data, baseVersion);
 
     if (versioned && isOfflineNoteSnapshot(noteId) && !isCurrentlyOffline()) {
       const offlineBase = getOfflineNoteSnapshot(noteId);
-      let fresh: Note;
-      try {
-        fresh = await originalGetNote(noteId);
-      } catch {
-        preserveConflict(noteId, data, baseVersion, null, "REMOTE_BASE_UNVERIFIED");
+      const previousConfirmed = confirmedNotes.get(noteId) || null;
+      const fresh = await fetchCurrentServerNote(noteId);
+      if (!fresh) {
+        preserveConflict(noteId, data, baseVersion, previousConfirmed, "REMOTE_BASE_UNVERIFIED");
+        if (previousConfirmed) {
+          return completePendingResponse(noteId, data, baseVersion, previousConfirmed, true);
+        }
         throw syncError(
           "REMOTE_BASE_UNVERIFIED",
           "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
@@ -335,10 +455,7 @@ export function installNoteSyncSafety(): void {
 
       if (isCurrentlyOffline()) {
         preserveConflict(noteId, data, baseVersion, fresh, "REMOTE_BASE_UNVERIFIED");
-        throw syncError(
-          "REMOTE_BASE_UNVERIFIED",
-          "服务端正文尚未成功加载，已阻止保存。",
-        );
+        return completePendingResponse(noteId, data, baseVersion, fresh, true);
       }
 
       clearOfflineNoteSnapshot(noteId);
@@ -347,14 +464,28 @@ export function installNoteSyncSafety(): void {
         fingerprintNoteContent(fresh.content) !== offlineBase.contentFingerprint
       );
       if (fresh.version !== baseVersion || baseContentMismatch) {
+        // A timeout can happen after the server committed the exact body. Treat the fetched
+        // note as the missing acknowledgement rather than manufacturing a conflict copy.
+        if (mutationMatchesNote(fresh, data)) {
+          clearResolvedConflictArtifacts(noteId);
+          rememberConfirmedNote(fresh, noteId);
+          return fresh;
+        }
+
+        // A version-only advance with an unchanged body is not a real editing conflict. Rebase
+        // the latest local snapshot once onto the server revision and continue silently.
+        if (previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
+          const retried = await retryOnFreshVersion(noteId, data, fresh);
+          if (retried) return retried;
+        }
+
         preserveConflict(noteId, data, baseVersion, fresh, "STALE_OFFLINE_BASE");
-        const error = syncError("VERSION_CONFLICT", "Version conflict", 409) as any;
-        error.currentVersion = fresh.version;
-        error.baseContentMismatch = baseContentMismatch;
-        throw error;
+        confirmedNotes.set(noteId, fresh);
+        return completePendingResponse(noteId, data, baseVersion, fresh, true);
       }
     }
 
+    const previousConfirmed = confirmedNotes.get(noteId) || null;
     try {
       const updated = await originalUpdateNote(noteId, data as Partial<Note>);
 
@@ -365,9 +496,11 @@ export function installNoteSyncSafety(): void {
           version: baseVersion,
           updatedAt: updated?.updatedAt,
         });
-        window.dispatchEvent(new CustomEvent(NOTE_SYNC_PENDING_EVENT, {
-          detail: { noteId, baseVersion, queued: true },
-        }));
+        const server = previousConfirmed || (isCompleteNote(updated, noteId) ? updated : null);
+        if (server) {
+          return completePendingResponse(noteId, data, baseVersion, server, false);
+        }
+        dispatchPending(noteId, baseVersion, { responseIncomplete: true });
         const error = syncError(
           "OFFLINE_WRITE_QUEUED",
           "修改已保存在本地并等待上传，尚未得到服务端确认。",
@@ -377,22 +510,50 @@ export function installNoteSyncSafety(): void {
       }
 
       clearOfflineNoteSnapshot(noteId);
+      clearResolvedConflictArtifacts(noteId);
+      rememberConfirmedNote(updated, noteId);
       return updated;
     } catch (error: any) {
-      if (error?.status === 409 || error?.code === "VERSION_CONFLICT") {
-        let server: Note | null = null;
-        try {
-          server = await originalGetNote(noteId);
-          if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
-        } catch {
-          // The version from the 409 is enough to stop the write safely.
-        }
-        const record = preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
-        if (typeof error.currentVersion !== "number" && typeof record.serverVersion === "number") {
-          error.currentVersion = record.serverVersion;
-        }
+      if (error?.status !== 409 && error?.code !== "VERSION_CONFLICT") throw error;
+
+      const fresh = await fetchCurrentServerNote(noteId);
+      if (fresh && mutationMatchesNote(fresh, data)) {
+        // Lost ACK: the server already contains the exact local mutation.
+        clearOfflineNoteSnapshot(noteId);
+        clearResolvedConflictArtifacts(noteId);
+        rememberConfirmedNote(fresh, noteId);
+        return fresh;
       }
-      throw error;
+
+      if (fresh && previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
+        const retried = await retryOnFreshVersion(noteId, data, fresh);
+        if (retried) return retried;
+      }
+
+      const currentVersion = typeof error.currentVersion === "number"
+        ? error.currentVersion
+        : undefined;
+      const fallbackServer = previousConfirmed
+        ? ({
+            ...previousConfirmed,
+            version: currentVersion ?? previousConfirmed.version,
+          } as Note)
+        : null;
+      const server = fresh || fallbackServer;
+      const record = preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
+      if (typeof error.currentVersion !== "number" && typeof record.serverVersion === "number") {
+        error.currentVersion = record.serverVersion;
+      }
+
+      if (server) {
+        if (fresh) confirmedNotes.set(noteId, fresh);
+        return completePendingResponse(noteId, data, baseVersion, server, true);
+      }
+
+      throw syncError(
+        "REMOTE_BASE_UNVERIFIED",
+        "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
+      );
     }
   };
 
@@ -400,6 +561,7 @@ export function installNoteSyncSafety(): void {
     (api as any).getNote = originalGetNote;
     (api as any).updateNote = originalUpdateNote;
     resolvingNoteIds.clear();
+    confirmedNotes.clear();
     delete guardedWindow[INSTALL_KEY];
   };
 }

--- a/frontend/src/lib/noteUpdateSerialQueue.ts
+++ b/frontend/src/lib/noteUpdateSerialQueue.ts
@@ -66,17 +66,21 @@ export function installNoteUpdateSerialQueue(): void {
       payload,
     });
 
-    // EditorPane and other callers historically clear drafts by noteId after their Promise
-    // resolves. All coalesced callers receive this same latest result, so record the exact
-    // authoritative body first. draftStorage will refuse a late caller's cleanup if a newer
-    // local snapshot has already replaced it.
-    markDraftAcknowledged({
-      noteId,
-      title: saved.result.title,
-      content: saved.result.content,
-      contentText: saved.result.contentText,
-      serverVersion: saved.result.version,
-    });
+    // A pending conflict is locally durable but is not a server acknowledgement of this body.
+    // Never let the editor clear the only recoverable draft for that state.
+    if ((saved.result as Note & { __syncPending?: boolean }).__syncPending !== true) {
+      // EditorPane and other callers historically clear drafts by noteId after their Promise
+      // resolves. All coalesced callers receive this same latest result, so record the exact
+      // authoritative body first. draftStorage will refuse a late caller's cleanup if a newer
+      // local snapshot has already replaced it.
+      markDraftAcknowledged({
+        noteId,
+        title: saved.result.title,
+        content: saved.result.content,
+        contentText: saved.result.contentText,
+        serverVersion: saved.result.version,
+      });
+    }
     return saved.result;
   };
 


### PR DESCRIPTION
## 问题

v1.4.5 在单端编辑时也可能因版本号滞后进入冲突流程，随后离线队列持续产生新的冲突项，导致：

- 反复提示版本冲突
- 同一笔记短时间生成多个冲突副本
- 同时显示“保存失败”和“已创建冲突副本”
- 冲突副本被删除后可能再次生成

## 修复

- 区分丢失 ACK、仅版本前进和真实正文冲突
- 版本仅前进时自动 rebase 并重试一次
- 服务端已经包含本地正文时直接视为保存成功
- 真实冲突改为完整的本地待处理状态，不再进入编辑器通用失败重入链路
- 同一笔记只保留一个冲突队列项，并保持队列 ID 稳定
- 后续编辑持续合并到同一冲突代次
- 已存在的确定性冲突副本更新为最新本地正文，不再新建第二份
- 待处理状态不会错误清除本地草稿

## 验证重点

- 单页面快速连续输入
- 409 后继续编辑
- 请求超时但服务端已成功写入
- 版本号变化但正文未变化
- 后台多次重复执行冲突处理
- 冲突副本创建请求成功但响应丢失
