### PR TITLE
fix(离线同步): 支持离线打开知识树

### DIFF
--- a/.github/workflows/knowledge-tree-ci.yml
+++ b/.github/workflows/knowledge-tree-ci.yml
@@ -22,6 +22,8 @@ on:
       - "frontend/src/components/MobileDrawerUxBridge.tsx"
       - "frontend/src/lib/knowledgeTree*.ts"
       - "frontend/src/lib/__tests__/knowledgeTree*.test.ts"
+      - "frontend/src/lib/offlineWorkspaceSync.ts"
+      - "frontend/src/lib/__tests__/offlineWorkspaceSync.test.ts"
       - ".github/workflows/knowledge-tree-ci.yml"
   pull_request:
     paths:
@@ -40,6 +42,8 @@ on:
       - "frontend/src/components/MobileDrawerUxBridge.tsx"
       - "frontend/src/lib/knowledgeTree*.ts"
       - "frontend/src/lib/__tests__/knowledgeTree*.test.ts"
+      - "frontend/src/lib/offlineWorkspaceSync.ts"
+      - "frontend/src/lib/__tests__/offlineWorkspaceSync.test.ts"
       - ".github/workflows/knowledge-tree-ci.yml"
 
 permissions:
@@ -148,6 +152,8 @@ jobs:
           npm run test:run --
           src/lib/__tests__/knowledgeTreeModel.test.ts
           src/lib/__tests__/editorWorkspaceLayout.test.ts
+          src/lib/__tests__/knowledgeTreeApi.test.ts
+          src/lib/__tests__/offlineWorkspaceSync.test.ts
       - name: Frontend typecheck
         if: always()
         run: npx tsc -b

