### PR TITLE
feat: add extension platform v1 and Android local-first mode

### DIFF
--- a/backend/build.bundle.mjs
+++ b/backend/build.bundle.mjs
@@ -20,7 +20,7 @@
 import { build } from "esbuild";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { rmSync, mkdirSync, statSync } from "node:fs";
+import { rmSync, mkdirSync, statSync, copyFileSync } from "node:fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outdir = join(__dirname, "dist");
@@ -69,6 +69,12 @@ await build({
     "unsupported-require-call": "silent",
   },
 });
+
+// PluginRunner 使用独立 Node 子进程；它不能被折叠进主进程 bundle。
+copyFileSync(
+  join(__dirname, "src", "plugins", "runner-child.mjs"),
+  join(outdir, "runner-child.mjs"),
+);
 
 const ms = Date.now() - start;
 const bundleBytes = statSync(outfile).size;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1211,6 +1211,7 @@
       "resolved": "https://registry.npmmirror.com/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2006,6 +2007,7 @@
     "node_modules/hono": {
       "version": "4.11.9",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2555,6 +2557,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -3582,6 +3585,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
       "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -49,6 +49,7 @@ import { syncWorkspaceScopeMigration } from "./syncWorkspaceScopeMigration.js";
 import { knowledgeTreeScopeTriggerRepairMigration } from "./knowledgeTreeScopeTriggerRepairMigration.js";
 import { knowledgeTreeRuntimeTriggerRepairMigration } from "./knowledgeTreeRuntimeTriggerRepairMigration.js";
 import { apiTokenUsageMigration } from "./apiTokenUsageMigration.js";
+import { pluginPlatformMigration } from "./pluginPlatformMigration.js";
 
 export type { Migration } from "./migrations.impl.js";
 
@@ -354,6 +355,7 @@ export const MIGRATIONS: Migration[] = [
   knowledgeTreeScopeTriggerRepairMigration,
   apiTokenUsageMigration,
   knowledgeTreeRuntimeTriggerRepairMigration,
+  pluginPlatformMigration,
 ].sort((a, b) => a.version - b.version);
 
 export const CURRENT_SCHEMA_VERSION: number = MIGRATIONS.reduce(

--- a/backend/src/db/pluginPlatformMigration.ts
+++ b/backend/src/db/pluginPlatformMigration.ts
@@ -1,0 +1,86 @@
+import type { Migration } from "./migrations.impl.js";
+
+export const pluginPlatformMigration: Migration = {
+  version: 93,
+  name: "nowen-extension-platform-v1",
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS plugin_registry (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        version TEXT NOT NULL,
+        apiVersion INTEGER NOT NULL,
+        runtime TEXT NOT NULL,
+        main TEXT NOT NULL,
+        source TEXT NOT NULL,
+        trustLevel TEXT NOT NULL,
+        status TEXT NOT NULL,
+        checksum TEXT NOT NULL,
+        manifestJson TEXT NOT NULL,
+        installedPath TEXT NOT NULL,
+        installedBy TEXT,
+        installedAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        lastError TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS plugin_permissions (
+        pluginId TEXT NOT NULL,
+        permission TEXT NOT NULL,
+        configJson TEXT NOT NULL DEFAULT '{}',
+        granted INTEGER NOT NULL DEFAULT 0,
+        grantedBy TEXT,
+        grantedAt TEXT,
+        PRIMARY KEY (pluginId, permission),
+        FOREIGN KEY (pluginId) REFERENCES plugin_registry(id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS plugin_executions (
+        id TEXT PRIMARY KEY,
+        pluginId TEXT NOT NULL,
+        actionId TEXT NOT NULL,
+        userId TEXT NOT NULL,
+        workspaceId TEXT,
+        status TEXT NOT NULL,
+        startedAt TEXT NOT NULL,
+        finishedAt TEXT,
+        durationMs INTEGER,
+        inputBytes INTEGER NOT NULL DEFAULT 0,
+        outputBytes INTEGER NOT NULL DEFAULT 0,
+        errorCode TEXT,
+        errorMessage TEXT,
+        logTail TEXT NOT NULL DEFAULT '[]',
+        FOREIGN KEY (pluginId) REFERENCES plugin_registry(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_plugin_executions_plugin_started
+        ON plugin_executions(pluginId, startedAt DESC);
+      CREATE INDEX IF NOT EXISTS idx_plugin_executions_user_started
+        ON plugin_executions(userId, startedAt DESC);
+
+      CREATE TABLE IF NOT EXISTS plugin_storage (
+        pluginId TEXT NOT NULL,
+        scopeType TEXT NOT NULL,
+        scopeId TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        PRIMARY KEY (pluginId, scopeType, scopeId, key),
+        FOREIGN KEY (pluginId) REFERENCES plugin_registry(id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS plugin_secrets (
+        id TEXT PRIMARY KEY,
+        pluginId TEXT NOT NULL,
+        ownerUserId TEXT NOT NULL,
+        name TEXT NOT NULL,
+        encryptedValue TEXT NOT NULL,
+        iv TEXT NOT NULL,
+        authTag TEXT NOT NULL,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        UNIQUE(pluginId, ownerUserId, name),
+        FOREIGN KEY (pluginId) REFERENCES plugin_registry(id) ON DELETE CASCADE
+      );
+    `);
+  },
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,6 +50,7 @@ import urlImportRouter from "./routes/url-import";
 
 import aiRouter from "./routes/ai";
 import pluginsRouter from "./routes/plugins";
+import pluginExecutionsRouter from "./routes/plugin-executions";
 import webhooksRouter from "./routes/webhooks";
 import auditRouter from "./routes/audit";
 import backupsRouter, { handleFullBackupJobDownload } from "./routes/backups";
@@ -521,6 +522,7 @@ app.route("/api/journals", journalsRouter);
 app.route("/api/url-import", urlImportRouter);
 app.route("/api/ai", aiRouter);
 app.route("/api/plugins", pluginsRouter);
+app.route("/api/plugin-executions", pluginExecutionsRouter);
 app.route("/api/webhooks", webhooksRouter);
 app.route("/api/audit", auditRouter);
 app.route("/api/backups", backupsRouter);

--- a/backend/src/plugins/executionManager.ts
+++ b/backend/src/plugins/executionManager.ts
@@ -1,0 +1,134 @@
+import crypto from "node:crypto";
+import { getDb } from "../db/schema.js";
+import { ExecutionLogTail } from "./logs.js";
+import { PACKAGE_LIMITS } from "./packageValidator.js";
+import { PluginRegistry } from "./registry.js";
+import { PluginRunner } from "./runner.js";
+import type { HostApiBroker } from "./hostApiBroker.js";
+import type { PluginExecutionContext, PluginExecutionResult } from "./types.js";
+
+const MAX_GLOBAL_CONCURRENCY = 2;
+let activeGlobalExecutions = 0;
+const globalWaiters: Array<() => void> = [];
+
+async function acquireGlobalSlot(): Promise<() => void> {
+  if (activeGlobalExecutions >= MAX_GLOBAL_CONCURRENCY) {
+    await new Promise<void>((resolve) => globalWaiters.push(resolve));
+  }
+  activeGlobalExecutions += 1;
+  return () => {
+    activeGlobalExecutions = Math.max(0, activeGlobalExecutions - 1);
+    globalWaiters.shift()?.();
+  };
+}
+
+function jsonSize(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+export class PluginExecutionManager {
+  private readonly runners = new Map<string, PluginRunner>();
+  private readonly cancelledBeforeStart = new Set<string>();
+
+  constructor(
+    private readonly broker: HostApiBroker,
+    private readonly registry = new PluginRegistry(),
+  ) {}
+
+  private runner(pluginId: string): PluginRunner {
+    const existing = this.runners.get(pluginId);
+    if (existing) return existing;
+    const record = this.registry.get(pluginId);
+    if (!record) throw new Error("插件不存在");
+    const runner = new PluginRunner(record, (context, call) => this.broker.call(context, call));
+    this.runners.set(pluginId, runner);
+    return runner;
+  }
+
+  async execute(input: {
+    pluginId: string;
+    actionId: string;
+    userId: string;
+    workspaceId?: string | null;
+    actionInput: Record<string, unknown>;
+    timeoutMs: number;
+    executionId?: string;
+  }): Promise<{ executionId: string; result: PluginExecutionResult }> {
+    const inputBytes = jsonSize(input.actionInput);
+    if (inputBytes > PACKAGE_LIMITS.inputBytes) throw Object.assign(new Error("Action input 超过 256KB"), { code: "PLUGIN_INPUT_TOO_LARGE" });
+    const executionId = input.executionId || crypto.randomUUID();
+    let startedAt = new Date();
+    const context: PluginExecutionContext = {
+      executionId,
+      pluginId: input.pluginId,
+      actionId: input.actionId,
+      userId: input.userId,
+      workspaceId: input.workspaceId || null,
+    };
+    getDb().prepare(`INSERT INTO plugin_executions
+      (id,pluginId,actionId,userId,workspaceId,status,startedAt,inputBytes,outputBytes,logTail)
+      VALUES (?,?,?,?,?,'queued',?,?,0,'[]')`)
+      .run(executionId, input.pluginId, input.actionId, input.userId, context.workspaceId, startedAt.toISOString(), inputBytes);
+    const logs = new ExecutionLogTail();
+    const release = await acquireGlobalSlot();
+    try {
+      if (this.cancelledBeforeStart.delete(executionId)) {
+        throw Object.assign(new Error("插件执行已取消"), { code: "PLUGIN_CANCELLED" });
+      }
+      startedAt = new Date();
+      getDb().prepare("UPDATE plugin_executions SET status='running',startedAt=? WHERE id=?").run(startedAt.toISOString(), executionId);
+      const result = await this.runner(input.pluginId).execute(context, input.actionInput, input.timeoutMs, logs);
+      const outputBytes = jsonSize(result);
+      if (outputBytes > PACKAGE_LIMITS.outputBytes) {
+        throw Object.assign(new Error("Action output 超过 1MB"), { code: "PLUGIN_OUTPUT_TOO_LARGE" });
+      }
+      const finishedAt = new Date();
+      getDb().prepare(`UPDATE plugin_executions SET status='completed',finishedAt=?,durationMs=?,outputBytes=?,logTail=? WHERE id=?`)
+        .run(finishedAt.toISOString(), finishedAt.getTime() - startedAt.getTime(), outputBytes, JSON.stringify(logs.toArray()), executionId);
+      return { executionId, result };
+    } catch (error) {
+      const coded = error as Error & { code?: string };
+      logs.add("error", coded.message);
+      const finishedAt = new Date();
+      getDb().prepare(`UPDATE plugin_executions SET status=?,finishedAt=?,durationMs=?,errorCode=?,errorMessage=?,logTail=? WHERE id=?`)
+        .run(coded.code === "PLUGIN_CANCELLED" ? "cancelled" : "failed", finishedAt.toISOString(), finishedAt.getTime() - startedAt.getTime(), coded.code || "PLUGIN_EXECUTION_FAILED", coded.message.slice(0, 2000), JSON.stringify(logs.toArray()), executionId);
+      if (coded.code === "PLUGIN_TIMEOUT") this.registry.setStatus(input.pluginId, "error", coded.message);
+      throw Object.assign(coded, { executionId });
+    } finally {
+      release();
+    }
+  }
+
+  get(executionId: string): Record<string, unknown> | undefined {
+    return getDb().prepare("SELECT * FROM plugin_executions WHERE id=?").get(executionId) as Record<string, unknown> | undefined;
+  }
+
+  list(pluginId: string, userId?: string, limit = 100): Record<string, unknown>[] {
+    if (userId) {
+      return getDb().prepare("SELECT * FROM plugin_executions WHERE pluginId=? AND userId=? ORDER BY startedAt DESC LIMIT ?")
+        .all(pluginId, userId, Math.min(500, Math.max(1, limit))) as Record<string, unknown>[];
+    }
+    return getDb().prepare("SELECT * FROM plugin_executions WHERE pluginId=? ORDER BY startedAt DESC LIMIT ?")
+      .all(pluginId, Math.min(500, Math.max(1, limit))) as Record<string, unknown>[];
+  }
+
+  cancel(executionId: string): boolean {
+    const row = this.get(executionId) as { pluginId?: string; status?: string } | undefined;
+    if (!row?.pluginId) return false;
+    if (row.status === "queued") {
+      this.cancelledBeforeStart.add(executionId);
+      return true;
+    }
+    return this.runners.get(row.pluginId)?.cancel(executionId) || false;
+  }
+
+  async restart(pluginId: string): Promise<void> {
+    const runner = this.runners.get(pluginId);
+    if (runner) await runner.terminate();
+    this.runners.delete(pluginId);
+  }
+
+  async shutdown(pluginId: string): Promise<void> {
+    await this.restart(pluginId);
+  }
+}

--- a/backend/src/plugins/hostApiBroker.ts
+++ b/backend/src/plugins/hostApiBroker.ts
@@ -1,0 +1,349 @@
+import crypto from "node:crypto";
+import dns from "node:dns/promises";
+import net from "node:net";
+import { getDb } from "../db/schema.js";
+import {
+  getUserWorkspaceRole,
+  hasPermission,
+  hasRole,
+  canManageResource,
+  resolveNotePermission,
+  resolveNotebookPermission,
+} from "../middleware/acl.js";
+import { ensureMindmapSchema } from "../lib/mindmap-schema.js";
+import { PluginPermissions } from "./permissions.js";
+import { PluginSecrets } from "./secrets.js";
+import type { HostCall, PluginExecutionContext, PluginPermission } from "./types.js";
+
+type JsonObject = Record<string, any>;
+
+function forbidden(message: string, code = "RESOURCE_FORBIDDEN"): never {
+  throw Object.assign(new Error(message), { code });
+}
+
+function argsObject(args: unknown): JsonObject {
+  if (!args || typeof args !== "object" || Array.isArray(args)) throw new Error("Host API 参数必须是对象");
+  return args as JsonObject;
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} 必须是非空字符串`);
+  return value;
+}
+
+function allowedWorkspace(workspaceId: string | null, userId: string, write = false): boolean {
+  if (!workspaceId) return true;
+  const role = getUserWorkspaceRole(workspaceId, userId);
+  return write ? hasRole(role, "editor") : role !== null;
+}
+
+function isPrivateAddress(address: string): boolean {
+  if (net.isIPv4(address)) {
+    const [a, b] = address.split(".").map(Number);
+    return a === 10 || a === 127 || a === 0 || (a === 169 && b === 254) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+  }
+  const lower = address.toLowerCase();
+  return lower === "::1" || lower === "::" || lower.startsWith("fc") || lower.startsWith("fd") || lower.startsWith("fe80:");
+}
+
+async function assertPublicHost(hostname: string): Promise<void> {
+  if (hostname === "localhost" || net.isIP(hostname) && isPrivateAddress(hostname)) forbidden("禁止访问本机或私有网络", "EXTERNAL_FETCH_DENIED");
+  const addresses = await dns.lookup(hostname, { all: true });
+  if (addresses.length === 0 || addresses.some((item) => isPrivateAddress(item.address))) {
+    forbidden("目标解析到私有网络", "EXTERNAL_FETCH_DENIED");
+  }
+}
+
+export class HostApiBroker {
+  constructor(
+    private readonly permissions = new PluginPermissions(),
+    private readonly secrets = new PluginSecrets(),
+  ) {}
+
+  async call(context: PluginExecutionContext, call: HostCall): Promise<unknown> {
+    const [namespace, operation] = call.method.split(".");
+    const args = argsObject(call.args || {});
+    switch (namespace) {
+      case "notes": return this.notes(context, operation, args);
+      case "notebooks": return this.notebooks(context, operation, args);
+      case "tags": return this.tags(context, operation, args);
+      case "tasks": return this.tasks(context, operation, args);
+      case "attachments": return this.attachments(context, operation, args);
+      case "diary": return this.diary(context, operation, args);
+      case "mindmaps": return this.mindmaps(context, operation, args);
+      case "storage": return this.storage(context, operation, args);
+      case "external": return this.external(context, operation, args);
+      default: throw Object.assign(new Error(`未知 Host API: ${call.method}`), { code: "HOST_METHOD_NOT_FOUND" });
+    }
+  }
+
+  private require(context: PluginExecutionContext, permission: PluginPermission): void {
+    this.permissions.require(context.pluginId, permission);
+  }
+
+  private notes(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    if (operation === "get") {
+      this.require(context, "notes:read");
+      const id = requireString(args.id ?? args.noteId, "noteId");
+      if (!hasPermission(resolveNotePermission(id, context.userId).permission, "read")) forbidden("无权读取该笔记");
+      return db.prepare("SELECT id, notebookId, title, content, contentText, contentFormat, workspaceId, version, createdAt, updatedAt FROM notes WHERE id=? AND isTrashed=0").get(id) || null;
+    }
+    if (operation === "list") {
+      this.require(context, "notes:read");
+      const limit = Math.max(1, Math.min(100, Number(args.limit) || 50));
+      const rows = db.prepare("SELECT id, notebookId, title, contentText, contentFormat, workspaceId, version, createdAt, updatedAt FROM notes WHERE isTrashed=0 ORDER BY updatedAt DESC LIMIT 500").all() as JsonObject[];
+      return rows.filter((row) => hasPermission(resolveNotePermission(row.id, context.userId).permission, "read")).slice(0, limit);
+    }
+    if (operation === "create") {
+      this.require(context, "notes:write");
+      const notebookId = requireString(args.notebookId, "notebookId");
+      const access = resolveNotebookPermission(notebookId, context.userId);
+      if (!hasPermission(access.permission, "write")) forbidden("无权在该笔记本创建笔记");
+      const id = crypto.randomUUID();
+      const content = typeof args.content === "string" ? args.content : "";
+      db.prepare(`INSERT INTO notes (id,userId,notebookId,title,content,contentText,contentFormat,workspaceId,createdAt,updatedAt)
+        VALUES (?,?,?,?,?,?,?,?,?,?)`).run(id, context.userId, notebookId, String(args.title || "无标题笔记"), content, String(args.contentText ?? content), String(args.contentFormat || "markdown"), access.workspaceId, new Date().toISOString(), new Date().toISOString());
+      return { id };
+    }
+    if (operation === "update") {
+      this.require(context, "notes:write");
+      const id = requireString(args.id ?? args.noteId, "noteId");
+      if (!hasPermission(resolveNotePermission(id, context.userId).permission, "write")) forbidden("无权修改该笔记");
+      const current = db.prepare("SELECT title,content,contentText,contentFormat,version FROM notes WHERE id=?").get(id) as JsonObject | undefined;
+      if (!current) throw new Error("笔记不存在");
+      db.prepare("UPDATE notes SET title=?,content=?,contentText=?,contentFormat=?,version=version+1,updatedAt=? WHERE id=?")
+        .run(args.title ?? current.title, args.content ?? current.content, args.contentText ?? current.contentText, args.contentFormat ?? current.contentFormat, new Date().toISOString(), id);
+      return { id, version: Number(current.version || 0) + 1 };
+    }
+    throw new Error(`未知 notes 操作: ${operation}`);
+  }
+
+  private notebooks(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    if (operation === "get") {
+      this.require(context, "notebooks:read");
+      const id = requireString(args.id ?? args.notebookId, "notebookId");
+      if (!hasPermission(resolveNotebookPermission(id, context.userId).permission, "read")) forbidden("无权读取该笔记本");
+      return db.prepare("SELECT id,parentId,name,description,icon,color,workspaceId,createdAt,updatedAt FROM notebooks WHERE id=? AND isDeleted=0").get(id) || null;
+    }
+    if (operation === "list") {
+      this.require(context, "notebooks:read");
+      const rows = db.prepare("SELECT id,parentId,name,description,icon,color,workspaceId,createdAt,updatedAt FROM notebooks WHERE isDeleted=0 ORDER BY sortOrder,name").all() as JsonObject[];
+      return rows.filter((row) => hasPermission(resolveNotebookPermission(row.id, context.userId).permission, "read"));
+    }
+    if (operation === "create") {
+      this.require(context, "notebooks:write");
+      const workspaceId = typeof args.workspaceId === "string" && args.workspaceId ? args.workspaceId : null;
+      if (!allowedWorkspace(workspaceId, context.userId, true)) forbidden("无权在该工作区创建笔记本");
+      if (args.parentId && !hasPermission(resolveNotebookPermission(String(args.parentId), context.userId).permission, "write")) forbidden("无权使用该父笔记本");
+      const id = crypto.randomUUID();
+      db.prepare(`INSERT INTO notebooks (id,userId,parentId,name,description,icon,color,workspaceId,createdAt,updatedAt)
+        VALUES (?,?,?,?,?,?,?,?,?,?)`).run(id, context.userId, args.parentId || null, requireString(args.name, "name"), String(args.description || ""), String(args.icon || "📒"), args.color || null, workspaceId, new Date().toISOString(), new Date().toISOString());
+      return { id };
+    }
+    throw new Error(`未知 notebooks 操作: ${operation}`);
+  }
+
+  private tags(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    if (operation === "list") {
+      this.require(context, "tags:read");
+      const rows = db.prepare("SELECT id,name,color,workspaceId,createdAt FROM tags WHERE userId=? OR workspaceId IS NOT NULL ORDER BY name").all(context.userId) as JsonObject[];
+      return rows.filter((row) => !row.workspaceId || allowedWorkspace(row.workspaceId, context.userId));
+    }
+    if (operation === "create") {
+      this.require(context, "tags:write");
+      const workspaceId = typeof args.workspaceId === "string" && args.workspaceId ? args.workspaceId : null;
+      if (!allowedWorkspace(workspaceId, context.userId, true)) forbidden("无权在该工作区创建标签");
+      const id = crypto.randomUUID();
+      db.prepare("INSERT INTO tags (id,userId,name,color,workspaceId,createdAt) VALUES (?,?,?,?,?,?)")
+        .run(id, context.userId, requireString(args.name, "name"), String(args.color || "#58a6ff"), workspaceId, new Date().toISOString());
+      return { id };
+    }
+    if (operation === "addToNote" || operation === "removeFromNote") {
+      this.require(context, "tags:write");
+      const noteId = requireString(args.noteId, "noteId");
+      const tagId = requireString(args.tagId, "tagId");
+      if (!hasPermission(resolveNotePermission(noteId, context.userId).permission, "write")) forbidden("无权修改该笔记标签");
+      if (operation === "addToNote") db.prepare("INSERT OR IGNORE INTO note_tags(noteId,tagId) VALUES (?,?)").run(noteId, tagId);
+      else db.prepare("DELETE FROM note_tags WHERE noteId=? AND tagId=?").run(noteId, tagId);
+      return { success: true };
+    }
+    throw new Error(`未知 tags 操作: ${operation}`);
+  }
+
+  private tasks(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    if (operation === "get") {
+      this.require(context, "tasks:read");
+      const row = db.prepare("SELECT * FROM tasks WHERE id=?").get(requireString(args.id ?? args.taskId, "taskId")) as JsonObject | undefined;
+      if (!row || (row.userId !== context.userId && !allowedWorkspace(row.workspaceId, context.userId))) forbidden("无权读取该任务");
+      return row;
+    }
+    if (operation === "list") {
+      this.require(context, "tasks:read");
+      const rows = db.prepare("SELECT * FROM tasks ORDER BY updatedAt DESC LIMIT 500").all() as JsonObject[];
+      return rows.filter((row) => row.userId === context.userId || allowedWorkspace(row.workspaceId, context.userId)).slice(0, Math.max(1, Math.min(100, Number(args.limit) || 50)));
+    }
+    if (operation === "create") {
+      this.require(context, "tasks:write");
+      const workspaceId = typeof args.workspaceId === "string" && args.workspaceId ? args.workspaceId : null;
+      if (!allowedWorkspace(workspaceId, context.userId, true)) forbidden("无权在该工作区创建任务");
+      const id = crypto.randomUUID();
+      db.prepare(`INSERT INTO tasks (id,userId,title,isCompleted,priority,dueDate,noteId,workspaceId,createdAt,updatedAt)
+        VALUES (?,?,?,?,?,?,?,?,?,?)`).run(id, context.userId, requireString(args.title, "title"), 0, Number(args.priority) || 2, args.dueDate || null, args.noteId || null, workspaceId, new Date().toISOString(), new Date().toISOString());
+      return { id };
+    }
+    if (operation === "update") {
+      this.require(context, "tasks:write");
+      const id = requireString(args.id ?? args.taskId, "taskId");
+      const current = db.prepare("SELECT * FROM tasks WHERE id=?").get(id) as JsonObject | undefined;
+      if (!current || (current.userId !== context.userId && !allowedWorkspace(current.workspaceId, context.userId, true))) forbidden("无权修改该任务");
+      db.prepare("UPDATE tasks SET title=?,isCompleted=?,priority=?,dueDate=?,updatedAt=? WHERE id=?")
+        .run(args.title ?? current.title, args.isCompleted === undefined ? current.isCompleted : (args.isCompleted ? 1 : 0), args.priority ?? current.priority, args.dueDate ?? current.dueDate, new Date().toISOString(), id);
+      return { id };
+    }
+    throw new Error(`未知 tasks 操作: ${operation}`);
+  }
+
+  private attachments(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    this.require(context, "attachments:read");
+    if (operation === "get") {
+      const row = db.prepare("SELECT id,noteId,filename,mimeType,size,createdAt FROM attachments WHERE id=?").get(requireString(args.id ?? args.attachmentId, "attachmentId")) as JsonObject | undefined;
+      if (!row || !hasPermission(resolveNotePermission(row.noteId, context.userId).permission, "read")) forbidden("无权读取该附件");
+      return row;
+    }
+    if (operation === "list") {
+      const rows = db.prepare("SELECT id,noteId,filename,mimeType,size,createdAt FROM attachments ORDER BY createdAt DESC LIMIT 500").all() as JsonObject[];
+      return rows.filter((row) => hasPermission(resolveNotePermission(row.noteId, context.userId).permission, "read")).slice(0, Math.max(1, Math.min(100, Number(args.limit) || 50)));
+    }
+    throw new Error(`未知 attachments 操作: ${operation}`);
+  }
+
+  private diary(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    if (operation === "get") {
+      this.require(context, "diary:read");
+      const row = db.prepare("SELECT id,userId,workspaceId,contentText,mood,images,media,createdAt FROM diaries WHERE id=?")
+        .get(requireString(args.id ?? args.diaryId, "diaryId")) as JsonObject | undefined;
+      if (!row || (row.userId !== context.userId && !allowedWorkspace(row.workspaceId, context.userId))) forbidden("无权读取该日记");
+      return row;
+    }
+    if (operation === "list") {
+      this.require(context, "diary:read");
+      const rows = db.prepare("SELECT id,userId,workspaceId,contentText,mood,images,media,createdAt FROM diaries ORDER BY createdAt DESC LIMIT 500").all() as JsonObject[];
+      return rows.filter((row) => row.userId === context.userId || allowedWorkspace(row.workspaceId, context.userId)).slice(0, Math.max(1, Math.min(100, Number(args.limit) || 50)));
+    }
+    if (operation === "create") {
+      this.require(context, "diary:write");
+      const workspaceId = typeof args.workspaceId === "string" && args.workspaceId ? args.workspaceId : null;
+      if (!allowedWorkspace(workspaceId, context.userId)) forbidden("无权在该工作区创建日记");
+      const id = crypto.randomUUID();
+      db.prepare("INSERT INTO diaries(id,userId,workspaceId,contentText,mood,images,media,createdAt) VALUES (?,?,?,?,?,'[]','[]',?)")
+        .run(id, context.userId, workspaceId, String(args.contentText || ""), String(args.mood || ""), new Date().toISOString());
+      return { id };
+    }
+    throw new Error(`未知 diary 操作: ${operation}`);
+  }
+
+  private mindmaps(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    ensureMindmapSchema();
+    const db = getDb();
+    if (operation === "get") {
+      this.require(context, "mindmaps:read");
+      const row = db.prepare("SELECT * FROM mindmaps WHERE id=?").get(requireString(args.id ?? args.mindmapId, "mindmapId")) as JsonObject | undefined;
+      if (!row || (row.userId !== context.userId && !allowedWorkspace(row.workspaceId, context.userId))) forbidden("无权读取该思维导图");
+      return row;
+    }
+    if (operation === "list") {
+      this.require(context, "mindmaps:read");
+      const rows = db.prepare("SELECT id,userId,workspaceId,title,starred,folderId,createdAt,updatedAt FROM mindmaps ORDER BY updatedAt DESC LIMIT 500").all() as JsonObject[];
+      return rows.filter((row) => row.userId === context.userId || allowedWorkspace(row.workspaceId, context.userId)).slice(0, Math.max(1, Math.min(100, Number(args.limit) || 50)));
+    }
+    if (operation === "create") {
+      this.require(context, "mindmaps:write");
+      const workspaceId = typeof args.workspaceId === "string" && args.workspaceId ? args.workspaceId : null;
+      if (!allowedWorkspace(workspaceId, context.userId)) forbidden("无权在该工作区创建思维导图");
+      const id = crypto.randomUUID();
+      const title = String(args.title || "无标题导图");
+      const data = args.data ?? { root: { id: "root", text: title, children: [] } };
+      db.prepare("INSERT INTO mindmaps(id,userId,workspaceId,title,data) VALUES (?,?,?,?,?)")
+        .run(id, context.userId, workspaceId, title, typeof data === "string" ? data : JSON.stringify(data));
+      return { id };
+    }
+    if (operation === "update") {
+      this.require(context, "mindmaps:write");
+      const id = requireString(args.id ?? args.mindmapId, "mindmapId");
+      const row = db.prepare("SELECT * FROM mindmaps WHERE id=?").get(id) as JsonObject | undefined;
+      if (!row || !canManageResource(row.userId, row.workspaceId, context.userId)) forbidden("无权修改该思维导图");
+      db.prepare("UPDATE mindmaps SET title=?,data=?,updatedAt=? WHERE id=?")
+        .run(args.title ?? row.title, args.data === undefined ? row.data : (typeof args.data === "string" ? args.data : JSON.stringify(args.data)), new Date().toISOString(), id);
+      return { id };
+    }
+    throw new Error(`未知 mindmaps 操作: ${operation}`);
+  }
+
+  private storage(context: PluginExecutionContext, operation: string, args: JsonObject): unknown {
+    const db = getDb();
+    const scopeType = args.scopeType === "workspace" ? "workspace" : "user";
+    const scopeId = scopeType === "workspace" ? requireString(args.scopeId ?? context.workspaceId, "workspace scopeId") : context.userId;
+    if (scopeType === "workspace" && !allowedWorkspace(scopeId, context.userId, operation !== "get")) forbidden("无权访问该工作区插件存储");
+    const key = requireString(args.key, "key");
+    if (Buffer.byteLength(key) > 200) throw new Error("storage key 过长");
+    if (operation === "get") {
+      this.require(context, "plugin-storage:read");
+      const row = db.prepare("SELECT value FROM plugin_storage WHERE pluginId=? AND scopeType=? AND scopeId=? AND key=?")
+        .get(context.pluginId, scopeType, scopeId, key) as { value: string } | undefined;
+      return row ? JSON.parse(row.value) : null;
+    }
+    if (operation === "set") {
+      this.require(context, "plugin-storage:write");
+      const value = JSON.stringify(args.value);
+      if (Buffer.byteLength(value) > 256 * 1024) throw new Error("plugin storage value 超过 256KB");
+      db.prepare(`INSERT INTO plugin_storage(pluginId,scopeType,scopeId,key,value,updatedAt) VALUES (?,?,?,?,?,?)
+        ON CONFLICT(pluginId,scopeType,scopeId,key) DO UPDATE SET value=excluded.value,updatedAt=excluded.updatedAt`)
+        .run(context.pluginId, scopeType, scopeId, key, value, new Date().toISOString());
+      return { success: true };
+    }
+    if (operation === "delete") {
+      this.require(context, "plugin-storage:write");
+      db.prepare("DELETE FROM plugin_storage WHERE pluginId=? AND scopeType=? AND scopeId=? AND key=?")
+        .run(context.pluginId, scopeType, scopeId, key);
+      return { success: true };
+    }
+    throw new Error(`未知 storage 操作: ${operation}`);
+  }
+
+  private async external(context: PluginExecutionContext, operation: string, args: JsonObject): Promise<unknown> {
+    if (operation !== "fetch") throw new Error(`未知 external 操作: ${operation}`);
+    const permission = this.permissions.require(context.pluginId, "external:fetch");
+    const url = new URL(requireString(args.url, "url"));
+    if (url.protocol !== "https:") forbidden("external.fetch 只允许 HTTPS", "EXTERNAL_FETCH_DENIED");
+    const config = JSON.parse(permission.configJson || "{}") as { hosts?: string[] };
+    if (!config.hosts?.includes(url.hostname)) forbidden(`Host 未在插件白名单: ${url.hostname}`, "EXTERNAL_FETCH_DENIED");
+    await assertPublicHost(url.hostname);
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(args.headers || {})) {
+      if (/^(authorization|cookie|proxy-authorization)$/i.test(name)) continue;
+      headers.set(name, String(value));
+    }
+    if (args.connection) {
+      this.require(context, "secrets:use");
+      headers.set("Authorization", `Bearer ${this.secrets.get(context.pluginId, context.userId, String(args.connection))}`);
+    }
+    const response = await fetch(url, {
+      method: String(args.method || "GET").toUpperCase(),
+      headers,
+      body: args.body === undefined ? undefined : (typeof args.body === "string" ? args.body : JSON.stringify(args.body)),
+      redirect: "manual",
+      signal: AbortSignal.timeout(15_000),
+    });
+    const contentLength = Number(response.headers.get("content-length") || 0);
+    if (contentLength > 1024 * 1024) throw new Error("external.fetch 响应超过 1MB");
+    const body = await response.text();
+    if (Buffer.byteLength(body, "utf8") > 1024 * 1024) throw new Error("external.fetch 响应超过 1MB");
+    return { status: response.status, ok: response.ok, headers: { "content-type": response.headers.get("content-type") }, body };
+  }
+}

--- a/backend/src/plugins/logs.ts
+++ b/backend/src/plugins/logs.ts
@@ -1,0 +1,27 @@
+const MAX_LOG_LINES = 500;
+const MAX_LOG_BYTES = 64 * 1024;
+
+const SECRET_PATTERN = /(authorization|cookie|jwt|api[-_ ]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi;
+
+export function redactPluginLog(message: unknown): string {
+  return String(message).replace(SECRET_PATTERN, "$1=[REDACTED]").slice(0, 4096);
+}
+
+export class ExecutionLogTail {
+  private lines: string[] = [];
+  private bytes = 0;
+
+  add(level: string, message: unknown): void {
+    const line = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${redactPluginLog(message)}`;
+    this.lines.push(line);
+    this.bytes += Buffer.byteLength(line, "utf8");
+    while (this.lines.length > MAX_LOG_LINES || this.bytes > MAX_LOG_BYTES) {
+      const removed = this.lines.shift();
+      if (removed) this.bytes -= Buffer.byteLength(removed, "utf8");
+    }
+  }
+
+  toArray(): string[] {
+    return [...this.lines];
+  }
+}

--- a/backend/src/plugins/manifest.ts
+++ b/backend/src/plugins/manifest.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+import { z } from "zod";
+import { NOWEN_VERSION, PLUGIN_API_VERSION, PLUGIN_PERMISSIONS, type PluginActionManifest, type PluginManifestV1 } from "./types.js";
+
+const inputFieldSchema = z.object({
+  type: z.enum(["string", "number", "boolean", "object", "array"]),
+  required: z.boolean().optional(),
+  description: z.string().max(500).optional(),
+  enum: z.array(z.union([z.string(), z.number(), z.boolean()])).max(100).optional(),
+  default: z.unknown().optional(),
+}).strict();
+
+const actionSchema = z.object({
+  id: z.string().regex(/^[a-z][a-z0-9-]{0,63}$/),
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  execution: z.enum(["interactive", "background"]).default("interactive"),
+  input: z.record(inputFieldSchema).default({}),
+}).strict();
+
+export const pluginManifestV1Schema = z.object({
+  id: z.string().regex(/^[a-z0-9]+(?:[.-][a-z0-9]+)+$/).max(150),
+  name: z.string().min(1).max(100),
+  description: z.string().max(1000).default(""),
+  version: z.string().regex(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/),
+  apiVersion: z.literal(PLUGIN_API_VERSION),
+  engines: z.object({ nowen: z.string().min(1).max(100) }).strict(),
+  runtime: z.literal("node-action"),
+  main: z.string().min(1).max(300),
+  author: z.object({ name: z.string().min(1).max(100), url: z.string().url().optional() }).strict().optional(),
+  permissions: z.array(z.enum(PLUGIN_PERMISSIONS)).max(32).default([]),
+  permissionConfig: z.object({
+    externalFetchHosts: z.array(z.string().min(1).max(253)).max(50).optional(),
+  }).strict().optional(),
+  actions: z.array(actionSchema).min(1).max(50),
+}).strict().superRefine((manifest, ctx) => {
+  if (new Set(manifest.actions.map((action) => action.id)).size !== manifest.actions.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["actions"], message: "Action id 不能重复" });
+  }
+  const normalized = manifest.main.replace(/\\/g, "/");
+  if (path.posix.isAbsolute(normalized) || normalized.split("/").includes("..")) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["main"], message: "main 必须位于插件目录内" });
+  }
+});
+
+function parseVersion(value: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(value);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function compareVersion(a: [number, number, number], b: [number, number, number]): number {
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index];
+  }
+  return 0;
+}
+
+/** V1 支持常见的 >=x.y.z、>、<=、< 和空格 AND 组合。 */
+export function nowenVersionSatisfies(range: string, current = NOWEN_VERSION): boolean {
+  const actual = parseVersion(current);
+  if (!actual) return false;
+  const clauses = range.trim().split(/\s+/).filter(Boolean);
+  if (clauses.length === 0) return false;
+  return clauses.every((clause) => {
+    const match = /^(>=|<=|>|<|=|\^|~)?(\d+\.\d+\.\d+)/.exec(clause);
+    if (!match) return false;
+    const expected = parseVersion(match[2]);
+    if (!expected) return false;
+    const comparison = compareVersion(actual, expected);
+    switch (match[1] || "=") {
+      case ">=": return comparison >= 0;
+      case "<=": return comparison <= 0;
+      case ">": return comparison > 0;
+      case "<": return comparison < 0;
+      case "^": return actual[0] === expected[0] && comparison >= 0;
+      case "~": return actual[0] === expected[0] && actual[1] === expected[1] && comparison >= 0;
+      default: return comparison === 0;
+    }
+  });
+}
+
+export function parsePluginManifest(value: unknown): PluginManifestV1 {
+  const manifest = pluginManifestV1Schema.parse(value) as PluginManifestV1;
+  if (!nowenVersionSatisfies(manifest.engines.nowen)) {
+    throw new Error(`插件要求 Nowen ${manifest.engines.nowen}，当前版本为 ${NOWEN_VERSION}`);
+  }
+  return manifest;
+}
+
+export function validateActionInput(action: PluginActionManifest, input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Action input 必须是对象");
+  }
+  const result = input as Record<string, unknown>;
+  const declared = action.input || {};
+  for (const key of Object.keys(result)) {
+    if (!declared[key]) throw new Error(`未知参数: ${key}`);
+  }
+  for (const [key, field] of Object.entries(declared)) {
+    const value = result[key];
+    if (value === undefined || value === null) {
+      if (field.required) throw new Error(`缺少必填参数: ${key}`);
+      continue;
+    }
+    const actualType = Array.isArray(value) ? "array" : typeof value;
+    if (actualType !== field.type) throw new Error(`参数 ${key} 应为 ${field.type}`);
+    if (field.enum && !field.enum.includes(value as never)) throw new Error(`参数 ${key} 不在允许范围内`);
+  }
+  return result;
+}

--- a/backend/src/plugins/packageInstaller.ts
+++ b/backend/src/plugins/packageInstaller.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import path from "node:path";
+import { PluginPermissions } from "./permissions.js";
+import { PluginRegistry } from "./registry.js";
+import { validatePluginPackage } from "./packageValidator.js";
+import type { PluginRegistryRecord, PluginSource, PluginTrustLevel } from "./types.js";
+
+export function getPluginRoot(): string {
+  return path.join(process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data"), "plugins");
+}
+
+export function getPluginDevRoot(): string {
+  return path.join(process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data"), "plugins-dev");
+}
+
+function assertInside(root: string, target: string): void {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (relative.startsWith("..") || path.isAbsolute(relative)) throw new Error("插件路径逃逸");
+}
+
+async function extract(zip: Awaited<ReturnType<typeof validatePluginPackage>>["zip"], destination: string): Promise<void> {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const file of Object.values(zip.files)) {
+    const normalized = file.name.replace(/\\/g, "/").replace(/\/$/, "");
+    if (!normalized) continue;
+    const target = path.join(destination, ...normalized.split("/"));
+    assertInside(destination, target);
+    if (file.dir) {
+      fs.mkdirSync(target, { recursive: true });
+    } else {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, await file.async("nodebuffer"), { flag: "wx" });
+    }
+  }
+}
+
+export class PluginPackageInstaller {
+  constructor(
+    private readonly registry = new PluginRegistry(),
+    private readonly permissions = new PluginPermissions(),
+  ) {}
+
+  async install(bytes: Buffer, installedBy: string): Promise<PluginRegistryRecord> {
+    const validated = await validatePluginPackage(bytes);
+    const root = getPluginRoot();
+    const quarantineRoot = path.join(root, "quarantine");
+    const destination = path.join(quarantineRoot, validated.manifest.id, validated.manifest.version);
+    assertInside(quarantineRoot, destination);
+    if (fs.existsSync(destination)) throw new Error("相同插件版本已存在，请先卸载");
+    try {
+      await extract(validated.zip, destination);
+      const record = this.registry.upsert({
+        manifest: validated.manifest,
+        source: "package",
+        trustLevel: "community",
+        status: "quarantined",
+        checksum: validated.checksum,
+        installedPath: destination,
+        installedBy,
+      });
+      this.permissions.initialize(validated.manifest);
+      return record;
+    } catch (error) {
+      try { if (fs.existsSync(destination)) fs.rmSync(destination, { recursive: true, force: true }); } catch { /* best effort */ }
+      throw error;
+    }
+  }
+
+  async loadDevelopmentDirectory(directory: string, installedBy: string): Promise<PluginRegistryRecord> {
+    const absolute = path.resolve(directory);
+    const manifestPath = path.join(absolute, "manifest.json");
+    if (!fs.statSync(absolute).isDirectory() || !fs.existsSync(manifestPath)) throw new Error("开发目录缺少 manifest.json");
+    const { parsePluginManifest } = await import("./manifest.js");
+    const manifest = parsePluginManifest(JSON.parse(fs.readFileSync(manifestPath, "utf8")));
+    const mainPath = path.resolve(absolute, manifest.main);
+    assertInside(absolute, mainPath);
+    if (!fs.existsSync(mainPath)) throw new Error(`插件入口不存在: ${manifest.main}`);
+    const { createHash } = await import("node:crypto");
+    const checksum = createHash("sha256").update(fs.readFileSync(manifestPath)).update(fs.readFileSync(mainPath)).digest("hex");
+    const record = this.registry.upsert({ manifest, source: "dev", trustLevel: "developer", status: "quarantined", checksum, installedPath: absolute, installedBy });
+    this.permissions.initialize(manifest);
+    return record;
+  }
+
+  moveToInstalled(record: PluginRegistryRecord): PluginRegistryRecord {
+    if (record.source === "dev") return record;
+    const root = getPluginRoot();
+    const installedRoot = path.join(root, "installed");
+    const destination = path.join(installedRoot, record.id, record.version);
+    assertInside(installedRoot, destination);
+    if (path.resolve(record.installedPath) !== path.resolve(destination)) {
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      if (fs.existsSync(destination)) fs.rmSync(destination, { recursive: true, force: true });
+      fs.renameSync(record.installedPath, destination);
+      this.registry.setPath(record.id, destination);
+    }
+    return this.registry.get(record.id)!;
+  }
+
+  removeFiles(record: PluginRegistryRecord): void {
+    if (record.source === "dev") return;
+    const root = getPluginRoot();
+    assertInside(root, record.installedPath);
+    if (fs.existsSync(record.installedPath)) fs.rmSync(record.installedPath, { recursive: true, force: true });
+  }
+}

--- a/backend/src/plugins/packageValidator.ts
+++ b/backend/src/plugins/packageValidator.ts
@@ -1,0 +1,95 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import JSZip from "jszip";
+import { parsePluginManifest } from "./manifest.js";
+import type { PluginManifestV1 } from "./types.js";
+
+export const PACKAGE_LIMITS = {
+  compressedBytes: 20 * 1024 * 1024,
+  extractedBytes: 50 * 1024 * 1024,
+  files: 500,
+  manifestBytes: 128 * 1024,
+  inputBytes: 256 * 1024,
+  outputBytes: 1024 * 1024,
+};
+
+export interface ValidatedPluginPackage {
+  zip: JSZip;
+  manifest: PluginManifestV1;
+  checksum: string;
+  fileCount: number;
+  extractedBytes: number;
+}
+
+function normalizeEntryName(name: string): string {
+  const normalized = name.replace(/\\/g, "/");
+  if (!normalized || normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized)) {
+    throw new Error(`非法 ZIP 路径: ${name}`);
+  }
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.includes("..")) throw new Error(`ZIP 路径穿越: ${name}`);
+  return segments.join("/");
+}
+
+function isSymlink(file: JSZip.JSZipObject): boolean {
+  const unixPermissions = typeof file.unixPermissions === "number" ? file.unixPermissions : 0;
+  return (unixPermissions & 0o170000) === 0o120000;
+}
+
+function isForbidden(name: string): boolean {
+  const lower = name.toLowerCase();
+  const base = path.posix.basename(lower);
+  return lower.split("/").includes("node_modules")
+    || lower.endsWith(".node")
+    || base === "install.js"
+    || base === "preinstall"
+    || base === "postinstall"
+    || base === "package-lock.json"
+    || /\.(exe|dll|so|dylib|bat|cmd|ps1|sh|com|msi)$/i.test(lower);
+}
+
+export async function validatePluginPackage(bytes: Buffer): Promise<ValidatedPluginPackage> {
+  if (bytes.length === 0 || bytes.length > PACKAGE_LIMITS.compressedBytes) {
+    throw new Error("插件包必须大于 0 且不超过 20MB");
+  }
+  const zip = await JSZip.loadAsync(bytes, { checkCRC32: true, createFolders: false });
+  const files = Object.values(zip.files).filter((file) => !file.dir);
+  if (files.length === 0 || files.length > PACKAGE_LIMITS.files) {
+    throw new Error(`插件包文件数量必须在 1-${PACKAGE_LIMITS.files} 之间`);
+  }
+  let extractedBytes = 0;
+  for (const file of Object.values(zip.files)) {
+    // JSZip 会把 ../ 自动清洗掉，但保留 unsafeOriginalName；必须检查原始名，
+    // 否则校验层会看见安全名而遗漏上传包本身的 Zip Slip 意图。
+    const originalName = (file as JSZip.JSZipObject & { unsafeOriginalName?: string }).unsafeOriginalName || file.name;
+    const normalized = normalizeEntryName(originalName);
+    if (isSymlink(file)) throw new Error(`插件包禁止符号链接: ${normalized}`);
+    if (!file.dir && isForbidden(normalized)) throw new Error(`插件包包含禁止文件: ${normalized}`);
+    if (!file.dir) {
+      const data = await file.async("uint8array");
+      extractedBytes += data.byteLength;
+      if (extractedBytes > PACKAGE_LIMITS.extractedBytes) throw new Error("插件解压后超过 50MB");
+    }
+  }
+  const manifestFile = zip.file("manifest.json");
+  if (!manifestFile) throw new Error("插件包根目录缺少 manifest.json");
+  const manifestBytes = await manifestFile.async("uint8array");
+  if (manifestBytes.byteLength > PACKAGE_LIMITS.manifestBytes) throw new Error("manifest.json 超过 128KB");
+  let rawManifest: unknown;
+  try {
+    rawManifest = JSON.parse(Buffer.from(manifestBytes).toString("utf8"));
+  } catch {
+    throw new Error("manifest.json 不是有效 JSON");
+  }
+  const manifest = parsePluginManifest(rawManifest);
+  const main = normalizeEntryName(manifest.main);
+  if (!zip.file(main)) throw new Error(`插件入口不存在: ${manifest.main}`);
+  if (!main.endsWith(".mjs") && !main.endsWith(".js")) throw new Error("插件入口必须是已构建的 ESM JavaScript");
+  return {
+    zip,
+    manifest,
+    checksum: crypto.createHash("sha256").update(bytes).digest("hex"),
+    fileCount: files.length,
+    extractedBytes,
+  };
+}

--- a/backend/src/plugins/permissions.ts
+++ b/backend/src/plugins/permissions.ts
@@ -1,0 +1,86 @@
+import { getDb } from "../db/schema.js";
+import { PLUGIN_PERMISSIONS, type PluginManifestV1, type PluginPermission } from "./types.js";
+
+const knownPermissions = new Set<string>(PLUGIN_PERMISSIONS);
+
+export interface PermissionRow {
+  pluginId: string;
+  permission: PluginPermission;
+  configJson: string;
+  granted: number;
+  grantedBy: string | null;
+  grantedAt: string | null;
+}
+
+export class PluginPermissions {
+  initialize(manifest: PluginManifestV1): void {
+    const db = getDb();
+    const insert = db.prepare(`
+      INSERT INTO plugin_permissions (pluginId, permission, configJson, granted)
+      VALUES (?, ?, ?, 0)
+      ON CONFLICT(pluginId, permission) DO UPDATE SET configJson=excluded.configJson, granted=0, grantedBy=NULL, grantedAt=NULL
+    `);
+    const transaction = db.transaction(() => {
+      db.prepare("DELETE FROM plugin_permissions WHERE pluginId=?").run(manifest.id);
+      for (const permission of manifest.permissions) {
+        const config = permission === "external:fetch"
+          ? { hosts: manifest.permissionConfig?.externalFetchHosts || [] }
+          : {};
+        insert.run(manifest.id, permission, JSON.stringify(config));
+      }
+    });
+    transaction();
+  }
+
+  list(pluginId: string): PermissionRow[] {
+    return getDb().prepare("SELECT * FROM plugin_permissions WHERE pluginId=? ORDER BY permission")
+      .all(pluginId) as PermissionRow[];
+  }
+
+  replaceGrants(pluginId: string, requested: string[], grantedBy: string): PermissionRow[] {
+    if (requested.some((permission) => !knownPermissions.has(permission))) {
+      throw new Error("包含未知插件权限");
+    }
+    const declared = new Set(this.list(pluginId).map((row) => row.permission));
+    if (requested.some((permission) => !declared.has(permission as PluginPermission))) {
+      throw new Error("不能授予 Manifest 未声明的权限");
+    }
+    const db = getDb();
+    const granted = new Set(requested);
+    const update = db.prepare(`
+      UPDATE plugin_permissions
+      SET granted=?, grantedBy=?, grantedAt=?
+      WHERE pluginId=? AND permission=?
+    `);
+    db.transaction(() => {
+      for (const row of this.list(pluginId)) {
+        const enabled = granted.has(row.permission);
+        update.run(enabled ? 1 : 0, enabled ? grantedBy : null, enabled ? new Date().toISOString() : null, pluginId, row.permission);
+      }
+    })();
+    return this.list(pluginId);
+  }
+
+  require(pluginId: string, permission: PluginPermission): PermissionRow {
+    const row = getDb().prepare(
+      "SELECT * FROM plugin_permissions WHERE pluginId=? AND permission=? AND granted=1",
+    ).get(pluginId, permission) as PermissionRow | undefined;
+    if (!row) {
+      const error = new Error(`插件未获权限: ${permission}`) as Error & { code?: string };
+      error.code = "PLUGIN_PERMISSION_DENIED";
+      throw error;
+    }
+    return row;
+  }
+
+  allDeclaredGranted(pluginId: string): boolean {
+    const row = getDb().prepare(
+      "SELECT COUNT(*) AS total, SUM(CASE WHEN granted=1 THEN 1 ELSE 0 END) AS granted FROM plugin_permissions WHERE pluginId=?",
+    ).get(pluginId) as { total: number; granted: number | null };
+    return row.total === (row.granted || 0);
+  }
+
+  resetAll(): void {
+    getDb().prepare("UPDATE plugin_permissions SET granted=0, grantedBy=NULL, grantedAt=NULL").run();
+  }
+}

--- a/backend/src/plugins/plugin-loader.ts
+++ b/backend/src/plugins/plugin-loader.ts
@@ -1,320 +1,82 @@
 /**
- * Nowen Note 插件加载器
+ * @deprecated Compatibility facade for callers compiled against the pre-V1 loader.
  *
- * 从 data/plugins/ 目录动态加载符合 NowenSkill 接口的插件。
- * 支持两种加载方式：
- * 1. 本地目录插件（含 manifest.json + JS 模块）
- * 2. 动态注册的内存插件
- *
- * 安全措施：
- * - 权限声明检查
- * - 执行超时限制
- * - 错误隔离（单个插件崩溃不影响系统）
+ * V1 never imports plugin code in the backend process. File scanning, apiToken/apiBaseUrl
+ * injection and in-memory registration were deliberately removed. New code must use
+ * PluginService and pluginId + actionId.
  */
-
-import fs from "fs";
-import path from "path";
-import { pathToFileURL } from "url";
-
-// ===== 类型定义 =====
-
-export interface SkillCapability {
-  action: string;
-  description: string;
-  inputTypes: string[];
-  outputTypes: string[];
-  params?: SkillParam[];
-}
-
-export interface SkillParam {
-  name: string;
-  type: "string" | "number" | "boolean" | "select";
-  description: string;
-  required?: boolean;
-  default?: any;
-  options?: { label: string; value: any }[];
-}
+import { getPluginService } from "./pluginService.js";
 
 export interface SkillContext {
-  log: (message: string) => void;
   userId: string;
-  // API 客户端会在执行时注入
-  apiBaseUrl: string;
-  apiToken: string;
+  workspaceId?: string | null;
+  log?: (message: string) => void;
 }
 
 export interface SkillResult {
   success: boolean;
-  data?: any;
+  data?: unknown;
   text?: string;
   error?: string;
 }
 
-export interface NowenSkill {
-  name: string;
-  version: string;
-  description: string;
-  author?: string;
-  capabilities: SkillCapability[];
-  init?(context: SkillContext): Promise<void>;
-  execute(context: SkillContext, params: Record<string, any>): Promise<SkillResult>;
-  destroy?(): Promise<void>;
-}
-
-export interface SkillManifest {
-  name: string;
-  version: string;
-  description: string;
-  author: string;
-  main: string;
-  capabilities: SkillCapability[];
-  permissions?: string[];
-}
-
-export interface LoadedSkill {
-  manifest: SkillManifest;
-  skill: NowenSkill;
-  directory: string;
-  loadedAt: string;
-  status: "active" | "error" | "disabled";
-  error?: string;
-}
-
-// ===== 插件加载器 =====
-
 export class PluginLoader {
-  private plugins: Map<string, LoadedSkill> = new Map();
-  private pluginsDir: string;
-  private logs: Map<string, string[]> = new Map();
-
-  constructor(pluginsDir?: string) {
-    this.pluginsDir = pluginsDir || path.join(
-      process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data"),
-      "plugins"
-    );
-  }
-
-  /** 获取插件目录路径 */
   getPluginsDir(): string {
-    return this.pluginsDir;
+    return "managed-by-extension-platform-v1";
   }
 
-  /** 确保插件目录存在 */
-  private ensureDir(): void {
-    if (!fs.existsSync(this.pluginsDir)) {
-      fs.mkdirSync(this.pluginsDir, { recursive: true });
-    }
-  }
-
-  /** 扫描并加载所有插件 */
   async loadAll(): Promise<void> {
-    this.ensureDir();
-
-    const entries = fs.readdirSync(this.pluginsDir, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-
-      const pluginDir = path.join(this.pluginsDir, entry.name);
-      const manifestPath = path.join(pluginDir, "manifest.json");
-
-      if (!fs.existsSync(manifestPath)) {
-        console.warn(`[PluginLoader] 跳过 ${entry.name}：缺少 manifest.json`);
-        continue;
-      }
-
-      try {
-        await this.loadPlugin(pluginDir);
-      } catch (err: any) {
-        console.error(`[PluginLoader] 加载 ${entry.name} 失败:`, err.message);
-      }
-    }
-
-    console.log(`[PluginLoader] 已加载 ${this.plugins.size} 个插件`);
+    // Unknown directories and restored code are intentionally never auto-loaded.
   }
 
-  /** 加载单个插件 */
-  async loadPlugin(pluginDir: string): Promise<LoadedSkill> {
-    const manifestPath = path.join(pluginDir, "manifest.json");
-    const manifestText = fs.readFileSync(manifestPath, "utf-8");
-    const manifest: SkillManifest = JSON.parse(manifestText);
-
-    // 验证 manifest
-    if (!manifest.name || !manifest.version || !manifest.main) {
-      throw new Error(`manifest.json 缺少必要字段 (name/version/main)`);
-    }
-
-    // 检查是否已加载
-    if (this.plugins.has(manifest.name)) {
-      const existing = this.plugins.get(manifest.name)!;
-      // 先卸载旧版本
-      if (existing.skill.destroy) {
-        try { await existing.skill.destroy(); } catch { /* 忽略清理错误 */ }
-      }
-    }
-
-    // 加载 JS 模块
-    const mainPath = path.join(pluginDir, manifest.main);
-    if (!fs.existsSync(mainPath)) {
-      throw new Error(`入口文件不存在: ${manifest.main}`);
-    }
-
-    // 安全检查：确保文件在插件目录内
-    const resolvedMain = path.resolve(mainPath);
-    const resolvedDir = path.resolve(pluginDir);
-    if (!resolvedMain.startsWith(resolvedDir)) {
-      throw new Error("安全违规：入口文件路径逃逸出插件目录");
-    }
-
-    let skill: NowenSkill;
-    try {
-      // 使用 dynamic import 加载 ES 模块
-      const moduleUrl = pathToFileURL(resolvedMain).href;
-      const mod = await import(moduleUrl);
-      skill = mod.default || mod;
-    } catch (err: any) {
-      const loaded: LoadedSkill = {
-        manifest,
-        skill: null as any,
-        directory: pluginDir,
-        loadedAt: new Date().toISOString(),
-        status: "error",
-        error: `模块加载失败: ${err.message}`,
-      };
-      this.plugins.set(manifest.name, loaded);
-      throw err;
-    }
-
-    // 验证 Skill 接口
-    if (typeof skill.execute !== "function") {
-      throw new Error(`插件 ${manifest.name} 未实现 execute() 方法`);
-    }
-
-    const loaded: LoadedSkill = {
-      manifest,
-      skill,
-      directory: pluginDir,
-      loadedAt: new Date().toISOString(),
-      status: "active",
-    };
-
-    this.plugins.set(manifest.name, loaded);
-    return loaded;
+  async loadPlugin(): Promise<never> {
+    throw new Error("旧式目录插件已停用，请打包为 .nowen-plugin 后由管理员安装");
   }
 
-  /** 卸载插件 */
   async unloadPlugin(name: string): Promise<boolean> {
-    const loaded = this.plugins.get(name);
-    if (!loaded) return false;
-
-    if (loaded.skill?.destroy) {
-      try { await loaded.skill.destroy(); } catch { /* 忽略 */ }
-    }
-
-    this.plugins.delete(name);
-    this.logs.delete(name);
+    const plugin = getPluginService().list(true).find((item) => item.id === name || item.name === name);
+    if (!plugin) return false;
+    await getPluginService().disable(String(plugin.id));
     return true;
   }
 
-  /** 注册内存插件（不需要文件） */
-  registerPlugin(manifest: SkillManifest, skill: NowenSkill): void {
-    this.plugins.set(manifest.name, {
-      manifest,
-      skill,
-      directory: "",
-      loadedAt: new Date().toISOString(),
-      status: "active",
-    });
+  registerPlugin(): never {
+    throw new Error("V1 不允许在主进程注册内存插件");
   }
 
-  /** 获取所有已加载的插件信息 */
-  listPlugins(): {
-    name: string;
-    version: string;
-    description: string;
-    author: string;
-    status: string;
-    capabilities: SkillCapability[];
-    loadedAt: string;
-    error?: string;
-  }[] {
-    return Array.from(this.plugins.values()).map(p => ({
-      name: p.manifest.name,
-      version: p.manifest.version,
-      description: p.manifest.description,
-      author: p.manifest.author,
-      status: p.status,
-      capabilities: p.manifest.capabilities,
-      loadedAt: p.loadedAt,
-      error: p.error,
-    }));
+  listPlugins(): Record<string, unknown>[] {
+    return getPluginService().list(true);
   }
 
-  /** 获取指定插件 */
-  getPlugin(name: string): LoadedSkill | undefined {
-    return this.plugins.get(name);
+  getPlugin(name: string): Record<string, unknown> | undefined {
+    return this.listPlugins().find((item) => item.id === name || item.name === name);
   }
 
-  /** 查找能处理指定 action 的所有插件 */
-  findByAction(action: string): LoadedSkill[] {
-    return Array.from(this.plugins.values()).filter(
-      p => p.status === "active" && p.manifest.capabilities.some(c => c.action === action)
-    );
+  findByAction(actionId: string): Record<string, unknown>[] {
+    const ids = new Set(getPluginService().listActions().filter((item) => item.actionId === actionId).map((item) => item.pluginId));
+    return this.listPlugins().filter((item) => ids.has(item.id));
   }
 
-  /** 执行插件（带超时和错误隔离） */
-  async executePlugin(
-    name: string,
-    params: Record<string, any>,
-    context: SkillContext,
-    timeoutMs: number = 30000,
-  ): Promise<SkillResult> {
-    const loaded = this.plugins.get(name);
-    if (!loaded) {
-      return { success: false, error: `插件 ${name} 不存在` };
-    }
-    if (loaded.status !== "active") {
-      return { success: false, error: `插件 ${name} 状态异常: ${loaded.status}` };
-    }
-
-    // 收集日志
-    const pluginLogs: string[] = [];
-    const logFn = (msg: string) => {
-      pluginLogs.push(`[${new Date().toISOString()}] ${msg}`);
-    };
-
-    const execContext: SkillContext = { ...context, log: logFn };
-
+  async executePlugin(name: string, params: Record<string, unknown>, context: SkillContext): Promise<SkillResult> {
+    const plugin = getPluginService().list(false).find((item) => item.id === name || item.name === name);
+    const action = (plugin?.actions as Array<{ id: string }> | undefined)?.[0];
+    if (!plugin || !action) return { success: false, error: `插件 ${name} 不存在或没有 Action` };
     try {
-      // 带超时的执行
-      const result = await Promise.race([
-        loaded.skill.execute(execContext, params),
-        new Promise<SkillResult>((_, reject) =>
-          setTimeout(() => reject(new Error(`执行超时 (${timeoutMs}ms)`)), timeoutMs)
-        ),
-      ]);
-
-      // 保存日志
-      this.logs.set(name, pluginLogs);
-      return result;
-    } catch (err: any) {
-      this.logs.set(name, [...pluginLogs, `[ERROR] ${err.message}`]);
-      return { success: false, error: err.message };
+      const execution = await getPluginService().execute(String(plugin.id), action.id, context.userId, context.workspaceId || null, params);
+      return execution.result as SkillResult;
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   }
 
-  /** 获取插件执行日志 */
-  getPluginLogs(name: string): string[] {
-    return this.logs.get(name) || [];
+  getPluginLogs(name: string): unknown[] {
+    const plugin = getPluginService().list(true).find((item) => item.id === name || item.name === name);
+    return plugin ? getPluginService().executions.list(String(plugin.id), undefined, 100) : [];
   }
 }
 
-// ===== 全局单例 =====
-let _loader: PluginLoader | null = null;
-
+let facade: PluginLoader | null = null;
 export function getPluginLoader(): PluginLoader {
-  if (!_loader) {
-    _loader = new PluginLoader();
-  }
-  return _loader;
+  if (!facade) facade = new PluginLoader();
+  return facade;
 }

--- a/backend/src/plugins/pluginService.ts
+++ b/backend/src/plugins/pluginService.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getDb } from "../db/schema.js";
+import { HostApiBroker } from "./hostApiBroker.js";
+import { PluginExecutionManager } from "./executionManager.js";
+import { validateActionInput } from "./manifest.js";
+import { PluginPackageInstaller } from "./packageInstaller.js";
+import { PluginPermissions } from "./permissions.js";
+import { PluginRegistry } from "./registry.js";
+import { PluginSecrets } from "./secrets.js";
+import type { PluginManifestV1, PluginRegistryRecord } from "./types.js";
+
+function manifestOf(record: PluginRegistryRecord): PluginManifestV1 {
+  return JSON.parse(record.manifestJson) as PluginManifestV1;
+}
+
+export class PluginService {
+  readonly registry = new PluginRegistry();
+  readonly permissions = new PluginPermissions();
+  readonly installer = new PluginPackageInstaller(this.registry, this.permissions);
+  readonly secrets = new PluginSecrets();
+  readonly broker = new HostApiBroker(this.permissions, this.secrets);
+  readonly executions = new PluginExecutionManager(this.broker, this.registry);
+
+  constructor() {
+    // 开发目录每次服务重启都要重新确认，不能继承上次的 enabled/granted 状态。
+    const db = getDb();
+    db.prepare("UPDATE plugin_registry SET status='quarantined',lastError='开发插件重启后需要重新确认',updatedAt=? WHERE source='dev'")
+      .run(new Date().toISOString());
+    db.prepare("UPDATE plugin_permissions SET granted=0,grantedBy=NULL,grantedAt=NULL WHERE pluginId IN (SELECT id FROM plugin_registry WHERE source='dev')").run();
+  }
+
+  list(includeDisabled = true): Array<Record<string, unknown>> {
+    return this.registry.list()
+      .filter((record) => includeDisabled || record.status === "enabled")
+      .map((record) => this.publicRecord(record));
+  }
+
+  get(pluginId: string): Record<string, unknown> {
+    const record = this.requireRecord(pluginId);
+    return this.publicRecord(record);
+  }
+
+  listActions(): Array<Record<string, unknown>> {
+    return this.registry.list().flatMap((record) => {
+      if (record.status !== "enabled") return [];
+      const manifest = manifestOf(record);
+      return manifest.actions.map((action) => ({
+        pluginId: record.id,
+        actionId: action.id,
+        name: action.name,
+        description: action.description || "",
+        execution: action.execution || "interactive",
+        input: action.input || {},
+      }));
+    });
+  }
+
+  async install(bytes: Buffer, installedBy: string): Promise<Record<string, unknown>> {
+    return this.publicRecord(await this.installer.install(bytes, installedBy));
+  }
+
+  async loadDevelopmentDirectory(directory: string, installedBy: string): Promise<Record<string, unknown>> {
+    if (!this.isDeveloperModeAvailable()) throw new Error("当前部署形态不支持本地开发插件");
+    if (!this.isDeveloperModeEnabled()) throw new Error("请先启用插件开发者模式");
+    return this.publicRecord(await this.installer.loadDevelopmentDirectory(directory, installedBy));
+  }
+
+  setDeveloperMode(enabled: boolean): void {
+    if (enabled && !this.isDeveloperModeAvailable()) throw new Error("开发者模式仅限 Desktop Embedded Backend 或开发环境");
+    getDb().prepare(`INSERT INTO system_settings(key,value,updatedAt) VALUES ('plugins:developerMode',?,?)
+      ON CONFLICT(key) DO UPDATE SET value=excluded.value,updatedAt=excluded.updatedAt`)
+      .run(enabled ? "1" : "0", new Date().toISOString());
+  }
+
+  isDeveloperModeEnabled(): boolean {
+    const row = getDb().prepare("SELECT value FROM system_settings WHERE key='plugins:developerMode'").get() as { value: string } | undefined;
+    return row?.value === "1";
+  }
+
+  isDeveloperModeAvailable(): boolean {
+    return process.env.NODE_ENV !== "production" || Boolean(process.env.ELECTRON_USER_DATA);
+  }
+
+  grantPermissions(pluginId: string, grants: string[], grantedBy: string): Record<string, unknown> {
+    this.requireRecord(pluginId);
+    return { pluginId, permissions: this.permissions.replaceGrants(pluginId, grants, grantedBy) };
+  }
+
+  async enable(pluginId: string): Promise<Record<string, unknown>> {
+    let record = this.requireRecord(pluginId);
+    if (!this.permissions.allDeclaredGranted(pluginId)) throw new Error("必须先确认并授予插件声明的全部权限");
+    if (!fs.existsSync(record.installedPath)) throw new Error("插件目录不存在");
+    record = this.installer.moveToInstalled(record);
+    await this.executions.restart(pluginId);
+    this.registry.setStatus(pluginId, "enabled");
+    return this.get(pluginId);
+  }
+
+  async disable(pluginId: string): Promise<Record<string, unknown>> {
+    this.requireRecord(pluginId);
+    await this.executions.shutdown(pluginId);
+    this.registry.setStatus(pluginId, "disabled");
+    return this.get(pluginId);
+  }
+
+  async reload(pluginId: string): Promise<Record<string, unknown>> {
+    const record = this.requireRecord(pluginId);
+    if (record.status !== "enabled") throw new Error("只有已启用插件可以重新加载");
+    await this.executions.restart(pluginId);
+    return this.get(pluginId);
+  }
+
+  async uninstall(pluginId: string): Promise<void> {
+    const record = this.requireRecord(pluginId);
+    await this.executions.shutdown(pluginId);
+    this.installer.removeFiles(record);
+    this.registry.remove(pluginId);
+  }
+
+  async execute(pluginId: string, actionId: string, userId: string, workspaceId: string | null, input: unknown, executionId?: string) {
+    const record = this.requireRecord(pluginId);
+    if (record.status !== "enabled") throw Object.assign(new Error(`插件当前状态为 ${record.status}`), { code: "PLUGIN_NOT_ENABLED" });
+    const manifest = manifestOf(record);
+    const action = manifest.actions.find((candidate) => candidate.id === actionId);
+    if (!action) throw Object.assign(new Error("Action 不存在"), { code: "PLUGIN_ACTION_NOT_FOUND" });
+    const validated = validateActionInput(action, input);
+    const timeoutMs = action.execution === "background" ? 30_000 : 10_000;
+    return this.executions.execute({ pluginId, actionId, userId, workspaceId, actionInput: validated, timeoutMs, executionId });
+  }
+
+  private publicRecord(record: PluginRegistryRecord): Record<string, unknown> {
+    const manifest = manifestOf(record);
+    return {
+      id: record.id,
+      name: record.name,
+      description: manifest.description,
+      version: record.version,
+      apiVersion: record.apiVersion,
+      source: record.source,
+      trustLevel: record.trustLevel,
+      status: record.status,
+      checksum: record.checksum,
+      installedAt: record.installedAt,
+      updatedAt: record.updatedAt,
+      lastError: record.lastError,
+      author: manifest.author,
+      actions: manifest.actions,
+      permissions: this.permissions.list(record.id),
+    };
+  }
+
+  private requireRecord(pluginId: string): PluginRegistryRecord {
+    const record = this.registry.get(pluginId);
+    if (!record) throw Object.assign(new Error("插件不存在"), { code: "PLUGIN_NOT_FOUND" });
+    return record;
+  }
+}
+
+let singleton: PluginService | null = null;
+export function getPluginService(): PluginService {
+  if (!singleton) singleton = new PluginService();
+  return singleton;
+}
+
+export function quarantineRestoredPlugins(): void {
+  const db = getDb();
+  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('plugin_registry','plugin_permissions')").all() as Array<{ name: string }>;
+  if (tables.length < 2) return;
+  const dataDir = process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data");
+  const records = db.prepare("SELECT id,version FROM plugin_registry").all() as Array<{ id: string; version: string }>;
+  db.transaction(() => {
+    const update = db.prepare("UPDATE plugin_registry SET status='quarantined',source='restore',installedPath=?,lastError='恢复后需要管理员重新确认',updatedAt=? WHERE id=?");
+    for (const record of records) {
+      const restored = path.join(dataDir, "plugins", "installed", record.id, record.version);
+      const quarantined = path.join(dataDir, "plugins", "quarantine", record.id, record.version);
+      if (fs.existsSync(restored)) {
+        fs.mkdirSync(path.dirname(quarantined), { recursive: true });
+        if (fs.existsSync(quarantined)) fs.rmSync(quarantined, { recursive: true, force: true });
+        fs.renameSync(restored, quarantined);
+      }
+      update.run(quarantined, new Date().toISOString(), record.id);
+    }
+    db.prepare("UPDATE plugin_permissions SET granted=0,grantedBy=NULL,grantedAt=NULL").run();
+  })();
+}

--- a/backend/src/plugins/registry.ts
+++ b/backend/src/plugins/registry.ts
@@ -1,0 +1,61 @@
+import { getDb } from "../db/schema.js";
+import type { PluginManifestV1, PluginRegistryRecord, PluginSource, PluginStatus, PluginTrustLevel } from "./types.js";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export class PluginRegistry {
+  list(): PluginRegistryRecord[] {
+    return getDb().prepare("SELECT * FROM plugin_registry ORDER BY name COLLATE NOCASE").all() as PluginRegistryRecord[];
+  }
+
+  get(id: string): PluginRegistryRecord | undefined {
+    return getDb().prepare("SELECT * FROM plugin_registry WHERE id = ?").get(id) as PluginRegistryRecord | undefined;
+  }
+
+  upsert(input: {
+    manifest: PluginManifestV1;
+    source: PluginSource;
+    trustLevel: PluginTrustLevel;
+    status: PluginStatus;
+    checksum: string;
+    installedPath: string;
+    installedBy: string | null;
+  }): PluginRegistryRecord {
+    const timestamp = now();
+    getDb().prepare(`
+      INSERT INTO plugin_registry (
+        id, name, version, apiVersion, runtime, main, source, trustLevel, status,
+        checksum, manifestJson, installedPath, installedBy, installedAt, updatedAt, lastError
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      ON CONFLICT(id) DO UPDATE SET
+        name=excluded.name, version=excluded.version, apiVersion=excluded.apiVersion,
+        runtime=excluded.runtime, main=excluded.main, source=excluded.source,
+        trustLevel=excluded.trustLevel, status=excluded.status, checksum=excluded.checksum,
+        manifestJson=excluded.manifestJson, installedPath=excluded.installedPath,
+        installedBy=excluded.installedBy, updatedAt=excluded.updatedAt, lastError=NULL
+    `).run(
+      input.manifest.id, input.manifest.name, input.manifest.version,
+      input.manifest.apiVersion, input.manifest.runtime, input.manifest.main,
+      input.source, input.trustLevel, input.status, input.checksum,
+      JSON.stringify(input.manifest), input.installedPath, input.installedBy,
+      timestamp, timestamp,
+    );
+    return this.get(input.manifest.id)!;
+  }
+
+  setStatus(id: string, status: PluginStatus, lastError: string | null = null): void {
+    getDb().prepare("UPDATE plugin_registry SET status=?, lastError=?, updatedAt=? WHERE id=?")
+      .run(status, lastError, now(), id);
+  }
+
+  setPath(id: string, installedPath: string): void {
+    getDb().prepare("UPDATE plugin_registry SET installedPath=?, updatedAt=? WHERE id=?")
+      .run(installedPath, now(), id);
+  }
+
+  remove(id: string): void {
+    getDb().prepare("DELETE FROM plugin_registry WHERE id = ?").run(id);
+  }
+}

--- a/backend/src/plugins/runner-child.mjs
+++ b/backend/src/plugins/runner-child.mjs
@@ -1,0 +1,89 @@
+import { pathToFileURL } from "node:url";
+
+const pendingHostCalls = new Map();
+let sequence = 0;
+let plugin = null;
+let activeExecutionId = null;
+
+function send(message) {
+  if (typeof process.send === "function") process.send(message);
+}
+
+function hostCall(method, args) {
+  const callId = `${process.pid}-${++sequence}`;
+  return new Promise((resolve, reject) => {
+    pendingHostCalls.set(callId, { resolve, reject });
+    send({ type: "host-call", callId, executionId: activeExecutionId, method, args });
+  });
+}
+
+function namespace(prefix, methods) {
+  return Object.fromEntries(methods.map((method) => [method, (args = {}) => hostCall(`${prefix}.${method}`, args)]));
+}
+
+const nowen = {
+  notes: namespace("notes", ["get", "list", "create", "update"]),
+  notebooks: namespace("notebooks", ["get", "list", "create"]),
+  tags: namespace("tags", ["list", "create", "addToNote", "removeFromNote"]),
+  tasks: namespace("tasks", ["get", "list", "create", "update"]),
+  attachments: namespace("attachments", ["get", "list"]),
+  diary: namespace("diary", ["get", "list", "create"]),
+  mindmaps: namespace("mindmaps", ["get", "list", "create", "update"]),
+  storage: namespace("storage", ["get", "set", "delete"]),
+  external: namespace("external", ["fetch"]),
+};
+
+for (const level of ["log", "info", "warn", "error"]) {
+  console[level] = (...parts) => send({
+    type: "log",
+    executionId: activeExecutionId,
+    level: level === "log" ? "info" : level,
+    message: parts.map((part) => typeof part === "string" ? part : JSON.stringify(part)).join(" "),
+  });
+}
+
+async function loadPlugin(mainPath) {
+  const module = await import(`${pathToFileURL(mainPath).href}?worker=${Date.now()}`);
+  plugin = module.default || module;
+  if (!plugin || (typeof plugin.actions !== "object" && typeof plugin.execute !== "function")) {
+    throw new Error("插件必须导出 actions 或 legacy execute 函数");
+  }
+  if (typeof plugin.activate === "function") await plugin.activate({ nowen });
+}
+
+process.on("message", async (message) => {
+  if (!message || typeof message !== "object") return;
+  if (message.type === "host-result") {
+    const pending = pendingHostCalls.get(message.callId);
+    if (!pending) return;
+    pendingHostCalls.delete(message.callId);
+    if (message.error) pending.reject(Object.assign(new Error(message.error.message || "Host API 调用失败"), { code: message.error.code }));
+    else pending.resolve(message.result);
+    return;
+  }
+  if (message.type !== "execute") return;
+  activeExecutionId = message.executionId;
+  try {
+    if (!plugin) await loadPlugin(message.mainPath);
+    const action = plugin.actions?.[message.actionId];
+    const result = typeof action === "function"
+      ? await action({ input: message.input, nowen })
+      : await plugin.execute({ userId: message.userId, workspaceId: message.workspaceId, log: console.info }, message.input);
+    send({ type: "execution-result", executionId: message.executionId, result: result ?? { success: true } });
+  } catch (error) {
+    send({
+      type: "execution-error",
+      executionId: message.executionId,
+      error: { message: error instanceof Error ? error.message : String(error), code: error?.code || "PLUGIN_EXECUTION_FAILED" },
+    });
+  } finally {
+    activeExecutionId = null;
+  }
+});
+
+process.on("disconnect", async () => {
+  try { if (typeof plugin?.deactivate === "function") await plugin.deactivate(); } catch { /* host is gone */ }
+  process.exit(0);
+});
+
+send({ type: "ready" });

--- a/backend/src/plugins/runner.ts
+++ b/backend/src/plugins/runner.ts
@@ -1,0 +1,164 @@
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExecutionLogTail } from "./logs.js";
+import type { HostCall, PluginExecutionContext, PluginExecutionResult, PluginRegistryRecord } from "./types.js";
+
+type HostCallHandler = (context: PluginExecutionContext, call: HostCall) => Promise<unknown>;
+
+interface PendingExecution {
+  context: PluginExecutionContext;
+  resolve: (result: PluginExecutionResult) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  logs: ExecutionLogTail;
+}
+
+function runnerChildPath(): string {
+  const candidates = [
+    path.join(__dirname, "runner-child.mjs"),
+    path.join(process.cwd(), "src", "plugins", "runner-child.mjs"),
+    path.join(process.cwd(), "backend", "src", "plugins", "runner-child.mjs"),
+    path.join(process.cwd(), "backend", "dist", "runner-child.mjs"),
+  ];
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) throw new Error("找不到插件子进程运行器 runner-child.mjs");
+  return found;
+}
+
+function sanitizedEnvironment(): NodeJS.ProcessEnv {
+  const allowed = ["PATH", "Path", "SystemRoot", "WINDIR", "TEMP", "TMP", "LANG", "LC_ALL", "TZ"];
+  const env: NodeJS.ProcessEnv = { NODE_ENV: "production", ELECTRON_RUN_AS_NODE: "1" };
+  for (const key of allowed) if (process.env[key]) env[key] = process.env[key];
+  return env;
+}
+
+export class PluginRunner {
+  private child: ChildProcess | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private pending = new Map<string, PendingExecution>();
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly record: PluginRegistryRecord,
+    private readonly hostCallHandler: HostCallHandler,
+  ) {}
+
+  private ensureChild(): Promise<void> {
+    if (this.child?.connected && this.readyPromise) return this.readyPromise;
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      const child = fork(runnerChildPath(), [], {
+        cwd: this.record.installedPath,
+        env: sanitizedEnvironment(),
+        execArgv: ["--max-old-space-size=128"],
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+      });
+      this.child = child;
+      const startupTimer = setTimeout(() => reject(new Error("插件 Worker 启动超时")), 5000);
+      child.on("message", (message: any) => {
+        if (message?.type === "ready") {
+          clearTimeout(startupTimer);
+          resolve();
+          return;
+        }
+        void this.handleMessage(message);
+      });
+      child.once("error", (error) => {
+        clearTimeout(startupTimer);
+        reject(error);
+        this.failAll(error);
+      });
+      child.once("exit", (code, signal) => {
+        clearTimeout(startupTimer);
+        this.child = null;
+        this.readyPromise = null;
+        this.failAll(new Error(`插件 Worker 已退出 (${signal || code || "unknown"})`));
+      });
+    });
+    return this.readyPromise;
+  }
+
+  private async handleMessage(message: any): Promise<void> {
+    if (!message || typeof message !== "object") return;
+    const pending = this.pending.get(String(message.executionId || ""));
+    if (message.type === "log" && pending) {
+      pending.logs.add(message.level || "info", message.message || "");
+      return;
+    }
+    if (message.type === "host-call" && pending && this.child?.connected) {
+      try {
+        const result = await this.hostCallHandler(pending.context, { method: message.method, args: message.args });
+        this.child.send({ type: "host-result", callId: message.callId, result });
+      } catch (error) {
+        const coded = error as Error & { code?: string };
+        this.child.send({ type: "host-result", callId: message.callId, error: { message: coded.message, code: coded.code || "HOST_CALL_FAILED" } });
+      }
+      return;
+    }
+    if (!pending) return;
+    if (message.type === "execution-result") {
+      clearTimeout(pending.timer);
+      this.pending.delete(pending.context.executionId);
+      pending.resolve(message.result);
+    } else if (message.type === "execution-error") {
+      clearTimeout(pending.timer);
+      this.pending.delete(pending.context.executionId);
+      const error = Object.assign(new Error(message.error?.message || "插件执行失败"), { code: message.error?.code });
+      pending.reject(error);
+    }
+  }
+
+  execute(context: PluginExecutionContext, input: Record<string, unknown>, timeoutMs: number, logs: ExecutionLogTail): Promise<PluginExecutionResult> {
+    const task = this.queue.then(async () => {
+      await this.ensureChild();
+      return new Promise<PluginExecutionResult>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const error = Object.assign(new Error(`插件执行超时 (${timeoutMs}ms)`), { code: "PLUGIN_TIMEOUT" });
+          this.pending.delete(context.executionId);
+          void this.terminate().finally(() => reject(error));
+        }, timeoutMs);
+        this.pending.set(context.executionId, { context, resolve, reject, timer, logs });
+        this.child!.send({
+          type: "execute",
+          ...context,
+          input,
+          mainPath: path.resolve(this.record.installedPath, this.record.main),
+        });
+      });
+    });
+    this.queue = task.catch(() => undefined);
+    return task;
+  }
+
+  cancel(executionId: string): boolean {
+    if (!this.pending.has(executionId)) return false;
+    const pending = this.pending.get(executionId)!;
+    clearTimeout(pending.timer);
+    this.pending.delete(executionId);
+    void this.terminate().finally(() => pending.reject(Object.assign(new Error("插件执行已取消"), { code: "PLUGIN_CANCELLED" })));
+    return true;
+  }
+
+  async terminate(): Promise<void> {
+    const child = this.child;
+    this.child = null;
+    this.readyPromise = null;
+    if (!child) return;
+    if (!child.killed) child.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      const force = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve();
+      }, 2000);
+      child.once("exit", () => { clearTimeout(force); resolve(); });
+    });
+  }
+
+  private failAll(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/backend/src/plugins/secrets.ts
+++ b/backend/src/plugins/secrets.ts
@@ -1,0 +1,58 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { getDb } from "../db/schema.js";
+
+function keyPath(): string {
+  return path.join(process.env.ELECTRON_USER_DATA || path.join(process.cwd(), "data"), ".plugin_secret_key");
+}
+
+function loadKey(): Buffer {
+  const target = keyPath();
+  if (!fs.existsSync(target)) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, crypto.randomBytes(32), { flag: "wx", mode: 0o600 });
+  }
+  const key = fs.readFileSync(target);
+  if (key.length !== 32) throw new Error("插件 Secret Key 长度无效");
+  return key;
+}
+
+export class PluginSecrets {
+  list(pluginId: string, ownerUserId: string): Array<{ name: string; createdAt: string; updatedAt: string }> {
+    return getDb().prepare(
+      "SELECT name, createdAt, updatedAt FROM plugin_secrets WHERE pluginId=? AND ownerUserId=? ORDER BY name",
+    ).all(pluginId, ownerUserId) as Array<{ name: string; createdAt: string; updatedAt: string }>;
+  }
+
+  set(pluginId: string, ownerUserId: string, name: string, value: string): void {
+    if (!/^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/.test(name)) throw new Error("连接名称格式无效");
+    if (!value || Buffer.byteLength(value, "utf8") > 64 * 1024) throw new Error("Secret 必须在 1-64KB 之间");
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", loadKey(), iv);
+    const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const timestamp = new Date().toISOString();
+    getDb().prepare(`
+      INSERT INTO plugin_secrets (id, pluginId, ownerUserId, name, encryptedValue, iv, authTag, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(pluginId, ownerUserId, name) DO UPDATE SET
+        encryptedValue=excluded.encryptedValue, iv=excluded.iv, authTag=excluded.authTag, updatedAt=excluded.updatedAt
+    `).run(crypto.randomUUID(), pluginId, ownerUserId, name, encrypted.toString("base64"), iv.toString("base64"), tag.toString("base64"), timestamp, timestamp);
+  }
+
+  get(pluginId: string, ownerUserId: string, name: string): string {
+    const row = getDb().prepare(
+      "SELECT encryptedValue, iv, authTag FROM plugin_secrets WHERE pluginId=? AND ownerUserId=? AND name=?",
+    ).get(pluginId, ownerUserId, name) as { encryptedValue: string; iv: string; authTag: string } | undefined;
+    if (!row) throw new Error(`插件连接不存在: ${name}`);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", loadKey(), Buffer.from(row.iv, "base64"));
+    decipher.setAuthTag(Buffer.from(row.authTag, "base64"));
+    return Buffer.concat([decipher.update(Buffer.from(row.encryptedValue, "base64")), decipher.final()]).toString("utf8");
+  }
+
+  remove(pluginId: string, ownerUserId: string, name: string): void {
+    getDb().prepare("DELETE FROM plugin_secrets WHERE pluginId=? AND ownerUserId=? AND name=?")
+      .run(pluginId, ownerUserId, name);
+  }
+}

--- a/backend/src/plugins/types.ts
+++ b/backend/src/plugins/types.ts
@@ -1,0 +1,91 @@
+export const PLUGIN_API_VERSION = 1;
+export const NOWEN_VERSION = "1.5.0";
+
+export const PLUGIN_PERMISSIONS = [
+  "notes:read", "notes:write",
+  "notebooks:read", "notebooks:write",
+  "tags:read", "tags:write",
+  "tasks:read", "tasks:write",
+  "attachments:read", "attachments:write",
+  "diary:read", "diary:write",
+  "mindmaps:read", "mindmaps:write",
+  "plugin-storage:read", "plugin-storage:write",
+  "external:fetch", "secrets:use",
+] as const;
+
+export type PluginPermission = typeof PLUGIN_PERMISSIONS[number];
+export type PluginStatus = "quarantined" | "disabled" | "enabled" | "error" | "incompatible";
+export type PluginSource = "package" | "official" | "dev" | "restore";
+export type PluginTrustLevel = "official" | "verified" | "community" | "developer";
+
+export interface PluginActionInputField {
+  type: "string" | "number" | "boolean" | "object" | "array";
+  required?: boolean;
+  description?: string;
+  enum?: Array<string | number | boolean>;
+  default?: unknown;
+}
+
+export interface PluginActionManifest {
+  id: string;
+  name: string;
+  description?: string;
+  execution?: "interactive" | "background";
+  input?: Record<string, PluginActionInputField>;
+}
+
+export interface PluginManifestV1 {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  apiVersion: 1;
+  engines: { nowen: string };
+  runtime: "node-action";
+  main: string;
+  author?: { name: string; url?: string };
+  permissions: PluginPermission[];
+  permissionConfig?: {
+    externalFetchHosts?: string[];
+  };
+  actions: PluginActionManifest[];
+}
+
+export interface PluginRegistryRecord {
+  id: string;
+  name: string;
+  version: string;
+  apiVersion: number;
+  runtime: string;
+  main: string;
+  source: PluginSource;
+  trustLevel: PluginTrustLevel;
+  status: PluginStatus;
+  checksum: string;
+  manifestJson: string;
+  installedPath: string;
+  installedBy: string | null;
+  installedAt: string;
+  updatedAt: string;
+  lastError: string | null;
+}
+
+export interface PluginExecutionContext {
+  executionId: string;
+  pluginId: string;
+  actionId: string;
+  userId: string;
+  workspaceId: string | null;
+}
+
+export interface PluginExecutionResult {
+  success: boolean;
+  data?: unknown;
+  text?: string;
+  error?: string;
+}
+
+export interface HostCall {
+  method: string;
+  args: unknown;
+}

--- a/backend/src/routes/plugin-executions.ts
+++ b/backend/src/routes/plugin-executions.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import { isSystemAdmin } from "../middleware/acl.js";
+import { getPluginService } from "../plugins/pluginService.js";
+
+const router = new Hono();
+
+router.get("/:executionId", (c) => {
+  const row = getPluginService().executions.get(c.req.param("executionId")) as { userId?: string } | undefined;
+  if (!row) return c.json({ error: "执行记录不存在", code: "NOT_FOUND" }, 404);
+  const actor = c.req.header("X-User-Id") || "";
+  if (row.userId !== actor && !isSystemAdmin(actor)) return c.json({ error: "无权查看该执行记录", code: "FORBIDDEN" }, 403);
+  return c.json(row);
+});
+
+router.post("/:executionId/cancel", (c) => {
+  const row = getPluginService().executions.get(c.req.param("executionId")) as { userId?: string } | undefined;
+  if (!row) return c.json({ error: "执行记录不存在", code: "NOT_FOUND" }, 404);
+  const actor = c.req.header("X-User-Id") || "";
+  if (row.userId !== actor && !isSystemAdmin(actor)) return c.json({ error: "无权取消该执行", code: "FORBIDDEN" }, 403);
+  return c.json({ success: getPluginService().executions.cancel(c.req.param("executionId")) });
+});
+
+export default router;

--- a/backend/src/routes/plugins.ts
+++ b/backend/src/routes/plugins.ts
@@ -1,110 +1,164 @@
-/**
- * Nowen Note 插件管理 API
- *
- * - GET    /api/plugins          — 列出已加载的插件
- * - POST   /api/plugins/reload   — 重新扫描和加载所有插件
- * - POST   /api/plugins/:name/execute — 执行插件
- * - GET    /api/plugins/:name/logs    — 获取插件日志
- * - DELETE /api/plugins/:name         — 卸载插件
- * - GET    /api/plugins/actions       — 列出所有可用 action
- */
-
 import { Hono } from "hono";
-import { getPluginLoader } from "../plugins/plugin-loader.js";
+import crypto from "node:crypto";
+import { isSystemAdmin, requireAdmin } from "../middleware/acl.js";
+import { getPluginService } from "../plugins/pluginService.js";
 
 const pluginsRouter = new Hono();
 
-// 初始化：加载插件
-let initialized = false;
-async function ensureInit() {
-  if (initialized) return;
-  initialized = true;
-  try {
-    const loader = getPluginLoader();
-    await loader.loadAll();
-  } catch (err) {
-    console.error("[Plugins] 初始化加载失败:", err);
-  }
+function userId(c: any): string {
+  return c.req.header("X-User-Id") || "";
 }
 
-// ===== GET /api/plugins — 列出插件 =====
-pluginsRouter.get("/", async (c) => {
-  await ensureInit();
-  const loader = getPluginLoader();
-  return c.json(loader.listPlugins());
+function errorResponse(c: any, error: unknown) {
+  const coded = error as Error & { code?: string; executionId?: string };
+  const status = coded.code === "PLUGIN_NOT_FOUND" || coded.code === "PLUGIN_ACTION_NOT_FOUND" ? 404
+    : coded.code === "RESOURCE_FORBIDDEN" || coded.code === "PLUGIN_PERMISSION_DENIED" ? 403
+      : coded.code === "PLUGIN_TIMEOUT" ? 408 : 400;
+  return c.json({ success: false, error: coded.message || String(error), code: coded.code || "PLUGIN_ERROR", executionId: coded.executionId }, status as any);
+}
+
+pluginsRouter.get("/", (c) => {
+  const actor = userId(c);
+  return c.json(getPluginService().list(isSystemAdmin(actor)));
 });
 
-// ===== POST /api/plugins/reload — 重新加载 =====
-pluginsRouter.post("/reload", async (c) => {
-  const loader = getPluginLoader();
-  await loader.loadAll();
-  return c.json({ success: true, count: loader.listPlugins().length });
+pluginsRouter.get("/actions", (c) => c.json(getPluginService().listActions()));
+
+pluginsRouter.post("/install", requireAdmin, async (c) => {
+  try {
+    const body = await c.req.parseBody();
+    const upload = body.file;
+    if (!(upload instanceof File)) return c.json({ error: "请上传 file 字段中的 .nowen-plugin 文件" }, 400);
+    if (!upload.name.endsWith(".nowen-plugin")) return c.json({ error: "文件扩展名必须是 .nowen-plugin" }, 400);
+    const record = await getPluginService().install(Buffer.from(await upload.arrayBuffer()), userId(c));
+    return c.json({ success: true, plugin: record }, 201);
+  } catch (error) {
+    return errorResponse(c, error);
+  }
 });
 
-// ===== GET /api/plugins/actions — 列出所有 action =====
-pluginsRouter.get("/actions", async (c) => {
-  await ensureInit();
-  const loader = getPluginLoader();
-  const plugins = loader.listPlugins();
+pluginsRouter.get("/developer-mode", requireAdmin, (c) => c.json({ enabled: getPluginService().isDeveloperModeEnabled(), available: getPluginService().isDeveloperModeAvailable() }));
+pluginsRouter.put("/developer-mode", requireAdmin, async (c) => {
+  try {
+    const body = await c.req.json().catch(() => ({})) as { enabled?: boolean };
+    getPluginService().setDeveloperMode(body.enabled === true);
+    return c.json({ success: true, enabled: body.enabled === true });
+  } catch (error) { return errorResponse(c, error); }
+});
 
-  const actions: { action: string; pluginName: string; description: string; params?: any[] }[] = [];
-  for (const p of plugins) {
-    if (p.status !== "active") continue;
-    for (const cap of p.capabilities) {
-      actions.push({
-        action: cap.action,
-        pluginName: p.name,
-        description: cap.description,
-        params: cap.params,
-      });
+pluginsRouter.post("/dev/load", requireAdmin, async (c) => {
+  try {
+    const body = await c.req.json() as { directory?: string };
+    const plugin = await getPluginService().loadDevelopmentDirectory(String(body.directory || ""), userId(c));
+    return c.json({ success: true, plugin }, 201);
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+});
+
+pluginsRouter.get("/:id", (c) => {
+  try {
+    const plugin = getPluginService().get(c.req.param("id"));
+    if (!isSystemAdmin(userId(c)) && plugin.status !== "enabled") return c.json({ error: "插件不可用", code: "PLUGIN_NOT_ENABLED" }, 404);
+    return c.json(plugin);
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+});
+
+pluginsRouter.put("/:id/permissions", requireAdmin, async (c) => {
+  try {
+    const body = await c.req.json() as { granted?: string[] };
+    return c.json({ success: true, ...getPluginService().grantPermissions(c.req.param("id"), Array.isArray(body.granted) ? body.granted : [], userId(c)) });
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+});
+
+for (const [action, handler] of [
+  ["enable", (id: string) => getPluginService().enable(id)],
+  ["disable", (id: string) => getPluginService().disable(id)],
+  ["reload", (id: string) => getPluginService().reload(id)],
+] as const) {
+  pluginsRouter.post(`/:id/${action}`, requireAdmin, async (c) => {
+    try { return c.json({ success: true, plugin: await handler(c.req.param("id")) }); }
+    catch (error) { return errorResponse(c, error); }
+  });
+}
+
+pluginsRouter.delete("/:id", requireAdmin, async (c) => {
+  try {
+    await getPluginService().uninstall(c.req.param("id"));
+    return c.json({ success: true });
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+});
+
+pluginsRouter.get("/:id/executions", (c) => {
+  const actor = userId(c);
+  const rows = getPluginService().executions.list(c.req.param("id"), isSystemAdmin(actor) ? undefined : actor, Number(c.req.query("limit")) || 100);
+  return c.json(rows);
+});
+
+pluginsRouter.get("/:id/logs", requireAdmin, (c) => {
+  const rows = getPluginService().executions.list(c.req.param("id"), undefined, 100);
+  return c.json(rows.map((row) => ({ executionId: row.id, startedAt: row.startedAt, status: row.status, logTail: row.logTail })));
+});
+
+pluginsRouter.get("/:id/secrets", (c) => {
+  try {
+    getPluginService().get(c.req.param("id"));
+    return c.json(getPluginService().secrets.list(c.req.param("id"), userId(c)));
+  } catch (error) { return errorResponse(c, error); }
+});
+
+pluginsRouter.put("/:id/secrets/:name", async (c) => {
+  try {
+    const body = await c.req.json() as { value?: string };
+    getPluginService().secrets.set(c.req.param("id"), userId(c), c.req.param("name"), String(body.value || ""));
+    return c.json({ success: true });
+  } catch (error) { return errorResponse(c, error); }
+});
+
+pluginsRouter.delete("/:id/secrets/:name", (c) => {
+  getPluginService().secrets.remove(c.req.param("id"), userId(c), c.req.param("name"));
+  return c.json({ success: true });
+});
+
+pluginsRouter.post("/:id/actions/:actionId/execute", async (c) => {
+  try {
+    const body = await c.req.json().catch(() => ({})) as { input?: unknown; workspaceId?: string | null };
+    const plugin = getPluginService().get(c.req.param("id"));
+    const action = (plugin.actions as Array<{ id: string; execution?: string }>).find((item) => item.id === c.req.param("actionId"));
+    if (action?.execution === "background") {
+      const executionId = crypto.randomUUID();
+      void getPluginService().execute(c.req.param("id"), c.req.param("actionId"), userId(c), body.workspaceId || null, body.input || {}, executionId).catch(() => undefined);
+      return c.json({ success: true, executionId, status: "queued" }, 202);
     }
+    const execution = await getPluginService().execute(c.req.param("id"), c.req.param("actionId"), userId(c), body.workspaceId || null, body.input || {});
+    return c.json({ success: true, executionId: execution.executionId, data: execution.result });
+  } catch (error) {
+    return errorResponse(c, error);
   }
-
-  return c.json(actions);
 });
 
-// ===== POST /api/plugins/:name/execute — 执行插件 =====
+/** @deprecated V1.5 compatibility shim. Prefer /:id/actions/:actionId/execute. */
 pluginsRouter.post("/:name/execute", async (c) => {
-  await ensureInit();
-  const name = c.req.param("name");
-  const userId = c.req.header("X-User-Id") || "demo";
-  const params = await c.req.json();
-
-  const loader = getPluginLoader();
-
-  const result = await loader.executePlugin(
-    name,
-    params,
-    {
-      log: () => {},
-      userId,
-      apiBaseUrl: "",
-      apiToken: "",
-    },
-    30000,
-  );
-
-  if (!result.success) {
-    return c.json(result, 400);
-  }
-
-  return c.json(result);
-});
-
-// ===== GET /api/plugins/:name/logs — 获取日志 =====
-pluginsRouter.get("/:name/logs", async (c) => {
-  await ensureInit();
-  const name = c.req.param("name");
-  const loader = getPluginLoader();
-  return c.json(loader.getPluginLogs(name));
-});
-
-// ===== DELETE /api/plugins/:name — 卸载插件 =====
-pluginsRouter.delete("/:name", async (c) => {
-  const name = c.req.param("name");
-  const loader = getPluginLoader();
-  const result = await loader.unloadPlugin(name);
-  return c.json({ success: result });
+  c.header("Deprecation", "true");
+  c.header("Sunset", "2027-02-23");
+  try {
+    const name = c.req.param("name");
+    const plugin = getPluginService().list(false).find((item) => item.id === name || item.name === name);
+    if (!plugin) return c.json({ success: false, error: "插件不存在", code: "PLUGIN_NOT_FOUND" }, 404);
+    const body = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const requestedAction = typeof body.actionId === "string" ? body.actionId : undefined;
+    const action = (plugin.actions as Array<{ id: string }>).find((item) => item.id === requestedAction) || (plugin.actions as Array<{ id: string }>)[0];
+    if (!action) return c.json({ success: false, error: "插件没有可执行 Action" }, 400);
+    const params = requestedAction ? (body.input || {}) : body;
+    const execution = await getPluginService().execute(String(plugin.id), action.id, userId(c), null, params);
+    return c.json({ ...execution.result, executionId: execution.executionId });
+  } catch (error) { return errorResponse(c, error); }
 });
 
 export default pluginsRouter;

--- a/backend/src/runtime/backup-restore-large-archive.ts
+++ b/backend/src/runtime/backup-restore-large-archive.ts
@@ -10,6 +10,7 @@ import {
   getDbPath,
 } from "../db/schema.js";
 import { BackupManager, type RestoreResult } from "../services/backup.js";
+import { quarantineRestoredPlugins } from "../plugins/pluginService.js";
 
 const unzipper = require("unzipper");
 
@@ -419,8 +420,10 @@ async function restoreZipStreaming(
   const stagingRoot = path.join(manager.dataDir, `.nowen-restore-staging-${restoreId}`);
   const stagedAttachments = path.join(stagingRoot, "attachments");
   const stagedFonts = path.join(stagingRoot, "fonts");
-  const stagedPlugins = path.join(stagingRoot, "plugins");
+  const hasInstalledLayout = directory.files.some((entry) => normalizeZipPath(entry.path).startsWith("plugins/installed/"));
+  const stagedPlugins = path.join(stagingRoot, hasInstalledLayout ? "plugins-installed" : "plugins-legacy");
   const stagedSecret = path.join(stagingRoot, ".jwt_secret");
+  const stagedPluginSecretKey = path.join(stagingRoot, ".plugin_secret_key");
 
   try {
     // All archive IO happens before the current database or live file directories are touched.
@@ -429,12 +432,14 @@ async function restoreZipStreaming(
 
     const attachmentCount = await extractDirectoryStreaming(directory, "attachments", stagedAttachments);
     const fontCount = await extractDirectoryStreaming(directory, "fonts", stagedFonts);
-    const pluginCount = await extractDirectoryStreaming(directory, "plugins", stagedPlugins);
+    const pluginCount = await extractDirectoryStreaming(directory, hasInstalledLayout ? "plugins/installed" : "plugins", stagedPlugins);
 
     const secretEntry = findZipEntry(directory, ".jwt_secret");
     if (secretEntry) {
       await streamEntryToFile(secretEntry, stagedSecret);
     }
+    const pluginSecretKeyEntry = findZipEntry(directory, ".plugin_secret_key");
+    if (pluginSecretKeyEntry) await streamEntryToFile(pluginSecretKeyEntry, stagedPluginSecretKey);
 
     const curDbPath = getDbPath();
     const safetyBak = curDbPath + `.before-restore.${Date.now()}.bak`;
@@ -453,7 +458,7 @@ async function restoreZipStreaming(
       replaceDirectoriesFromStaging([
         { stagedDir: stagedAttachments, destDir: path.join(manager.dataDir, "attachments") },
         { stagedDir: stagedFonts, destDir: path.join(manager.dataDir, "fonts") },
-        { stagedDir: stagedPlugins, destDir: path.join(manager.dataDir, "plugins") },
+        { stagedDir: stagedPlugins, destDir: hasInstalledLayout ? path.join(manager.dataDir, "plugins", "installed") : path.join(manager.dataDir, "plugins") },
       ], restoreId);
     } catch (error) {
       rollbackDb(curDbPath, safetyBak, error);
@@ -472,6 +477,17 @@ async function restoreZipStreaming(
         );
       }
     }
+
+    if (pluginSecretKeyEntry && fs.existsSync(stagedPluginSecretKey)) {
+      const target = path.join(manager.dataDir, ".plugin_secret_key");
+      fs.copyFileSync(stagedPluginSecretKey, target);
+      try { fs.chmodSync(target, 0o600); } catch { /* Windows */ }
+    } else {
+      try { getDb().prepare("DELETE FROM plugin_secrets").run(); } catch { /* old backup */ }
+    }
+
+    // 流式大备份与普通恢复遵守同一供应链边界：恢复代码进入 quarantine，授权清零。
+    quarantineRestoredPlugins();
 
     const stats: Record<string, number> = {
       attachments: attachmentCount,

--- a/backend/src/services/backup-archive.ts
+++ b/backend/src/services/backup-archive.ts
@@ -69,7 +69,8 @@ export async function createFullBackupArchive(options: FullBackupArchiveOptions)
   const files: FullBackupFileStats = {
     attachments: addDirectory(archive, path.join(options.dataDir, "attachments"), "attachments"),
     fonts: addDirectory(archive, path.join(options.dataDir, "fonts"), "fonts"),
-    plugins: addDirectory(archive, path.join(options.dataDir, "plugins"), "plugins"),
+    // 只备份正式安装包；runtime、quarantine 和 plugins-dev 都是临时/未信任状态。
+    plugins: addDirectory(archive, path.join(options.dataDir, "plugins", "installed"), "plugins/installed"),
   };
 
   const secretPath = path.join(options.dataDir, ".jwt_secret");
@@ -80,6 +81,13 @@ export async function createFullBackupArchive(options: FullBackupArchiveOptions)
     hasSecret = true;
   } catch {
     // 密钥不存在或不可读时保持旧行为：跳过该文件，并在 meta.json 中明确标记。
+  }
+  const pluginSecretKeyPath = path.join(options.dataDir, ".plugin_secret_key");
+  try {
+    fs.accessSync(pluginSecretKeyPath, fs.constants.R_OK);
+    archive.file(pluginSecretKeyPath, { name: ".plugin_secret_key" });
+  } catch {
+    // 尚未配置任何插件连接时该密钥可能不存在。
   }
   archive.append(JSON.stringify(options.buildMeta(files, hasSecret), null, 2), { name: "meta.json" });
 

--- a/backend/src/services/backup.ts
+++ b/backend/src/services/backup.ts
@@ -32,6 +32,7 @@ import Database from "better-sqlite3";
 import { closeDb, getDb, getDbSchemaVersion } from "../db/schema.js";
 import { noteVersionsRepository } from "../repositories";
 import { createBackupFilename, createFullBackupArchive, hashFileSha256 } from "./backup-archive.js";
+import { quarantineRestoredPlugins } from "../plugins/pluginService.js";
 
 // ===== 常量 =====
 
@@ -1235,6 +1236,8 @@ export class BackupManager {
       // 对账会逐实体比对而不是盲目覆盖，因此恢复旧备份**不会**把
       // 服务端的新数据冲掉（第二十条）。
       if (result.success && !opts.dryRun) {
+        // 恢复包中的第三方代码永不自动启用：迁入 quarantine，并清空所有授权。
+        quarantineRestoredPlugins();
         try {
           markSyncNeedsReconcile();
         } catch (error) {
@@ -1383,12 +1386,13 @@ export class BackupManager {
     const stagingRoot = path.join(this.dataDir, `.nowen-restore-staging-${restoreId}`);
     const stagedAttDir = path.join(stagingRoot, "attachments");
     const stagedFontsDir = path.join(stagingRoot, "fonts");
-    const stagedPluginsDir = path.join(stagingRoot, "plugins");
+    const hasInstalledLayout = Object.keys(zip.files).some((name) => name.startsWith("plugins/installed/"));
+    const stagedPluginsDir = path.join(stagingRoot, hasInstalledLayout ? "plugins-installed" : "plugins-legacy");
 
     // 先解压到 staging，避免失败时直接清空正式附件/字体/插件目录。
     const attCount = await extractDirFromZip(zip, "attachments", stagedAttDir);
     const fntCount = await extractDirFromZip(zip, "fonts", stagedFontsDir);
-    const plgCount = await extractDirFromZip(zip, "plugins", stagedPluginsDir);
+    const plgCount = await extractDirFromZip(zip, hasInstalledLayout ? "plugins/installed" : "plugins", stagedPluginsDir);
 
     const curDbPath = getDbPath();
     const safetyBak = curDbPath + `.before-restore.${Date.now()}.bak`;
@@ -1408,7 +1412,7 @@ export class BackupManager {
       replaceDirectoriesFromStaging([
         { stagedDir: stagedAttDir, destDir: path.join(this.dataDir, "attachments") },
         { stagedDir: stagedFontsDir, destDir: path.join(this.dataDir, "fonts") },
-        { stagedDir: stagedPluginsDir, destDir: path.join(this.dataDir, "plugins") },
+        { stagedDir: stagedPluginsDir, destDir: hasInstalledLayout ? path.join(this.dataDir, "plugins", "installed") : path.join(this.dataDir, "plugins") },
       ], restoreId);
     } catch (e) {
       rollbackDb(curDbPath, safetyBak, e);
@@ -1431,6 +1435,16 @@ export class BackupManager {
       } catch (e) {
         console.warn("[Backup] .jwt_secret 恢复失败，已保留当前密钥:", e instanceof Error ? e.message : e);
       }
+    }
+
+    const pluginSecretKeyEntry = zip.file(".plugin_secret_key");
+    if (pluginSecretKeyEntry) {
+      const pluginSecretKeyPath = path.join(this.dataDir, ".plugin_secret_key");
+      fs.writeFileSync(pluginSecretKeyPath, await pluginSecretKeyEntry.async("nodebuffer"));
+      try { fs.chmodSync(pluginSecretKeyPath, 0o600); } catch { /* Windows */ }
+    } else {
+      // 没有配套密钥的密文不可恢复；显式清空，避免误用当前机器的另一把密钥。
+      try { getDb().prepare("DELETE FROM plugin_secrets").run(); } catch { /* 老备份没有插件表 */ }
     }
 
     const stats: Record<string, number> = {

--- a/backend/tests/plugin-platform-routes.test.ts
+++ b/backend/tests/plugin-platform-routes.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after } from "node:test";
+import JSZip from "jszip";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-plugin-routes-test-"));
+process.env.NODE_ENV = "test";
+process.env.DB_PATH = path.join(root, "plugin-routes.test.db");
+process.env.ELECTRON_USER_DATA = path.join(root, "data");
+
+const ADMIN = "plugin-admin";
+const USER = "plugin-user";
+
+async function createPackage(): Promise<File> {
+  const zip = new JSZip();
+  zip.file("manifest.json", JSON.stringify({
+    id: "com.example.route-test", name: "Route Test", description: "route e2e", version: "1.0.0",
+    apiVersion: 1, engines: { nowen: ">=1.5.0 <2.0.0" }, runtime: "node-action", main: "dist/index.mjs",
+    permissions: ["notes:write"], actions: [
+      { id: "hello", name: "Hello", input: { name: { type: "string", required: true } } },
+      { id: "create-note", name: "Create Note", input: { notebookId: { type: "string", required: true }, title: { type: "string", required: true } } },
+    ],
+  }));
+  zip.file("dist/index.mjs", "export default {actions:{hello:async({input})=>({text:`Hello ${input.name}`}),'create-note':async({input,nowen})=>nowen.notes.create(input)}};");
+  return new File([await zip.generateAsync({ type: "uint8array" })], "route-test.nowen-plugin", { type: "application/zip" });
+}
+
+test("admin lifecycle and ordinary-user boundaries work end to end", async () => {
+  const [{ Hono }, { getDb, closeDb }, { default: router }] = await Promise.all([
+    import("hono"), import("../src/db/schema"), import("../src/routes/plugins"),
+  ]);
+  const db = getDb();
+  const passwordHash = "not-used";
+  db.prepare("INSERT INTO users(id,username,passwordHash,role,createdAt,updatedAt) VALUES (?,?,?,?,?,?)")
+    .run(ADMIN, "plugin-admin", passwordHash, "admin", new Date().toISOString(), new Date().toISOString());
+  db.prepare("INSERT INTO users(id,username,passwordHash,role,createdAt,updatedAt) VALUES (?,?,?,?,?,?)")
+    .run(USER, "plugin-user", passwordHash, "user", new Date().toISOString(), new Date().toISOString());
+  db.prepare("INSERT INTO workspaces(id,name,ownerId) VALUES ('plugin-ws','Plugin Workspace',?)").run(ADMIN);
+  db.prepare("INSERT INTO workspace_members(workspaceId,userId,role) VALUES ('plugin-ws',?,'owner')").run(ADMIN);
+  db.prepare("INSERT INTO workspace_members(workspaceId,userId,role) VALUES ('plugin-ws',?,'viewer')").run(USER);
+  db.prepare("INSERT INTO notebooks(id,userId,name,workspaceId) VALUES ('plugin-notebook',?,'Plugin Notebook','plugin-ws')").run(ADMIN);
+  const app = new Hono();
+  app.route("/plugins", router);
+
+  const forbiddenInstall = await app.request("/plugins/install", { method: "POST", headers: { "X-User-Id": USER } });
+  assert.equal(forbiddenInstall.status, 403);
+  const forbiddenDelete = await app.request("/plugins/com.example.route-test", { method: "DELETE", headers: { "X-User-Id": USER } });
+  assert.equal(forbiddenDelete.status, 403);
+
+  const form = new FormData();
+  form.append("file", await createPackage());
+  const installedResponse = await app.request("/plugins/install", { method: "POST", headers: { "X-User-Id": ADMIN }, body: form });
+  if (installedResponse.status !== 201) assert.fail(await installedResponse.text());
+  const installed = await installedResponse.json() as any;
+  assert.equal(installed.plugin.status, "quarantined");
+
+  const grant = await app.request("/plugins/com.example.route-test/permissions", { method: "PUT", headers: { "X-User-Id": ADMIN, "Content-Type": "application/json" }, body: JSON.stringify({ granted: ["notes:write"] }) });
+  assert.equal(grant.status, 200);
+  const enable = await app.request("/plugins/com.example.route-test/enable", { method: "POST", headers: { "X-User-Id": ADMIN } });
+  if (enable.status !== 200) assert.fail(await enable.text());
+
+  const actions = await app.request("/plugins/actions", { headers: { "X-User-Id": USER } });
+  assert.deepEqual((await actions.json() as any[]).map((item) => `${item.pluginId}/${item.actionId}`), ["com.example.route-test/hello", "com.example.route-test/create-note"]);
+  const execute = await app.request("/plugins/com.example.route-test/actions/hello/execute", { method: "POST", headers: { "X-User-Id": USER, "Content-Type": "application/json" }, body: JSON.stringify({ input: { name: "Nowen" } }) });
+  if (execute.status !== 200) assert.fail(await execute.text());
+  const result = await execute.json() as any;
+  assert.equal(result.data.text, "Hello Nowen");
+  assert.ok(result.executionId);
+
+  const viewerWrite = await app.request("/plugins/com.example.route-test/actions/create-note/execute", { method: "POST", headers: { "X-User-Id": USER, "Content-Type": "application/json" }, body: JSON.stringify({ input: { notebookId: "plugin-notebook", title: "Denied" } }) });
+  assert.equal(viewerWrite.status, 403);
+  assert.equal((db.prepare("SELECT COUNT(*) AS count FROM notes WHERE title='Denied'").get() as { count: number }).count, 0);
+
+  db.prepare("UPDATE workspace_members SET role='editor' WHERE workspaceId='plugin-ws' AND userId=?").run(USER);
+  const editorWrite = await app.request("/plugins/com.example.route-test/actions/create-note/execute", { method: "POST", headers: { "X-User-Id": USER, "Content-Type": "application/json" }, body: JSON.stringify({ input: { notebookId: "plugin-notebook", title: "Created by Plugin" } }) });
+  if (editorWrite.status !== 200) assert.fail(await editorWrite.text());
+  assert.equal((db.prepare("SELECT COUNT(*) AS count FROM notes WHERE title='Created by Plugin' AND userId=?").get(USER) as { count: number }).count, 1);
+
+  await app.request("/plugins/com.example.route-test/disable", { method: "POST", headers: { "X-User-Id": ADMIN } });
+  closeDb();
+});
+
+after(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* Windows may still release a worker handle */ }
+});

--- a/backend/tests/plugin-platform.test.ts
+++ b/backend/tests/plugin-platform.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import JSZip from "jszip";
+import { parsePluginManifest, validateActionInput } from "../src/plugins/manifest";
+import { validatePluginPackage } from "../src/plugins/packageValidator";
+import { ExecutionLogTail } from "../src/plugins/logs";
+import { PluginRunner } from "../src/plugins/runner";
+import type { PluginRegistryRecord } from "../src/plugins/types";
+
+const databaseDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-plugin-platform-test-"));
+process.env.NODE_ENV = "test";
+process.env.DB_PATH = path.join(databaseDirectory, "plugin-platform.test.db");
+
+const manifest = {
+  id: "com.example.hello",
+  name: "Hello",
+  description: "test",
+  version: "1.0.0",
+  apiVersion: 1 as const,
+  engines: { nowen: ">=1.5.0 <2.0.0" },
+  runtime: "node-action" as const,
+  main: "dist/index.mjs",
+  permissions: [],
+  actions: [{ id: "hello", name: "Hello", input: { name: { type: "string" as const, required: true } } }],
+};
+
+test("Manifest V1 rejects main path escape and undeclared permissions", () => {
+  assert.throws(() => parsePluginManifest({ ...manifest, main: "../index.mjs" }), /main/);
+  assert.throws(() => parsePluginManifest({ ...manifest, permissions: ["database:write"] }), /Invalid enum value/);
+});
+
+test("Action input validates required, type and unknown fields", () => {
+  const parsed = parsePluginManifest(manifest);
+  assert.throws(() => validateActionInput(parsed.actions[0], {}), /缺少必填参数/);
+  assert.throws(() => validateActionInput(parsed.actions[0], { name: 1 }), /应为 string/);
+  assert.throws(() => validateActionInput(parsed.actions[0], { name: "A", extra: true }), /未知参数/);
+  assert.deepEqual(validateActionInput(parsed.actions[0], { name: "A" }), { name: "A" });
+});
+
+test("package validation rejects Zip Slip and native addons", async () => {
+  const slipping = new JSZip();
+  slipping.file("../evil.mjs", "export default {};");
+  slipping.file("manifest.json", JSON.stringify(manifest));
+  slipping.file("dist/index.mjs", "export default {actions:{hello(){}}};");
+  const slippingBytes = Buffer.from(await slipping.generateAsync({ type: "uint8array" }));
+  await assert.rejects(() => validatePluginPackage(slippingBytes), /非法 ZIP 路径|路径穿越/);
+
+  const native = new JSZip();
+  native.file("manifest.json", JSON.stringify(manifest));
+  native.file("dist/index.mjs", "export default {actions:{hello(){}}};");
+  native.file("dist/addon.node", "binary");
+  const nativeBytes = Buffer.from(await native.generateAsync({ type: "uint8array" }));
+  await assert.rejects(() => validatePluginPackage(nativeBytes), /禁止文件/);
+});
+
+test("runner isolates execution and kills a timed-out worker", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nowen-plugin-runner-"));
+  const mainPath = path.join(directory, "index.mjs");
+  fs.writeFileSync(mainPath, `export default { actions: { hello: async ({input}) => ({text:'Hello '+input.name}), hang: async () => new Promise(()=>{}) } };`);
+  const record: PluginRegistryRecord = {
+    id: manifest.id, name: manifest.name, version: manifest.version, apiVersion: 1,
+    runtime: "node-action", main: "index.mjs", source: "dev", trustLevel: "developer",
+    status: "enabled", checksum: "test", manifestJson: JSON.stringify(manifest), installedPath: directory,
+    installedBy: null, installedAt: new Date().toISOString(), updatedAt: new Date().toISOString(), lastError: null,
+  };
+  const runner = new PluginRunner(record, async () => null);
+  try {
+    const result = await runner.execute({ executionId: "one", pluginId: record.id, actionId: "hello", userId: "u", workspaceId: null }, { name: "Nowen" }, 2000, new ExecutionLogTail());
+    assert.deepEqual(result, { text: "Hello Nowen" });
+    await assert.rejects(() => runner.execute({ executionId: "two", pluginId: record.id, actionId: "hang", userId: "u", workspaceId: null }, {}, 100, new ExecutionLogTail()), /执行超时/);
+    const recovered = await runner.execute({ executionId: "three", pluginId: record.id, actionId: "hello", userId: "u", workspaceId: null }, { name: "Again" }, 2000, new ExecutionLogTail());
+    assert.deepEqual(recovered, { text: "Hello Again" });
+  } finally {
+    await runner.terminate();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("schema v93 creates the five isolated plugin tables", async () => {
+  const { getDb, closeDb, getDbSchemaVersion } = await import("../src/db/schema");
+  const db = getDb();
+  assert.equal(getDbSchemaVersion(), 93);
+  const names = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'plugin_%' ORDER BY name").all() as Array<{ name: string }>;
+  assert.deepEqual(names.map((row) => row.name), ["plugin_executions", "plugin_permissions", "plugin_registry", "plugin_secrets", "plugin_storage"]);
+  closeDb();
+  fs.rmSync(databaseDirectory, { recursive: true, force: true });
+});

--- a/docs/plugin-platform/README.md
+++ b/docs/plugin-platform/README.md
@@ -1,0 +1,42 @@
+# Nowen Extension Platform V1
+
+V1 只支持服务端 Action 插件。Web、Desktop、Mobile、MCP 和 AI 都调用同一组服务端 Action API；移动端不会加载本地 Node 插件。
+
+## 五分钟开始
+
+```bash
+npm create nowen-plugin
+cd my-plugin
+npm install
+npm run dev
+npm run pack
+```
+
+`npm run pack` 生成 `.nowen-plugin` 文件。管理员在“设置 → 插件”选择该文件，阅读第三方代码警告和权限说明后安装。新插件先进入 `quarantined`，管理员确认权限后才能启用。
+
+插件默认导出：
+
+```ts
+import { definePlugin } from "@nowen/plugin-sdk";
+
+export default definePlugin({
+  actions: {
+    summarize: async ({ input, nowen }) => {
+      const note = await nowen.notes.get({ noteId: input.noteId });
+      return { text: note.contentText };
+    },
+  },
+});
+```
+
+插件不会收到数据库句柄、JWT、密码或同步凭证。`nowen.*` 调用通过 IPC 返回后端，由 Plugin Permission、用户权限、Workspace Role 和资源 ACL 共同裁决。
+
+## 安全边界
+
+- `.nowen-plugin` 是 ZIP，但禁止路径穿越、符号链接、`node_modules`、安装脚本、native addon 和可执行文件。
+- 单包不超过 20MB，解压后不超过 50MB、500 个文件；输入 256KB、输出 1MB。
+- 每个插件一个子进程，单插件串行、全局最多两个执行；交互 Action 默认 10 秒，后台 Action 最多 30 秒。超时会终止 Worker。
+- Community 插件仍是受信任代码模型。子进程提供故障隔离，不是安全沙箱；插件理论上仍可使用 Node 内置模块。只安装可信来源。
+- 完整备份只包含 `plugins/installed`。恢复后所有插件进入 quarantine，授权清零；`plugins/runtime`、`plugins-dev`、执行日志不进入备份。
+
+参见 [Manifest V1](./manifest-v1.md)、[权限与 Host API](./permissions.md) 和 [社区贡献指南](./community.md)。

--- a/docs/plugin-platform/community.md
+++ b/docs/plugin-platform/community.md
@@ -1,0 +1,12 @@
+# 社区插件贡献指南
+
+提交前请确保：
+
+1. 包内只有已构建 ESM、Manifest、文档和静态资源。
+2. 权限最小化；网络域名必须逐个声明。
+3. 日志不包含正文、Token、Cookie、Authorization、密码或 Secret。
+4. Action 在 30 秒内完成；长流程拆成可重试的小步骤。
+5. 对输入做业务层校验，错误信息不泄露敏感数据。
+6. 用 `examples/plugins/hello-nowen` 验证最小包，再运行 `npm run pack`。
+
+信任标记分为 Official、Verified 和 Community。Verified 只是审核标记，不会把 Node 子进程变成安全沙箱。

--- a/docs/plugin-platform/manifest-v1.md
+++ b/docs/plugin-platform/manifest-v1.md
@@ -1,0 +1,29 @@
+# Manifest V1
+
+```json
+{
+  "id": "com.example.ai-tools",
+  "name": "AI Tools",
+  "description": "AI 内容处理工具",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "engines": { "nowen": ">=1.5.0 <2.0.0" },
+  "runtime": "node-action",
+  "main": "dist/index.mjs",
+  "author": { "name": "example", "url": "https://example.com" },
+  "permissions": ["notes:read", "external:fetch"],
+  "permissionConfig": { "externalFetchHosts": ["api.openai.com"] },
+  "actions": [
+    {
+      "id": "summarize",
+      "name": "总结笔记",
+      "execution": "interactive",
+      "input": { "noteId": { "type": "string", "required": true } }
+    }
+  ]
+}
+```
+
+`id`、Action id 和公开协议字段都是稳定契约。`main` 必须是包内已构建的 `.js` 或 `.mjs`，不能包含 `..`。V1 input 字段支持 `string`、`number`、`boolean`、`object`、`array`，未声明参数会被拒绝。
+
+包根目录必须含 `manifest.json`，其余常见文件为 `dist/index.mjs`、`README.md`、`icon.png`。Nowen 不为插件执行 `npm install`。

--- a/docs/plugin-platform/permissions.md
+++ b/docs/plugin-platform/permissions.md
@@ -1,0 +1,20 @@
+# 权限与 Host API
+
+V1 权限：
+
+- `notes:read/write`
+- `notebooks:read/write`
+- `tags:read/write`
+- `tasks:read/write`
+- `attachments:read/write`
+- `diary:read/write`
+- `mindmaps:read/write`
+- `plugin-storage:read/write`
+- `external:fetch`
+- `secrets:use`
+
+V1 绝不提供 `database:*`、`filesystem:*`、`process:*`、`shell:*`、`sync:*`、`credentials:*` 或系统设置写权限。
+
+授权结果始终是“插件权限 + 当前用户权限 + Workspace Role + Resource ACL”的交集。比如插件得到 `notes:write`，当前用户对 Restricted Note 只有 read，插件仍不能写。
+
+`external.fetch` 仅允许 Manifest 白名单内的 HTTPS Host，阻止本机/私有网地址和自动重定向。连接密钥由 AES-256-GCM 加密存放，Broker 请求时注入；插件只引用连接名，不接触真实密钥。

--- a/examples/plugins/hello-nowen/manifest.json
+++ b/examples/plugins/hello-nowen/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "com.nowen.hello",
+  "name": "Hello Nowen",
+  "description": "Nowen Extension Platform V1 最小示例",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "engines": { "nowen": ">=1.5.0 <2.0.0" },
+  "runtime": "node-action",
+  "main": "dist/index.mjs",
+  "author": { "name": "Nowen" },
+  "permissions": [],
+  "actions": [
+    {
+      "id": "hello",
+      "name": "Hello Nowen",
+      "description": "返回一条问候语",
+      "execution": "interactive",
+      "input": { "name": { "type": "string", "required": false } }
+    }
+  ]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,6 +60,13 @@ import {
   refreshAccessToken,
   storeAuthTokens,
 } from "@/lib/authSession";
+import {
+  completeMobileAccountLogin,
+  continueMobileLocalMode,
+  getMobileLocalUser,
+  isAndroidNativeRuntime,
+  isMobileLocalMode,
+} from "@/lib/mobileLocalMode";
 
 const AUTH_USER_CACHE_PREFIX = "nowen-auth-user:";
 
@@ -905,7 +912,13 @@ function AuthGate() {
   const checkAuth = useCallback(() => {
     const token = getAccessToken();
     if (!token) {
-      setIsAuthenticated(false);
+      if (isMobileLocalMode()) {
+        setUser(getMobileLocalUser());
+        setIsAuthenticated(true);
+      } else {
+        setUser(null);
+        setIsAuthenticated(false);
+      }
       return;
     }
 
@@ -1040,14 +1053,14 @@ function AuthGate() {
           return;
         }
         // 主进程没给 token（lite 模式 / ensureLocalAccount 失败）→ 退回原有判定
-        if (isClientMode && !getServerUrl()) {
+        if (isClientMode && !getServerUrl() && !isMobileLocalMode()) {
           setIsAuthenticated(false);
         } else {
           checkAuth();
         }
       }).catch(() => {
         if (cancelled) return;
-        if (isClientMode && !getServerUrl()) {
+        if (isClientMode && !getServerUrl() && !isMobileLocalMode()) {
           setIsAuthenticated(false);
         } else {
           checkAuth();
@@ -1058,7 +1071,7 @@ function AuthGate() {
 
     // 非桌面端 / 已有 token：走原有逻辑
     // 客户端模式但没有服务器地址：直接显示登录页（含服务器输入框）
-    if (isClientMode && !getServerUrl()) {
+    if (isClientMode && !getServerUrl() && !isMobileLocalMode()) {
       setIsAuthenticated(false);
       return;
     }
@@ -1066,7 +1079,7 @@ function AuthGate() {
   }, [checkAuth, isClientMode]);
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || isMobileLocalMode()) return;
     let cancelled = false;
     let timer: number | undefined;
 
@@ -1182,7 +1195,7 @@ function AuthGate() {
   // 任何登录入口（密码 / 快速登录 / 桌面零登录）最终都会落到 setUser，
   // 这里集中接管，避免每个入口都重复挂钩。失败不阻塞 UI。
   useEffect(() => {
-    if (!user?.id) return;
+    if (!user?.id || isMobileLocalMode()) return;
     void syncBootstrap(user).catch((e) => {
       console.warn("[App] syncBootstrap failed:", e);
     });
@@ -1225,6 +1238,7 @@ function AuthGate() {
   };
 
   const handleLogin = (token: string, userData: User) => {
+    completeMobileAccountLogin();
     saveCachedAuthUser(getAuthCacheScope(getServerUrl()), token, userData);
     setUser(userData);
     setActiveToken(token);
@@ -1262,6 +1276,11 @@ function AuthGate() {
   const handlePasswordLogin = (token: string, userData: User) => {
     setJustPasswordLogin(true);
     handleLogin(token, userData);
+  };
+
+  const handleContinueLocal = () => {
+    continueMobileLocalMode();
+    window.location.reload();
   };
 
   // 加载中
@@ -1303,6 +1322,7 @@ function AuthGate() {
         onAccountLogin={handleLogin}
         isClientMode={isClientMode}
         onDisconnect={isClientMode ? handleDisconnect : undefined}
+        onContinueLocal={isAndroidNativeRuntime() ? handleContinueLocal : undefined}
       />
     );
   }

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -38,6 +38,8 @@ interface LoginPageProps {
   /** 是否为客户端模式（Electron / Android / 曾配置过服务器地址） */
   isClientMode?: boolean;
   onDisconnect?: () => void;
+  /** Android 账号登录页返回设备本地模式。 */
+  onContinueLocal?: () => void;
 }
 
 type Mode = "login" | "register";
@@ -53,7 +55,7 @@ function isMobileNativeClientRuntime(): boolean {
   }
 }
 
-export default function LoginPage({ onLogin, onAccountLogin, isClientMode = false, onDisconnect }: LoginPageProps) {
+export default function LoginPage({ onLogin, onAccountLogin, isClientMode = false, onDisconnect, onContinueLocal }: LoginPageProps) {
   const { t } = useTranslation();
   const { siteConfig } = useSiteSettings();
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -915,6 +917,21 @@ export default function LoginPage({ onLogin, onAccountLogin, isClientMode = fals
             </>
             )}
           </form>
+
+          {!isTwoFactorStep && onContinueLocal && (
+            <div className="mt-4 border-t border-zinc-100 pt-4 dark:border-zinc-800">
+              <button
+                type="button"
+                onClick={onContinueLocal}
+                className="w-full rounded-xl border border-zinc-200 bg-white px-4 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:border-indigo-300 hover:text-indigo-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-indigo-500/50 dark:hover:text-indigo-300"
+              >
+                {t("auth.continueLocal")}
+              </button>
+              <p className="mt-2 text-center text-[11px] leading-5 text-zinc-400 dark:text-zinc-500">
+                {t("auth.localModeNote")}
+              </p>
+            </div>
+          )}
 
           {!isTwoFactorStep && <p className="text-center text-xs text-zinc-400 dark:text-zinc-600 mt-6">
             {isRegister ? t("auth.registerHint") : (hasUsers ? null : t("auth.defaultCredentials"))}

--- a/frontend/src/components/NavRail.tsx
+++ b/frontend/src/components/NavRail.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   ListTodo,
   Link2,
+  LogIn,
   LogOut,
   NotebookPen,
   PanelLeft,
@@ -34,6 +35,7 @@ import {
 import { clearLocalIdMap, clearQueue, getQueueLength } from "@/lib/offlineQueue";
 import { AccountLoginHistoryDialog } from "@/components/AccountLoginHistory";
 import { isAccountLoginHistorySupported } from "@/lib/accountLoginHistory";
+import { isMobileLocalMode, requestMobileAccountLogin } from "@/lib/mobileLocalMode";
 
 type NavGroup = "workspace" | "modules" | "tools";
 
@@ -71,6 +73,7 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
   const effectiveMode = variant === "mobile" ? "icon" : railMode;
   const showLabel = effectiveMode === "label";
   const isMobile = variant === "mobile";
+  const localDeviceMode = isMobileLocalMode();
 
   const [features, setFeatures] = useState<WorkspaceFeatures | null>(null);
   const [showSettings, setShowSettings] = useState(false);
@@ -136,7 +139,10 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
     && (usingDesktopLiteMode || !isLoopbackUrl(serverUrl) || (!!currentOrigin && normalizeUrl(serverUrl) !== normalizeUrl(currentOrigin)));
   const canSwitchBackToLocal = isDesktopApp() && (usingRemoteServer || usingDesktopLiteMode);
 
-  const items = features ? NAV_CONFIG.filter((item) => !item.feature || features[item.feature] !== false) : NAV_CONFIG;
+  const availableItems = features ? NAV_CONFIG.filter((item) => !item.feature || features[item.feature] !== false) : NAV_CONFIG;
+  const items = localDeviceMode
+    ? availableItems.filter((item) => item.mode === "favorites" || item.mode === "trash")
+    : availableItems;
 
   const handleClick = useCallback((mode: ViewMode) => {
     actions.setViewMode(mode);
@@ -189,6 +195,11 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
     }
     window.location.reload();
   }, [canSwitchBackToLocal]);
+
+  const handleAccountLogin = useCallback(() => {
+    requestMobileAccountLogin();
+    window.location.reload();
+  }, []);
 
   const railWidthClass = showLabel ? "w-16" : "w-12";
   const itemBaseClass = showLabel
@@ -272,7 +283,7 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
         {showLabel && <span className="text-[10px] leading-none mt-0.5 max-w-full truncate px-1">{t("sidebar.settings")}</span>}
       </button>
 
-      {isAccountLoginHistorySupported() && (
+      {!localDeviceMode && isAccountLoginHistorySupported() && (
         <button
           data-mobile-drawer-rail-item=""
           onClick={() => setLoginHistoryOpen(true)}
@@ -298,16 +309,29 @@ export default function NavRail({ variant = "desktop" }: { variant?: "desktop" |
         </button>
       )}
 
-      <button
-        data-mobile-drawer-rail-item=""
-        onClick={handleLogout}
-        title={showLabel ? undefined : t("sidebar.logout")}
-        aria-label={t("sidebar.logout")}
-        className={cn(itemBaseClass, "text-tx-tertiary hover:text-accent-danger hover:bg-accent-danger/10")}
-      >
-        <LogOut size={16} />
-        {showLabel && <span className="text-[10px] leading-none mt-0.5 max-w-full truncate px-1">{t("sidebar.logout")}</span>}
-      </button>
+      {localDeviceMode ? (
+        <button
+          data-mobile-drawer-rail-item=""
+          onClick={handleAccountLogin}
+          title={showLabel ? undefined : t("sidebar.loginAndSync")}
+          aria-label={t("sidebar.loginAndSync")}
+          className={cn(itemBaseClass, "text-tx-tertiary hover:bg-app-hover hover:text-accent-primary")}
+        >
+          <LogIn size={16} />
+          {showLabel && <span className="text-[10px] leading-none mt-0.5 max-w-full truncate px-1">{t("sidebar.loginAndSync")}</span>}
+        </button>
+      ) : (
+        <button
+          data-mobile-drawer-rail-item=""
+          onClick={handleLogout}
+          title={showLabel ? undefined : t("sidebar.logout")}
+          aria-label={t("sidebar.logout")}
+          className={cn(itemBaseClass, "text-tx-tertiary hover:text-accent-danger hover:bg-accent-danger/10")}
+        >
+          <LogOut size={16} />
+          {showLabel && <span className="text-[10px] leading-none mt-0.5 max-w-full truncate px-1">{t("sidebar.logout")}</span>}
+        </button>
+      )}
 
       <AnimatePresence>{showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}</AnimatePresence>
       <AccountLoginHistoryDialog open={loginHistoryOpen} onClose={() => setLoginHistoryOpen(false)} />

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { Palette, Shield, Database, X, Settings, Camera, Save, Loader2, Trash2, Upload, Type, Check, ChevronDown, Globe, Bot, Users, Info, ExternalLink, Heart, Sparkles, RefreshCw, ZoomIn, Key, Keyboard, Building2, BookOpen, ToggleLeft, Download, FolderSync, Mail } from "lucide-react";
+import { Palette, Shield, Database, X, Settings, Camera, Save, Loader2, Trash2, Upload, Type, Check, ChevronDown, Globe, Bot, Users, Info, ExternalLink, Heart, Sparkles, RefreshCw, ZoomIn, Key, Keyboard, Building2, BookOpen, ToggleLeft, Download, FolderSync, Mail, Puzzle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import wechatSponsorQr from "@/assets/sponsor/weixin.jpg";
 import alipaySponsorQr from "@/assets/sponsor/zhifubao.png";
@@ -15,6 +15,7 @@ import DataManager from "@/components/DataManager";
 import FolderSyncSettings from "@/components/settings/FolderSyncSettings";
 import SyncSettingsTab from "@/components/settings/SyncSettingsTab";
 import ShortcutSettingsPanel from "@/components/settings/ShortcutSettingsPanel";
+import PluginSettingsTab from "@/components/settings/plugins/PluginSettingsTab";
 import AISettingsPanel from "@/components/AISettingsPanel";
 import UserManagement from "@/components/UserManagement";
 import WorkspaceManagement from "@/components/WorkspaceManagement";
@@ -46,7 +47,7 @@ import {
   type MobileKnowledgeTreeViewMode,
 } from "@/lib/mobileKnowledgeTreeViewMode";
 
-type TabId = "appearance" | "switches" | "shortcuts" | "ai" | "security" | "tokens" | "data" | "sync" | "folderSync" | "users" | "workspaces" | "download" | "about";
+type TabId = "appearance" | "switches" | "shortcuts" | "ai" | "plugins" | "security" | "tokens" | "data" | "sync" | "folderSync" | "users" | "workspaces" | "download" | "about";
 
 interface SettingsModalProps {
   onClose: () => void;
@@ -1585,6 +1586,7 @@ const SettingsModal = React.forwardRef<HTMLDivElement, SettingsModalProps>(
     { id: "switches" as const, label: t('settings.switches'), icon: ToggleLeft },
     ...(shortcutSurface !== "android" ? [{ id: "shortcuts" as const, label: "快捷键", icon: Keyboard }] : []),
     { id: "ai" as const, label: t('settings.ai'), icon: Bot },
+    { id: "plugins" as const, label: "插件", icon: Puzzle },
     { id: "security" as const, label: t('settings.security'), icon: Shield },
     // 【个人访问令牌】任意登录用户都可管理自己的 token；与 security 同为"账号安全"类别，
     // 不需要 isAdmin 判定。
@@ -1783,6 +1785,7 @@ const SettingsModal = React.forwardRef<HTMLDivElement, SettingsModalProps>(
             {activeTab === "switches" && <SwitchesPanel />}
             {activeTab === "shortcuts" && shortcutSurface !== "android" && <ShortcutSettingsPanel />}
             {activeTab === "ai" && <AISettingsPanel />}
+            {activeTab === "plugins" && <PluginSettingsTab isAdmin={isAdmin} />}
             {activeTab === "security" && <SecuritySettings />}
             {activeTab === "tokens" && <TokenManagement />}
                   {activeTab === "users" && isAdmin && <UserManagement currentUserId={currentUser?.id ?? null} />}

--- a/frontend/src/components/settings/plugins/PluginSettingsTab.tsx
+++ b/frontend/src/components/settings/plugins/PluginSettingsTab.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import JSZip from "jszip";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Code2, Loader2, PackagePlus, Play, RefreshCw, Trash2 } from "lucide-react";
+import { pluginApi, type InstalledPlugin, type PluginAction } from "@/lib/pluginApi";
+
+const permissionLabels: Record<string, string> = {
+  "notes:read": "读取笔记", "notes:write": "创建和修改笔记",
+  "notebooks:read": "读取笔记本", "notebooks:write": "创建和修改笔记本",
+  "tags:read": "读取标签", "tags:write": "创建和修改标签",
+  "tasks:read": "读取任务", "tasks:write": "创建和修改任务",
+  "attachments:read": "读取附件信息", "attachments:write": "创建和修改附件",
+  "plugin-storage:read": "读取插件自己的数据", "plugin-storage:write": "保存插件自己的数据",
+  "external:fetch": "访问声明的外部网络服务", "secrets:use": "使用你配置的连接密钥（插件看不到原值）",
+  "diary:read": "读取日记", "diary:write": "创建和修改日记",
+  "mindmaps:read": "读取思维导图", "mindmaps:write": "创建和修改思维导图",
+};
+
+type PendingPackage = { file: File; manifest: any };
+
+function statusLabel(status: InstalledPlugin["status"]): string {
+  return ({ quarantined: "待确认", disabled: "已禁用", enabled: "已启用", error: "运行错误", incompatible: "不兼容" })[status];
+}
+
+function ActionTester({ plugin, action }: { plugin: InstalledPlugin; action: PluginAction }) {
+  const initial = useMemo(() => Object.fromEntries(Object.entries(action.input || {}).map(([key, field]) => [key, field.type === "boolean" ? false : field.type === "number" ? 0 : ""])), [action]);
+  const [input, setInput] = useState(JSON.stringify(initial, null, 2));
+  const [result, setResult] = useState("");
+  const [running, setRunning] = useState(false);
+  const run = async () => {
+    setRunning(true); setResult("");
+    try { setResult(JSON.stringify(await pluginApi.execute(plugin.id, action.id, JSON.parse(input)), null, 2)); }
+    catch (error) { setResult(error instanceof Error ? error.message : String(error)); }
+    finally { setRunning(false); }
+  };
+  return <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 space-y-2">
+    <div><div className="text-sm font-medium">{action.name}</div><div className="text-xs text-zinc-500">{action.description || action.id}</div></div>
+    <textarea value={input} onChange={(event) => setInput(event.target.value)} className="w-full min-h-24 rounded-md border border-zinc-200 dark:border-zinc-700 bg-transparent p-2 font-mono text-xs" aria-label={`${action.name} 参数`} />
+    <button onClick={run} disabled={running || plugin.status !== "enabled"} className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"><Play size={13} />{running ? "执行中" : "执行"}</button>
+    {result && <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-md bg-zinc-100 dark:bg-zinc-900 p-2 text-xs">{result}</pre>}
+  </div>;
+}
+
+function PluginCard({ plugin, isAdmin, refresh }: { plugin: InstalledPlugin; isAdmin: boolean; refresh: () => Promise<void> }) {
+  const [expanded, setExpanded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [executions, setExecutions] = useState<any[]>([]);
+  const act = async (operation: () => Promise<unknown>) => { setBusy(true); try { await operation(); await refresh(); } catch (error) { window.alert(error instanceof Error ? error.message : String(error)); } finally { setBusy(false); } };
+  const toggleDetails = async () => { const next = !expanded; setExpanded(next); if (next) setExecutions(await pluginApi.executions(plugin.id).catch(() => [])); };
+  return <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 p-4 space-y-3">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0"><h3 className="font-semibold text-zinc-900 dark:text-zinc-100">🧩 {plugin.name}</h3><p className="font-mono text-[11px] text-zinc-400 truncate">{plugin.id}</p><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{plugin.description}</p></div>
+      <span className={`shrink-0 rounded-full px-2 py-1 text-[11px] ${plugin.status === "enabled" ? "bg-emerald-500/15 text-emerald-600" : plugin.status === "error" ? "bg-red-500/15 text-red-600" : "bg-amber-500/15 text-amber-600"}`}>{statusLabel(plugin.status)}</span>
+    </div>
+    <div className="text-xs text-zinc-500">v{plugin.version} · {plugin.trustLevel} · {plugin.actions.length} Actions</div>
+    <div className="flex flex-wrap gap-2">
+      <button onClick={toggleDetails} className="inline-flex items-center gap-1 rounded-md border border-zinc-200 dark:border-zinc-700 px-2.5 py-1.5 text-xs">详情 {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}</button>
+      {isAdmin && plugin.status === "enabled" && <button disabled={busy} onClick={() => act(() => pluginApi.disable(plugin.id))} className="rounded-md border px-2.5 py-1.5 text-xs">禁用</button>}
+      {isAdmin && plugin.status !== "enabled" && <button disabled={busy} onClick={() => act(async () => { await pluginApi.grant(plugin.id, plugin.permissions.map((item) => item.permission)); await pluginApi.enable(plugin.id); })} className="rounded-md bg-indigo-600 px-2.5 py-1.5 text-xs text-white">确认权限并启用</button>}
+      {isAdmin && <button disabled={busy} onClick={() => act(() => pluginApi.reload(plugin.id))} className="rounded-md border px-2.5 py-1.5 text-xs disabled:opacity-40"><RefreshCw size={12} /></button>}
+      {isAdmin && <button disabled={busy} onClick={() => window.confirm(`确定卸载 ${plugin.name}？`) && act(() => pluginApi.uninstall(plugin.id))} className="rounded-md border border-red-200 px-2.5 py-1.5 text-xs text-red-600"><Trash2 size={12} /></button>}
+    </div>
+    {expanded && <div className="space-y-4 border-t border-zinc-200 dark:border-zinc-800 pt-3">
+      <div><h4 className="mb-2 text-xs font-semibold">权限</h4><ul className="space-y-1">{plugin.permissions.length ? plugin.permissions.map((item) => <li key={item.permission} className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400">{item.granted ? <CheckCircle2 size={13} className="text-emerald-500" /> : <AlertTriangle size={13} className="text-amber-500" />}{permissionLabels[item.permission] || item.permission}<span className="ml-auto font-mono text-[10px] text-zinc-400">{item.permission}</span></li>) : <li className="text-xs text-zinc-500">不请求数据权限</li>}</ul></div>
+      <div className="space-y-2"><h4 className="text-xs font-semibold">Actions</h4>{plugin.actions.map((action) => <ActionTester key={action.id} plugin={plugin} action={action} />)}</div>
+      <div><h4 className="mb-2 text-xs font-semibold">最近执行</h4>{executions.length ? <div className="max-h-48 overflow-auto space-y-1">{executions.map((item) => <div key={item.id} className="rounded bg-zinc-100 dark:bg-zinc-900 p-2 text-[11px]"><span className="font-mono">{item.actionId}</span> · {item.status} · {item.durationMs ?? "—"}ms{item.errorMessage && <div className="mt-1 text-red-500">{item.errorMessage}</div>}</div>)}</div> : <p className="text-xs text-zinc-500">暂无执行记录</p>}</div>
+    </div>}
+  </div>;
+}
+
+export default function PluginSettingsTab({ isAdmin }: { isAdmin: boolean }) {
+  const [plugins, setPlugins] = useState<InstalledPlugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState<PendingPackage | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [developerMode, setDeveloperMode] = useState(false);
+  const [developerModeAvailable, setDeveloperModeAvailable] = useState(false);
+  const [devDirectory, setDevDirectory] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const refresh = useCallback(async () => { setPlugins(await pluginApi.list()); setLoading(false); }, []);
+  useEffect(() => { void refresh().catch(() => setLoading(false)); if (isAdmin) void pluginApi.getDeveloperMode().then((value) => { setDeveloperMode(value.enabled); setDeveloperModeAvailable(value.available); }).catch(() => {}); }, [isAdmin, refresh]);
+  const choosePackage = async (file?: File) => {
+    if (!file) return;
+    try {
+      const zip = await JSZip.loadAsync(file);
+      const manifestFile = zip.file("manifest.json");
+      if (!manifestFile) throw new Error("插件包缺少 manifest.json");
+      setPending({ file, manifest: JSON.parse(await manifestFile.async("string")) });
+    } catch (error) { window.alert(error instanceof Error ? error.message : String(error)); }
+  };
+  const install = async () => { if (!pending) return; setInstalling(true); try { await pluginApi.install(pending.file); setPending(null); await refresh(); } catch (error) { window.alert(error instanceof Error ? error.message : String(error)); } finally { setInstalling(false); } };
+  return <div className="space-y-5">
+    <div className="flex items-start justify-between gap-3"><div><h2 className="text-xl font-bold">插件</h2><p className="mt-1 text-sm text-zinc-500">服务端 Action 插件在独立进程中运行，移动端只会远程调用，不会在本机加载 Node 代码。</p></div>{isAdmin && <><input ref={inputRef} type="file" accept=".nowen-plugin" className="hidden" onChange={(event) => void choosePackage(event.target.files?.[0])} /><button onClick={() => inputRef.current?.click()} className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white"><PackagePlus size={14} />安装插件</button></>}</div>
+    {loading ? <div className="flex items-center gap-2 py-12 text-sm text-zinc-500"><Loader2 className="animate-spin" size={16} />正在加载插件</div> : plugins.length ? <div className="grid gap-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} isAdmin={isAdmin} refresh={refresh} />)}</div> : <div className="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 py-12 text-center text-sm text-zinc-500">尚未安装插件</div>}
+    {isAdmin && developerModeAvailable && <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4 space-y-3"><div className="flex items-center justify-between"><div><h3 className="flex items-center gap-2 text-sm font-semibold"><Code2 size={15} />开发者模式</h3><p className="mt-1 text-xs text-zinc-500">仅加载你信任的本地开发目录；开发插件不进入备份。</p></div><input type="checkbox" checked={developerMode} onChange={async (event) => { const enabled = event.target.checked; await pluginApi.setDeveloperMode(enabled); setDeveloperMode(enabled); }} /></div>{developerMode && <div className="flex gap-2"><input value={devDirectory} onChange={(event) => setDevDirectory(event.target.value)} placeholder="D:\\Projects\\nowen-plugin-test" className="min-w-0 flex-1 rounded-md border border-zinc-200 dark:border-zinc-700 bg-transparent px-3 py-2 text-xs" /><button onClick={async () => { await pluginApi.loadDevelopment(devDirectory); await refresh(); }} className="rounded-md border px-3 py-2 text-xs">加载开发插件</button></div>}</div>}
+    {pending && <div className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/60 p-4"><div className="w-full max-w-lg rounded-2xl bg-white dark:bg-zinc-950 p-5 shadow-2xl space-y-4"><div><h3 className="text-lg font-bold">安装 {pending.manifest.name || "社区插件"}</h3><p className="mt-1 font-mono text-xs text-zinc-500">{pending.manifest.id} · v{pending.manifest.version}</p></div><div className="rounded-lg border border-amber-300/60 bg-amber-50 dark:bg-amber-950/20 p-3 text-sm text-amber-800 dark:text-amber-300"><div className="flex gap-2"><AlertTriangle className="mt-0.5 shrink-0" size={16} /><span>此插件包含第三方可执行代码。Node 子进程提供故障隔离，但不是真正安全沙箱；请仅安装你信任的来源。</span></div></div><div><h4 className="mb-2 text-sm font-semibold">它希望获得：</h4><ul className="space-y-1 text-sm">{pending.manifest.permissions?.length ? pending.manifest.permissions.map((permission: string) => <li key={permission}>✓ {permissionLabels[permission] || permission}</li>) : <li className="text-zinc-500">不请求数据权限</li>}</ul>{pending.manifest.permissionConfig?.externalFetchHosts?.length > 0 && <p className="mt-2 text-xs text-zinc-500">网络访问：{pending.manifest.permissionConfig.externalFetchHosts.join(", ")}</p>}</div><p className="text-xs text-zinc-500">安装后默认进入隔离状态；你需要再次确认权限并启用。</p><div className="flex justify-end gap-2"><button onClick={() => setPending(null)} className="rounded-md border px-3 py-2 text-sm">取消</button><button disabled={installing} onClick={install} className="rounded-md bg-indigo-600 px-3 py-2 text-sm text-white disabled:opacity-50">{installing ? "正在验证" : "信任并安装"}</button></div></div></div>}
+  </div>;
+}

--- a/frontend/src/hooks/useUserPreferences.tsx
+++ b/frontend/src/hooks/useUserPreferences.tsx
@@ -28,6 +28,7 @@ import {
   type UserPreferencePatch,
   type UserPreferences,
 } from "@/lib/userPreferenceAccountCache";
+import { isMobileLocalMode, MOBILE_LOCAL_USER_ID } from "@/lib/mobileLocalMode";
 
 export type {
   CodeBlockThemeId,
@@ -67,6 +68,7 @@ const UserPreferencesContext = createContext<UserPreferencesContextValue>({
 
 function currentIdentity(): { token: string; userId: string } | null {
   try {
+    if (isMobileLocalMode()) return { token: "device-local", userId: MOBILE_LOCAL_USER_ID };
     const token = localStorage.getItem("nowen-token") || "";
     const userId = decodeUserIdFromToken(token);
     return token && userId ? { token, userId } : null;
@@ -235,6 +237,11 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
       return;
     }
 
+    if (isMobileLocalMode()) {
+      resetForIdentity(identity.userId);
+      return;
+    }
+
     const { userId } = identity;
     const cachedAtStart = resetForIdentity(userId);
 
@@ -317,7 +324,8 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
       if (!identity) return next;
 
       const existing = readAccountPreferenceCache(localStorage, identity.userId);
-      const pending: UserPreferencePatch = {
+      const localOnly = isMobileLocalMode();
+      const pending: UserPreferencePatch = localOnly ? {} : {
         ...(existing?.pending || pendingRef.current),
         [key]: value,
       };
@@ -332,7 +340,7 @@ export function UserPreferencesProvider({ children }: { children: React.ReactNod
       activeUserIdRef.current = identity.userId;
       revisionRef.current = cache.revision;
       pendingRef.current = pending;
-      void persistPatch(identity.userId, { [key]: value } as UserPreferencePatch);
+      if (!localOnly) void persistPatch(identity.userId, { [key]: value } as UserPreferencePatch);
       return next;
     });
   }, [persistPatch]);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -53,6 +53,8 @@
     "serverHint": "Pick a protocol and enter host and port (port is optional)",
     "serverRequired": "Server address is required",
     "resetServer": "Clear server config",
+    "continueLocal": "Continue in local mode",
+    "localModeNote": "Local notes stay on this device. Sign in only when you want to connect and sync.",
     "clientNote": "Make sure the server is running and reachable from this device",
     "ugreenAccess": {
       "title": "UGREEN authentication required",
@@ -178,6 +180,7 @@
     "noTags": "No tags",
     "settings": "Settings",
     "logout": "Logout",
+    "loginAndSync": "Sign in and sync",
     "accountMenu": "Account",
     "currentLocalAccount": "Current: local account",
     "currentCloudAccount": "Current: cloud account",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -53,6 +53,8 @@
     "serverHint": "选择协议、填写主机和端口（端口可留空走默认值）",
     "serverRequired": "请输入服务器地址",
     "resetServer": "清除服务器配置",
+    "continueLocal": "继续使用本地模式",
+    "localModeNote": "本地笔记只保存在此设备；登录账号后才会连接服务器并同步。",
     "clientNote": "请确保服务器已启动且网络可达，客户端通过 HTTP 连接到服务器",
     "ugreenAccess": {
       "title": "此地址需要绿联认证",
@@ -183,6 +185,7 @@
     "noTags": "暂无标签",
     "settings": "设置",
     "logout": "退出登录",
+    "loginAndSync": "登录并同步",
     "accountMenu": "账号",
     "currentLocalAccount": "当前：本地账号",
     "currentCloudAccount": "当前：云端账号",

--- a/frontend/src/lib/__tests__/androidNativeHttpBridge.test.ts
+++ b/frontend/src/lib/__tests__/androidNativeHttpBridge.test.ts
@@ -26,6 +26,8 @@ describe("androidNativeHttpBridge", () => {
   let browserFetch: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    localStorage.clear();
+    delete (window as any).Capacitor;
     capacitorState.native = true;
     capacitorState.platform = "android";
     capacitorState.request.mockReset();
@@ -143,6 +145,20 @@ describe("androidNativeHttpBridge", () => {
 
     expect(capacitorState.request).not.toHaveBeenCalled();
     expect(browserFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks every API transport while Android is in unsigned local mode", async () => {
+    (window as any).Capacitor = {
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      platform: "android",
+    };
+    cleanup = installAndroidNativeHttpBridge();
+
+    await expect(fetch("https://note.example.com/api/attachments/file-1/download"))
+      .rejects.toMatchObject({ code: "MOBILE_LOCAL_ONLY" });
+    expect(capacitorState.request).not.toHaveBeenCalled();
+    expect(browserFetch).not.toHaveBeenCalled();
   });
 
   it("does not intercept non-API resources", async () => {

--- a/frontend/src/lib/__tests__/mobileLocalApiIsolation.test.ts
+++ b/frontend/src/lib/__tests__/mobileLocalApiIsolation.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api.impl";
+import { MobileLocalModeRemoteRequestError } from "@/lib/mobileLocalMode";
+
+describe("Android 本地模式远程 API 隔离", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (window as any).Capacitor = {
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      platform: "android",
+    };
+  });
+
+  it("未登录时在发出网络请求前拒绝非本地 API", async () => {
+    const network = vi.spyOn(globalThis, "fetch");
+
+    await expect(api.getMe()).rejects.toBeInstanceOf(MobileLocalModeRemoteRequestError);
+    expect(network).not.toHaveBeenCalled();
+
+    network.mockRestore();
+  });
+});

--- a/frontend/src/lib/__tests__/mobileLocalFirstGuestRuntime.test.ts
+++ b/frontend/src/lib/__tests__/mobileLocalFirstGuestRuntime.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const repository = {
+    warmAttachmentUrls: vi.fn(async () => undefined),
+    exportWorkspaceScope: vi.fn(async () => ({ version: 1 })),
+  };
+  const db = { close: vi.fn(async () => undefined) };
+  return {
+    repository,
+    db,
+    openNativeDatabase: vi.fn(async () => db),
+    createNativeAttachmentStore: vi.fn(async () => ({})),
+    createNativeLocalRepository: vi.fn(() => repository),
+    createMobileSyncEngine: vi.fn(),
+    installMobileLocalFirstBridge: vi.fn(() => vi.fn()),
+    setLocalRepository: vi.fn(),
+    setSyncLocalAdminAdapter: vi.fn(),
+    setCurrentUser: vi.fn(),
+    setCurrentWorkspace: vi.fn(),
+  };
+});
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => true, getPlatform: () => "android" },
+}));
+vi.mock("@/lib/api.impl", () => ({
+  getCurrentWorkspace: () => "personal",
+  getServerUrl: () => "",
+  setCurrentWorkspace: mocks.setCurrentWorkspace,
+  SERVER_URL_CHANGED_EVENT: "nowen:server-url-changed",
+}));
+vi.mock("@/lib/authSession", () => ({ getAccessToken: () => null }));
+vi.mock("@/lib/localStore", () => ({
+  getAllNotebooks: vi.fn(async () => []),
+  getAllNotes: vi.fn(async () => []),
+  getAllOfflineAttachmentJobs: vi.fn(async () => []),
+  getAllTags: vi.fn(async () => []),
+  getOfflineAttachmentsByNote: vi.fn(async () => []),
+  setCurrentUser: mocks.setCurrentUser,
+}));
+vi.mock("@/lib/mobileLocalFirstBridge", () => ({ installMobileLocalFirstBridge: mocks.installMobileLocalFirstBridge }));
+vi.mock("@/lib/mobileSyncEngine", () => ({ createMobileSyncEngine: mocks.createMobileSyncEngine }));
+vi.mock("@/lib/nativeAttachmentStore", () => ({ createNativeAttachmentStore: mocks.createNativeAttachmentStore }));
+vi.mock("@/lib/nativeDatabase", () => ({ openNativeDatabase: mocks.openNativeDatabase }));
+vi.mock("@/lib/nativeLocalRepository", () => ({ createNativeLocalRepository: mocks.createNativeLocalRepository }));
+vi.mock("@/lib/localRepository", () => ({ newLocalId: () => "local-id", setLocalRepository: mocks.setLocalRepository }));
+vi.mock("@/lib/offlineQueue", () => ({ clearQueue: vi.fn(), getQueue: vi.fn(() => []) }));
+vi.mock("@/lib/syncLocalApi", () => ({
+  setSyncLocalAdminAdapter: mocks.setSyncLocalAdminAdapter,
+  SYNC_CONFLICT_ENTITY_TYPES: [],
+}));
+
+import { initializeMobileLocalFirstRuntime } from "@/lib/mobileLocalFirstRuntime";
+
+describe("Android 本地优先游客运行时", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (window as any).Capacitor = {
+      isNativePlatform: () => true,
+      getPlatform: () => "android",
+      platform: "android",
+    };
+  });
+
+  it("无 token 仍打开独立 SQLite，但不创建同步引擎", async () => {
+    await initializeMobileLocalFirstRuntime();
+
+    expect(mocks.openNativeDatabase).toHaveBeenCalledWith("android-device-local");
+    expect(mocks.setCurrentUser).toHaveBeenCalledWith("android-local-user");
+    expect(mocks.setCurrentWorkspace).toHaveBeenCalledWith("personal");
+    expect(mocks.createNativeLocalRepository).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: "android-device-local",
+      userId: "android-local-user",
+    }));
+    expect(mocks.installMobileLocalFirstBridge).toHaveBeenCalledWith(mocks.repository);
+    expect(mocks.setSyncLocalAdminAdapter).toHaveBeenCalledWith(expect.any(Function));
+    expect(mocks.createMobileSyncEngine).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/mobileLocalMode.test.ts
+++ b/frontend/src/lib/__tests__/mobileLocalMode.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  completeMobileAccountLogin,
+  continueMobileLocalMode,
+  getMobileLocalUser,
+  isMobileLocalMode,
+  requestMobileAccountLogin,
+} from "@/lib/mobileLocalMode";
+
+function installCapacitor(platform: string, native = true): void {
+  (window as any).Capacitor = {
+    isNativePlatform: () => native,
+    getPlatform: () => platform,
+    platform,
+  };
+}
+
+describe("Android 未登录本地模式", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installCapacitor("android");
+  });
+
+  it("Android 无 token 时默认进入稳定的设备本地账号", () => {
+    expect(isMobileLocalMode()).toBe(true);
+    expect(getMobileLocalUser()).toMatchObject({
+      id: "android-local-user",
+      username: "local",
+      displayName: "本地用户",
+    });
+  });
+
+  it("用户主动进入登录页后暂停本地模式，返回后恢复", () => {
+    requestMobileAccountLogin();
+    expect(isMobileLocalMode()).toBe(false);
+
+    continueMobileLocalMode();
+    expect(isMobileLocalMode()).toBe(true);
+  });
+
+  it("登录成功或已有 token 时不再使用本地账号", () => {
+    requestMobileAccountLogin();
+    completeMobileAccountLogin();
+    localStorage.setItem("nowen-token", "signed-in-token");
+    expect(isMobileLocalMode()).toBe(false);
+  });
+
+  it("不会改变 Web 和 iOS 的既有登录流程", () => {
+    installCapacitor("web", false);
+    expect(isMobileLocalMode()).toBe(false);
+
+    installCapacitor("ios");
+    expect(isMobileLocalMode()).toBe(false);
+  });
+});

--- a/frontend/src/lib/androidNativeHttpBridge.ts
+++ b/frontend/src/lib/androidNativeHttpBridge.ts
@@ -1,4 +1,5 @@
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
+import { isMobileLocalMode, MobileLocalModeRemoteRequestError } from "./mobileLocalMode";
 
 const BRIDGE_FLAG = "__nowenAndroidNativeHttpBridgeInstalled";
 const DEFAULT_NATIVE_TIMEOUT_MS = 30_000;
@@ -230,6 +231,16 @@ export function installAndroidNativeHttpBridge(
   const nativeTimeoutMs = Math.max(1000, options.nativeTimeoutMs ?? DEFAULT_NATIVE_TIMEOUT_MS);
 
   const bridgedFetch: FetchFn = async (input, init) => {
+    if (isMobileLocalMode()) {
+      try {
+        const url = new URL(getRequestUrl(input), window.location.href);
+        if (/(?:^|\/)api(?:\/|$)/.test(url.pathname)) {
+          throw new MobileLocalModeRemoteRequestError(url.pathname);
+        }
+      } catch (error) {
+        if (error instanceof MobileLocalModeRemoteRequestError) throw error;
+      }
+    }
     if (!shouldUseAndroidNativeHttp(input, init)) {
       return originalFetch(input, init);
     }

--- a/frontend/src/lib/api.impl.ts
+++ b/frontend/src/lib/api.impl.ts
@@ -61,11 +61,16 @@ import {
   getRefreshToken,
   storeAuthTokens,
 } from "@/lib/authSession";
+import { isMobileLocalMode, MobileLocalModeRemoteRequestError } from "@/lib/mobileLocalMode";
 
 // 本模块所有显式携带 Authorization 的请求共享同一套 401 刷新与单飞锁；
 // 公共请求不带 Authorization，authSession 会原样透传。
-const fetch: typeof globalThis.fetch = (input, init) =>
-  fetchWithAuthRefresh(input, init, getBaseUrl());
+const fetch: typeof globalThis.fetch = (input, init) => {
+  if (isMobileLocalMode()) {
+    return Promise.reject(new MobileLocalModeRemoteRequestError(String(input)));
+  }
+  return fetchWithAuthRefresh(input, init, getBaseUrl());
+};
 
 function protectNoteMutationPayload<T extends Partial<Note>>(
   data: T,
@@ -739,6 +744,9 @@ interface RequestOptions extends RequestInit {
 }
 
 async function request<T>(url: string, options?: RequestOptions): Promise<T> {
+  if (isMobileLocalMode()) {
+    throw new MobileLocalModeRemoteRequestError(url);
+  }
   const token = getToken();
   const { sudoToken, _skipOfflineQueue, ...restOptions } = options || {};
   const fullUrl = `${getBaseUrl()}${url}`;

--- a/frontend/src/lib/mobileLocalFirstBridge.ts
+++ b/frontend/src/lib/mobileLocalFirstBridge.ts
@@ -2,6 +2,7 @@ import { api } from "./api";
 import { newLocalId } from "./localRepository";
 import type { NativeLocalRepository } from "./nativeLocalRepository";
 import type { Note, Notebook, Tag, Workspace } from "@/types";
+import { isMobileLocalMode } from "./mobileLocalMode";
 
 let installed = false;
 
@@ -149,12 +150,12 @@ export function installMobileLocalFirstBridge(repository: NativeLocalRepository)
     const url = await repository.attachments.resolveUrl(id);
     return {
       ...record,
-      url: url || `/api/attachments/${id}`,
+      url: url || (isMobileLocalMode() ? "about:blank" : `/api/attachments/${id}`),
       category: record.mimeType.startsWith("image/") ? "image" : "file",
     };
   };
   target.attachments.urlFor = (id: string) =>
-    repository.getCachedAttachmentUrl(id) || originals.attachmentUrlFor(id);
+    repository.getCachedAttachmentUrl(id) || (isMobileLocalMode() ? "about:blank" : originals.attachmentUrlFor(id));
   target.attachments.remove = async (id: string) => {
     await repository.attachments.remove(id);
     return { success: true };

--- a/frontend/src/lib/mobileLocalFirstRuntime.ts
+++ b/frontend/src/lib/mobileLocalFirstRuntime.ts
@@ -1,5 +1,5 @@
 import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
-import { getCurrentWorkspace, getServerUrl, SERVER_URL_CHANGED_EVENT } from "./api.impl";
+import { getCurrentWorkspace, getServerUrl, setCurrentWorkspace, SERVER_URL_CHANGED_EVENT } from "./api.impl";
 import { getAccessToken } from "./authSession";
 import {
   getAllNotebooks,
@@ -19,6 +19,13 @@ import { newLocalId, setLocalRepository } from "./localRepository";
 import { clearQueue, getQueue } from "./offlineQueue";
 import { setSyncLocalAdminAdapter, SYNC_CONFLICT_ENTITY_TYPES } from "./syncLocalApi";
 import type { NativeLocalRepository } from "./nativeLocalRepository";
+import {
+  MOBILE_LOCAL_ACCOUNT_ID,
+  MOBILE_LOCAL_MODE_CHANGED_EVENT,
+  MOBILE_LOCAL_USER_ID,
+  MobileLocalModeRemoteRequestError,
+  isMobileLocalMode,
+} from "./mobileLocalMode";
 
 const MIGRATION_KEY = "indexeddbMigrationV1";
 const QUEUE_MIGRATION_KEY = "legacyOfflineQueueMigrationV1";
@@ -29,7 +36,7 @@ const TOKEN_PREFIX = "nowen.localFirst.token.";
 interface RuntimeHandle {
   identity: string;
   db: NativeDatabase;
-  engine: MobileSyncEngine;
+  engine?: MobileSyncEngine;
   restoreBridge: () => void;
   removeListeners: Array<() => Promise<void> | void>;
 }
@@ -357,11 +364,71 @@ function createNativeAdminAdapter(
   };
 }
 
+function createDeviceOnlyAdminAdapter(repository: NativeLocalRepository) {
+  return async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const method = (init?.method || "GET").toUpperCase();
+    if (path === "/settings" && method === "GET") {
+      return {
+        mode: "device-only",
+        activeProfile: null,
+        profiles: [],
+        authorized: false,
+        authorizationState: "missing",
+        engineRunning: false,
+      } as T;
+    }
+    if (path === "/settings/disable" && method === "POST") {
+      return {
+        mode: "device-only",
+        retainedPendingMutations: 0,
+        message: "当前已是设备本地模式。",
+      } as T;
+    }
+    if (path === "/engine") {
+      return {
+        running: false,
+        state: "disabled",
+        pendingCount: 0,
+        conflictCount: 0,
+        lastError: null,
+        localAuthoritative: true,
+      } as T;
+    }
+    if (path === "/sync-now" && method === "POST") {
+      return { engineRunning: false, message: "登录账号后才能同步。" } as T;
+    }
+    if (path === "/diagnostics") {
+      return {
+        profileId: null,
+        serverUrl: null,
+        deviceId: null,
+        lastSeenAt: null,
+        localCursor: 0,
+        lastSyncAt: null,
+        lastError: null,
+        pendingMutations: 0,
+        conflictCount: 0,
+        pendingSample: [],
+      } as T;
+    }
+    if (path === "/scopes") return { items: [] } as T;
+    if (path === "/conflicts") return { total: 0, items: [] } as T;
+    if (new URL(path, "http://localhost").pathname === "/conflicts/history") {
+      return { total: 0, limit: 20, offset: 0, hasMore: false, items: [] } as T;
+    }
+    const exportMatch = path.match(/^\/scopes\/([^/]+)\/export$/);
+    if (exportMatch && method === "GET") {
+      return await repository.exportWorkspaceScope(decodeURIComponent(exportMatch[1])) as T;
+    }
+    throw new MobileLocalModeRemoteRequestError(`/sync/local${path}`);
+  };
+}
+
 async function disposeActive(): Promise<void> {
   const current = active;
   active = null;
   if (!current) return;
-  current.engine.stop();
+  current.engine?.stop();
   for (const remove of current.removeListeners) await remove();
   current.restoreBridge();
   setLocalRepository(null);
@@ -371,6 +438,37 @@ async function disposeActive(): Promise<void> {
 
 async function configureRuntime(): Promise<void> {
   if (!Capacitor.isNativePlatform()) return;
+  if (isMobileLocalMode()) {
+    const identity = `local\n${MOBILE_LOCAL_ACCOUNT_ID}`;
+    if (active?.identity === identity) return;
+    await disposeActive();
+    setCurrentUser(MOBILE_LOCAL_USER_ID);
+    setCurrentWorkspace("personal");
+    const db = await openNativeDatabase(MOBILE_LOCAL_ACCOUNT_ID);
+    let restoreBridge: () => void = () => undefined;
+    try {
+      const attachmentStore = await createNativeAttachmentStore(MOBILE_LOCAL_ACCOUNT_ID);
+      const repository = createNativeLocalRepository({
+        db,
+        attachments: attachmentStore,
+        accountId: MOBILE_LOCAL_ACCOUNT_ID,
+        userId: MOBILE_LOCAL_USER_ID,
+        getScopeKey: () => "personal",
+      });
+      await repository.warmAttachmentUrls();
+      setLocalRepository(repository);
+      setSyncLocalAdminAdapter(createDeviceOnlyAdminAdapter(repository));
+      restoreBridge = installMobileLocalFirstBridge(repository);
+      active = { identity, db, restoreBridge, removeListeners: [] };
+    } catch (error) {
+      restoreBridge();
+      setLocalRepository(null);
+      setSyncLocalAdminAdapter(null);
+      await db.close().catch(() => undefined);
+      throw error;
+    }
+    return;
+  }
   const token = getAccessToken();
   const userId = token ? decodeUserId(token) : null;
   const serverUrl = getServerUrl().replace(/\/+$/, "");
@@ -446,6 +544,7 @@ export async function initializeMobileLocalFirstRuntime(): Promise<void> {
     globalListenersInstalled = true;
     window.addEventListener("nowen:token-changed",scheduleConfigure);
     window.addEventListener(SERVER_URL_CHANGED_EVENT,scheduleConfigure);
+    window.addEventListener(MOBILE_LOCAL_MODE_CHANGED_EVENT,scheduleConfigure);
   }
   scheduleConfigure();
   await lifecycle;

--- a/frontend/src/lib/mobileLocalMode.ts
+++ b/frontend/src/lib/mobileLocalMode.ts
@@ -1,0 +1,76 @@
+import type { User } from "@/types";
+
+const LOGIN_REQUESTED_KEY = "nowen-mobile-account-login-requested";
+
+export const MOBILE_LOCAL_ACCOUNT_ID = "android-device-local";
+export const MOBILE_LOCAL_USER_ID = "android-local-user";
+export const MOBILE_LOCAL_MODE_CHANGED_EVENT = "nowen:mobile-local-mode-changed";
+
+export function isAndroidNativeRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const capacitor = (window as any).Capacitor;
+    const native = !!capacitor?.isNativePlatform?.()
+      || (!!capacitor?.platform && capacitor.platform !== "web");
+    const platform = capacitor?.getPlatform?.() || capacitor?.platform;
+    return native && platform === "android";
+  } catch {
+    return false;
+  }
+}
+
+function hasAccessToken(): boolean {
+  try {
+    return !!localStorage.getItem("nowen-token");
+  } catch {
+    return false;
+  }
+}
+
+export function isMobileLocalMode(): boolean {
+  if (!isAndroidNativeRuntime() || hasAccessToken()) return false;
+  try {
+    return localStorage.getItem(LOGIN_REQUESTED_KEY) !== "1";
+  } catch {
+    return true;
+  }
+}
+
+function notifyModeChanged(): void {
+  try { window.dispatchEvent(new Event(MOBILE_LOCAL_MODE_CHANGED_EVENT)); } catch { /* ignore */ }
+}
+
+export function requestMobileAccountLogin(): void {
+  try { localStorage.setItem(LOGIN_REQUESTED_KEY, "1"); } catch { /* ignore */ }
+  notifyModeChanged();
+}
+
+export function continueMobileLocalMode(): void {
+  try { localStorage.removeItem(LOGIN_REQUESTED_KEY); } catch { /* ignore */ }
+  notifyModeChanged();
+}
+
+export function completeMobileAccountLogin(): void {
+  try { localStorage.removeItem(LOGIN_REQUESTED_KEY); } catch { /* ignore */ }
+}
+
+export function getMobileLocalUser(): User {
+  return {
+    id: MOBILE_LOCAL_USER_ID,
+    username: "local",
+    displayName: "本地用户",
+    email: null,
+    avatarUrl: null,
+    role: "user",
+    createdAt: new Date(0).toISOString(),
+  };
+}
+
+export class MobileLocalModeRemoteRequestError extends Error {
+  readonly code = "MOBILE_LOCAL_ONLY";
+
+  constructor(path: string) {
+    super(`Android 本地模式不会访问服务器：${path}`);
+    this.name = "MobileLocalModeRemoteRequestError";
+  }
+}

--- a/frontend/src/lib/pluginApi.ts
+++ b/frontend/src/lib/pluginApi.ts
@@ -1,0 +1,65 @@
+import { getBaseUrl } from "./api.impl";
+import { fetchWithAuthRefresh, getAccessToken } from "./authSession";
+
+export interface PluginPermissionRow {
+  permission: string;
+  configJson: string;
+  granted: number;
+}
+
+export interface PluginAction {
+  id: string;
+  name: string;
+  description?: string;
+  execution?: "interactive" | "background";
+  input?: Record<string, { type: string; required?: boolean; description?: string }>;
+}
+
+export interface InstalledPlugin {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  source: string;
+  trustLevel: string;
+  status: "quarantined" | "disabled" | "enabled" | "error" | "incompatible";
+  checksum: string;
+  lastError?: string | null;
+  actions: PluginAction[];
+  permissions: PluginPermissionRow[];
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = getAccessToken();
+  const response = await fetchWithAuthRefresh(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.body instanceof FormData ? {} : { "Content-Type": "application/json" }),
+      ...(init.headers || {}),
+    },
+  }, getBaseUrl());
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw Object.assign(new Error(payload.error || `HTTP ${response.status}`), { code: payload.code, status: response.status });
+  return payload as T;
+}
+
+export const pluginApi = {
+  list: () => request<InstalledPlugin[]>("/api/plugins"),
+  get: (id: string) => request<InstalledPlugin>(`/api/plugins/${encodeURIComponent(id)}`),
+  install: (file: File) => {
+    const form = new FormData();
+    form.append("file", file);
+    return request<{ success: true; plugin: InstalledPlugin }>("/api/plugins/install", { method: "POST", body: form });
+  },
+  grant: (id: string, granted: string[]) => request(`/api/plugins/${encodeURIComponent(id)}/permissions`, { method: "PUT", body: JSON.stringify({ granted }) }),
+  enable: (id: string) => request(`/api/plugins/${encodeURIComponent(id)}/enable`, { method: "POST" }),
+  disable: (id: string) => request(`/api/plugins/${encodeURIComponent(id)}/disable`, { method: "POST" }),
+  reload: (id: string) => request(`/api/plugins/${encodeURIComponent(id)}/reload`, { method: "POST" }),
+  uninstall: (id: string) => request(`/api/plugins/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  execute: (pluginId: string, actionId: string, input: Record<string, unknown>) => request<{ success: boolean; executionId: string; data: unknown }>(`/api/plugins/${encodeURIComponent(pluginId)}/actions/${encodeURIComponent(actionId)}/execute`, { method: "POST", body: JSON.stringify({ input }) }),
+  executions: (id: string) => request<any[]>(`/api/plugins/${encodeURIComponent(id)}/executions`),
+  getDeveloperMode: () => request<{ enabled: boolean; available: boolean }>("/api/plugins/developer-mode"),
+  setDeveloperMode: (enabled: boolean) => request<{ enabled: boolean }>("/api/plugins/developer-mode", { method: "PUT", body: JSON.stringify({ enabled }) }),
+  loadDevelopment: (directory: string) => request("/api/plugins/dev/load", { method: "POST", body: JSON.stringify({ directory }) }),
+};

--- a/packages/create-nowen-plugin/README.md
+++ b/packages/create-nowen-plugin/README.md
@@ -1,0 +1,3 @@
+# create-nowen-plugin
+
+Run `npm create nowen-plugin` to scaffold, build, and pack a Nowen Extension Platform V1 plugin.

--- a/packages/create-nowen-plugin/bin/create-nowen-plugin.mjs
+++ b/packages/create-nowen-plugin/bin/create-nowen-plugin.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import { stdin, stdout } from "node:process";
+
+const cliArgs = process.argv.slice(2);
+const valueOf = (flag) => {
+  const index = cliArgs.indexOf(flag);
+  return index >= 0 ? cliArgs[index + 1] : "";
+};
+const directoryArg = cliArgs.find((value, index) => !value.startsWith("--") && (index === 0 || !cliArgs[index - 1].startsWith("--"))) || "";
+const rl = readline.createInterface({ input: stdin, output: stdout });
+const name = valueOf("--name") || (await rl.question("Plugin Name (Hello Nowen): ")).trim() || "Hello Nowen";
+const suggestedId = `com.example.${name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+const id = valueOf("--id") || (await rl.question(`Plugin ID (${suggestedId}): `)).trim() || suggestedId;
+const description = valueOf("--description") || (await rl.question("Description: ")).trim() || "A Nowen community plugin";
+const author = valueOf("--author") || (await rl.question("Author: ")).trim() || "community";
+rl.close();
+
+const directoryName = directoryArg || name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+const target = path.resolve(directoryName);
+const localSdk = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "nowen-plugin-sdk");
+const sdkDependency = fs.existsSync(path.join(localSdk, "package.json")) ? `file:${localSdk.replace(/\\/g, "/")}` : "^1.0.0";
+if (fs.existsSync(target) && fs.readdirSync(target).length > 0) throw new Error(`目标目录非空: ${target}`);
+fs.mkdirSync(path.join(target, "src"), { recursive: true });
+fs.mkdirSync(path.join(target, "scripts"), { recursive: true });
+
+const files = {
+  "manifest.json": JSON.stringify({
+    id, name, description, version: "1.0.0", apiVersion: 1,
+    engines: { nowen: ">=1.5.0 <2.0.0" }, runtime: "node-action", main: "dist/index.mjs",
+    author: { name: author }, permissions: [],
+    actions: [{ id: "hello", name: "Hello Nowen", description: "Return a greeting", execution: "interactive", input: { name: { type: "string", required: false } } }],
+  }, null, 2) + "\n",
+  "package.json": JSON.stringify({
+    name: directoryName, version: "1.0.0", private: true, type: "module",
+    scripts: { dev: "npm run build -- --watch", build: "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.mjs", pack: "npm run build && node scripts/pack.mjs" },
+    dependencies: { "@nowen/plugin-sdk": sdkDependency },
+    devDependencies: { archiver: "^7.0.1", esbuild: "^0.24.0", typescript: "^5.7.3" },
+  }, null, 2) + "\n",
+  "tsconfig.json": JSON.stringify({ compilerOptions: { target: "ES2022", module: "NodeNext", moduleResolution: "NodeNext", strict: true, noEmit: true }, include: ["src"] }, null, 2) + "\n",
+  "nowen.config.ts": `export default { manifest: "manifest.json", output: "dist/${directoryName}-1.0.0.nowen-plugin" };\n`,
+  "src/index.ts": `import { definePlugin } from "@nowen/plugin-sdk";\n\nexport default definePlugin({\n  actions: {\n    hello: async ({ input }) => ({ text: \`Hello \${input.name ?? "Nowen"}!\` }),\n  },\n});\n`,
+  "scripts/pack.mjs": `import archiver from "archiver";\nimport fs from "node:fs";\nimport path from "node:path";\nconst manifest=JSON.parse(fs.readFileSync("manifest.json","utf8"));\nfs.mkdirSync("dist",{recursive:true});\nconst output=fs.createWriteStream(path.join("dist",\`${directoryName}-\${manifest.version}.nowen-plugin\`));\nconst archive=archiver("zip",{zlib:{level:9}});\narchive.pipe(output); archive.file("manifest.json",{name:"manifest.json"}); archive.file("dist/index.mjs",{name:"dist/index.mjs"});\nif(fs.existsSync("README.md")) archive.file("README.md",{name:"README.md"}); await archive.finalize();\n`,
+  "README.md": `# ${name}\n\n${description}\n\n## Development\n\n\`npm install\`, then \`npm run dev\`, \`npm run build\`, or \`npm run pack\`.\n`,
+};
+
+for (const [relative, contents] of Object.entries(files)) {
+  const destination = path.join(target, relative);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, contents, { flag: "wx" });
+}
+stdout.write(`\nCreated ${name} in ${target}\nNext: cd ${directoryName} && npm install && npm run pack\n`);

--- a/packages/create-nowen-plugin/package.json
+++ b/packages/create-nowen-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "create-nowen-plugin",
+  "version": "1.0.0",
+  "description": "Create a Nowen Extension Platform V1 plugin",
+  "type": "module",
+  "bin": { "create-nowen-plugin": "bin/create-nowen-plugin.mjs" },
+  "files": ["bin", "README.md"],
+  "engines": { "node": ">=20" }
+}

--- a/packages/nowen-mcp/package-lock.json
+++ b/packages/nowen-mcp/package-lock.json
@@ -12,7 +12,7 @@
         "zod": "^3.24.1"
       },
       "bin": {
-        "nowen-mcp": "dist/index.js"
+        "nowen-mcp": "bin/nowen-mcp.mjs"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -871,6 +871,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1103,6 +1104,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1703,6 +1705,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/nowen-mcp/src/api-client.ts
+++ b/packages/nowen-mcp/src/api-client.ts
@@ -584,6 +584,23 @@ export class NowenApiClient {
     return this.request("/api/plugins");
   }
 
+  /** 获取 AI/MCP 可发现的已启用 Plugin Actions。 */
+  async listPluginActions(): Promise<any[]> {
+    return this.request("/api/plugins/actions");
+  }
+
+  /** 按稳定的 pluginId + actionId 协议执行。 */
+  async executePluginAction(pluginId: string, actionId: string, input: Record<string, any>): Promise<any> {
+    return this.request(`/api/plugins/${encodeURIComponent(pluginId)}/actions/${encodeURIComponent(actionId)}/execute`, {
+      method: "POST",
+      body: { input },
+    });
+  }
+
+  async getPluginExecution(executionId: string): Promise<any> {
+    return this.request(`/api/plugin-executions/${encodeURIComponent(executionId)}`);
+  }
+
   /** 执行插件 */
   async executePlugin(name: string, params: Record<string, any>): Promise<any> {
     return this.request("/api/plugins/" + name + "/execute", {

--- a/packages/nowen-mcp/src/index.ts
+++ b/packages/nowen-mcp/src/index.ts
@@ -667,13 +667,13 @@ server.tool(
 // ==================== 插件工具 ====================
 
 server.tool(
-  "nowen_list_plugins",
-  "获取 Nowen Note 中已加载的插件列表，每个插件声明了它支持的能力（action）",
+  "nowen_list_plugin_actions",
+  "发现 Nowen Note 中已启用的插件 Action 及其输入结构",
   {},
   async () => {
     try {
-      const plugins = await api.listPlugins();
-      return { content: [{ type: "text" as const, text: JSON.stringify(plugins, null, 2) }] };
+      const actions = await api.listPluginActions();
+      return { content: [{ type: "text" as const, text: JSON.stringify(actions, null, 2) }] };
     } catch (err: any) {
       return { content: [{ type: "text" as const, text: `错误: ${err.message}` }], isError: true };
     }
@@ -681,18 +681,30 @@ server.tool(
 );
 
 server.tool(
-  "nowen_execute_plugin",
-  "执行 Nowen Note 中指定名称的插件，传入参数并获取处理结果",
+  "nowen_execute_plugin_action",
+  "按 pluginId 和 actionId 执行已授权的 Nowen 插件 Action",
   {
-    pluginName: z.string().describe("插件名称"),
-    params: z.record(z.any()).describe("传给插件的参数对象"),
+    pluginId: z.string().describe("Manifest 中稳定的插件 ID"),
+    actionId: z.string().describe("Manifest 中稳定的 Action ID"),
+    input: z.record(z.any()).describe("符合 Action input schema 的参数对象"),
   },
-  async ({ pluginName, params }) => {
+  async ({ pluginId, actionId, input }) => {
     try {
-      const result = await api.executePlugin(pluginName, params);
-      if (result.text) {
-        return { content: [{ type: "text" as const, text: result.text }] };
-      }
+      const result = await api.executePluginAction(pluginId, actionId, input);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    } catch (err: any) {
+      return { content: [{ type: "text" as const, text: `错误: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool(
+  "nowen_get_plugin_execution",
+  "查询一次插件 Action 的执行状态、错误和截断日志",
+  { executionId: z.string().describe("执行 ID") },
+  async ({ executionId }) => {
+    try {
+      const result = await api.getPluginExecution(executionId);
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     } catch (err: any) {
       return { content: [{ type: "text" as const, text: `错误: ${err.message}` }], isError: true };

--- a/packages/nowen-plugin-sdk/README.md
+++ b/packages/nowen-plugin-sdk/README.md
@@ -1,0 +1,13 @@
+# @nowen/plugin-sdk
+
+Nowen Extension Platform V1 的薄类型层。插件只导出 `definePlugin({ actions })`；数据访问必须通过执行上下文中的 `nowen` Host API，不会得到数据库句柄或登录 Token。
+
+```ts
+import { definePlugin } from "@nowen/plugin-sdk";
+
+export default definePlugin({
+  actions: {
+    hello: async ({ input }) => ({ text: `Hello ${input.name ?? "Nowen"}` }),
+  },
+});
+```

--- a/packages/nowen-plugin-sdk/package-lock.json
+++ b/packages/nowen-plugin-sdk/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@nowen/plugin-sdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nowen/plugin-sdk",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/nowen-plugin-sdk/package.json
+++ b/packages/nowen-plugin-sdk/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nowen/plugin-sdk",
+  "version": "1.0.0",
+  "description": "Types and helpers for Nowen Extension Platform V1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
+  "files": ["dist", "README.md"],
+  "scripts": { "build": "tsc", "test": "npm run build" },
+  "devDependencies": { "typescript": "^5.7.3" }
+}

--- a/packages/nowen-plugin-sdk/src/index.ts
+++ b/packages/nowen-plugin-sdk/src/index.ts
@@ -1,0 +1,38 @@
+export type ActionResult = { success?: boolean; data?: unknown; text?: string } | unknown;
+
+export interface PluginActionContext<TInput = Record<string, unknown>> {
+  input: TInput;
+  nowen: NowenHostApi;
+}
+
+type HostNamespace = Record<string, (args?: Record<string, unknown>) => Promise<any>>;
+
+export interface NowenHostApi {
+  notes: HostNamespace;
+  notebooks: HostNamespace;
+  tags: HostNamespace;
+  tasks: HostNamespace;
+  attachments: HostNamespace;
+  diary: HostNamespace;
+  mindmaps: HostNamespace;
+  storage: HostNamespace;
+  external: HostNamespace;
+}
+
+export interface NowenPluginDefinition {
+  activate?(context: { nowen: NowenHostApi }): void | Promise<void>;
+  actions: Record<string, (context: PluginActionContext<any>) => ActionResult | Promise<ActionResult>>;
+  deactivate?(): void | Promise<void>;
+}
+
+export class NowenPluginError extends Error {
+  constructor(message: string, readonly code = "PLUGIN_ERROR") {
+    super(message);
+    this.name = "NowenPluginError";
+  }
+}
+
+/** 编译期保留完整类型，运行时原样返回，不夹带业务实现或凭证。 */
+export function definePlugin<T extends NowenPluginDefinition>(plugin: T): T {
+  return plugin;
+}

--- a/packages/nowen-plugin-sdk/tsconfig.json
+++ b/packages/nowen-plugin-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add unsigned Android device-local mode with explicit sign-in and sync entry.
- Add Nowen Extension Platform V1: package validation, quarantine, permissions, resource ACL checks, isolated workers, encrypted secrets, audit logs, execution lifecycle, and backup restore safeguards.
- Add plugin management UI, SDK, scaffolder, example plugin, documentation, and MCP action tools.

## Validation

- Backend full regression: 243/243 test files passed, 0 failures, 0 timeouts.
- Plugin platform targeted regression: 11/11 passed.
- Android local-mode regression: 15/15 passed.
- MCP regression: 16/16 passed.
- Backend, frontend, SDK, and MCP production builds passed.
- Git diff checks and added-content secret-pattern checks passed.

## Commits

- 6b5c9910 feat(android): support unsigned local-first mode
- 858b6659 feat: add Nowen extension platform v1