### PR TITLE
feat: Markdown 选中文字支持语法符号自动包裹 (#726)

### DIFF
--- a/frontend/src/lib/__tests__/markdownSelectionWrap.test.ts
+++ b/frontend/src/lib/__tests__/markdownSelectionWrap.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import {
+  MARKDOWN_SELECTION_WRAP_DELIMITERS,
+  createMarkdownSelectionWrapSpec,
+} from "@/lib/markdownSelectionWrap";
+
+function applyWrap(
+  doc: string,
+  anchor: number,
+  head: number,
+  delimiter: string,
+) {
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.single(anchor, head),
+  });
+  const spec = createMarkdownSelectionWrapSpec(state, delimiter);
+  if (!spec) return null;
+  return state.update(spec).state;
+}
+
+describe("markdownSelectionWrap", () => {
+  it.each(MARKDOWN_SELECTION_WRAP_DELIMITERS)(
+    "wraps selected text with %s and keeps the inner text selected",
+    (delimiter) => {
+      const next = applyWrap("hello", 0, 5, delimiter);
+
+      expect(next?.doc.toString()).toBe(`${delimiter}hello${delimiter}`);
+      expect(next?.selection.main.from).toBe(1);
+      expect(next?.selection.main.to).toBe(6);
+    },
+  );
+
+  it("preserves a reverse selection after wrapping", () => {
+    const next = applyWrap("hello", 5, 0, "*");
+
+    expect(next?.doc.toString()).toBe("*hello*");
+    expect(next?.selection.main.anchor).toBe(6);
+    expect(next?.selection.main.head).toBe(1);
+  });
+
+  it("does not intercept normal typing when there is no selected text", () => {
+    const state = EditorState.create({
+      doc: "hello",
+      selection: EditorSelection.cursor(5),
+    });
+
+    expect(createMarkdownSelectionWrapSpec(state, "*")).toBeNull();
+  });
+
+  it("ignores characters outside the Markdown wrapping contract", () => {
+    const state = EditorState.create({
+      doc: "hello",
+      selection: EditorSelection.single(0, 5),
+    });
+
+    expect(createMarkdownSelectionWrapSpec(state, "(")).toBeNull();
+    expect(createMarkdownSelectionWrapSpec(state, "'")).toBeNull();
+  });
+});

--- a/frontend/src/lib/markdownInternalMarkers.ts
+++ b/frontend/src/lib/markdownInternalMarkers.ts
@@ -5,6 +5,7 @@ import {
   projectMarkdownForUser,
   sanitizeMarkdownClipboardText,
 } from "@/lib/markdownUserContent";
+import { markdownSelectionWrapExtension } from "@/lib/markdownSelectionWrap";
 
 function buildMarkerDecorations(markdown: string): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
@@ -63,8 +64,14 @@ const cleanClipboard = EditorView.domEventHandlers({
   },
 });
 
+/**
+ * Shared CodeMirror extensions used by both the normal Markdown editor and the
+ * large-document safe editor. Keeping selection wrapping here guarantees the same
+ * typing behavior when a note crosses the large-document runtime threshold.
+ */
 export const internalMarkdownMarkerExtensions: Extension[] = [
   markerField,
   markerTheme,
   cleanClipboard,
+  markdownSelectionWrapExtension,
 ];

