### PR TITLE
ci: validate P1 note image persistence fix

### DIFF
--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -159,6 +159,17 @@ jobs:
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b
+      - name: Changed image persistence files lint
+        if: always()
+        run: >-
+          npx eslint
+          src/hooks/useNoteLoader.ts
+          src/lib/noteLoadSource.ts
+          src/lib/noteAttachmentAccessPriming.ts
+          src/lib/__tests__/noteLoadSource.test.ts
+          src/lib/__tests__/noteAttachmentAccessPriming.test.ts
+          src/lib/__tests__/noteImageSaveRace.test.ts
+          src/lib/__tests__/editorLifecycleSafety.test.ts
       - name: Frontend lint
         if: always()
         run: npm run lint

--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -142,3 +142,9 @@ jobs:
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b
+      - name: Frontend lint
+        if: always()
+        run: npm run lint
+      - name: Frontend build
+        if: always()
+        run: npm run build

--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -18,6 +18,7 @@ on:
       - "backend/tests/yjs-durability.test.ts"
       - "backend/tests/note-yupdates-repository-async.test.ts"
       - "frontend/src/hooks/useYDoc.ts"
+      - "frontend/src/hooks/useNoteLoader.ts"
       - "frontend/src/components/EditorPane.tsx"
       - "frontend/src/components/TiptapEditor.tsx"
       - "frontend/src/components/MarkdownEditorImpl.tsx"
@@ -31,12 +32,17 @@ on:
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
+      - "frontend/src/lib/noteLoadSource.ts"
+      - "frontend/src/lib/noteAttachmentAccessPriming.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
       - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
+      - "frontend/src/lib/__tests__/noteLoadSource.test.ts"
+      - "frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts"
+      - "frontend/src/lib/__tests__/noteImageSaveRace.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
   pull_request:
     paths:
@@ -54,6 +60,7 @@ on:
       - "backend/tests/yjs-durability.test.ts"
       - "backend/tests/note-yupdates-repository-async.test.ts"
       - "frontend/src/hooks/useYDoc.ts"
+      - "frontend/src/hooks/useNoteLoader.ts"
       - "frontend/src/components/EditorPane.tsx"
       - "frontend/src/components/TiptapEditor.tsx"
       - "frontend/src/components/MarkdownEditorImpl.tsx"
@@ -67,12 +74,17 @@ on:
       - "frontend/src/lib/noteUpdateSerialQueue.ts"
       - "frontend/src/lib/latestOnlyVersionedSaveQueue.ts"
       - "frontend/src/lib/conflictResolution.ts"
+      - "frontend/src/lib/noteLoadSource.ts"
+      - "frontend/src/lib/noteAttachmentAccessPriming.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
       - "frontend/src/lib/__tests__/noteSyncSafety.integration.test.ts"
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
+      - "frontend/src/lib/__tests__/noteLoadSource.test.ts"
+      - "frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts"
+      - "frontend/src/lib/__tests__/noteImageSaveRace.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
 
 permissions:
@@ -114,7 +126,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
-      - name: Yjs, REST queue, draft and lifecycle regressions
+      - name: Yjs, REST queue, draft, lifecycle and image persistence regressions
         run: >-
           npm run test:run --
           src/lib/__tests__/yjsDurability.test.ts
@@ -124,6 +136,9 @@ jobs:
           src/lib/__tests__/noteSyncSafety.integration.test.ts
           src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
           src/lib/__tests__/conflictResolution.test.ts
+          src/lib/__tests__/noteLoadSource.test.ts
+          src/lib/__tests__/noteAttachmentAccessPriming.test.ts
+          src/lib/__tests__/noteImageSaveRace.test.ts
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b

--- a/.github/workflows/issue-612-data-protection-ci.yml
+++ b/.github/workflows/issue-612-data-protection-ci.yml
@@ -17,6 +17,10 @@ on:
       - "backend/tests/knowledge-tree-migration-registry.test.ts"
       - "backend/tests/yjs-durability.test.ts"
       - "backend/tests/note-yupdates-repository-async.test.ts"
+      - "backend/tests/attachment-cache-contract.test.ts"
+      - "backend/tests/attachment-references-repository-async.test.ts"
+      - "backend/tests/attachment-shared-access.test.ts"
+      - "backend/tests/attachment-signed-url-window.test.ts"
       - "frontend/src/hooks/useYDoc.ts"
       - "frontend/src/hooks/useNoteLoader.ts"
       - "frontend/src/components/EditorPane.tsx"
