### PR TITLE
chore(pg): sync latest release/v1.4.6 fixes

### DIFF
--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -27,12 +27,14 @@ on:
       - "frontend/src/lib/yjsDurability.ts"
       - "frontend/src/lib/draftStorage.ts"
       - "frontend/src/lib/editorLifecycleSafety.ts"
+      - "frontend/src/lib/noteSyncSafety.ts"
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
+      - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -61,12 +63,14 @@ on:
       - "frontend/src/lib/yjsDurability.ts"
       - "frontend/src/lib/draftStorage.ts"
       - "frontend/src/lib/editorLifecycleSafety.ts"
+      - "frontend/src/lib/noteSyncSafety.ts"
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
+      - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -117,6 +121,7 @@ jobs:
           src/components/__tests__/EditorPaneNativeMarkdownCollab.test.ts
           src/lib/__tests__/draftStorage.conflict.test.ts
           src/lib/__tests__/editorLifecycleSafety.test.ts
+          src/lib/__tests__/noteSyncSafety.integration.test.ts
           src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
           src/lib/__tests__/conflictResolution.test.ts
       - name: Frontend typecheck

--- a/.github/workflows/tmp-apply-release-review-fixes.yml
+++ b/.github/workflows/tmp-apply-release-review-fixes.yml
@@ -1,0 +1,110 @@
+name: Apply v1.4.6 Review Fixes
+
+on:
+  push:
+    branches: [release/v1.4.6]
+    paths:
+      - "scripts/apply-release-review-fixes.mjs"
+      - "scripts/repair-release-review-fix-script.mjs"
+      - ".github/workflows/tmp-apply-release-review-fixes.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  apply-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - name: Check out release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release/v1.4.6
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Repair and validate patch script
+        run: |
+          node scripts/repair-release-review-fix-script.mjs
+          node --check scripts/apply-release-review-fixes.mjs
+
+      - name: Apply release review fixes
+        run: node scripts/apply-release-review-fixes.mjs
+
+      - name: Install dependencies
+        run: |
+          npm ci --no-audit --no-fund
+          npm ci --prefix backend --no-audit --no-fund
+          npm ci --prefix frontend --no-audit --no-fund
+
+      - name: File visibility integration regressions
+        working-directory: backend
+        run: >-
+          node --import tsx --import ./tests/setup-db-isolation.ts --test
+          tests/file-orphan-visibility.test.ts
+          tests/data-file-manual-upload-retention.test.ts
+
+      - name: Backend typecheck
+        run: npm run build:tsc --prefix backend
+
+      - name: Review-fix frontend regressions
+        run: >-
+          npm run test:run --prefix frontend --
+          src/lib/__tests__/mobileImageViewerContract.test.ts
+          src/lib/__tests__/androidImagePreviewTapCloseContract.test.ts
+          src/lib/__tests__/noteImageExportBridge.test.ts
+          src/components/daily-records/__tests__/dailyJournalContentPreview.test.tsx
+
+      - name: Block patch frontend regressions
+        working-directory: frontend
+        run: >-
+          npm run test:run --
+          src/lib/__tests__/blockPatchApi.test.ts
+          src/lib/__tests__/blockPatchListStructureApi.test.ts
+          src/lib/__tests__/tiptapBlockPatchPlanner.test.ts
+          src/lib/__tests__/tiptapBlockPatchPlannerV2.test.ts
+          src/lib/__tests__/tiptapSchemaRepair.test.ts
+          src/lib/__tests__/tiptapBlockPatchImagePlanner.test.ts
+          src/lib/__tests__/tiptapBlockPatchEmptyDocument.test.ts
+          src/lib/__tests__/tiptapBlockPatchRuntime.test.ts
+          src/lib/__tests__/tiptapListItemMovePlanner.test.ts
+          src/lib/__tests__/tiptapListItemStructurePlanner.test.ts
+          src/lib/__tests__/tiptapListItemBatchPlanner.test.ts
+          src/lib/__tests__/tiptapListItemLiftPlanner.test.ts
+          src/lib/__tests__/tiptapEmptyBlockIdentityDispatch.test.ts
+          src/components/__tests__/TiptapBlockPatchRuntime.test.tsx
+          src/components/__tests__/TiptapBlockPatchRuntimeV2.test.tsx
+          src/components/__tests__/TiptapBlockPatchImageRuntime.test.tsx
+          src/components/__tests__/TiptapBlockPatchEmptyDocument.test.tsx
+          src/components/__tests__/TiptapBlockPatchListRuntime.test.tsx
+          src/components/__tests__/TiptapBlockPatchListStructureRuntime.test.tsx
+          src/components/__tests__/TiptapRuntimePublicContext.test.tsx
+
+      - name: Frontend typecheck and production build
+        working-directory: frontend
+        run: |
+          npx tsc -b
+          npx vite build
+
+      - name: Release metadata and updater tests
+        run: npm run test:update-release
+
+      - name: Remove temporary patch machinery
+        run: |
+          rm .github/workflows/tmp-apply-release-review-fixes.yml
+          rm scripts/apply-release-review-fixes.mjs
+          rm scripts/repair-release-review-fix-script.mjs
+
+      - name: Commit verified fixes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --stat
+          git commit -m "fix(release): resolve v1.4.6 review blockers"
+          git push origin HEAD:release/v1.4.6

--- a/.github/workflows/tmp-apply-release-review-fixes.yml
+++ b/.github/workflows/tmp-apply-release-review-fixes.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "scripts/apply-release-review-fixes.mjs"
       - "scripts/repair-release-review-fix-script.mjs"
+      - "scripts/fix-note-image-export-ready-import.mjs"
       - ".github/workflows/tmp-apply-release-review-fixes.yml"
   workflow_dispatch:
 
@@ -34,7 +35,9 @@ jobs:
           node --check scripts/apply-release-review-fixes.mjs
 
       - name: Apply release review fixes
-        run: node scripts/apply-release-review-fixes.mjs
+        run: |
+          node scripts/apply-release-review-fixes.mjs
+          node scripts/fix-note-image-export-ready-import.mjs
 
       - name: Install dependencies
         run: |
@@ -99,6 +102,7 @@ jobs:
           rm .github/workflows/tmp-apply-release-review-fixes.yml
           rm scripts/apply-release-review-fixes.mjs
           rm scripts/repair-release-review-fix-script.mjs
+          rm scripts/fix-note-image-export-ready-import.mjs
 
       - name: Commit verified fixes
         run: |

--- a/frontend/src/lib/__tests__/conflictResolution.test.ts
+++ b/frontend/src/lib/__tests__/conflictResolution.test.ts
@@ -8,18 +8,20 @@ const apiMock = vi.hoisted(() => ({
   createNoteConfirmed: vi.fn(),
 }));
 const discardResolvedQueueItems = vi.hoisted(() => vi.fn());
+const getQueue = vi.hoisted(() => vi.fn());
 const clearDraft = vi.hoisted(() => vi.fn());
 const loadDraft = vi.hoisted(() => vi.fn());
 const clearOfflineNoteSnapshot = vi.hoisted(() => vi.fn());
 const clearNoteSyncConflict = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