--- a/frontend/src/lib/__tests__/knowledgeTreeApi.test.ts
+++ b/frontend/src/lib/__tests__/knowledgeTreeApi.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { KNOWLEDGE_TREE_SORT_STORAGE_KEY } from "@/lib/knowledgeTreeSort";
+
+const localStore = vi.hoisted(() => ({
+  getOfflineKnowledgeTree: vi.fn(),
+  putCompleteOfflineKnowledgeTree: vi.fn(),
+}));
+const api = vi.hoisted(() => ({
+  getCurrentWorkspace: vi.fn(() => "personal"),
+  getServerUrl: vi.fn(() => "https://notes.example.com"),
+}));
+
+vi.mock("@/lib/localStore", () => localStore);
+vi.mock("@/lib/api", () => api);
+
+import { knowledgeTreeApi, type KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
+
+function knowledgeTreeNode(): KnowledgeTreeNode {
+  return {
+    id: "node-1",
+    userId: "user-1",
+    workspaceId: null,
+    scopeKey: "personal",
+    parentId: null,
+    nodeType: "note",
+    resourceType: "note",
+    resourceId: "note-1",
+    title: "离线笔记",
+    sortOrder: 0,
+    isExpanded: 0,
+    isDeleted: 0,
+    childCount: 0,
+    createdAt: "2026-08-11T00:00:00.000Z",
+    updatedAt: "2026-08-11T00:00:00.000Z",
+    access: {
+      nodeId: "node-1",
+      rolePreset: "admin",
+      capabilities: {
+        canView: true,
+        canComment: true,
+        canCreate: true,
+        canEdit: true,
+        canDelete: true,
+        canMove: true,
+        canDownload: true,
+        canReshare: true,
+        canManageMembers: true,
+      },
+      source: "owner",
+      sourceNodeId: null,
+    },
+  };
+}
+
+describe("knowledgeTreeApi offline fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    api.getCurrentWorkspace.mockReturnValue("personal");
+    api.getServerUrl.mockReturnValue("https://notes.example.com");
+    localStore.putCompleteOfflineKnowledgeTree.mockResolvedValue(undefined);
+    localStore.getOfflineKnowledgeTree.mockResolvedValue(undefined);
+  });
+
+  it("caches the online tree for the current workspace", async () => {
+    const node = knowledgeTreeNode();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ nodes: [node] }))));
+
+    await expect(knowledgeTreeApi.list()).resolves.toEqual({ nodes: [node] });
+
+    expect(localStore.putCompleteOfflineKnowledgeTree).toHaveBeenCalledWith("personal", [node]);
+  });
+
+  it("preserves the server manual order when the display sort changes offline", async () => {
+    const first = { ...knowledgeTreeNode(), title: "Zulu" };
+    const second = { ...knowledgeTreeNode(), id: "node-2", resourceId: "note-2", title: "Alpha", sortOrder: 1 };
+    let cachedNodes: KnowledgeTreeNode[] | undefined;
+    localStore.putCompleteOfflineKnowledgeTree.mockImplementation(async (_workspaceId, nodes) => {
+      cachedNodes = nodes;
+    });
+    localStore.getOfflineKnowledgeTree.mockImplementation(async () => cachedNodes);
+    localStorage.setItem(KNOWLEDGE_TREE_SORT_STORAGE_KEY, "title-asc");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ nodes: [first, second] }))));
+
+    await expect(knowledgeTreeApi.list()).resolves.toMatchObject({
+      nodes: [{ id: "node-1", sortOrder: 1 }, { id: "node-2", sortOrder: 0 }],
+    });
+    expect(cachedNodes).toEqual([first, second]);
+
+    localStorage.setItem(KNOWLEDGE_TREE_SORT_STORAGE_KEY, "manual");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+
+    await expect(knowledgeTreeApi.list()).resolves.toMatchObject({
+      nodes: [{ id: "node-1", sortOrder: 0 }, { id: "node-2", sortOrder: 1 }],
+    });
+  });
+
+  it("uses the current workspace snapshot when the tree request fails offline", async () => {
+    const node = knowledgeTreeNode();
+    localStore.getOfflineKnowledgeTree.mockResolvedValue([node]);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+
+    await expect(knowledgeTreeApi.list()).resolves.toEqual({ nodes: [node] });
+
+    expect(localStore.getOfflineKnowledgeTree).toHaveBeenCalledWith("personal");
+  });
+
+  it.each([401, 403])("does not expose a cached tree after an authorization failure (%i)", async (status) => {
+    localStore.getOfflineKnowledgeTree.mockResolvedValue([knowledgeTreeNode()]);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: "没有访问权限" }),
+      { status },
+    )));
+
+    await expect(knowledgeTreeApi.list()).rejects.toMatchObject({ status });
+
+    expect(localStore.getOfflineKnowledgeTree).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/offlineWorkspaceSync.test.ts
+++ b/frontend/src/lib/__tests__/offlineWorkspaceSync.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   isOfflineAttachmentWanted,
@@ -31,5 +32,15 @@ describe("complete offline workspace settings", () => {
     expect(isOfflineAttachmentWanted(image, normalizeOfflineSyncSettings({ attachmentMode: "images" }))).toBe(true);
     expect(isOfflineAttachmentWanted(pdf, normalizeOfflineSyncSettings({ attachmentMode: "images" }))).toBe(false);
     expect(isOfflineAttachmentWanted(image, normalizeOfflineSyncSettings({ attachmentMode: "none" }))).toBe(false);
+  });
+
+  it("syncs the knowledge tree before note data", () => {
+    const source = readFileSync("src/lib/offlineWorkspaceSync.ts", "utf8");
+    const syncTarget = source.slice(source.indexOf("async function syncTarget("));
+    const knowledgeTreeSync = syncTarget.indexOf("`/knowledge-tree/?${scopeQuery(target.workspaceId)}`");
+    const notebookSync = syncTarget.indexOf("await putCompleteOfflineNotebooks(plan.notebooks);");
+
+    expect(knowledgeTreeSync).toBeGreaterThan(-1);
+    expect(notebookSync).toBeGreaterThan(knowledgeTreeSync);
   });
 });

--- a/frontend/src/lib/knowledgeTreeApi.ts
+++ b/frontend/src/lib/knowledgeTreeApi.ts
@@ -1,5 +1,9 @@
 import { getCurrentWorkspace, getServerUrl } from "@/lib/api";
 import { applyKnowledgeTreeSort } from "@/lib/knowledgeTreeSort";
+import {
+  getOfflineKnowledgeTree,
+  putCompleteOfflineKnowledgeTree,
+} from "@/lib/localStore";
 
 export type KnowledgeNodeType = "folder" | "note" | "markdown" | "word" | "mindmap" | "file";
 export type KnowledgeRolePreset = "readonly" | "editor" | "maintainer" | "admin" | "deny";
