### PR TITLE
fix: Mermaid 导出预栅格化避免 PNG 空白 (#728)

### DIFF
--- a/frontend/src/lib/mermaidExportRaster.ts
+++ b/frontend/src/lib/mermaidExportRaster.ts
@@ -1,0 +1,109 @@
+const DEFAULT_WIDTH = 640;
+const DEFAULT_HEIGHT = 360;
+const MAX_PIXEL_RATIO = 2;
+const LOAD_TIMEOUT_MS = 10_000;
+
+export interface RasterizedMermaidSvg {
+  dataUri: string;
+  width: number;
+  height: number;
+}
+
+function finitePositive(value: number): number | null {
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function numericLength(value: string | null): number | null {
+  if (!value) return null;
+  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/i);
+  return match ? finitePositive(Number.parseFloat(match[1])) : null;
+}
+
+function readSvgSize(svg: string): { width: number | null; height: number | null } {
+  try {
+    const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+    const root = parsed.documentElement;
+    if (!root || root.nodeName.toLowerCase() !== "svg") return { width: null, height: null };
+
+    const viewBox = (root.getAttribute("viewBox") || "")
+      .trim()
+      .split(/[\s,]+/)
+      .map((part) => Number.parseFloat(part));
+    if (viewBox.length === 4) {
+      const width = finitePositive(viewBox[2]);
+      const height = finitePositive(viewBox[3]);
+      if (width && height) return { width, height };
+    }
+
+    return {
+      width: numericLength(root.getAttribute("width")),
+      height: numericLength(root.getAttribute("height")),
+    };
+  } catch {
+    return { width: null, height: null };
+  }
+}
+
+function ensureStandaloneSvg(svg: string): string {
+  if (/\sxmlns\s*=/.test(svg)) return svg;
+  return svg.replace(/<svg\b/i, '<svg xmlns="http://www.w3.org/2000/svg"');
+}
+
+async function loadSvgImage(svg: string): Promise<HTMLImageElement> {
+  const blob = new Blob([ensureStandaloneSvg(svg)], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const image = new Image();
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = window.setTimeout(() => reject(new Error("MERMAID_SVG_LOAD_TIMEOUT")), LOAD_TIMEOUT_MS);
+      image.onload = () => {
+        window.clearTimeout(timer);
+        resolve();
+      };
+      image.onerror = () => {
+        window.clearTimeout(timer);
+        reject(new Error("MERMAID_SVG_LOAD_FAILED"));
+      };
+      image.src = url;
+    });
+    return image;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * html2canvas can silently skip an SVG data URL even after the browser has laid out the
+ * corresponding <img>. Rasterize Mermaid with the browser first, then let html2canvas deal
+ * only with an ordinary PNG. This also gives the export DOM explicit dimensions, avoiding
+ * the large blank boxes produced by SVGs whose width is expressed as a percentage.
+ */
+export async function rasterizeMermaidSvgForExport(
+  svg: string,
+  maxCssWidth: number,
+  pixelRatio = MAX_PIXEL_RATIO,
+): Promise<RasterizedMermaidSvg> {
+  if (!svg.trim()) throw new Error("MERMAID_SVG_EMPTY");
+
+  const declared = readSvgSize(svg);
+  const image = await loadSvgImage(svg);
+  const sourceWidth = declared.width || finitePositive(image.naturalWidth) || DEFAULT_WIDTH;
+  const sourceHeight = declared.height || finitePositive(image.naturalHeight) || DEFAULT_HEIGHT;
+  const cssWidth = Math.min(Math.max(1, maxCssWidth), sourceWidth);
+  const cssHeight = Math.max(1, sourceHeight * (cssWidth / sourceWidth));
+  const ratio = Math.min(MAX_PIXEL_RATIO, Math.max(1, pixelRatio || 1));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.ceil(cssWidth * ratio));
+  canvas.height = Math.max(1, Math.ceil(cssHeight * ratio));
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("MERMAID_CANVAS_CONTEXT_UNAVAILABLE");
+
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  return {
+    dataUri: canvas.toDataURL("image/png"),
+    width: cssWidth,
+    height: cssHeight,
+  };
+}

