### PR TITLE
chore(pg): sync follow-up release/v1.4.6 fixes

### DIFF
--- a/scripts/fix-note-image-export-ready-import.mjs
+++ b/scripts/fix-note-image-export-ready-import.mjs
@@ -51,7 +51,7 @@ test("release version sources stay consistent", () => {
   const [major, minor, patch] = root.version.split(".").map(Number);
   const expectedCode = major * 10_000 + minor * 100 + patch;
   assert.ok(android.includes(\`versionName "\${root.version}"\`));
-  assert.match(android, new RegExp(\`versionCode\\s+\${expectedCode}\\b\`));
+  assert.ok(android.includes(\`versionCode \${expectedCode}\`));
   assert.equal(frontend.engines?.node, ">=22.0.0");
 });
 `);

--- a/scripts/fix-note-image-export-ready-import.mjs
+++ b/scripts/fix-note-image-export-ready-import.mjs
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 
-const file = "frontend/src/components/NoteImageExportCenter.tsx";
-let source = fs.readFileSync(file, "utf8");
+const exportCenterFile = "frontend/src/components/NoteImageExportCenter.tsx";
+let exportCenterSource = fs.readFileSync(exportCenterFile, "utf8");
 const importPattern = /import\s*\{([\s\S]*?)\}\s*from\s*"@\/lib\/noteImageExportBridge";/;
-const match = source.match(importPattern);
+const match = exportCenterSource.match(importPattern);
 
 if (!match) {
   throw new Error("noteImageExportBridge import block not found");
@@ -11,11 +11,49 @@ if (!match) {
 
 if (!match[1].includes("setNoteImageExportCenterReady")) {
   const names = match[1].trimEnd();
-  source = source.replace(
+  exportCenterSource = exportCenterSource.replace(
     importPattern,
     `import {${names},\n  setNoteImageExportCenterReady,\n} from "@/lib/noteImageExportBridge";`,
   );
 }
 
-fs.writeFileSync(file, source);
-console.log("Ensured NoteImageExportCenter imports setNoteImageExportCenterReady");
+fs.writeFileSync(exportCenterFile, exportCenterSource);
+
+const releaseTestFile = "scripts/tests/release-version-consistency.test.mjs";
+fs.writeFileSync(releaseTestFile, `import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const json = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+test("release version sources stay consistent", () => {
+  const root = json("package.json");
+  const rootLock = json("package-lock.json");
+  const backend = json("backend/package.json");
+  const backendLock = json("backend/package-lock.json");
+  const frontend = json("frontend/package.json");
+  const changelog = json("frontend/public/changelog.json");
+  const android = fs.readFileSync("frontend/android/app/build.gradle", "utf8");
+  const markdown = fs.readFileSync("CHANGELOG.md", "utf8");
+
+  assert.match(root.version, /^\\d+\\.\\d+\\.\\d+$/);
+  assert.equal(rootLock.version, root.version);
+  assert.equal(rootLock.packages[""].version, root.version);
+  assert.equal(backend.version, root.version);
+  assert.equal(backendLock.version, root.version);
+  assert.equal(backendLock.packages[""].version, root.version);
+  assert.equal(changelog.entries[0].version, root.version);
+  assert.match(
+    markdown,
+    new RegExp(\`## v\${root.version.replace(/\\./g, "\\\\.")} - \\d{4}-\\d{2}-\\d{2}\`),
+  );
+
+  const [major, minor, patch] = root.version.split(".").map(Number);
+  const expectedCode = major * 10_000 + minor * 100 + patch;
+  assert.ok(android.includes(\`versionName "\${root.version}"\`));
+  assert.match(android, new RegExp(\`versionCode\\s+\${expectedCode}\\b\`));
+  assert.equal(frontend.engines?.node, ">=22.0.0");
+});
+`);
+
+console.log("Completed release-review post-patch fixes");


### PR DESCRIPTION
## 目的

补充同步 `release/v1.4.6@243438d6dfcefa80b0ca07a0a58d7a1e3b4b4708` 在 PR #685 之后新增的 2 个提交。

## 变更范围

- 修正 note image export ready import 脚本
- 简化 Android release version assertion

使用 merge commit 保留长期分支历史，不 rebase、不 force push。同步完成后继续合并 #251 的规模化迁移演练与最终报告切片。