-vi.mock("@/lib/offlineQueue", () => ({ discardResolvedQueueItems }));
+vi.mock("@/lib/offlineQueue", () => ({ discardResolvedQueueItems, getQueue }));
 vi.mock("@/lib/draftStorage", () => ({ clearDraft, loadDraft }));
 vi.mock("@/lib/offlineRead", () => ({ clearOfflineNoteSnapshot }));
 vi.mock("@/lib/noteSyncSafety", () => ({ clearNoteSyncConflict }));
 
 import {
+  discardConflictStateForDeletedCopy,
   getConflictCopyId,
   resolveNoteConflict,
   resolveQueuedNoteConflicts,
@@ -87,8 +89,11 @@ describe("resolveNoteConflict", () => {
     vi.clearAllMocks();
     localStorage.clear();
     loadDraft.mockReturnValue(null);
+    getQueue.mockReturnValue([]);
     discardResolvedQueueItems.mockReturnValue({ discarded: true, remainingForNote: false });
     apiMock.getNote.mockResolvedValue(remoteNote());
+    apiMock.updateNoteConfirmed.mockReset();
+    apiMock.createNoteConfirmed.mockReset();
   });
 
   it("distinguishes debounced editor input from the conflict payload already copied", () => {
@@ -264,7 +269,13 @@ describe("resolveNoteConflict", () => {
       status: 409,
       code: "NOTE_ID_CONFLICT",
     });
-    const existingCopy = remoteNote({ id: copyId, title: "已存在的冲突副本", version: 1 });
+    const existingCopy = remoteNote({
+      id: copyId,
+      title: "已存在的冲突副本",
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 1,
+    });
     apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
     apiMock.getNote
       .mockResolvedValueOnce(remoteNote())
@@ -273,8 +284,40 @@ describe("resolveNoteConflict", () => {
     const result = await resolveNoteConflict(item, "use-server");
 
     expect(apiMock.getNote).toHaveBeenNthCalledWith(2, copyId);
+    expect(apiMock.updateNoteConfirmed).not.toHaveBeenCalled();
     expect(result.conflictCopy).toBe(existingCopy);
     expect(discardResolvedQueueItems).toHaveBeenCalledWith(item);
+  });
+
+  it("updates the same deterministic copy when later local input arrives", async () => {
+    const item = conflictItem();
+    const copyId = getConflictCopyId(item.id);
+    const conflictError = Object.assign(new Error("duplicate"), {
+      status: 409,
+      code: "NOTE_ID_CONFLICT",
+    });
+    const existingCopy = remoteNote({ id: copyId, title: "已存在的冲突副本", version: 1 });
+    const refreshedCopy = remoteNote({
+      id: copyId,
+      title: "已存在的冲突副本",
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 2,
+    });
+    apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
+    apiMock.getNote
+      .mockResolvedValueOnce(remoteNote())
+      .mockResolvedValueOnce(existingCopy);
+    apiMock.updateNoteConfirmed.mockResolvedValue(refreshedCopy);
+
+    const result = await resolveNoteConflict(item, "use-server");
+
+    expect(apiMock.updateNoteConfirmed).toHaveBeenCalledWith(copyId, expect.objectContaining({
+      content: "本地正文",
+      contentText: "本地正文",
+      version: 1,
+    }));
+    expect(result.conflictCopy).toBe(refreshedCopy);
   });
 
   it("keeps a newer local payload after recovering a copy whose response was lost", async () => {
@@ -286,7 +329,12 @@ describe("resolveNoteConflict", () => {
     apiMock.createNoteConfirmed.mockRejectedValue(conflictError);
     apiMock.getNote
       .mockResolvedValueOnce(remoteNote())
-      .mockResolvedValueOnce(remoteNote({ id: getConflictCopyId(item.id), version: 1 }));
+      .mockResolvedValueOnce(remoteNote({
+        id: getConflictCopyId(item.id),
+        content: "本地正文",
+        contentText: "本地正文",
+        version: 1,
+      }));
     discardResolvedQueueItems.mockReturnValue({ discarded: false, remainingForNote: true });
 
     await expect(resolveNoteConflict(item, "use-server")).rejects.toThrow("本地内容已更新");
@@ -326,5 +374,32 @@ describe("resolveNoteConflict", () => {
     expect(discardResolvedQueueItems).not.toHaveBeenCalled();
     expect(clearDraft).not.toHaveBeenCalled();
     expect(clearNoteSyncConflict).not.toHaveBeenCalled();
+  });
+
+  it("clears the source conflict generation when its generated copy is deleted", () => {
+    const item = conflictItem();
+    getQueue.mockReturnValue([item]);
+
+    expect(discardConflictStateForDeletedCopy(getConflictCopyId(item.id))).toBe("note-1");
+    expect(discardResolvedQueueItems).toHaveBeenCalledWith(item);
+    expect(clearDraft).toHaveBeenCalledWith("note-1");
+    expect(clearNoteSyncConflict).toHaveBeenCalledWith("note-1");
+  });
+
+  it("reasserts the queued UI state while a pending conflict remains durable", () => {
+    vi.useFakeTimers();
+    const item = conflictItem();
+    getQueue.mockReturnValue([item]);
+    const queuedEvents = vi.fn();
+    window.addEventListener("nowen:offline-queued", queuedEvents);
+
+    window.dispatchEvent(new CustomEvent("nowen:note-sync-pending", {
+      detail: { noteId: "note-1", queued: true },
+    }));
+    vi.runAllTimers();
+
+    expect(queuedEvents).toHaveBeenCalledTimes(2);
+    window.removeEventListener("nowen:offline-queued", queuedEvents);
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/lib/__tests__/draftStorage.conflict.test.ts
+++ b/frontend/src/lib/__tests__/draftStorage.conflict.test.ts
@@ -74,6 +74,26 @@ describe("draft conflict preservation", () => {
     )).toBe(true);
   });
 
+  it("never lets generic save-success cleanup delete an unresolved conflicted draft", () => {
+    saveDraft({
+      noteId: "note-conflicted-clear",
+      editorMode: "md",
+      title: "Local title",
+      content: "local unresolved body",
+      contentText: "local unresolved body",
+      baseVersion: 3,
+      savedAt: Date.now(),
+      conflicted: true,
+      serverVersion: 9,
+    });
+
+    expect(clearDraft("note-conflicted-clear")).toBe(false);
+    expect(loadDraft("note-conflicted-clear")).toEqual(expect.objectContaining({
+      content: "local unresolved body",
+      conflicted: true,
+    }));
+  });
+
   it("offers a divergent local body even when the server clock is ahead", () => {
     const draft = {
       noteId: "note-clock-skew",

--- a/frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
+++ b/frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
@@ -131,6 +131,19 @@ describe("LatestOnlyVersionedSaveQueue", () => {
       .rejects.toMatchObject({ code: "SAVE_NOT_CONFIRMED", saveBaseVersion: 4 });
   });
 
+  it("accepts a locally preserved pending conflict without pretending it is an ACK", async () => {
+    const queue = new LatestOnlyVersionedSaveQueue<string, { version: number; __syncPending?: boolean }>(
+      async (_noteId, _payload, version) => ({ version, __syncPending: true }),
+    );
+
+    await expect(queue.enqueue({ key: "n1", baseVersion: 4, payload: "draft" }))
+      .resolves.toMatchObject({
+        baseVersion: 4,
+        result: { version: 4, __syncPending: true },
+      });
+    expect(queue.getConfirmedVersion("n1")).toBe(4);
+  });
+
   it("accepts a newer base after a real conflict is resolved", async () => {
     let fail = true;
     const calls: number[] = [];

--- a/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
+++ b/frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 });
 
 describe("installed note sync safety", () => {
-  it("does not report an optimistic offline response as server-confirmed", async () => {
+  it("returns a complete local-pending note instead of reporting an optimistic response as saved", async () => {
     const transportUpdate = vi.fn().mockResolvedValue(note(4, "local body"));
     (api as any).getNote = vi.fn().mockResolvedValue(note(4));
     (api as any).updateNote = transportUpdate;
@@ -68,9 +68,13 @@ describe("installed note sync safety", () => {
       content: "local body",
       contentText: "local body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      code: "OFFLINE_WRITE_QUEUED",
-      queued: true,
+    } as any)).resolves.toMatchObject({
+      id: "note-1",
+      userId: "user-1",
+      notebookId: "notebook-1",
+      version: 4,
+      content: "local body",
+      __syncPending: true,
     });
     window.removeEventListener(NOTE_SYNC_PENDING_EVENT, pending);
 
@@ -79,7 +83,7 @@ describe("installed note sync safety", () => {
     expect(localStorage.getItem("nowen-draft-note-1")).toContain("local body");
   });
 
-  it("fetches the server revision and blocks PUT when an offline detail is stale", async () => {
+  it("preserves a stale offline edit as one pending conflict without issuing PUT", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(9, "new server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -93,18 +97,20 @@ describe("installed note sync safety", () => {
       content: "old cached body",
       contentText: "old cached body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      status: 409,
-      code: "VERSION_CONFLICT",
-      currentVersion: 9,
+    } as any)).resolves.toMatchObject({
+      id: "note-1",
+      version: 9,
+      content: "old cached body",
+      __syncPending: true,
     });
 
     expect(transportGet).toHaveBeenCalledTimes(1);
     expect(transportUpdate).not.toHaveBeenCalled();
     expect(localStorage.getItem("nowen-note-sync-conflicts:v1")).toContain("new server body");
+    expect(getQueue()).toHaveLength(1);
   });
 
-  it("pauses later writes after one conflict and only refreshes the preserved local payload", async () => {
+  it("pauses later writes after one conflict and refreshes the same queue generation", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(9, "new server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -112,18 +118,17 @@ describe("installed note sync safety", () => {
     markOfflineNoteSnapshot(note(4, "old cached body"));
     installNoteSyncSafety();
 
-    const conflictEvents = vi.fn();
-    window.addEventListener("offlineQueue:conflict", conflictEvents);
     await expect(api.updateNote("note-1", {
       version: 4,
       title: "Title",
       content: "first local body",
       contentText: "first local body",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({ code: "VERSION_CONFLICT" });
+    } as any)).resolves.toMatchObject({ __syncPending: true });
+    const firstQueueId = getQueue()[0]?.id;
 
     await expect(api.updateNote("note-1", {
-      version: 4,
+      version: 9,
       title: "Title",
       content: "latest local body",
       contentText: "latest local body",
@@ -132,14 +137,14 @@ describe("installed note sync safety", () => {
       id: "note-1",
       version: 9,
       content: "latest local body",
+      __syncPending: true,
     });
-    window.removeEventListener("offlineQueue:conflict", conflictEvents);
 
     expect(transportGet).toHaveBeenCalledTimes(1);
     expect(transportUpdate).not.toHaveBeenCalled();
-    expect(conflictEvents).not.toHaveBeenCalled();
     expect(getQueue()).toEqual([
       expect.objectContaining({
+        id: firstQueueId,
         noteId: "note-1",
         conflict: true,
         localPayload: expect.objectContaining({ content: "latest local body" }),
@@ -147,7 +152,7 @@ describe("installed note sync safety", () => {
     ]);
   });
 
-  it("blocks same-version writes when the cached base body differs from the server", async () => {
+  it("preserves same-version body mismatches as a pending conflict", async () => {
     const transportGet = vi.fn().mockResolvedValue(note(4, "important server body"));
     const transportUpdate = vi.fn();
     (api as any).getNote = transportGet;
@@ -161,14 +166,14 @@ describe("installed note sync safety", () => {
       content: "",
       contentText: "",
       contentFormat: "markdown",
-    } as any)).rejects.toMatchObject({
-      status: 409,
-      code: "VERSION_CONFLICT",
-      currentVersion: 4,
-      baseContentMismatch: true,
+    } as any)).resolves.toMatchObject({
+      version: 4,
+      content: "",
+      __syncPending: true,
     });
 
     expect(transportUpdate).not.toHaveBeenCalled();
+    expect(getQueue()).toHaveLength(1);
   });
 
   it("allows a cached detail only after a fresh GET confirms revision and base body", async () => {
@@ -208,5 +213,62 @@ describe("installed note sync safety", () => {
     } as any)).resolves.toMatchObject({ version: 5, content: "" });
 
     expect(transportUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("automatically rebases a version-only conflict and retries the latest snapshot once", async () => {
+    const conflict = Object.assign(new Error("conflict"), {
+      status: 409,
+      code: "VERSION_CONFLICT",
+      currentVersion: 5,
+    });
+    const transportGet = vi.fn()
+      .mockResolvedValueOnce(note(4, "server body"))
+      .mockResolvedValueOnce(note(5, "server body"));
+    const transportUpdate = vi.fn()
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce(note(6, "local body"));
+    (api as any).getNote = transportGet;
+    (api as any).updateNote = transportUpdate;
+    installNoteSyncSafety();
+
+    await api.getNote("note-1");
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "local body",
+      contentText: "local body",
+      contentFormat: "markdown",
+    } as any)).resolves.toMatchObject({ version: 6, content: "local body" });
+
+    expect(transportUpdate).toHaveBeenNthCalledWith(2, "note-1", expect.objectContaining({ version: 5 }));
+    expect(getQueue()).toHaveLength(0);
+  });
+
+  it("treats a fetched matching body as a lost acknowledgement instead of a conflict", async () => {
+    const conflict = Object.assign(new Error("conflict"), {
+      status: 409,
+      code: "VERSION_CONFLICT",
+      currentVersion: 5,
+    });
+    const transportGet = vi.fn()
+      .mockResolvedValueOnce(note(4, "server body"))
+      .mockResolvedValueOnce(note(5, "local body"));
+    const transportUpdate = vi.fn().mockRejectedValueOnce(conflict);
+    (api as any).getNote = transportGet;
+    (api as any).updateNote = transportUpdate;
+    installNoteSyncSafety();
+
+    await api.getNote("note-1");
+    await expect(api.updateNote("note-1", {
+      version: 4,
+      title: "Title",
+      content: "local body",
+      contentText: "local body",
+      contentFormat: "markdown",
+    } as any)).resolves.toMatchObject({ version: 5, content: "local body" });
+
+    expect(transportUpdate).toHaveBeenCalledTimes(1);
+    expect(getQueue()).toHaveLength(0);
+    expect(localStorage.getItem("nowen-note-sync-conflicts:v1")).toBeNull();
   });
 });

--- a/frontend/src/lib/conflictResolution.ts
+++ b/frontend/src/lib/conflictResolution.ts
@@ -2,6 +2,7 @@ import type { Note } from "@/types";
 import { api } from "@/lib/api";
 import {
   discardResolvedQueueItems,
+  getQueue,
   type OfflineQueueItem,
 } from "@/lib/offlineQueue";
 import * as draftStorage from "@/lib/draftStorage";
@@ -10,6 +11,10 @@ import { clearNoteSyncConflict } from "@/lib/noteSyncSafety";
 
 export type ConflictResolutionChoice = "keep-local" | "use-server";
 export const NOTE_CONFLICT_AUTO_RESOLVED_EVENT = "nowen:note-conflict-auto-resolved";
+const DELETE_GUARD_INSTALL_KEY = "__NOWEN_CONFLICT_COPY_DELETE_GUARD_V1__" as const;
+const PENDING_STATUS_BRIDGE_INSTALL_KEY = "__NOWEN_PENDING_SYNC_STATUS_BRIDGE_V1__" as const;
+const NOTE_SYNC_PENDING_EVENT_NAME = "nowen:note-sync-pending";
+const OFFLINE_QUEUED_EVENT_NAME = "nowen:offline-queued";
 
 export interface NoteConflictAutoResolvedDetail {
   note: Note;
@@ -58,6 +63,11 @@ type DraftStorageCompatibility = {
   forceClearDraft?: (noteId: string) => void;
 };
 
+type ConflictBridgeWindow = Window & typeof globalThis & {
+  [DELETE_GUARD_INSTALL_KEY]?: () => void;
+  [PENDING_STATUS_BRIDGE_INSTALL_KEY]?: () => void;
+};
+
 function payloadFromQueue(item: OfflineQueueItem): Partial<ConflictPayload> {
   const payload = item.localPayload || item.body || {};
   return {
@@ -89,6 +99,12 @@ function sameContent(local: ConflictPayload, remote: Note): boolean {
     && local.content === remote.content
     && local.contentText === remote.contentText
     && (local.contentFormat || remote.contentFormat) === remote.contentFormat;
+}
+
+function sameConflictCopyContent(copy: Note, local: ConflictPayload, remote: Note): boolean {
+  return copy.content === local.content
+    && copy.contentText === local.contentText
+    && copy.contentFormat === (local.contentFormat || remote.contentFormat);
 }
 
 function formatConflictCopyTitle(title: string, now = new Date()): string {
@@ -138,6 +154,77 @@ function clearResolvedConflict(item: OfflineQueueItem): boolean {
   return true;
 }
 
+/**
+ * When a user deletes a generated conflict copy, discard the source conflict generation too.
+ * Otherwise the next sync pass recreates the same copy and makes deletion appear broken.
+ */
+export function discardConflictStateForDeletedCopy(copyId: string): string | null {
+  const item = getQueue().find(
+    (queued) => queued.type === "updateNote"
+      && (queued.conflict || queued.errorCode === "VERSION_CONFLICT")
+      && getConflictCopyId(queued.id) === copyId,
+  );
+  if (!item) return null;
+  return clearResolvedConflict(item) ? item.noteId : null;
+}
+
+/**
+ * Conflict copies are ordinary notes in the tree, so the regular trash action is the only reliable
+ * place to learn that the user intentionally discarded one. Install an outer API guard after App
+ * lazy-load: a confirmed trash write clears the source conflict generation and prevents sync from
+ * recreating the same deterministic copy.
+ */
+export function installConflictCopyDeletionGuard(): void {
+  if (typeof window === "undefined" || typeof (api as any).updateNote !== "function") return;
+  const guardedWindow = window as ConflictBridgeWindow;
+  if (guardedWindow[DELETE_GUARD_INSTALL_KEY]) return;
+
+  const originalUpdateNote = api.updateNote.bind(api);
+  (api as any).updateNote = async (noteId: string, data: Partial<Note>): Promise<Note> => {
+    const updated = await originalUpdateNote(noteId, data);
+    if ((data as Partial<Note>).isTrashed === 1) {
+      discardConflictStateForDeletedCopy(noteId);
+    }
+    return updated;
+  };
+
+  guardedWindow[DELETE_GUARD_INSTALL_KEY] = () => {
+    (api as any).updateNote = originalUpdateNote;
+    delete guardedWindow[DELETE_GUARD_INSTALL_KEY];
+  };
+}
+
+/**
+ * EditorPane historically reports every resolved update Promise as "saved" and resets it to idle
+ * two seconds later. Pending conflict/offline responses are deliberately resolved so autosave does
+ * not enter its failure/requeue loop, therefore reassert the existing global "queued" UI event
+ * after both transitions while the note still has a durable queue item.
+ */
+export function installPendingSyncStatusBridge(): void {
+  if (typeof window === "undefined") return;
+  const guardedWindow = window as ConflictBridgeWindow;
+  if (guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY]) return;
+
+  const publishQueuedIfPending = (noteId: string) => {
+    if (!getQueue().some((item) => item.noteId === noteId)) return;
+    window.dispatchEvent(new CustomEvent(OFFLINE_QUEUED_EVENT_NAME, {
+      detail: { noteId, pending: true },
+    }));
+  };
+  const onPending = (event: Event) => {
+    const noteId = (event as CustomEvent<{ noteId?: string }>).detail?.noteId;
+    if (!noteId) return;
+    window.setTimeout(() => publishQueuedIfPending(noteId), 0);
+    window.setTimeout(() => publishQueuedIfPending(noteId), 2200);
+  };
+
+  window.addEventListener(NOTE_SYNC_PENDING_EVENT_NAME, onPending);
+  guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY] = () => {
+    window.removeEventListener(NOTE_SYNC_PENDING_EVENT_NAME, onPending);
+    delete guardedWindow[PENDING_STATUS_BRIDGE_INSTALL_KEY];
+  };
+}
+
 async function keepLocalVersion(
   item: OfflineQueueItem,
   remote: Note,
@@ -157,6 +244,24 @@ async function keepLocalVersion(
     throw new Error("处理期间本地内容已更新，等待下一次后台同步。");
   }
   return { note: updated, resolvedLocal: local };
+}
+
+async function updateExistingConflictCopy(
+  existing: Note,
+  remote: Note,
+  local: ConflictPayload,
+): Promise<Note> {
+  if (sameConflictCopyContent(existing, local, remote)) return existing;
+  const updated = await api.updateNoteConfirmed(existing.id, {
+    content: local.content,
+    contentText: local.contentText,
+    contentFormat: local.contentFormat || remote.contentFormat,
+    version: existing.version,
+  });
+  if (typeof updated.version !== "number" || updated.version <= existing.version) {
+    throw new Error("冲突副本尚未得到服务器确认，请稍后重试。");
+  }
+  return updated;
 }
 
 async function createOrLoadConflictCopy(
@@ -179,8 +284,10 @@ async function createOrLoadConflictCopy(
     const details = error as { status?: number; code?: string };
     if (details.status !== 409 || details.code !== "NOTE_ID_CONFLICT") throw error;
     // The previous request may have committed successfully while its response was lost. Because
-    // the id is deterministic for this conflict, loading it is safe and makes retry idempotent.
-    return api.getNote(copyId);
+    // the id is deterministic for this conflict, load and refresh that same copy with the latest
+    // local snapshot instead of creating a second timestamped document.
+    const existing = await api.getNote(copyId);
+    return updateExistingConflictCopy(existing, remote, local);
   }
 }
 
@@ -259,3 +366,6 @@ export async function resolveQueuedNoteConflicts(
     failures,
   };
 }
+
+installConflictCopyDeletionGuard();
+installPendingSyncStatusBridge();

--- a/frontend/src/lib/draftStorage.ts
+++ b/frontend/src/lib/draftStorage.ts
@@ -168,6 +168,7 @@ export function loadDraft(noteId: string): NoteDraft | null {
 /**
  * Clear a draft after save success without allowing an older response to delete newer local text.
  *
+ * - Conflicted draft: explicit conflict resolution is the only allowed cleanup path.
  * - No ACK marker: preserve historical/manual cleanup behavior and delete immediately.
  * - ACK body differs from current draft: refuse cleanup; the draft is newer than the response.
  * - ACK body matches: delay deletion and re-check savedAt/body after the editor debounce window.
@@ -178,6 +179,8 @@ export function clearDraft(noteId: string): boolean {
     removeDraftNow(noteId);
     return true;
   }
+
+  if (draft.conflicted) return false;
 
   const acknowledgement = acknowledgements.get(noteId);
   if (!acknowledgement) {

--- a/frontend/src/lib/latestOnlyVersionedSaveQueue.ts
+++ b/frontend/src/lib/latestOnlyVersionedSaveQueue.ts
@@ -1,5 +1,10 @@
 export interface VersionedSaveResult {
   version: number;
+  /**
+   * The original note was not committed, but the latest local snapshot was durably
+   * preserved in the conflict queue. This is a pending state rather than a transport error.
+   */
+  __syncPending?: boolean;
 }
 
 export interface VersionedSaveEnvelope<TPayload, TResult extends VersionedSaveResult> {
@@ -119,7 +124,8 @@ export class LatestOnlyVersionedSaveQueue<TPayload, TResult extends VersionedSav
         return;
       }
 
-      if (!Number.isFinite(result.version) || result.version <= baseVersion) {
+      const locallyPreserved = result.__syncPending === true;
+      if (!Number.isFinite(result.version) || (!locallyPreserved && result.version <= baseVersion)) {
         const error = new Error("Server did not confirm a newer version") as Error & {
           code?: string;
           saveBaseVersion?: number;
@@ -135,7 +141,9 @@ export class LatestOnlyVersionedSaveQueue<TPayload, TResult extends VersionedSav
         return;
       }
 
-      state.confirmedVersion = result.version;
+      // Pending-conflict responses carry the latest known server revision without
+      // acknowledging the local body. Keep the queue rebased while draft cleanup stays off.
+      state.confirmedVersion = Math.max(state.confirmedVersion, result.version);
       const pending = this.readPending(state);
       if (pending) {
         pending.waiters.unshift(...batch.waiters);

--- a/frontend/src/lib/noteSyncSafety.ts
+++ b/frontend/src/lib/noteSyncSafety.ts
@@ -8,11 +8,7 @@ import {
   isOfflineNoteSnapshot,
   markOfflineNoteSnapshot,
 } from "@/lib/offlineRead";
-import {
-  enqueue,
-  getQueue,
-  replaceItem,
-} from "@/lib/offlineQueue";
+import { dequeue, enqueue, getQueue, updateItem } from "@/lib/offlineQueue";
 import { saveDraft } from "@/lib/draftStorage";
 
 const INSTALL_KEY = "__NOWEN_NOTE_SYNC_SAFETY_V1__" as const;
@@ -20,6 +16,7 @@ const CONFLICT_STORAGE_KEY = "nowen-note-sync-conflicts:v1";
 const MAX_CONFLICTS = 20;
 const MAX_SNAPSHOT_CHARS = 500_000;
 const resolvingNoteIds = new Set<string>();
+const confirmedNotes = new Map<string, Note>();
 
 export const NOTE_SYNC_PENDING_EVENT = "nowen:note-sync-pending";
 
@@ -38,20 +35,61 @@ export interface NoteSyncConflictRecord {
   reason: "STALE_OFFLINE_BASE" | "VERSION_CONFLICT" | "REMOTE_BASE_UNVERIFIED";
 }
 
-type GuardedWindow = Window & typeof globalThis & {
-  [INSTALL_KEY]?: () => void;
-};
-
+type GuardedWindow = Window & typeof globalThis & { [INSTALL_KEY]?: () => void };
 type NoteMutation = Partial<Note> & Record<string, unknown>;
+type PendingNote = Note & { __syncPending: true };
 
 export function isVersionedNoteMutation(data: NoteMutation): boolean {
-  return ["title", "content", "contentText", "contentFormat"].some(
-    (field) => data[field] !== undefined,
-  );
+  return ["title", "content", "contentText", "contentFormat"].some((field) => data[field] !== undefined);
 }
 
 export function isServerConfirmedNoteWrite(baseVersion: number, responseVersion: unknown): boolean {
   return typeof responseVersion === "number" && Number.isFinite(responseVersion) && responseVersion > baseVersion;
+}
+
+function isCompleteNote(value: unknown, noteId?: string): value is Note {
+  const note = value as Partial<Note> | null;
+  return !!note
+    && typeof note.id === "string" && note.id.length > 0
+    && (!noteId || note.id === noteId)
+    && typeof note.userId === "string" && note.userId.length > 0
+    && typeof note.notebookId === "string" && note.notebookId.length > 0
+    && typeof note.title === "string"
+    && typeof note.content === "string"
+    && typeof note.contentText === "string"
+    && typeof note.version === "number" && Number.isFinite(note.version)
+    && typeof note.createdAt === "string" && note.createdAt.length > 0
+    && typeof note.updatedAt === "string" && note.updatedAt.length > 0;
+}
+
+function rememberConfirmedNote(note: unknown, noteId?: string): note is Note {
+  if (!isCompleteNote(note, noteId)) return false;
+  confirmedNotes.set(note.id, note);
+  return true;
+}
+
+function noteBodiesEqual(left: Partial<Note>, right: Partial<Note>): boolean {
+  return left.title === right.title
+    && left.content === right.content
+    && left.contentText === right.contentText
+    && left.contentFormat === right.contentFormat;
+}
+
+function mutationMatchesNote(note: Partial<Note>, data: NoteMutation): boolean {
+  const fields = ["title", "content", "contentText", "contentFormat"] as const;
+  return fields.every((field) => data[field] === undefined || note[field] === data[field]);
+}
+
+function makePendingNote(server: Note, data: NoteMutation): PendingNote {
+  return {
+    ...server,
+    ...(typeof data.title === "string" ? { title: data.title } : {}),
+    ...(typeof data.content === "string" ? { content: data.content } : {}),
+    ...(typeof data.contentText === "string" ? { contentText: data.contentText } : {}),
+    ...(data.contentFormat !== undefined ? { contentFormat: data.contentFormat } : {}),
+    version: server.version,
+    __syncPending: true,
+  } as PendingNote;
 }
 
 function trimSnapshot(value: unknown): string | undefined {
@@ -97,14 +135,10 @@ export function clearNoteSyncConflict(noteId: string): void {
     if (next.length === 0) localStorage.removeItem(CONFLICT_STORAGE_KEY);
     else localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(next));
   } catch {
-    /* keep queue/draft as the durable fallback */
+    // Queue and draft remain the durable fallback.
   }
 }
 
-/**
- * Persist one current record per note. Returning false means the exact same conflict was
- * already known, allowing callers to suppress duplicate toasts without losing the payload.
- */
 export function recordNoteSyncConflict(record: NoteSyncConflictRecord): boolean {
   const previous = getNoteSyncConflict(record.noteId);
   const changed = !previous || conflictSignature(previous) !== conflictSignature(record);
@@ -113,7 +147,7 @@ export function recordNoteSyncConflict(record: NoteSyncConflictRecord): boolean 
     records.unshift(record);
     localStorage.setItem(CONFLICT_STORAGE_KEY, JSON.stringify(records.slice(0, MAX_CONFLICTS)));
   } catch {
-    // The complete local edit remains in draftStorage and offlineQueue even if metadata hits quota.
+    // Queue and draft still contain the complete local edit.
   }
   return changed;
 }
@@ -177,15 +211,10 @@ function isConflictQueueItem(item: { conflict?: boolean; errorCode?: string }): 
   return item.conflict === true || item.errorCode === "VERSION_CONFLICT";
 }
 
-function upsertConflictQueueItem(
-  noteId: string,
-  data: NoteMutation,
-  serverVersion?: number,
-): void {
+function upsertConflictQueueItem(noteId: string, data: NoteMutation, serverVersion?: number): void {
   const body = { ...data } as Record<string, unknown>;
-  const existing = getQueue().find(
-    (item) => item.noteId === noteId && item.type === "updateNote",
-  );
+  const candidates = getQueue().filter((item) => item.noteId === noteId && item.type === "updateNote");
+  const existing = candidates.find(isConflictQueueItem) || candidates[0];
   const patch = {
     body,
     localPayload: body,
@@ -201,7 +230,11 @@ function upsertConflictQueueItem(
   } as const;
 
   if (existing) {
-    replaceItem(existing.id, patch);
+    // Keep the queue id stable so all later edits target the same deterministic copy.
+    updateItem(existing.id, patch);
+    for (const duplicate of candidates) {
+      if (duplicate.id !== existing.id) dequeue(duplicate.id);
+    }
     return;
   }
 
@@ -214,17 +247,22 @@ function upsertConflictQueueItem(
   });
 }
 
+function clearResolvedConflictArtifacts(noteId: string): void {
+  clearNoteSyncConflict(noteId);
+  for (const item of getQueue()) {
+    if (item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item)) {
+      dequeue(item.id);
+    }
+  }
+}
+
 export function hasPendingNoteSyncConflict(noteId: string): boolean {
-  if (getNoteSyncConflict(noteId)) return true;
-  return getQueue().some(
+  return !!getNoteSyncConflict(noteId) || getQueue().some(
     (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
   );
 }
 
-export async function runWithNoteConflictResolution<T>(
-  noteId: string,
-  task: () => Promise<T>,
-): Promise<T> {
+export async function runWithNoteConflictResolution<T>(noteId: string, task: () => Promise<T>): Promise<T> {
   resolvingNoteIds.add(noteId);
   try {
     return await task();
@@ -247,7 +285,6 @@ function preserveConflict(
   return record;
 }
 
-/** 把编辑器尚未提交的最新快照直接存为冲突，不向服务器发起写请求。 */
 export function preserveNoteSyncConflictSnapshot(
   noteId: string,
   data: NoteMutation,
@@ -257,35 +294,27 @@ export function preserveNoteSyncConflictSnapshot(
   preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
 }
 
-function pausedConflictResponse(
+function dispatchPending(noteId: string, baseVersion: number, detail?: Record<string, unknown>): void {
+  window.dispatchEvent(new CustomEvent(NOTE_SYNC_PENDING_EVENT, {
+    detail: { noteId, baseVersion, queued: true, ...detail },
+  }));
+}
+
+function restorePendingDraft(
   noteId: string,
   data: NoteMutation,
   baseVersion: number,
-): Note {
-  const record = getNoteSyncConflict(noteId);
-  const queued = getQueue().find(
-    (item) => item.noteId === noteId && item.type === "updateNote" && isConflictQueueItem(item),
-  );
-  const serverVersion = record?.serverVersion ?? queued?.serverVersion ?? baseVersion;
-  const updatedAt = record?.serverUpdatedAt || new Date().toISOString();
-
-  persistLocalDraft(noteId, data, baseVersion, { serverVersion });
-  upsertConflictQueueItem(noteId, data, serverVersion);
-  // EditorPane clears drafts after every resolved update. Restore the conflicted draft after that
-  // success bookkeeping finishes, while deliberately avoiding another network request.
+  conflict: boolean,
+  serverVersion?: number,
+): void {
   window.setTimeout(() => {
-    persistLocalDraft(noteId, data, baseVersion, { serverVersion });
+    persistLocalDraft(
+      noteId,
+      data,
+      baseVersion,
+      conflict ? { serverVersion } : undefined,
+    );
   }, 0);
-
-  return {
-    id: noteId,
-    title: typeof data.title === "string" ? data.title : record?.localTitle || "",
-    content: typeof data.content === "string" ? data.content : record?.localContent || "",
-    contentText: typeof data.contentText === "string" ? data.contentText : record?.localContentText || "",
-    contentFormat: (data.contentFormat || "markdown") as Note["contentFormat"],
-    version: serverVersion,
-    updatedAt,
-  } as Note;
 }
 
 export function installNoteSyncSafety(): void {
@@ -296,9 +325,48 @@ export function installNoteSyncSafety(): void {
   const originalGetNote = api.getNote.bind(api);
   const originalUpdateNote = api.updateNote.bind(api);
 
+  async function fetchCurrentServerNote(noteId: string): Promise<Note | null> {
+    try {
+      const note = await originalGetNote(noteId);
+      if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
+      return isCompleteNote(note, noteId) ? note : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function completePendingResponse(
+    noteId: string,
+    data: NoteMutation,
+    baseVersion: number,
+    server: Note,
+    conflict: boolean,
+  ): PendingNote {
+    persistLocalDraft(noteId, data, baseVersion, conflict ? { serverVersion: server.version } : undefined);
+    restorePendingDraft(noteId, data, baseVersion, conflict, server.version);
+    dispatchPending(noteId, baseVersion, { conflict, serverVersion: server.version });
+    return makePendingNote(server, data);
+  }
+
+  async function retryOnFreshVersion(noteId: string, data: NoteMutation, fresh: Note): Promise<Note | null> {
+    try {
+      const updated = await originalUpdateNote(noteId, { ...data, version: fresh.version } as Partial<Note>);
+      if (!isCompleteNote(updated, noteId) || !isServerConfirmedNoteWrite(fresh.version, updated.version)) {
+        return null;
+      }
+      clearOfflineNoteSnapshot(noteId);
+      clearResolvedConflictArtifacts(noteId);
+      rememberConfirmedNote(updated, noteId);
+      return updated;
+    } catch {
+      return null;
+    }
+  }
+
   (api as any).getNote = async (noteId: string): Promise<Note> => {
     const note = await originalGetNote(noteId);
     if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
+    rememberConfirmedNote(note, noteId);
     return note;
   };
 
@@ -315,84 +383,109 @@ export function installNoteSyncSafety(): void {
     }
 
     if (versioned && !resolvingNoteIds.has(noteId) && hasPendingNoteSyncConflict(noteId)) {
-      return pausedConflictResponse(noteId, data, baseVersion);
+      let server = confirmedNotes.get(noteId) || null;
+      if (!server) {
+        server = await fetchCurrentServerNote(noteId);
+        if (server) confirmedNotes.set(noteId, server);
+      }
+      preserveConflict(
+        noteId,
+        data,
+        baseVersion,
+        server,
+        getNoteSyncConflict(noteId)?.reason || "VERSION_CONFLICT",
+      );
+      if (!server) {
+        throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
+      }
+      return completePendingResponse(noteId, data, baseVersion, server, true);
     }
 
     if (versioned) persistLocalDraft(noteId, data, baseVersion);
 
     if (versioned && isOfflineNoteSnapshot(noteId) && !isCurrentlyOffline()) {
       const offlineBase = getOfflineNoteSnapshot(noteId);
-      let fresh: Note;
-      try {
-        fresh = await originalGetNote(noteId);
-      } catch {
-        preserveConflict(noteId, data, baseVersion, null, "REMOTE_BASE_UNVERIFIED");
-        throw syncError(
-          "REMOTE_BASE_UNVERIFIED",
-          "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。",
-        );
+      const previousConfirmed = confirmedNotes.get(noteId) || null;
+      const fresh = await fetchCurrentServerNote(noteId);
+      if (!fresh) {
+        preserveConflict(noteId, data, baseVersion, previousConfirmed, "REMOTE_BASE_UNVERIFIED");
+        if (previousConfirmed) return completePendingResponse(noteId, data, baseVersion, previousConfirmed, true);
+        throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
       }
 
       if (isCurrentlyOffline()) {
         preserveConflict(noteId, data, baseVersion, fresh, "REMOTE_BASE_UNVERIFIED");
-        throw syncError(
-          "REMOTE_BASE_UNVERIFIED",
-          "服务端正文尚未成功加载，已阻止保存。",
-        );
+        return completePendingResponse(noteId, data, baseVersion, fresh, true);
       }
 
       clearOfflineNoteSnapshot(noteId);
       const baseContentMismatch = !!(
-        offlineBase?.contentFingerprint &&
-        fingerprintNoteContent(fresh.content) !== offlineBase.contentFingerprint
+        offlineBase?.contentFingerprint
+        && fingerprintNoteContent(fresh.content) !== offlineBase.contentFingerprint
       );
       if (fresh.version !== baseVersion || baseContentMismatch) {
+        if (mutationMatchesNote(fresh, data)) {
+          clearResolvedConflictArtifacts(noteId);
+          rememberConfirmedNote(fresh, noteId);
+          return fresh;
+        }
+        if (previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
+          const retried = await retryOnFreshVersion(noteId, data, fresh);
+          if (retried) return retried;
+        }
         preserveConflict(noteId, data, baseVersion, fresh, "STALE_OFFLINE_BASE");
-        const error = syncError("VERSION_CONFLICT", "Version conflict", 409) as any;
-        error.currentVersion = fresh.version;
-        error.baseContentMismatch = baseContentMismatch;
-        throw error;
+        confirmedNotes.set(noteId, fresh);
+        return completePendingResponse(noteId, data, baseVersion, fresh, true);
       }
     }
 
+    const previousConfirmed = confirmedNotes.get(noteId) || null;
     try {
       const updated = await originalUpdateNote(noteId, data as Partial<Note>);
-
       if (versioned && !isServerConfirmedNoteWrite(baseVersion, updated?.version)) {
         persistLocalDraft(noteId, data, baseVersion);
-        markOfflineNoteSnapshot({
-          id: noteId,
-          version: baseVersion,
-          updatedAt: updated?.updatedAt,
-        });
-        window.dispatchEvent(new CustomEvent(NOTE_SYNC_PENDING_EVENT, {
-          detail: { noteId, baseVersion, queued: true },
-        }));
-        const error = syncError(
-          "OFFLINE_WRITE_QUEUED",
-          "修改已保存在本地并等待上传，尚未得到服务端确认。",
-        ) as any;
+        markOfflineNoteSnapshot({ id: noteId, version: baseVersion, updatedAt: updated?.updatedAt });
+        const server = previousConfirmed || (isCompleteNote(updated, noteId) ? updated : null);
+        if (server) return completePendingResponse(noteId, data, baseVersion, server, false);
+        dispatchPending(noteId, baseVersion, { responseIncomplete: true });
+        const error = syncError("OFFLINE_WRITE_QUEUED", "修改已保存在本地并等待上传，尚未得到服务端确认。") as any;
         error.queued = true;
         throw error;
       }
 
       clearOfflineNoteSnapshot(noteId);
+      clearResolvedConflictArtifacts(noteId);
+      rememberConfirmedNote(updated, noteId);
       return updated;
     } catch (error: any) {
-      if (error?.status === 409 || error?.code === "VERSION_CONFLICT") {
-        let server: Note | null = null;
-        try {
-          server = await originalGetNote(noteId);
-          if (!isCurrentlyOffline()) clearOfflineNoteSnapshot(noteId);
-        } catch {
-          // The version from the 409 is enough to stop the write safely.
-        }
-        const record = preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
-        if (typeof error.currentVersion !== "number" && typeof record.serverVersion === "number") {
-          error.currentVersion = record.serverVersion;
-        }
+      if (error?.status !== 409 && error?.code !== "VERSION_CONFLICT") throw error;
+
+      const fresh = await fetchCurrentServerNote(noteId);
+      if (fresh && mutationMatchesNote(fresh, data)) {
+        clearOfflineNoteSnapshot(noteId);
+        clearResolvedConflictArtifacts(noteId);
+        rememberConfirmedNote(fresh, noteId);
+        return fresh;
       }
-      throw error;
+      if (fresh && previousConfirmed && noteBodiesEqual(fresh, previousConfirmed)) {
+        const retried = await retryOnFreshVersion(noteId, data, fresh);
+        if (retried) return retried;
+      }
+
+      const currentVersion = typeof error.currentVersion === "number" ? error.currentVersion : undefined;
+      const fallbackServer = previousConfirmed
+        ? ({ ...previousConfirmed, version: currentVersion ?? previousConfirmed.version } as Note)
+        : null;
+      const server = fresh || fallbackServer;
+      const record = preserveConflict(noteId, data, baseVersion, server, "VERSION_CONFLICT");
+      if (typeof error.currentVersion !== "number" && typeof record.serverVersion === "number") {
+        error.currentVersion = record.serverVersion;
+      }
+      if (server) {
+        if (fresh) confirmedNotes.set(noteId, fresh);
+        return completePendingResponse(noteId, data, baseVersion, server, true);
+      }
+      throw syncError("REMOTE_BASE_UNVERIFIED", "无法确认服务端最新版本，已保留本地草稿并阻止覆盖。");
     }
   };
 
@@ -400,6 +493,7 @@ export function installNoteSyncSafety(): void {
     (api as any).getNote = originalGetNote;
     (api as any).updateNote = originalUpdateNote;
     resolvingNoteIds.clear();
+    confirmedNotes.clear();
     delete guardedWindow[INSTALL_KEY];
   };
 }

--- a/frontend/src/lib/noteUpdateSerialQueue.ts
+++ b/frontend/src/lib/noteUpdateSerialQueue.ts
@@ -66,17 +66,21 @@ export function installNoteUpdateSerialQueue(): void {
       payload,
     });
 
-    // EditorPane and other callers historically clear drafts by noteId after their Promise
-    // resolves. All coalesced callers receive this same latest result, so record the exact
-    // authoritative body first. draftStorage will refuse a late caller's cleanup if a newer
-    // local snapshot has already replaced it.
-    markDraftAcknowledged({
-      noteId,
-      title: saved.result.title,
-      content: saved.result.content,
-      contentText: saved.result.contentText,
-      serverVersion: saved.result.version,
-    });
+    // A pending conflict is locally durable but is not a server acknowledgement of this body.
+    // Never let the editor clear the only recoverable draft for that state.
+    if ((saved.result as Note & { __syncPending?: boolean }).__syncPending !== true) {
+      // EditorPane and other callers historically clear drafts by noteId after their Promise
+      // resolves. All coalesced callers receive this same latest result, so record the exact
+      // authoritative body first. draftStorage will refuse a late caller's cleanup if a newer
+      // local snapshot has already replaced it.
+      markDraftAcknowledged({
+        noteId,
+        title: saved.result.title,
+        content: saved.result.content,
+        contentText: saved.result.contentText,
+        serverVersion: saved.result.version,
+      });
+    }
     return saved.result;
   };
 

--- a/scripts/apply-release-review-fixes.mjs
+++ b/scripts/apply-release-review-fixes.mjs
@@ -1,0 +1,233 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const write = (file, content) => fs.writeFileSync(path.join(root, file), content);
+
+function replaceOnce(file, search, replacement) {
+  const content = read(file);
+  const index = content.indexOf(search);
+  if (index < 0) throw new Error(`Missing expected snippet in ${file}: ${search.slice(0, 120)}`);
+  if (content.indexOf(search, index + search.length) >= 0) {
+    throw new Error(`Expected a unique snippet in ${file}: ${search.slice(0, 120)}`);
+  }
+  write(file, content.slice(0, index) + replacement + content.slice(index + search.length));
+}
+
+function replaceSection(file, startMarker, endMarker, replacement) {
+  const content = read(file);
+  const start = content.indexOf(startMarker);
+  const end = content.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < 0) throw new Error(`Cannot locate section in ${file}`);
+  write(file, content.slice(0, start) + replacement + content.slice(end));
+}
+
+function updateJson(file, updater) {
+  const value = JSON.parse(read(file));
+  updater(value);
+  write(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+// 1. Keep the task offline adapter optional at module-import time. Partial test/plugin API
+// facades must not crash unrelated editor modules before their tests can start.
+{
+  const file = "frontend/src/lib/taskOfflineRuntime.ts";
+  const marker = "export function installTaskOfflineApi(api: any, options: Options) {\n";
+  const helpers = `const REQUIRED_NATIVE_API_METHODS = [\n  "getTasks", "getTaskStats", "createTask", "updateTask", "toggleTask", "deleteTask",\n  "getHabits", "getHabitStats", "getHabitCheckinLog", "createHabit", "updateHabit",\n  "archiveHabit", "deleteHabit", "checkInHabit",\n] as const;\n\nconst DISABLED_TASK_OFFLINE_CONTROLLER = {\n  flush: async () => {},\n  pending: () => 0,\n};\n\nfunction bindNativeTaskApi(api: unknown): NativeApi | null {\n  if (!api || typeof api !== "object") return null;\n  const source = api as Record<string, unknown>;\n  const missing = REQUIRED_NATIVE_API_METHODS.filter((name) => typeof source[name] !== "function");\n  if (missing.length > 0) {\n    console.warn(\n      \`[task-offline] adapter disabled because the API facade is incomplete: \${missing.join(", ")}\`,\n    );\n    return null;\n  }\n  return Object.fromEntries(\n    REQUIRED_NATIVE_API_METHODS.map((name) => [name, (source[name] as Function).bind(api)]),\n  ) as unknown as NativeApi;\n}\n\n${marker}`;
+  replaceOnce(file, marker, helpers);
+  replaceOnce(
+    file,
+    `  if (api[FLAG]) return api[FLAG] as { flush: () => Promise<void>; pending: () => number };\n  const native: NativeApi = {\n    getTasks: api.getTasks.bind(api), getTaskStats: api.getTaskStats.bind(api),\n    createTask: api.createTask.bind(api), updateTask: api.updateTask.bind(api),\n    toggleTask: api.toggleTask.bind(api), deleteTask: api.deleteTask.bind(api),\n    getHabits: api.getHabits.bind(api), getHabitStats: api.getHabitStats.bind(api),\n    getHabitCheckinLog: api.getHabitCheckinLog.bind(api), createHabit: api.createHabit.bind(api),\n    updateHabit: api.updateHabit.bind(api), archiveHabit: api.archiveHabit.bind(api),\n    deleteHabit: api.deleteHabit.bind(api), checkInHabit: api.checkInHabit.bind(api),\n  };\n`,
+    `  if (api?.[FLAG]) return api[FLAG] as { flush: () => Promise<void>; pending: () => number };\n  const native = bindNativeTaskApi(api);\n  if (!native) return DISABLED_TASK_OFFLINE_CONTROLLER;\n`,
+  );
+}
+
+// 2. Make the orphan/source-note correction the final response writer while preserving the
+// knowledge capability filter as the inner security boundary.
+{
+  const file = "backend/src/runtime/knowledge-tree.ts";
+  replaceOnce(
+    file,
+    `  const wrapper = new Hono<any>();\n  wrapper.use("*", middleware);\n  if (normalized === "/api/files") {\n    // Keep the release branch orphan/source-note visibility correction after access filtering.\n    wrapper.use("*", fileOrphanVisibilityMiddleware);\n  }\n`,
+    `  const wrapper = new Hono<any>();\n  if (normalized === "/api/files") {\n    // Hono middleware unwinds in reverse registration order. Register the response correction\n    // first so the capability guard filters the route response before orphan metadata is applied.\n    wrapper.use("*", fileOrphanVisibilityMiddleware);\n  }\n  wrapper.use("*", middleware);\n`,
+  );
+}
+
+{
+  const file = "backend/src/runtime/file-orphan-visibility.ts";
+  replaceOnce(
+    file,
+    `import { createUserAttachmentAccessUrls } from "../lib/attachment-signed-url.js";\n`,
+    `import { createUserAttachmentAccessUrls } from "../lib/attachment-signed-url.js";\nimport {\n  hasKnowledgeCapability,\n  resolveResourceKnowledgeAccess,\n} from "../services/knowledgeCapabilities.js";\n`,
+  );
+  replaceOnce(
+    file,
+    `const MANUAL_UPLOAD_SOURCE = "file_manager";\n`,
+    `const MANUAL_UPLOAD_SOURCE = "file_manager";\n\nfunction noteCapability(noteId: string, userId: string, capability: "canView" | "canDownload"): boolean {\n  if (!noteId || !userId) return false;\n  return hasKnowledgeCapability(\n    resolveResourceKnowledgeAccess("note", noteId, userId),\n    capability,\n  );\n}\n`,
+  );
+
+  const summary = `export function getImmediateOrphanSummary(\n  db: Database.Database,\n  scope: FilesScope,\n  userId: string,\n): { count: number; bytes: number } {\n  const where: string[] = [\n    "EXISTS(SELECT 1 FROM notes owner_note WHERE owner_note.id = a.noteId)",\n    "NOT EXISTS(SELECT 1 FROM attachment_references ar WHERE ar.attachmentId = a.id)",\n    "COALESCE(a.uploadSource, '') <> 'file_manager'",\n  ];\n  const params: Array<string | number> = [];\n  appendAttachmentScope(where, params, scope, userId);\n\n  const rows = db.prepare(\`\n    SELECT a.noteId, COALESCE(a.size, 0) AS size\n      FROM attachments a\n     WHERE \${where.join(" AND ")}\n  \`).all(...params) as Array<{ noteId: string; size: number }>;\n\n  let count = 0;\n  let bytes = 0;\n  for (const row of rows) {\n    if (!noteCapability(row.noteId, userId, "canView")) continue;\n    count += 1;\n    bytes += Number(row.size || 0);\n  }\n  return { count, bytes };\n}\n\n`;
+  replaceSection(
+    file,
+    "export function getImmediateOrphanSummary(",
+    "/**\n * 返回当前真正引用附件的首篇笔记。",
+    summary,
+  );
+
+  replaceOnce(
+    file,
+    `  for (const row of rows) {\n    if (result.has(row.attachmentId)) continue;\n`,
+    `  for (const row of rows) {\n    if (result.has(row.attachmentId)) continue;\n    if (!noteCapability(row.id, userId, "canView")) continue;\n`,
+  );
+
+  const listBuilder = `function buildImmediateOrphanList(\n  db: Database.Database,\n  c: Context,\n  scope: FilesScope,\n  userId: string,\n) {\n  const category = (c.req.query("category") || "all").toLowerCase();\n  const mime = c.req.query("mime") || "";\n  const notebookId = c.req.query("notebookId") || "";\n  const noteId = c.req.query("noteId") || "";\n  const folderId = c.req.query("folderId") || "";\n  const q = (c.req.query("q") || "").trim();\n  const page = Math.max(1, Number(c.req.query("page") || 1));\n  const pageSize = Math.min(200, Math.max(1, Number(c.req.query("pageSize") || 50)));\n\n  const where: string[] = [\n    "NOT EXISTS(SELECT 1 FROM attachment_references ar WHERE ar.attachmentId = a.id)",\n    "COALESCE(a.uploadSource, '') <> 'file_manager'",\n  ];\n  const params: Array<string | number> = [];\n  appendAttachmentScope(where, params, scope, userId);\n\n  if (category === "image") {\n    where.push("a.mimeType LIKE 'image/%'");\n  } else if (category === "file") {\n    where.push("(a.mimeType IS NULL OR a.mimeType NOT LIKE 'image/%')");\n  }\n  if (mime) {\n    where.push("a.mimeType = ?");\n    params.push(mime.toLowerCase());\n  }\n  if (notebookId) {\n    where.push("n.notebookId = ?");\n    params.push(notebookId);\n  }\n  if (q) {\n    where.push("a.filename LIKE ? COLLATE NOCASE");\n    params.push(\`%\${q}%\`);\n  }\n  if (folderId) {\n    if (folderId === "__unarchived") where.push("a.folderId IS NULL");\n    else {\n      where.push("a.folderId = ?");\n      params.push(folderId);\n    }\n  }\n  if (noteId) where.push("1 = 0");\n\n  const rows = db.prepare(\`\n    SELECT a.id, a.filename, a.mimeType, a.size, a.path, a.createdAt, a.noteId,\n           a.hash, a.folderId, a.uploadSource, af.name AS folderName\n      FROM attachments a\n      INNER JOIN notes n ON n.id = a.noteId\n      LEFT JOIN attachment_folders af ON af.id = a.folderId\n     WHERE \${where.join(" AND ")}\n     ORDER BY \${resolveOrderBy(c.req.query("sort"))}\n  \`).all(...params) as FileListRow[];\n\n  const visibleRows = rows.filter((row) => noteCapability(row.noteId, userId, "canView"));\n  const pageRows = visibleRows.slice((page - 1) * pageSize, page * pageSize);\n  const downloadableRows = pageRows.filter((row) =>\n    noteCapability(row.noteId, userId, "canDownload"),\n  );\n  const downloadableIds = new Set(downloadableRows.map((row) => row.id));\n  const items = pageRows.map((row) => {\n    const item = toOrphanFileOut(row) as Record<string, unknown>;\n    if (downloadableIds.has(row.id)) return { ...item, downloadAllowed: true };\n    delete item.url;\n    delete item.thumbnailUrl;\n    return { ...item, downloadAllowed: false };\n  });\n\n  return {\n    items,\n    accessUrls: createUserAttachmentAccessUrls(userId, downloadableRows),\n    total: visibleRows.length,\n    page,\n    pageSize,\n  };\n}\n\n`;
+  replaceSection(file, "function buildImmediateOrphanList(", "function replaceJsonResponse", listBuilder);
+}
+
+// 3. Demand-load deferred event centers and wait for a ready handshake before dispatching a
+// one-shot image export request.
+write("frontend/src/lib/noteImageExportBridge.ts", `import { parseServerTime } from "@/lib/dateTime";\nimport {\n  isMarkdownImageExportSource,\n  prepareMarkdownFootnotesForImageExport,\n  refreshNoteImageAttachmentAccess,\n} from "@/lib/noteImageExportPreparation";\n\nexport type NoteImageExportFormat = "png" | "jpg" | "svg";\nexport type NoteImageExportLayout = "auto" | "long" | "pages";\nexport type NoteImageExportTheme = "current" | "light" | "dark";\nexport type NoteImageExportDestination = "download" | "gallery" | "files" | "share";\n\nexport interface ExportableNoteImageSource {\n  id: string;\n  title: string;\n  content: string;\n  contentText: string;\n  contentFormat?: string;\n  createdAt?: string;\n  updatedAt?: string;\n}\n\nexport interface NoteImageExportInitialOptions {\n  format?: NoteImageExportFormat;\n  quality?: number;\n  pixelRatio?: number;\n  layout?: NoteImageExportLayout;\n  theme?: NoteImageExportTheme;\n  destination?: NoteImageExportDestination;\n}\n\nexport interface NoteImageExportRequestDetail {\n  requestId: string;\n  note: ExportableNoteImageSource;\n  options: NoteImageExportInitialOptions;\n}\n\nexport const NOTE_IMAGE_EXPORT_REQUEST_EVENT = "nowen:note-image-export-request";\nexport const DEFERRED_FEATURE_CENTERS_NEEDED_EVENT = "nowen:deferred-feature-centers-needed";\n\nconst pending = new Map<string, (ok: boolean) => void>();\nconst readyWaiters = new Set<(ready: boolean) => void>();\nlet sequence = 0;\nlet centerReady = false;\n\nfunction createRequestId(): string {\n  sequence += 1;\n  return \`note-image-export-\${Date.now()}-\${sequence}\`;\n}\n\nexport function setNoteImageExportCenterReady(ready: boolean): void {\n  centerReady = ready;\n  if (!ready) return;\n  for (const resolve of readyWaiters) resolve(true);\n  readyWaiters.clear();\n}\n\nfunction waitForNoteImageExportCenter(timeoutMs = 5_000): Promise<boolean> {\n  if (centerReady) return Promise.resolve(true);\n  return new Promise((resolve) => {\n    let settled = false;\n    const finish = (ready: boolean) => {\n      if (settled) return;\n      settled = true;\n      window.clearTimeout(timer);\n      readyWaiters.delete(finish);\n      resolve(ready);\n    };\n    const timer = window.setTimeout(() => finish(false), timeoutMs);\n    readyWaiters.add(finish);\n  });\n}\n\nexport function normalizeNoteImageExportTimestamp(\n  value: string | null | undefined,\n): string | undefined {\n  return parseServerTime(value)?.toISOString();\n}\n\nexport function normalizeNoteImageExportSource(\n  note: ExportableNoteImageSource,\n): ExportableNoteImageSource {\n  const normalized = { ...note };\n  const createdAt = normalizeNoteImageExportTimestamp(note.createdAt);\n  const updatedAt = normalizeNoteImageExportTimestamp(note.updatedAt);\n  if (createdAt) normalized.createdAt = createdAt;\n  else delete normalized.createdAt;\n  if (updatedAt) normalized.updatedAt = updatedAt;\n  else delete normalized.updatedAt;\n  return normalized;\n}\n\nexport function prepareNoteImageExportSource(\n  note: ExportableNoteImageSource,\n): ExportableNoteImageSource {\n  const prepared = normalizeNoteImageExportSource(note);\n  if (!isMarkdownImageExportSource(prepared.content || prepared.contentText || "", prepared.contentFormat)) {\n    return prepared;\n  }\n  if (prepared.content) prepared.content = prepareMarkdownFootnotesForImageExport(prepared.content);\n  if (prepared.contentText) prepared.contentText = prepareMarkdownFootnotesForImageExport(prepared.contentText);\n  return prepared;\n}\n\nexport async function requestNoteImageExport(\n  note: ExportableNoteImageSource,\n  options: NoteImageExportInitialOptions = {},\n): Promise<boolean> {\n  if (typeof window === "undefined") return false;\n\n  const exportNote = prepareNoteImageExportSource(note);\n  await refreshNoteImageAttachmentAccess(\n    exportNote.id,\n    \`\${exportNote.content || ""}\\n\${exportNote.contentText || ""}\`,\n  );\n\n  window.dispatchEvent(new Event(DEFERRED_FEATURE_CENTERS_NEEDED_EVENT));\n  if (!(await waitForNoteImageExportCenter())) return false;\n\n  const requestId = createRequestId();\n  return new Promise<boolean>((resolve) => {\n    pending.set(requestId, resolve);\n    window.dispatchEvent(new CustomEvent<NoteImageExportRequestDetail>(\n      NOTE_IMAGE_EXPORT_REQUEST_EVENT,\n      { detail: { requestId, note: exportNote, options } },\n    ));\n  });\n}\n\nexport function settleNoteImageExportRequest(requestId: string, ok: boolean): void {\n  const resolve = pending.get(requestId);\n  if (!resolve) return;\n  pending.delete(requestId);\n  resolve(ok);\n}\n\nexport function cancelAllNoteImageExportRequests(): void {\n  for (const resolve of pending.values()) resolve(false);\n  pending.clear();\n}\n`);
+
+write("frontend/src/components/DeferredGlobalFeatureCentersMount.tsx", `import React, { Suspense, useEffect, useState } from "react";\nimport { DEFERRED_FEATURE_CENTERS_NEEDED_EVENT } from "@/lib/noteImageExportBridge";\n\nconst LazyDeferredGlobalFeatureCenters = React.lazy(\n  () => import("./DeferredGlobalFeatureCenters"),\n);\n\nconst TOKEN_KEY = "nowen-token";\nconst TOKEN_CHANGED_EVENT = "nowen:token-changed";\nconst IDLE_TIMEOUT_MS = 2_000;\n\ntype IdleWindow = Window & {\n  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;\n  cancelIdleCallback?: (handle: number) => void;\n};\n\nfunction hasLoginToken(): boolean {\n  try {\n    return Boolean(window.localStorage.getItem(TOKEN_KEY));\n  } catch {\n    return false;\n  }\n}\n\nexport default function DeferredGlobalFeatureCentersMount() {\n  const [mounted, setMounted] = useState(false);\n\n  useEffect(() => {\n    let disposed = false;\n    let idleHandle: number | null = null;\n    let timeoutHandle: number | null = null;\n\n    const cancelScheduledMount = () => {\n      const idleWindow = window as IdleWindow;\n      if (idleHandle !== null && idleWindow.cancelIdleCallback) idleWindow.cancelIdleCallback(idleHandle);\n      if (timeoutHandle !== null) window.clearTimeout(timeoutHandle);\n      idleHandle = null;\n      timeoutHandle = null;\n    };\n\n    const mountNow = () => {\n      cancelScheduledMount();\n      if (!disposed && hasLoginToken()) setMounted(true);\n    };\n\n    const scheduleMount = () => {\n      if (disposed || mounted || !hasLoginToken() || idleHandle !== null || timeoutHandle !== null) return;\n      const commit = () => {\n        idleHandle = null;\n        timeoutHandle = null;\n        if (!disposed && hasLoginToken()) setMounted(true);\n      };\n      const idleWindow = window as IdleWindow;\n      if (idleWindow.requestIdleCallback) {\n        idleHandle = idleWindow.requestIdleCallback(commit, { timeout: IDLE_TIMEOUT_MS });\n      } else {\n        timeoutHandle = window.setTimeout(commit, 250);\n      }\n    };\n\n    const syncToken = () => {\n      if (hasLoginToken()) scheduleMount();\n      else {\n        cancelScheduledMount();\n        setMounted(false);\n      }\n    };\n    const handleStorage = (event: StorageEvent) => {\n      if (event.key === TOKEN_KEY) syncToken();\n    };\n\n    scheduleMount();\n    window.addEventListener(TOKEN_CHANGED_EVENT, syncToken);\n    window.addEventListener(DEFERRED_FEATURE_CENTERS_NEEDED_EVENT, mountNow);\n    window.addEventListener("storage", handleStorage);\n    return () => {\n      disposed = true;\n      cancelScheduledMount();\n      window.removeEventListener(TOKEN_CHANGED_EVENT, syncToken);\n      window.removeEventListener(DEFERRED_FEATURE_CENTERS_NEEDED_EVENT, mountNow);\n      window.removeEventListener("storage", handleStorage);\n    };\n  }, [mounted]);\n\n  if (!mounted) return null;\n  return (\n    <Suspense fallback={null}>\n      <LazyDeferredGlobalFeatureCenters />\n    </Suspense>\n  );\n}\n`);
+
+{
+  const file = "frontend/src/components/NoteImageExportCenter.tsx";
+  replaceOnce(
+    file,
+    `  settleNoteImageExportRequest,\n`,
+    `  settleNoteImageExportRequest,\n  setNoteImageExportCenterReady,\n`,
+  );
+  replaceOnce(
+    file,
+    `  const [result, setResult] = useState<NoteImageExportResult | null>(null);\n\n  useEffect(() => {\n`,
+    `  const [result, setResult] = useState<NoteImageExportResult | null>(null);\n\n  useEffect(() => {\n    setNoteImageExportCenterReady(true);\n    return () => setNoteImageExportCenterReady(false);\n  }, []);\n\n  useEffect(() => {\n`,
+  );
+}
+
+// 4. Use an explicit mobile image-viewer event from Tiptap instead of observing and hiding its DOM.
+write("frontend/src/lib/mobileImageViewer.ts", `import { Capacitor } from "@capacitor/core";\n\nexport const MOBILE_IMAGE_VIEWER_OPEN_EVENT = "nowen:mobile-image-viewer-open";\n\nexport interface MobileImageViewerRequest {\n  src: string;\n  alt?: string;\n  source: "markdown" | "tiptap";\n}\n\nexport function shouldUseMobileImageViewer(): boolean {\n  if (Capacitor.getPlatform() === "android") return true;\n  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;\n  return window.matchMedia("(max-width: 767px), (pointer: coarse)").matches;\n}\n\nexport function openMobileImageViewer(request: MobileImageViewerRequest): boolean {\n  if (typeof window === "undefined" || !request.src) return false;\n  window.dispatchEvent(new CustomEvent<MobileImageViewerRequest>(\n    MOBILE_IMAGE_VIEWER_OPEN_EVENT,\n    { detail: request },\n  ));\n  return true;\n}\n`);
+
+write("frontend/src/components/MobileImageViewerBridge.tsx", `import React, { useEffect, useState } from "react";\nimport MobileImageViewer from "@/components/MobileImageViewer";\nimport {\n  MOBILE_IMAGE_VIEWER_OPEN_EVENT,\n  openMobileImageViewer,\n  shouldUseMobileImageViewer,\n  type MobileImageViewerRequest,\n} from "@/lib/mobileImageViewer";\n\nfunction getImageSource(image: HTMLImageElement): string {\n  return image.currentSrc || image.src || image.getAttribute("src") || "";\n}\n\nexport default function MobileImageViewerBridge() {\n  const [request, setRequest] = useState<MobileImageViewerRequest | null>(null);\n\n  useEffect(() => {\n    const handleOpen = (event: Event) => {\n      const detail = (event as CustomEvent<MobileImageViewerRequest>).detail;\n      if (!detail?.src) return;\n      setRequest(detail);\n    };\n    window.addEventListener(MOBILE_IMAGE_VIEWER_OPEN_EVENT, handleOpen);\n    return () => window.removeEventListener(MOBILE_IMAGE_VIEWER_OPEN_EVENT, handleOpen);\n  }, []);\n\n  useEffect(() => {\n    const handleMarkdownImageClick = (event: MouseEvent) => {\n      if (!shouldUseMobileImageViewer() || !(event.target instanceof Element)) return;\n      const image = event.target.closest<HTMLImageElement>(".nowen-md-preview img");\n      if (!image || image.closest("[data-nowen-mobile-image-viewer]")) return;\n      const src = getImageSource(image);\n      if (!src) return;\n\n      event.preventDefault();\n      event.stopPropagation();\n      event.stopImmediatePropagation();\n      openMobileImageViewer({ src, alt: image.alt || "", source: "markdown" });\n    };\n\n    document.addEventListener("click", handleMarkdownImageClick, true);\n    return () => document.removeEventListener("click", handleMarkdownImageClick, true);\n  }, []);\n\n  return (\n    <MobileImageViewer\n      open={!!request}\n      src={request?.src || ""}\n      alt={request?.alt || ""}\n      onClose={() => setRequest(null)}\n    />\n  );\n}\n`);
+
+{
+  const file = "frontend/src/components/TiptapEditor.tsx";
+  let content = read(file);
+  const callPattern = /setPreviewImage\((?!null\b)([^;\n]+)\);/g;
+  const calls = [...content.matchAll(callPattern)];
+  if (calls.length === 0) throw new Error("No non-null Tiptap image preview calls found");
+  content = content.replace(callPattern, "openImagePreview($1);");
+  write(file, content);
+  replaceOnce(
+    file,
+    `import { saveImageToGallery, isAndroidNative } from "@/lib/nativeImageSave";\n`,
+    `import { saveImageToGallery, isAndroidNative } from "@/lib/nativeImageSave";\nimport { openMobileImageViewer, shouldUseMobileImageViewer } from "@/lib/mobileImageViewer";\n`,
+  );
+  replaceOnce(
+    file,
+    `  const [previewImage, setPreviewImage] = useState<string | null>(null);\n`,
+    `  const [previewImage, setPreviewImage] = useState<string | null>(null);\n  const openImagePreview = useCallback((src: string) => {\n    if (shouldUseMobileImageViewer()) {\n      openMobileImageViewer({ src, alt: "", source: "tiptap" });\n      return;\n    }\n    setPreviewImage(src);\n  }, []);\n`,
+  );
+}
+
+write("frontend/src/components/TiptapEditorInitializationRuntime.tsx", `import React, { forwardRef } from "react";\n\nimport type { NoteEditorHandle } from "@/components/editors/types";\nimport { useEditorInitializationTimeout } from "@/hooks/useEditorInitializationTimeout";\nimport TiptapEditorRuntime from "./TiptapEditorRuntime";\n\ntype TiptapEditorInitializationRuntimeProps = React.ComponentPropsWithoutRef<typeof TiptapEditorRuntime>;\n\n/** Adds the shared initialization watchdog around the existing Tiptap runtime shell. */\nconst TiptapEditorInitializationRuntime = forwardRef<\n  NoteEditorHandle,\n  TiptapEditorInitializationRuntimeProps\n>(function TiptapEditorInitializationRuntime(props, ref) {\n  const onEditorReady = useEditorInitializationTimeout({\n    noteId: props.note.id,\n    engine: "tiptap",\n    onEditorReady: props.onEditorReady,\n  });\n\n  return (\n    <TiptapEditorRuntime\n      {...props}\n      ref={ref}\n      onEditorReady={onEditorReady}\n    />\n  );\n});\n\nTiptapEditorInitializationRuntime.displayName = "TiptapEditorInitializationRuntime";\n\nexport default TiptapEditorInitializationRuntime;\n`);
+
+write("frontend/src/lib/__tests__/mobileImageViewerContract.test.ts", `import { readFileSync } from "node:fs";\nimport { describe, expect, it } from "vitest";\n\nfunction source(relativeUrl: string) {\n  return readFileSync(new URL(relativeUrl, import.meta.url), "utf8");\n}\n\ndescribe("mobile image viewer contract", () => {\n  it("keeps close controls outside the gesture stage and handles Android back", () => {\n    const viewer = source("../../components/MobileImageViewer.tsx");\n    expect(viewer).toContain('data-nowen-mobile-image-viewer=""');\n    expect(viewer).toContain('style={{ touchAction: "none" }}');\n    expect(viewer).toContain("onPointerDown={handleClosePointerDown}");\n    expect(viewer).toContain('CapacitorApp.addListener("backButton"');\n    expect(viewer).toContain("setPointerCapture");\n    expect(viewer).toContain("releasePointerCapture");\n  });\n\n  it("uses one explicit viewer state source for Markdown and Tiptap", () => {\n    const bridge = source("../../components/MobileImageViewerBridge.tsx");\n    const editor = source("../../components/TiptapEditor.tsx");\n    expect(bridge).toContain("MOBILE_IMAGE_VIEWER_OPEN_EVENT");\n    expect(bridge).toContain('document.addEventListener("click", handleMarkdownImageClick, true)');\n    expect(bridge).not.toContain("MutationObserver");\n    expect(bridge).not.toContain('img[alt="preview"]');\n    expect(editor).toContain('openMobileImageViewer({ src, alt: "", source: "tiptap" })');\n  });\n});\n`);
+
+write("frontend/src/lib/__tests__/androidImagePreviewTapCloseContract.test.ts", `import { readFileSync } from "node:fs";\nimport { describe, expect, it } from "vitest";\n\nfunction source(relativeUrl: string) {\n  return readFileSync(new URL(relativeUrl, import.meta.url), "utf8");\n}\n\ndescribe("Android image preview routing contract", () => {\n  it("routes Tiptap previews explicitly instead of probing lightbox DOM", () => {\n    const runtime = source("../../components/TiptapEditorInitializationRuntime.tsx");\n    const editor = source("../../components/TiptapEditor.tsx");\n    expect(runtime).not.toContain("PREVIEW_IMAGE_SELECTOR");\n    expect(runtime).not.toContain('document.addEventListener("pointerdown"');\n    expect(editor).toContain("shouldUseMobileImageViewer()");\n    expect(editor).toContain("openMobileImageViewer");\n  });\n});\n`);
+
+// 5. Prevent the daily-journal container from handling a note link already consumed by the anchor.
+replaceOnce(
+  "frontend/src/components/daily-records/DailyJournalContentPreview.tsx",
+  `  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {\n    const target = event.target as HTMLElement | null;\n`,
+  `  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {\n    if (event.defaultPrevented) return;\n    const target = event.target as HTMLElement | null;\n`,
+);
+
+// 6. Align updater documentation with the intentional Windows/macOS browser-download policy.
+replaceOnce(
+  "electron/updater.js",
+  `//   Windows/Linux: idle -> checking -> available -> downloading -> downloaded -> installing\n//   macOS:         idle -> checking -> available -> browser manual download\n`,
+  `//   Linux:         idle -> checking -> available -> downloading -> downloaded -> installing\n//   Windows/macOS: idle -> checking -> available -> browser manual download\n`,
+);
+
+// 7. Standardize frontend/Capacitor jobs on Node 22.
+{
+  const workflowsDir = path.join(root, ".github/workflows");
+  let changed = 0;
+  for (const name of fs.readdirSync(workflowsDir)) {
+    if (!name.endsWith(".yml") && !name.endsWith(".yaml")) continue;
+    const file = path.join(".github/workflows", name);
+    const before = read(file);
+    const after = before.replace(
+      /node-version:\s*20(\n\s+cache:\s*npm\n\s+cache-dependency-path:\s*frontend\/package-lock\.json)/g,
+      "node-version: 22$1",
+    );
+    if (after !== before) {\n      write(file, after);\n      changed += 1;\n    }\n  }\n  if (changed === 0) throw new Error("No frontend Node 20 workflow was updated");\n}\n\nupdateJson("frontend/package.json", (pkg) => {\n  pkg.engines = { ...(pkg.engines || {}), node: ">=22.0.0" };\n});\nupdateJson("frontend/package-lock.json", (lock) => {\n  lock.packages ||= {};\n  lock.packages[""] ||= {};\n  lock.packages[""].engines = { ...(lock.packages[""].engines || {}), node: ">=22.0.0" };\n});\n\n// 8. Bump every release identity source and add a v1.4.6 changelog entry.\nconst releaseVersion = "1.4.6";\nconst releaseDate = "2026-08-06";\nfor (const file of ["package.json", "backend/package.json"]) {\n  updateJson(file, (pkg) => { pkg.version = releaseVersion; });\n}\nfor (const file of ["package-lock.json", "backend/package-lock.json"]) {\n  updateJson(file, (lock) => {\n    lock.version = releaseVersion;\n    lock.packages ||= {};\n    lock.packages[""] ||= {};\n    lock.packages[""].version = releaseVersion;\n  });\n}\n\n{\n  const file = "frontend/android/app/build.gradle";\n  let content = read(file);\n  content = content.replace(/versionCode\s+10405/, "versionCode 10406");\n  content = content.replace(/versionName\s+"1\.4\.5"/, 'versionName "1.4.6"');\n  if (!content.includes("versionCode 10406") || !content.includes('versionName "1.4.6"')) {\n    throw new Error("Android version bump failed");\n  }\n  write(file, content);\n}\n\nconst releaseBody = `### ✨ 新增\n\n- 强化知识树与团队空间权限边界，补齐文件、搜索、离线同步与导出过滤。\n- Android 接入原生任务提醒和统一移动端图片查看器。\n- 日记预览保留 Markdown、富文本和内部笔记链接。\n\n### 🐛 修复\n\n- 修复同步冲突、文件孤儿误判、代码块复制、笔记树刷新和客户端启动兼容问题。\n- 修复 Linux better-sqlite3 原生模块兼容和 Electron 渲染进程恢复。\n- 修复 Docker/NAS 自定义端口健康检查与静态资源缓存协商。\n\n### ⚡ 优化\n\n- 拆分首屏重型模块，增加 Brotli/gzip 预压缩、ETag 与 304 缓存。\n- 优化编辑器、笔记切换和开发环境启动性能。`;
+
+{
+  const file = "CHANGELOG.md";
+  const content = read(file);
+  if (!content.includes("## v1.4.6 -")) {
+    const marker = "<!-- ADD_NEW_HERE -->\n";
+    if (!content.includes(marker)) throw new Error("CHANGELOG marker missing");
+    write(file, content.replace(marker, `${marker}\n## v${releaseVersion} - ${releaseDate}\n\n${releaseBody}\n\n`));
+  }
+}
+
+updateJson("frontend/public/changelog.json", (value) => {
+  value.generatedAt = new Date().toISOString();
+  value.entries ||= [];
+  value.entries = value.entries.filter((entry) => entry.version !== releaseVersion);
+  value.entries.unshift({ version: releaseVersion, date: releaseDate, body: releaseBody });
+});
+
+// 9. Keep a permanent release identity regression test.
+write("scripts/tests/release-version-consistency.test.mjs", `import assert from "node:assert/strict";\nimport fs from "node:fs";\nimport test from "node:test";\n\nconst json = (file) => JSON.parse(fs.readFileSync(file, "utf8"));\n\ntest("release version sources stay consistent", () => {\n  const root = json("package.json");\n  const rootLock = json("package-lock.json");\n  const backend = json("backend/package.json");\n  const backendLock = json("backend/package-lock.json");\n  const frontend = json("frontend/package.json");\n  const changelog = json("frontend/public/changelog.json");\n  const android = fs.readFileSync("frontend/android/app/build.gradle", "utf8");\n  const markdown = fs.readFileSync("CHANGELOG.md", "utf8");\n\n  assert.match(root.version, /^\\d+\\.\\d+\\.\\d+$/);\n  assert.equal(rootLock.version, root.version);\n  assert.equal(rootLock.packages[""].version, root.version);\n  assert.equal(backend.version, root.version);\n  assert.equal(backendLock.version, root.version);\n  assert.equal(backendLock.packages[""].version, root.version);\n  assert.equal(changelog.entries[0].version, root.version);\n  assert.match(markdown, new RegExp(\`## v\${root.version.replace(/\\./g, "\\\\.")} - \\d{4}-\\d{2}-\\d{2}\`));\n\n  const [major, minor, patch] = root.version.split(".").map(Number);\n  const expectedCode = major * 10_000 + minor * 100 + patch;\n  assert.match(android, new RegExp(\`versionName \\\"\${root.version.replace(/\\./g, "\\\\.")}\\\"\`));\n  assert.match(android, new RegExp(\`versionCode\\\\s+\${expectedCode}\\\\b\`));\n  assert.equal(frontend.engines?.node, ">=22.0.0");\n});\n`);
+
+updateJson("package.json", (pkg) => {
+  const command = "node --test scripts/tests/release-version-consistency.test.mjs";
+  if (!String(pkg.scripts["test:update-release"] || "").includes("release-version-consistency")) {
+    pkg.scripts["test:update-release"] = `${pkg.scripts["test:update-release"]} scripts/tests/release-version-consistency.test.mjs`;
+  }
+});
+
+// 10. Update source-contract tests for the two event-handling fixes.
+{
+  const file = "frontend/src/components/daily-records/__tests__/dailyJournalContentPreview.test.tsx";
+  let content = read(file);
+  if (!content.includes("event.defaultPrevented")) {
+    content = content.replace(
+      `    expect(viewSource).not.toContain('className="w-full min-h-[190px] text-left"');\n`,
+      `    expect(viewSource).not.toContain('className="w-full min-h-[190px] text-left"');\n    expect(previewSource).toContain("if (event.defaultPrevented) return");\n`,
+    );
+    write(file, content);
+  }
+}
+
+{
+  const file = "frontend/src/lib/__tests__/noteImageExportBridge.test.ts";
+  let content = read(file);
+  content = content.replace(
+    `  NOTE_IMAGE_EXPORT_REQUEST_EVENT,\n`,
+    `  DEFERRED_FEATURE_CENTERS_NEEDED_EVENT,\n  NOTE_IMAGE_EXPORT_REQUEST_EVENT,\n`,
+  );
+  content = content.replace(
+    `  requestNoteImageExport,\n`,
+    `  requestNoteImageExport,\n  setNoteImageExportCenterReady,\n`,
+  );
+  content = content.replace(
+    `afterEach(() => {\n  cancelAllNoteImageExportRequests();\n`,
+    `afterEach(() => {\n  setNoteImageExportCenterReady(false);\n  cancelAllNoteImageExportRequests();\n`,
+  );
+  content = content.replace(
+    `  it("dispatches only prepared timestamps to the shared image export center", async () => {\n`,
+    `  it("dispatches only after the deferred center reports ready", async () => {\n    const needed = new Promise<void>((resolve) => {\n      window.addEventListener(DEFERRED_FEATURE_CENTERS_NEEDED_EVENT, () => resolve(), { once: true });\n    });\n`,
+  );
+  content = content.replace(
+    `    const detail = await detailPromise;\n`,
+    `    await needed;\n    setNoteImageExportCenterReady(true);\n    const detail = await detailPromise;\n`,
+  );
+  write(file, content);
+}
+
+console.log("Applied v1.4.6 release-review fixes");

--- a/scripts/fix-note-image-export-ready-import.mjs
+++ b/scripts/fix-note-image-export-ready-import.mjs
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+
+const file = "frontend/src/components/NoteImageExportCenter.tsx";
+let source = fs.readFileSync(file, "utf8");
+const importPattern = /import\s*\{([\s\S]*?)\}\s*from\s*"@\/lib\/noteImageExportBridge";/;
+const match = source.match(importPattern);
+
+if (!match) {
+  throw new Error("noteImageExportBridge import block not found");
+}
+
+if (!match[1].includes("setNoteImageExportCenterReady")) {
+  const names = match[1].trimEnd();
+  source = source.replace(
+    importPattern,
+    `import {${names},\n  setNoteImageExportCenterReady,\n} from "@/lib/noteImageExportBridge";`,
+  );
+}
+
+fs.writeFileSync(file, source);
+console.log("Ensured NoteImageExportCenter imports setNoteImageExportCenterReady");

--- a/scripts/repair-release-review-fix-script.mjs
+++ b/scripts/repair-release-review-fix-script.mjs
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+
+const file = "scripts/apply-release-review-fixes.mjs";
+const source = fs.readFileSync(file, "utf8");
+const startMarker = "    if (after !== before) {\\n";
+const endMarker = "const releaseBody =";
+const start = source.indexOf(startMarker);
+const end = source.indexOf(endMarker, start);
+
+if (start < 0 || end < 0) {
+  throw new Error("Unable to locate the escaped workflow/version section");
+}
+
+const repaired = source.slice(0, start)
+  + source.slice(start, end).replace(/\\n/g, "\n")
+  + source.slice(end);
+
+fs.writeFileSync(file, repaired);
+console.log("Repaired staged release fix script");


### PR DESCRIPTION
## 目的

将 `release/v1.4.6@5b0545efa457ca499cb7f35365485689ca7aedab` 的最新 4 个提交同步到 `pg-migration-unified`，作为后续 PostgreSQL 数据迁移演练与收口的新业务基线。

## 本次发布分支变更

主要覆盖：

- 冲突副本生成与解析安全
- 草稿冲突处理
- latest-only versioned save queue
- note sync safety 集成回归
- issue #612 数据保护 CI 修正

## 合并策略

- 使用 merge commit，保留长期分支完整历史
- 不 rebase、不 force push
- 同步后继续保持 `businessRoutesReady = false`
- 临时 review-fix workflow/script 将单独评估是否应保留，不在同步阶段擅自删除发布分支内容

同步完成后继续 #251 的最终报告、apply → verify → rollback drill、失败注入和中/大型数据集验证。