--- a/frontend/src/lib/markdownSelectionWrap.ts
+++ b/frontend/src/lib/markdownSelectionWrap.ts
@@ -1,0 +1,93 @@
+import {
+  EditorSelection,
+  type EditorState,
+  Prec,
+  type Extension,
+  type TransactionSpec,
+} from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+/**
+ * Markdown delimiters that should wrap an existing text selection when typed.
+ *
+ * Empty selections deliberately fall through to CodeMirror's normal input handling,
+ * so typing `*`, `_`, `~`, `$` or a backtick without selecting text still inserts
+ * exactly the character the user typed.
+ */
+export const MARKDOWN_SELECTION_WRAP_DELIMITERS = ["`", "*", "_", "~", "$"] as const;
+
+type MarkdownSelectionWrapDelimiter = (typeof MARKDOWN_SELECTION_WRAP_DELIMITERS)[number];
+
+const MARKDOWN_SELECTION_WRAP_DELIMITER_SET = new Set<string>(MARKDOWN_SELECTION_WRAP_DELIMITERS);
+
+export function isMarkdownSelectionWrapDelimiter(value: string): value is MarkdownSelectionWrapDelimiter {
+  return MARKDOWN_SELECTION_WRAP_DELIMITER_SET.has(value);
+}
+
+/**
+ * Build the CodeMirror transaction for wrapping selected Markdown text.
+ *
+ * The selected text remains selected after the delimiters are inserted, matching the
+ * existing bracket-pair experience. Multiple selections are supported; an empty
+ * secondary cursor receives the literal delimiter just like normal multi-cursor input.
+ */
+export function createMarkdownSelectionWrapSpec(
+  state: EditorState,
+  delimiter: string,
+): TransactionSpec | null {
+  if (!isMarkdownSelectionWrapDelimiter(delimiter)) return null;
+  if (state.selection.ranges.every((range) => range.empty)) return null;
+
+  return state.changeByRange((range) => {
+    if (range.empty) {
+      return {
+        changes: { from: range.from, insert: delimiter },
+        range: EditorSelection.cursor(range.from + delimiter.length),
+      };
+    }
+
+    const selected = state.doc.sliceString(range.from, range.to);
+    const innerFrom = range.from + delimiter.length;
+    const innerTo = innerFrom + selected.length;
+    const reversed = range.anchor > range.head;
+
+    return {
+      changes: {
+        from: range.from,
+        to: range.to,
+        insert: `${delimiter}${selected}${delimiter}`,
+      },
+      range: reversed
+        ? EditorSelection.range(innerTo, innerFrom)
+        : EditorSelection.range(innerFrom, innerTo),
+    };
+  });
+}
+
+function hasShortcutModifier(event: KeyboardEvent): boolean {
+  const altGraph = event.getModifierState?.("AltGraph") === true;
+  if (event.metaKey) return true;
+  if (altGraph) return false;
+  return event.ctrlKey || event.altKey;
+}
+
+/**
+ * Highest-precedence key handler so Markdown delimiters get a chance to wrap selected
+ * text before CodeMirror's close-brackets/default keymaps replace the selection.
+ */
+export const markdownSelectionWrapExtension: Extension = Prec.highest(
+  EditorView.domEventHandlers({
+    keydown(event, view) {
+      if (event.isComposing || hasShortcutModifier(event)) return false;
+      if (!isMarkdownSelectionWrapDelimiter(event.key)) return false;
+      if (!view.state.facet(EditorView.editable)) return false;
+
+      const transaction = createMarkdownSelectionWrapSpec(view.state, event.key);
+      if (!transaction) return false;
+
+      event.preventDefault();
+      view.dispatch(transaction);
+      return true;
+    },
+  }),
+);


### PR DESCRIPTION
## 需求分析
#726 反馈 Markdown 编辑器在选中文字后，输入 `'`、`(` 等 CodeMirror 默认括号字符可以包裹选区，但 `~`、`` ` ``、`*`、`_`、`$` 会直接覆盖选中文字。

根因是当前编辑器启用了 CodeMirror `closeBrackets()`，它只处理语言级括号/引号；这些 Markdown 语法分隔符不属于默认 close-brackets 配置。

## 实现
- 新增共享 Markdown 选区包裹扩展。
- 选中非空文本时支持：`` ` ``、`*`、`_`、`~`、`$`。
- 包裹后保持原文本处于选中状态，交互与现有括号包裹一致。
- 没有选中文字时不拦截，保持原本单字符输入行为。
- 保留 CodeMirror 现有 `'`、`"`、`()` 等括号能力，不重复实现。
- 支持反向选区和多选区/多光标语义。
- 使用最高优先级键盘处理，避免 Markdown 字符在默认输入阶段先覆盖选区。
- 扩展接入 Markdown 共用 CodeMirror 扩展层，因此普通编辑器和大文档安全编辑器行为一致。

## 回归覆盖
- `hello` + `` ` `` → `` `hello` ``
- `hello` + `*` → `*hello*`
- `hello` + `_` → `_hello_`
- `hello` + `~` → `~hello~`
- `x^2` + `$` → `$x^2$`
- 空选区不拦截普通输入
- `(` / `'` 不由新扩展接管，继续走 CodeMirror 原能力

Fixes #726