--- a/frontend/src/lib/noteImageExportCore.ts
+++ b/frontend/src/lib/noteImageExportCore.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/noteImageExportTables";
 import { isMermaidLang, renderMermaid } from "@/lib/mermaidRenderer";
 import { sanitizeSvg } from "@/lib/sanitizeHtml";
+import { rasterizeMermaidSvgForExport } from "@/lib/mermaidExportRaster";
 
 const EXPORT_WIDTH = 794;
 const EXPORT_HORIZONTAL_PADDING = 56;
@@ -224,9 +225,9 @@ function codeBlockLanguage(element: HTMLElement): string {
 
 /**
  * The editor renders Mermaid at runtime, but image export starts from serialized note HTML.
- * Materialize Mermaid code blocks into sanitized, self-contained SVG data images before
- * syntax highlighting and before html2canvas clones the export DOM. Invalid diagrams keep
- * their original source so one bad block never aborts the whole note export.
+ * Materialize Mermaid code blocks into browser-rasterized PNG data images before syntax
+ * highlighting and before html2canvas clones the export DOM. Invalid diagrams keep their
+ * original source so one bad block never aborts the whole note export.
  */
 async function renderMermaidCodeBlocks(root: ParentNode): Promise<void> {
   const blocks = Array.from(root.querySelectorAll("pre > code")) as HTMLElement[];
@@ -258,13 +259,26 @@ async function renderMermaidCodeBlocks(root: ParentNode): Promise<void> {
       continue;
     }
 
+    let raster;
+    try {
+      raster = await rasterizeMermaidSvgForExport(svg, EXPORT_CONTENT_WIDTH);
+    } catch (error) {
+      console.warn(
+        "[note-image-export] Mermaid SVG rasterization failed; keeping source code in exported image.",
+        error,
+      );
+      continue;
+    }
+
     const figure = document.createElement("figure");
     figure.className = "nowen-note-image-export-mermaid";
     figure.setAttribute("data-nowen-mermaid-export", "rendered");
 
     const image = document.createElement("img");
-    image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+    image.src = raster.dataUri;
     image.alt = "Mermaid diagram";
+    image.width = Math.max(1, Math.round(raster.width));
+    image.height = Math.max(1, Math.round(raster.height));
     image.setAttribute("data-nowen-mermaid-export-image", "true");
     figure.appendChild(image);
 


### PR DESCRIPTION
## 现象
第一版 #729 已让图片导出识别 Mermaid，不再把源码代码块直接导出；但实际浏览器测试发现，Mermaid SVG 被转换为 `data:image/svg+xml` 后，`html2canvas` 会出现“DOM 已占位但 SVG 图像未绘制”的情况，因此最终 PNG 中对应区域是大片空白。

## 根因
问题不在 Mermaid 解析，而在第二阶段 SVG data URI → html2canvas 的兼容链路。浏览器可以完成 SVG 的布局，但 html2canvas 对该 SVG 图像可能静默漏绘。

## 修复
- 新增 `mermaidExportRaster.ts`。
- Mermaid 先复用现有 `renderMermaid()` 生成 SVG，并继续使用 `sanitizeSvg()` 清洗。
- 在进入整篇笔记 `html2canvas` 之前，使用浏览器原生 Image + Canvas 把 Mermaid SVG 预栅格化成高清 PNG data URI。
- 根据 SVG `viewBox`/尺寸计算宽高，并限制在导出正文宽度内，显式设置最终图片尺寸，避免出现异常空白占位。
- 整篇笔记截图阶段只处理普通 PNG，不再依赖 html2canvas 对 SVG data URI 的支持。
- SVG 加载/栅格化失败时仍保留 Mermaid 源码作为降级，不阻断整篇导出。

## 验收
使用用户当前同一篇 `mindmap` 测试笔记：
1. 编辑器中 Mermaid 正常显示。
2. 导出 PNG 后，`test` 与后续正文之间应实际出现 Mermaid 思维导图，不允许只留空白。
3. 再验证 flowchart / sequenceDiagram。
4. 普通代码块和普通图片导出不受影响。

Follow-up to #729 / #728