@@ -85,19 +89,29 @@ function token(): string {
   }
 }
 
+type KnowledgeTreeRequestError = Error & {
+  status?: number;
+  code?: string;
+  payload?: unknown;
+  isNetworkError?: true;
+};
+
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   const headers = new Headers(init.headers || {});
   const bearer = token();
   if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
   if (init.body !== undefined && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
-  const response = await fetch(`${apiBase()}${path}`, { ...init, headers, cache: "no-store" });
+  let response: Response;
+  try {
+    response = await fetch(`${apiBase()}${path}`, { ...init, headers, cache: "no-store" });
+  } catch (cause) {
+    const error = new Error(cause instanceof Error ? cause.message : "网络请求失败") as KnowledgeTreeRequestError;
+    error.isNetworkError = true;
+    throw error;
+  }
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
-    const error = new Error(payload?.error || `请求失败 (${response.status})`) as Error & {
-      status?: number;
-      code?: string;
-      payload?: unknown;
-    };
+    const error = new Error(payload?.error || `请求失败 (${response.status})`) as KnowledgeTreeRequestError;
     error.status = response.status;
     error.code = payload?.code;
     error.payload = payload;
@@ -117,15 +131,45 @@ function withDisplaySort(result: { nodes: KnowledgeTreeNode[] }): { nodes: Knowl
   return { nodes: applyKnowledgeTreeSort(result.nodes) };
 }
 
+function canUseOfflineFallback(error: unknown): boolean {
+  const requestError = error as KnowledgeTreeRequestError;
+  if (requestError?.isNetworkError) return true;
+  const status = requestError?.status;
+  return status === 408 || status === 429 || (typeof status === "number" && status >= 500 && status < 600);
+}
+
+async function listWithOfflineFallback(
+  workspaceId: string,
+  includeDeleted: boolean,
+): Promise<{ nodes: KnowledgeTreeNode[] }> {
+  try {
+    const result = await request<{ nodes: KnowledgeTreeNode[] }>(
+      `/?${workspaceQuery(includeDeleted, workspaceId)}`,
+    );
+    if (!includeDeleted) {
+      try {
+        await putCompleteOfflineKnowledgeTree(workspaceId, result.nodes);
+      } catch (error) {
+        console.warn("[knowledgeTreeApi] failed to cache knowledge tree:", error);
+      }
+    }
+    return withDisplaySort(result);
+  } catch (error) {
+    if (!includeDeleted && canUseOfflineFallback(error)) {
+      const cachedNodes = await getOfflineKnowledgeTree(workspaceId);
+      if (cachedNodes) return withDisplaySort({ nodes: cachedNodes });
+    }
+    throw error;
+  }
+}
+
 export const knowledgeTreeApi = {
   list(includeDeleted = false) {
-    return request<{ nodes: KnowledgeTreeNode[] }>(`/?${workspaceQuery(includeDeleted)}`).then(withDisplaySort);
+    return listWithOfflineFallback(getCurrentWorkspace(), includeDeleted);
   },
 
   listForWorkspace(workspaceId: string, includeDeleted = false) {
-    return request<{ nodes: KnowledgeTreeNode[] }>(
-      `/?${workspaceQuery(includeDeleted, workspaceId)}`,
-    ).then(withDisplaySort);
+    return listWithOfflineFallback(workspaceId, includeDeleted);
   },
 
   listShared() {

--- a/frontend/src/lib/localStore.ts
+++ b/frontend/src/lib/localStore.ts
@@ -1,4 +1,5 @@
 import { openDB, type IDBPDatabase, type DBSchema } from "idb";
+import type { KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
 import type { Note, NoteListItem, Notebook, Tag } from "@/types";
 
 /** Extra IndexedDB-only metadata. It is never sent to the server. */
@@ -97,6 +98,7 @@ interface NowenCacheSchema extends DBSchema {
 
 const DB_NAME_PREFIX = "nowen-cache-v2-";
 const DB_VERSION = 2;
+const OFFLINE_KNOWLEDGE_TREE_META_PREFIX = "offlineKnowledgeTree:";
 
 let currentUserId: string | null = null;
 let currentCacheIdentity: string | null = null;
@@ -388,6 +390,30 @@ export async function getMeta<T = unknown>(key: string): Promise<T | undefined> 
   }, undefined, "getMeta");
 }
 
+function offlineKnowledgeTreeMetaKey(workspaceId: string | null): string {
+  return `${OFFLINE_KNOWLEDGE_TREE_META_PREFIX}${workspaceId || "personal"}`;
+}
+
+export async function putCompleteOfflineKnowledgeTree(
+  workspaceId: string | null,
+  nodes: KnowledgeTreeNode[],
+): Promise<void> {
+  const connection = getDb();
+  if (!connection) throw new Error("离线数据库尚未初始化");
+  await (await connection).put("meta", {
+    key: offlineKnowledgeTreeMetaKey(workspaceId),
+    value: { nodes },
+    updatedAt: Date.now(),
+  });
+}
+
+export async function getOfflineKnowledgeTree(
+  workspaceId: string | null,
+): Promise<KnowledgeTreeNode[] | undefined> {
+  const snapshot = await getMeta<{ nodes?: unknown }>(offlineKnowledgeTreeMetaKey(workspaceId));
+  return Array.isArray(snapshot?.nodes) ? snapshot.nodes as KnowledgeTreeNode[] : undefined;
+}
+
 export async function clearAll(): Promise<void> {
   const connection = getDb();
   if (!connection) return;
@@ -669,12 +695,19 @@ export async function clearOfflineScope(
   workspaceId: string | null,
   preserveNoteIds: ReadonlySet<string> = new Set(),
 ): Promise<string[]> {
-  return reconcileOfflineScope(workspaceId, {
+  const removedAttachmentIds = await reconcileOfflineScope(workspaceId, {
     noteIds: new Set(),
     notebookIds: new Set(),
     tagIds: new Set(),
     preserveNoteIds,
   });
+  const connection = getDb();
+  if (connection) {
+    await safe(async () => {
+      await (await connection).delete("meta", offlineKnowledgeTreeMetaKey(workspaceId));
+    }, undefined, "clearOfflineKnowledgeTree");
+  }
+  return removedAttachmentIds;
 }
 
 export async function getOfflineStorageStats(): Promise<OfflineStorageStats> {

--- a/frontend/src/lib/offlineWorkspaceSync.ts
+++ b/frontend/src/lib/offlineWorkspaceSync.ts
@@ -11,6 +11,7 @@ import {
   putCompleteOfflineNote,
   putCompleteOfflineNotebooks,
   putCompleteOfflineTags,
+  putCompleteOfflineKnowledgeTree,
   putOfflineAttachment,
   putOfflineAttachmentJob,
   reconcileOfflineAttachmentJobs,
@@ -23,6 +24,7 @@ import {
   type OfflineStorageStats,
 } from "@/lib/localStore";
 import { getQueue } from "@/lib/offlineQueue";
+import type { KnowledgeTreeNode } from "@/lib/knowledgeTreeApi";
 import type { Note, Notebook, Tag, Workspace } from "@/types";
 
 export type OfflineAttachmentMode = "none" | "images" | "all";
@@ -701,6 +703,13 @@ async function syncTarget(
     {},
     signal,
   );
+  const knowledgeTree = await requestJson<{ nodes: KnowledgeTreeNode[] }>(
+    `/knowledge-tree/?${scopeQuery(target.workspaceId)}`,
+    {},
+    signal,
+  );
+  await putCompleteOfflineKnowledgeTree(target.workspaceId, knowledgeTree.nodes);
+
   await putCompleteOfflineNotebooks(plan.notebooks);
   await putCompleteOfflineTags(plan.tags);
   await reconcileOfflineScope(target.workspaceId, {


### PR DESCRIPTION
## 变更内容
- 离线同步时先保存知识树快照，再同步笔记数据。
- 网络错误、408/429、5xx 时离线回退同工作区知识树快照；401/403 不读取缓存。
- 缓存服务端原始 sortOrder，离线切回手动排序时保留原始顺序。
- 将知识树 API 与离线同步测试纳入知识树 CI。

## 验证
- `npm run test:run -- src/lib/__tests__/knowledgeTreeModel.test.ts src/lib/__tests__/editorWorkspaceLayout.test.ts src/lib/__tests__/knowledgeTreeApi.test.ts src/lib/__tests__/offlineWorkspaceSync.test.ts`

Closes #706