@@ -34,6 +38,7 @@ on:
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/noteLoadSource.ts"
       - "frontend/src/lib/noteAttachmentAccessPriming.ts"
+      - "frontend/src/lib/noteAttachmentAccessBridge.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
@@ -41,6 +46,7 @@ on:
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - "frontend/src/lib/__tests__/noteLoadSource.test.ts"
+      - "frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts"
       - "frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts"
       - "frontend/src/lib/__tests__/noteImageSaveRace.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -59,6 +65,10 @@ on:
       - "backend/tests/knowledge-tree-migration-registry.test.ts"
       - "backend/tests/yjs-durability.test.ts"
       - "backend/tests/note-yupdates-repository-async.test.ts"
+      - "backend/tests/attachment-cache-contract.test.ts"
+      - "backend/tests/attachment-references-repository-async.test.ts"
+      - "backend/tests/attachment-shared-access.test.ts"
+      - "backend/tests/attachment-signed-url-window.test.ts"
       - "frontend/src/hooks/useYDoc.ts"
       - "frontend/src/hooks/useNoteLoader.ts"
       - "frontend/src/components/EditorPane.tsx"
@@ -76,6 +86,7 @@ on:
       - "frontend/src/lib/conflictResolution.ts"
       - "frontend/src/lib/noteLoadSource.ts"
       - "frontend/src/lib/noteAttachmentAccessPriming.ts"
+      - "frontend/src/lib/noteAttachmentAccessBridge.ts"
       - "frontend/src/lib/__tests__/yjsDurability.test.ts"
       - "frontend/src/lib/__tests__/draftStorage.conflict.test.ts"
       - "frontend/src/lib/__tests__/editorLifecycleSafety.test.ts"
@@ -83,6 +94,7 @@ on:
       - "frontend/src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts"
       - "frontend/src/lib/__tests__/conflictResolution.test.ts"
       - "frontend/src/lib/__tests__/noteLoadSource.test.ts"
+      - "frontend/src/lib/__tests__/noteAttachmentAccessBridge.test.ts"
       - "frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts"
       - "frontend/src/lib/__tests__/noteImageSaveRace.test.ts"
       - ".github/workflows/issue-612-data-protection-ci.yml"
@@ -104,11 +116,15 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
-      - name: Yjs durability, repository and migration registry regressions
+      - name: Durability, repository, migration and attachment regressions
         run: |
           node --import tsx --import ./tests/setup-db-isolation.ts --test tests/yjs-durability.test.ts
           node --import tsx --import ./tests/setup-db-isolation.ts --test tests/note-yupdates-repository-async.test.ts
           node --import tsx --import ./tests/setup-db-isolation.ts --test tests/knowledge-tree-migration-registry.test.ts
+          node --import tsx --test tests/attachment-cache-contract.test.ts
+          node --import tsx --test tests/attachment-references-repository-async.test.ts
+          node --import tsx --test tests/attachment-shared-access.test.ts
+          node --import tsx --test tests/attachment-signed-url-window.test.ts
       - name: Backend typecheck
         if: always()
         run: npm run build:tsc
@@ -137,6 +153,7 @@ jobs:
           src/lib/__tests__/latestOnlyVersionedSaveQueue.test.ts
           src/lib/__tests__/conflictResolution.test.ts
           src/lib/__tests__/noteLoadSource.test.ts
+          src/lib/__tests__/noteAttachmentAccessBridge.test.ts
           src/lib/__tests__/noteAttachmentAccessPriming.test.ts
           src/lib/__tests__/noteImageSaveRace.test.ts
       - name: Frontend typecheck

--- a/frontend/src/hooks/useNoteLoader.ts
+++ b/frontend/src/hooks/useNoteLoader.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import { useApp, useAppActions } from "@/store/AppContext";
 import type { Note } from "@/types";
