### PR TITLE
fix(tasks): 修复截止时间提醒未自动创建

### DIFF
--- a/frontend/src/components/tasks/__tests__/taskSmartRecognition.test.ts
+++ b/frontend/src/components/tasks/__tests__/taskSmartRecognition.test.ts
@@ -195,6 +195,7 @@ describe("taskSmartRecognition - date/time", () => {
 
         expect(parsed.taskPatch.dueDate).toBe("2026-03-06");
         expect(parsed.taskPatch.dueAt).toBe("2026-03-06T09:00");
+        expect(parsed.reminderOffsets).toEqual([]);
         expect(parsed.cleanTitle).toBe("exam");
         expect(parsed.recognizedRanges.map((range) => "Mar. 6, 2026 9am exam".slice(range.start, range.end))).toEqual([
             "Mar. 6, 2026",
@@ -379,6 +380,23 @@ describe("taskSmartRecognition - repeat", () => {
 });
 
 describe("taskSmartRecognition - reminders and cleanup", () => {
+    it("creates an at-due reminder only for recognized time deadlines", () => {
+        const now = dt("2026-07-08T10:00:00");
+
+        const dateOnly = parseTaskQuickAdd("明天 提交报告", now);
+        expect(dateOnly.taskPatch.dueDate).toBe("2026-07-09");
+        expect(dateOnly.reminderOffsets).toEqual([]);
+
+        const dateOnlyWithReminder = parseTaskQuickAdd("明天 提醒我 提交报告", now);
+        expect(dateOnlyWithReminder.taskPatch.dueDate).toBe("2026-07-09");
+        expect(dateOnlyWithReminder.taskPatch.dueAt).toBe("2026-07-09T08:30");
+        expect(dateOnlyWithReminder.reminderOffsets).toEqual([0]);
+
+        const dateAndTime = parseTaskQuickAdd("明天下午3点 开会", now);
+        expect(dateAndTime.taskPatch.dueAt).toBe("2026-07-09T15:00");
+        expect(dateAndTime.reminderOffsets).toEqual([0]);
+    });
+
     it("creates due reminder + advance reminder", () => {
         const now = dt("2026-07-08T10:00:00");
         const parsed = parseTaskQuickAdd("今天下午3点 开会，提前3小时", now);

--- a/frontend/src/components/tasks/taskSmartRecognition.ts
+++ b/frontend/src/components/tasks/taskSmartRecognition.ts
@@ -275,9 +275,15 @@ export function parseTaskQuickAdd(input: string, now = new Date()): TaskQuickAdd
         reminderOffsets.push(0, advanceSpec.offsetMinutes);
         consumedRanges.push(advanceSpec.range);
         if (dueReminderSpec) consumedRanges.push(dueReminderSpec.range);
-    } else if (dueReminderSpec && taskPatch.dueAt) {
+    } else if (dueReminderSpec && (taskPatch.dueDate || taskPatch.dueAt)) {
+        if (taskPatch.dueDate && !taskPatch.dueAt) {
+            taskPatch.dueAt = `${taskPatch.dueDate}T08:30`;
+        }
         reminderOffsets.push(0);
         consumedRanges.push(dueReminderSpec.range);
+    }
+    if (hasFutureDueAt(taskPatch, now) && reminderOffsets.length === 0) {
+        reminderOffsets.push(0);
     }
 
     const cleanTitle = cleanupTitle(removeRanges(raw, consumedRanges));
@@ -288,6 +294,10 @@ export function parseTaskQuickAdd(input: string, now = new Date()): TaskQuickAdd
         reminderOffsets: sortUniqueOffsets(reminderOffsets),
         recognizedRanges: mergeRanges(consumedRanges),
     };
+}
+
+function hasFutureDueAt(taskPatch: Partial<Task>, now: Date): boolean {
+    return !!taskPatch.dueAt && new Date(taskPatch.dueAt).getTime() > now.getTime();
 }
 
 function parseTimeSpec(text: string, protectedRanges: MatchRange[]): TimeSpec | null {


### PR DESCRIPTION
## 变更说明

修复任务智能识别截止时间后未自动创建到期提醒的问题。

- 为未来的精确截止时间自动创建到期提醒
- 纯日期任务仅在明确输入“提醒我”时创建提醒，默认时间为 08:30
- 已过期的截止时间不会自动创建提醒
- 补充日期、时间及过期场景测试

## 测试

- `taskSmartRecognition.test.ts`
- 43 个测试全部通过