+import { getBaseUrl } from "@/lib/api";
 import {
   primaryNoteLoadCoordinator,
   type NoteLoadOptions,
@@ -10,6 +11,10 @@ import {
   canApplyRevalidatedNote,
   loadNoteCacheFirst,
 } from "@/lib/noteLoadSource";
+import {
+  hasPersistentNoteAttachmentReference,
+  primeNoteAttachmentAccess,
+} from "@/lib/noteAttachmentAccessPriming";
 import { loadDraft } from "@/lib/draftStorage";
 import {
   getEditorRuntimeDecisionForNote,
@@ -84,6 +89,14 @@ export function useNoteLoader() {
         const loaded = await loadNoteCacheFirst({
           noteId: options.noteId,
           fetchRemote,
+          beforeUseCached: async (cached) => {
+            // Cache-first can otherwise mount Tiptap/Markdown before the background GET /notes/:id
+            // has refreshed signed attachment URLs. The persisted body is correct, but the first
+            // raw `/api/attachments/<id>` request is rejected and the editor gets stuck on its
+            // image-error placeholder. Prime only notes that actually persist attachment refs.
+            if (!hasPersistentNoteAttachmentReference(cached.content)) return;
+            await primeNoteAttachmentAccess(cached.id, getBaseUrl());
+          },
           onRevalidated: (remote, cached) => {
             const currentState = stateRef.current;
             const current = currentState.activeNote;

--- a/frontend/src/hooks/useNoteLoader.ts
+++ b/frontend/src/hooks/useNoteLoader.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import { useApp, useAppActions } from "@/store/AppContext";
 import type { Note } from "@/types";
-import { getBaseUrl } from "@/lib/api";
 import {
   primaryNoteLoadCoordinator,
   type NoteLoadOptions,
@@ -11,10 +10,6 @@ import {
   canApplyRevalidatedNote,
   loadNoteCacheFirst,
 } from "@/lib/noteLoadSource";
-import {
-  hasPersistentNoteAttachmentReference,
-  primeNoteAttachmentAccess,
-} from "@/lib/noteAttachmentAccessPriming";
 import { loadDraft } from "@/lib/draftStorage";
 import {
   getEditorRuntimeDecisionForNote,
@@ -89,14 +84,6 @@ export function useNoteLoader() {
         const loaded = await loadNoteCacheFirst({
           noteId: options.noteId,
           fetchRemote,
-          beforeUseCached: async (cached) => {
-            // Cache-first can otherwise mount Tiptap/Markdown before the background GET /notes/:id
-            // has refreshed signed attachment URLs. The persisted body is correct, but the first
-            // raw `/api/attachments/<id>` request is rejected and the editor gets stuck on its
-            // image-error placeholder. Prime only notes that actually persist attachment refs.
-            if (!hasPersistentNoteAttachmentReference(cached.content)) return;
-            await primeNoteAttachmentAccess(cached.id, getBaseUrl());
-          },
           onRevalidated: (remote, cached) => {
             const currentState = stateRef.current;
             const current = currentState.activeNote;

--- a/frontend/src/lib/__tests__/editorLifecycleSafety.test.ts
+++ b/frontend/src/lib/__tests__/editorLifecycleSafety.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import { resolveEditorLifecycleSave } from "@/lib/editorLifecycleSafety";
 
 describe("editor lifecycle save safety", () => {
-  it("flushes pending content even when the title is unchanged", () => {
+  it("Case 2: flushes pending image/content immediately when the user switches notes", () => {
+    // Image insertion is a document transaction, so Tiptap has a pending content debounce here.
+    // The before-note-switch lifecycle path must force the latest editor JSON out immediately.
     expect(resolveEditorLifecycleSave({
       hasPendingContent: true,
       title: "Title",

--- a/frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts
+++ b/frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn() },
+}));
+
+import {
+  hasPersistentNoteAttachmentReference,
+  primeNoteAttachmentAccess,
+} from "@/lib/noteAttachmentAccessPriming";
+import {
+  resetAttachmentAccessStateForTests,
+  resolveAttachmentAccessUrl,
+} from "@/lib/noteAttachmentAccessBridge";
+
+const ATTACHMENT_A = "123e4567-e89b-42d3-a456-426614174216";
+const ATTACHMENT_B = "223e4567-e89b-42d3-a456-426614174217";
+
+function signedUrl(id: string, sig: string): string {
+  return `/api/attachments/${id}?exp=2000000000&sig=${sig}&scope=v2.scope`;
+}
+
+describe("noteAttachmentAccessPriming", () => {
+  beforeEach(() => {
+    resetAttachmentAccessStateForTests();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/notes/test");
+  });
+
+  it("Case 1/5: detects persisted attachment references in Tiptap, Markdown and legacy absolute URLs", () => {
+    expect(hasPersistentNoteAttachmentReference(JSON.stringify({
+      type: "image",
+      attrs: { src: `/api/attachments/${ATTACHMENT_A}` },
+    }))).toBe(true);
+    expect(hasPersistentNoteAttachmentReference(`![image](/api/attachments/${ATTACHMENT_A})`)).toBe(true);
+    expect(hasPersistentNoteAttachmentReference(
+      `http://127.0.0.1:3001/api/attachments/${ATTACHMENT_A}`,
+    )).toBe(true);
+    expect(hasPersistentNoteAttachmentReference("blob:http://localhost/transient-preview")).toBe(false);
+  });
+
+  it("Case 1/5: primes signed access before a persisted raw attachment reference is rendered", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      noteId: "note-1",
+      urls: { [ATTACHMENT_A]: signedUrl(ATTACHMENT_A, "signed-a") },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const persistentSrc = `/api/attachments/${ATTACHMENT_A}`;
+    const registered = await primeNoteAttachmentAccess("note-1", "https://notes.example.com/api", {
+      token: "jwt-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(registered).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [requestUrl, requestInit] = fetchImpl.mock.calls[0];
+    expect(requestUrl).toBe("https://notes.example.com/api/attachments/access/urls?noteId=note-1");
+    expect(requestInit?.headers).toEqual({ Authorization: "Bearer jwt-token" });
+
+    const resolved = new URL(resolveAttachmentAccessUrl(persistentSrc));
+    expect(resolved.origin).toBe("https://notes.example.com");
+    expect(resolved.pathname).toBe(`/api/attachments/${ATTACHMENT_A}`);
+    expect(resolved.searchParams.get("sig")).toBe("signed-a");
+    // The note body stays stable; only the runtime request URL is signed.
+    expect(persistentSrc).toBe(`/api/attachments/${ATTACHMENT_A}`);
+  });
+
+  it("Case 3: primes all images in a note without converting their persisted references", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      urls: {
+        [ATTACHMENT_A]: signedUrl(ATTACHMENT_A, "signed-a"),
+        [ATTACHMENT_B]: signedUrl(ATTACHMENT_B, "signed-b"),
+      },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const registered = await primeNoteAttachmentAccess("note-many", "/api", {
+      token: "jwt-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(registered).toBe(2);
+    expect(resolveAttachmentAccessUrl(`/api/attachments/${ATTACHMENT_A}`)).toContain("sig=signed-a");
+    expect(resolveAttachmentAccessUrl(`/api/attachments/${ATTACHMENT_B}`)).toContain("sig=signed-b");
+  });
+
+  it("does not issue an access request when no authenticated session is available", async () => {
+    const fetchImpl = vi.fn();
+    await expect(primeNoteAttachmentAccess("note-1", "/api", {
+      token: null,
+      fetchImpl: fetchImpl as typeof fetch,
+    })).resolves.toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts
+++ b/frontend/src/lib/__tests__/noteAttachmentAccessPriming.test.ts
@@ -42,7 +42,7 @@ describe("noteAttachmentAccessPriming", () => {
   });
 
   it("Case 1/5: primes signed access before a persisted raw attachment reference is rendered", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       noteId: "note-1",
       urls: { [ATTACHMENT_A]: signedUrl(ATTACHMENT_A, "signed-a") },
     }), {
@@ -53,7 +53,7 @@ describe("noteAttachmentAccessPriming", () => {
     const persistentSrc = `/api/attachments/${ATTACHMENT_A}`;
     const registered = await primeNoteAttachmentAccess("note-1", "https://notes.example.com/api", {
       token: "jwt-token",
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl,
     });
 
     expect(registered).toBe(1);
@@ -71,7 +71,7 @@ describe("noteAttachmentAccessPriming", () => {
   });
 
   it("Case 3: primes all images in a note without converting their persisted references", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       urls: {
         [ATTACHMENT_A]: signedUrl(ATTACHMENT_A, "signed-a"),
         [ATTACHMENT_B]: signedUrl(ATTACHMENT_B, "signed-b"),
@@ -83,7 +83,7 @@ describe("noteAttachmentAccessPriming", () => {
 
     const registered = await primeNoteAttachmentAccess("note-many", "/api", {
       token: "jwt-token",
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl,
     });
 
     expect(registered).toBe(2);
@@ -92,10 +92,10 @@ describe("noteAttachmentAccessPriming", () => {
   });
 
   it("does not issue an access request when no authenticated session is available", async () => {
-    const fetchImpl = vi.fn();
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response());
     await expect(primeNoteAttachmentAccess("note-1", "/api", {
       token: null,
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl,
     })).resolves.toBe(0);
     expect(fetchImpl).not.toHaveBeenCalled();
   });

--- a/frontend/src/lib/__tests__/noteImageSaveRace.test.ts
+++ b/frontend/src/lib/__tests__/noteImageSaveRace.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { LatestOnlyVersionedSaveQueue } from "@/lib/latestOnlyVersionedSaveQueue";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+const IMAGE_SRC = "/api/attachments/123e4567-e89b-42d3-a456-426614174216";
+
+function tiptapBody(text: string, withImage: boolean): string {
+  return JSON.stringify({
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text", text }] },
+      ...(withImage ? [{ type: "image", attrs: { src: IMAGE_SRC } }] : []),
+    ],
+  });
+}
+
+describe("note image persistence save races", () => {
+  it("Case 4: an older in-flight autosave cannot overwrite the latest image + text snapshot", async () => {
+    const first = deferred<{ version: number }>();
+    const second = deferred<{ version: number }>();
+    const secondStarted = deferred<void>();
+    const writes: Array<{ content: string; version: number }> = [];
+
+    const send = vi.fn(async (
+      _noteId: string,
+      payload: { content: string },
+      version: number,
+    ) => {
+      writes.push({ content: payload.content, version });
+      if (writes.length === 2) secondStarted.resolve();
+      return writes.length === 1 ? first.promise : second.promise;
+    });
+
+    const queue = new LatestOnlyVersionedSaveQueue(
+      send,
+      (previous, next) => ({ ...previous, ...next }),
+    );
+
+    const oldSave = queue.enqueue({
+      key: "note-1",
+      baseVersion: 10,
+      payload: { content: tiptapBody("before upload", false) },
+    });
+    const imageSave = queue.enqueue({
+      key: "note-1",
+      baseVersion: 10,
+      payload: { content: tiptapBody("after upload", true) },
+    });
+    const latestSave = queue.enqueue({
+      key: "note-1",
+      baseVersion: 10,
+      payload: { content: tiptapBody("after upload + fast edit", true) },
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].content).not.toContain(IMAGE_SRC);
+
+    first.resolve({ version: 11 });
+    await secondStarted.promise;
+
+    expect(writes).toHaveLength(2);
+    expect(writes[1].version).toBe(11);
+    expect(writes[1].content).toContain(IMAGE_SRC);
+    expect(writes[1].content).toContain("after upload + fast edit");
+
+    second.resolve({ version: 12 });
+    const results = await Promise.all([oldSave, imageSave, latestSave]);
+    expect(results.every((result) => result.result.version === 12)).toBe(true);
+    expect(results.every((result) => result.payload.content.includes(IMAGE_SRC))).toBe(true);
+    expect(results.every((result) => result.payload.content.includes("after upload + fast edit"))).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/noteLoadSource.test.ts
+++ b/frontend/src/lib/__tests__/noteLoadSource.test.ts
@@ -6,12 +6,21 @@ const localStore = vi.hoisted(() => ({
   isNoteDetailCached: vi.fn(),
   putNote: vi.fn(),
 }));
+const attachmentRuntime = vi.hoisted(() => ({
+  hasPersistentNoteAttachmentReference: vi.fn((content: string | null | undefined) =>
+    typeof content === "string" && content.includes("/api/attachments/")),
+  primeNoteAttachmentAccess: vi.fn(async () => 1),
+}));
 
 vi.mock("@/lib/localStore", () => ({
   getNote: localStore.getNote,
   isNoteDetailCached: localStore.isNoteDetailCached,
   putNote: localStore.putNote,
 }));
+vi.mock("@/lib/api", () => ({
+  getBaseUrl: () => "https://notes.example.com/api",
+}));
+vi.mock("@/lib/noteAttachmentAccessPriming", () => attachmentRuntime);
 
 import { canApplyRevalidatedNote, loadNoteCacheFirst } from "@/lib/noteLoadSource";
 
@@ -98,6 +107,9 @@ describe("loadNoteCacheFirst", () => {
     vi.clearAllMocks();
     localStore.isNoteDetailCached.mockReturnValue(true);
     localStore.putNote.mockResolvedValue(undefined);
+    attachmentRuntime.hasPersistentNoteAttachmentReference.mockImplementation((content) =>
+      typeof content === "string" && content.includes("/api/attachments/"));
+    attachmentRuntime.primeNoteAttachmentAccess.mockResolvedValue(1);
   });
 
   it("Case 1/2: prepares a cached image note before it is reopened after a switch", async () => {
@@ -127,6 +139,44 @@ describe("loadNoteCacheFirst", () => {
     prepareGate.resolve();
     await expect(loadPromise).resolves.toBe(cached);
 
+    remoteGate.resolve(makeNote({ version: 4 }));
+    await vi.waitFor(() => expect(localStore.putNote).toHaveBeenCalled());
+  });
+
+  it("covers split-editor/direct callers by priming attachments by default", async () => {
+    const cached = makeNote({
+      content: `![image](/api/attachments/123e4567-e89b-42d3-a456-426614174216)`,
+      contentFormat: "markdown",
+    });
+    localStore.getNote.mockResolvedValue(cached);
+    const remoteGate = deferred<Note>();
+
+    await expect(loadNoteCacheFirst({
+      noteId: cached.id,
+      fetchRemote: () => remoteGate.promise,
+    })).resolves.toBe(cached);
+
+    expect(attachmentRuntime.hasPersistentNoteAttachmentReference).toHaveBeenCalledWith(cached.content);
+    expect(attachmentRuntime.primeNoteAttachmentAccess).toHaveBeenCalledWith(
+      cached.id,
+      "https://notes.example.com/api",
+    );
+
+    remoteGate.resolve(makeNote({ version: 4 }));
+    await vi.waitFor(() => expect(localStore.putNote).toHaveBeenCalled());
+  });
+
+  it("does not prime cached text-only notes", async () => {
+    const cached = makeNote({ content: "plain text only" });
+    localStore.getNote.mockResolvedValue(cached);
+    const remoteGate = deferred<Note>();
+
+    await expect(loadNoteCacheFirst({
+      noteId: cached.id,
+      fetchRemote: () => remoteGate.promise,
+    })).resolves.toBe(cached);
+
+    expect(attachmentRuntime.primeNoteAttachmentAccess).not.toHaveBeenCalled();
     remoteGate.resolve(makeNote({ version: 4 }));
     await vi.waitFor(() => expect(localStore.putNote).toHaveBeenCalled());
   });

--- a/frontend/src/lib/__tests__/noteLoadSource.test.ts
+++ b/frontend/src/lib/__tests__/noteLoadSource.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it } from "vitest";
-import { canApplyRevalidatedNote } from "@/lib/noteLoadSource";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Note } from "@/types";
+
+const localStore = vi.hoisted(() => ({
+  getNote: vi.fn(),
+  isNoteDetailCached: vi.fn(),
+  putNote: vi.fn(),
+}));
+
+vi.mock("@/lib/localStore", () => ({
+  getNote: localStore.getNote,
+  isNoteDetailCached: localStore.isNoteDetailCached,
+  putNote: localStore.putNote,
+}));
+
+import { canApplyRevalidatedNote, loadNoteCacheFirst } from "@/lib/noteLoadSource";
 
 function makeNote(overrides: Partial<Note> = {}): Note {
   return {
@@ -22,6 +35,16 @@ function makeNote(overrides: Partial<Note> = {}): Note {
     updatedAt: "2026-07-20T00:00:00.000Z",
     ...overrides,
   } as Note;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("canApplyRevalidatedNote", () => {
@@ -67,5 +90,80 @@ describe("canApplyRevalidatedNote", () => {
       hasDraft: false,
       pendingNoteId: null,
     })).toBe(false);
+  });
+});
+
+describe("loadNoteCacheFirst", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStore.isNoteDetailCached.mockReturnValue(true);
+    localStore.putNote.mockResolvedValue(undefined);
+  });
+
+  it("Case 1/2: prepares a cached image note before it is reopened after a switch", async () => {
+    const cached = makeNote({
+      content: '{"type":"doc","content":[{"type":"image","attrs":{"src":"/api/attachments/123e4567-e89b-42d3-a456-426614174216"}}]}',
+    });
+    localStore.getNote.mockResolvedValue(cached);
+    const prepareGate = deferred<void>();
+    const remoteGate = deferred<Note>();
+    const beforeUseCached = vi.fn(() => prepareGate.promise);
+    const fetchRemote = vi.fn(() => remoteGate.promise);
+    let settled = false;
+
+    const loadPromise = loadNoteCacheFirst({
+      noteId: cached.id,
+      fetchRemote,
+      beforeUseCached,
+    }).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    await vi.waitFor(() => expect(beforeUseCached).toHaveBeenCalledWith(cached));
+    expect(fetchRemote).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    prepareGate.resolve();
+    await expect(loadPromise).resolves.toBe(cached);
+
+    remoteGate.resolve(makeNote({ version: 4 }));
+    await vi.waitFor(() => expect(localStore.putNote).toHaveBeenCalled());
+  });
+
+  it("keeps cached notes available if runtime preparation fails while offline", async () => {
+    const cached = makeNote();
+    localStore.getNote.mockResolvedValue(cached);
+    const remoteGate = deferred<Note>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(loadNoteCacheFirst({
+      noteId: cached.id,
+      fetchRemote: () => remoteGate.promise,
+      beforeUseCached: async () => { throw new Error("offline"); },
+    })).resolves.toBe(cached);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[noteLoadSource] cached-note preparation failed:",
+      expect.any(Error),
+    );
+    remoteGate.reject(new Error("offline"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    warn.mockRestore();
+  });
+
+  it("uses and persists the remote body when no detailed cache exists", async () => {
+    localStore.getNote.mockResolvedValue(null);
+    const remote = makeNote({ version: 5 });
+    const beforeUseCached = vi.fn();
+
+    await expect(loadNoteCacheFirst({
+      noteId: remote.id,
+      fetchRemote: async () => remote,
+      beforeUseCached,
+    })).resolves.toBe(remote);
+
+    expect(beforeUseCached).not.toHaveBeenCalled();
+    expect(localStore.putNote).toHaveBeenCalledWith({ ...remote, __detailCached: true });
   });
 });

--- a/frontend/src/lib/noteAttachmentAccessPriming.ts
+++ b/frontend/src/lib/noteAttachmentAccessPriming.ts
@@ -44,6 +44,7 @@ export async function primeNoteAttachmentAccess(
   options: PrimeNoteAttachmentAccessOptions = {},
 ): Promise<number> {
   if (!noteId) return 0;
+  if (typeof navigator !== "undefined" && navigator.onLine === false) return 0;
 
   const token = options.token !== undefined ? options.token : readStoredToken();
   if (!token) return 0;

--- a/frontend/src/lib/noteAttachmentAccessPriming.ts
+++ b/frontend/src/lib/noteAttachmentAccessPriming.ts
@@ -1,0 +1,79 @@
+import { registerAttachmentAccessUrls } from "@/lib/noteAttachmentAccessBridge";
+
+const PERSISTED_ATTACHMENT_REF_RE = /\/api\/attachments\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:[?"'\\)\s]|$)/i;
+const DEFAULT_PRIME_TIMEOUT_MS = 4_000;
+
+export interface PrimeNoteAttachmentAccessOptions {
+  fetchImpl?: typeof fetch;
+  token?: string | null;
+  timeoutMs?: number;
+}
+
+export function hasPersistentNoteAttachmentReference(content: string | null | undefined): boolean {
+  return typeof content === "string" && PERSISTED_ATTACHMENT_REF_RE.test(content);
+}
+
+function readStoredToken(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    return localStorage.getItem("nowen-token");
+  } catch {
+    return null;
+  }
+}
+
+function joinApiPath(apiBaseUrl: string, path: string): string {
+  const base = (apiBaseUrl || "/api").replace(/\/+$/, "");
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+/**
+ * Prime the short-lived attachment access map for a cached note before its editor mounts.
+ *
+ * notes.content intentionally persists only `/api/attachments/<id>` references. Since those
+ * raw URLs are no longer authorization capabilities, a fresh renderer must exchange its JWT
+ * for signed access URLs before native image/media requests are allowed to leave the page.
+ *
+ * A normal remote GET /notes/:id already performs the same exchange through
+ * noteAttachmentAccessBridge. Cache-first note loading can skip that GET on the critical path,
+ * so this lightweight request closes the lifecycle gap without changing persisted content.
+ */
+export async function primeNoteAttachmentAccess(
+  noteId: string,
+  apiBaseUrl: string,
+  options: PrimeNoteAttachmentAccessOptions = {},
+): Promise<number> {
+  if (!noteId) return 0;
+
+  const token = options.token !== undefined ? options.token : readStoredToken();
+  if (!token) return 0;
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = Number.isFinite(options.timeoutMs)
+    ? Math.max(250, Number(options.timeoutMs))
+    : DEFAULT_PRIME_TIMEOUT_MS;
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timer = controller
+    ? setTimeout(() => controller.abort(), timeoutMs)
+    : null;
+  const url = joinApiPath(
+    apiBaseUrl,
+    `/attachments/access/urls?noteId=${encodeURIComponent(noteId)}`,
+  );
+
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+      signal: controller?.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Attachment access priming failed: ${response.status}`);
+    }
+    const payload = await response.json() as { urls?: Record<string, string> };
+    return registerAttachmentAccessUrls(payload.urls, url);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/frontend/src/lib/noteLoadSource.ts
+++ b/frontend/src/lib/noteLoadSource.ts
@@ -10,6 +10,12 @@ export interface CacheFirstNoteLoadOptions {
   noteId: string;
   fetchRemote: () => Promise<Note>;
   onRevalidated?: (remote: Note, cached: CachedNote) => void | Promise<void>;
+  /**
+   * Called before a cached note becomes visible. Use this for lightweight runtime prerequisites
+   * that are normally prepared by the remote note request (for example signed attachment access).
+   * Failures are non-fatal so offline cached-note opening keeps working.
+   */
+  beforeUseCached?: (cached: CachedNote) => void | Promise<void>;
 }
 
 export interface RevalidatedNoteGuardInput {
@@ -46,9 +52,12 @@ export async function loadNoteCacheFirst({
   noteId,
   fetchRemote,
   onRevalidated,
+  beforeUseCached,
 }: CacheFirstNoteLoadOptions): Promise<Note> {
   const cached = await getCachedNote(noteId);
   if (cached && isNoteDetailCached(cached)) {
+    // Start freshness revalidation immediately, but do not let cache-first rendering race runtime
+    // prerequisites that the remote request normally prepares (attachment access is the P1 case).
     void fetchRemote()
       .then(async (remote) => {
         await persistDetail(remote);
@@ -57,6 +66,16 @@ export async function loadNoteCacheFirst({
       .catch((error) => {
         console.warn("[noteLoadSource] background revalidation failed:", error);
       });
+
+    if (beforeUseCached) {
+      try {
+        await beforeUseCached(cached);
+      } catch (error) {
+        // Cached notes must remain available offline. The background revalidation above may still
+        // recover the runtime prerequisite when connectivity returns.
+        console.warn("[noteLoadSource] cached-note preparation failed:", error);
+      }
+    }
     return cached;
   }
 

--- a/frontend/src/lib/noteLoadSource.ts
+++ b/frontend/src/lib/noteLoadSource.ts
@@ -1,18 +1,23 @@
 import type { Note } from "@/types";
+import { getBaseUrl } from "@/lib/api";
 import {
   getNote as getCachedNote,
   isNoteDetailCached,
   putNote,
   type CachedNote,
 } from "@/lib/localStore";
+import {
+  hasPersistentNoteAttachmentReference,
+  primeNoteAttachmentAccess,
+} from "@/lib/noteAttachmentAccessPriming";
 
 export interface CacheFirstNoteLoadOptions {
   noteId: string;
   fetchRemote: () => Promise<Note>;
   onRevalidated?: (remote: Note, cached: CachedNote) => void | Promise<void>;
   /**
-   * Called before a cached note becomes visible. Use this for lightweight runtime prerequisites
-   * that are normally prepared by the remote note request (for example signed attachment access).
+   * Optional override for runtime prerequisites before a cached note becomes visible.
+   * The default prepares signed attachment access for persisted `/api/attachments/<id>` refs.
    * Failures are non-fatal so offline cached-note opening keeps working.
    */
   beforeUseCached?: (cached: CachedNote) => void | Promise<void>;
@@ -48,11 +53,16 @@ async function persistDetail(note: Note): Promise<void> {
   await putNote({ ...note, __detailCached: true });
 }
 
+async function prepareCachedNoteRuntime(cached: CachedNote): Promise<void> {
+  if (!hasPersistentNoteAttachmentReference(cached.content)) return;
+  await primeNoteAttachmentAccess(cached.id, getBaseUrl());
+}
+
 export async function loadNoteCacheFirst({
   noteId,
   fetchRemote,
   onRevalidated,
-  beforeUseCached,
+  beforeUseCached = prepareCachedNoteRuntime,
 }: CacheFirstNoteLoadOptions): Promise<Note> {
   const cached = await getCachedNote(noteId);
   if (cached && isNoteDetailCached(cached)) {
@@ -67,14 +77,12 @@ export async function loadNoteCacheFirst({
         console.warn("[noteLoadSource] background revalidation failed:", error);
       });
 
-    if (beforeUseCached) {
-      try {
-        await beforeUseCached(cached);
-      } catch (error) {
-        // Cached notes must remain available offline. The background revalidation above may still
-        // recover the runtime prerequisite when connectivity returns.
-        console.warn("[noteLoadSource] cached-note preparation failed:", error);
-      }
+    try {
+      await beforeUseCached(cached);
+    } catch (error) {
+      // Cached notes must remain available offline. The background revalidation above may still
+      // recover the runtime prerequisite when connectivity returns.
+      console.warn("[noteLoadSource] cached-note preparation failed:", error);
     }
     return cached;
   }


### PR DESCRIPTION
Temporary validation PR for the P1 cached-note attachment access fix already committed to `release/v1.4.6`. Do not merge from this PR; it exists only to run the repository's pull-request CI against the actual fix and regression tests.